### PR TITLE
v0.7.2: Headless server mode + Docker/K8s support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build outputs
+src-tauri/target/
+dist/
+node_modules/
+
+# IDE / OS
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.github/
+
+# Dev files
+*.md
+LICENSE
+scripts/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# MooshieUI Server — Environment Variables
+# Copy this file to .env and adjust as needed.
+
+# Port to expose the web UI (default: 3200)
+MOOSHIEUI_PORT=3200
+
+# Host path to external models directory (optional)
+# MODELS_PATH=./models
+
+# Log level: error, warn, info, debug, trace
+RUST_LOG=info
+
+# Cloudflare Tunnel token (uncomment cloudflared service in docker-compose.yml)
+# CLOUDFLARE_TUNNEL_TOKEN=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -192,3 +193,82 @@ jobs:
             --title "MooshieUI ${TAG}" \
             --notes-file /tmp/release-body.md \
             /tmp/release-files/*
+
+  # -------------------------------------------------------------------------
+  # Headless server binary (no webkit / Tauri deps required)
+  # -------------------------------------------------------------------------
+  build-server:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libssl-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build server binary
+        run: |
+          cd src-tauri
+          cargo build --release --no-default-features --features server --bin mooshieui-server
+
+      - name: Upload server binary
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: mooshieui-server-linux-x86_64
+          path: src-tauri/target/release/mooshieui-server
+          if-no-files-found: error
+
+  # -------------------------------------------------------------------------
+  # Docker image → GitHub Container Registry
+  # -------------------------------------------------------------------------
+  docker-publish:
+    needs: build-server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mooshieui
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
+          pattern: artifacts-*
           merge-multiple: true
 
       - name: Collect release files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,115 @@
+# =============================================================================
+# MooshieUI Server — Multi-stage Docker Build
+# =============================================================================
+# Builds a headless MooshieUI server with ComfyUI + PyTorch pre-installed.
+#
+#   docker build -t mooshieui .
+#   docker run --gpus all -p 3200:3200 -v mooshie-data:/data mooshieui
+#
+# Build args:
+#   COMFYUI_VERSION  — ComfyUI git tag/branch (default: master)
+#   TORCH_VERSION    — PyTorch version string (default: 2.7.1)
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the Svelte frontend
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS frontend
+
+WORKDIR /build
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY index.html svelte.config.js tsconfig.json vite.config.ts ./
+COPY src/ src/
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build the Rust server binary
+# ---------------------------------------------------------------------------
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+# Copy Cargo manifests first for dependency caching
+COPY src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/build.rs ./src-tauri/
+# Create stub files so cargo can resolve the workspace
+RUN mkdir -p src-tauri/src && \
+    echo 'fn main() {}' > src-tauri/src/main.rs && \
+    echo '' > src-tauri/src/lib.rs && \
+    echo '#[tokio::main] async fn main() {}' > src-tauri/src/server_main.rs
+# Copy comfyui-nodes (needed by include_str! in nodes.rs)
+COPY comfyui-nodes/ comfyui-nodes/
+# Pre-build dependencies
+RUN cd src-tauri && \
+    cargo build --release --no-default-features --features server --bin mooshieui-server 2>/dev/null || true
+
+# Now copy the real source and build
+COPY src-tauri/ src-tauri/
+RUN touch src-tauri/src/lib.rs src-tauri/src/server_main.rs src-tauri/src/main.rs && \
+    cd src-tauri && \
+    cargo build --release --no-default-features --features server --bin mooshieui-server
+
+# ---------------------------------------------------------------------------
+# Stage 3: Runtime with CUDA + Python + ComfyUI
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
+
+ARG COMFYUI_VERSION=master
+ARG TORCH_VERSION=2.7.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    MOOSHIEUI_DATA_DIR=/data \
+    COMFYUI_PATH=/opt/comfyui \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# System packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 python3.12-venv python3-pip \
+    git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (fast Python package manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    mv /root/.local/bin/uv /usr/local/bin/uv
+
+# Clone ComfyUI
+RUN git clone --depth=1 --branch ${COMFYUI_VERSION} \
+    https://github.com/comfyanonymous/ComfyUI.git ${COMFYUI_PATH}
+
+# Create venv and install PyTorch + ComfyUI requirements
+RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
+    . ${COMFYUI_PATH}/.venv/bin/activate && \
+    uv pip install torch==${TORCH_VERSION} torchvision torchaudio \
+        --index-url https://download.pytorch.org/whl/cu126 && \
+    uv pip install -r ${COMFYUI_PATH}/requirements.txt
+
+# Copy custom nodes (auto-deployed by the binary on startup, but also
+# pre-copy them so they're available even if the binary doesn't run the
+# deploy step — e.g. if ComfyUI is already running)
+COPY comfyui-nodes/nodes_tiled_diffusion.py ${COMFYUI_PATH}/custom_nodes/
+COPY comfyui-nodes/nodes_guidance.py ${COMFYUI_PATH}/custom_nodes/
+COPY comfyui-nodes/nodes_sdxl_flux2vae.py ${COMFYUI_PATH}/custom_nodes/
+COPY comfyui-nodes/nodes_sdxl_flux2vae_combined.py ${COMFYUI_PATH}/custom_nodes/
+COPY comfyui-nodes/nanosaur_support/ ${COMFYUI_PATH}/custom_nodes/nanosaur_support/
+
+# Copy server binary and frontend
+COPY --from=builder /build/src-tauri/target/release/mooshieui-server /app/mooshieui-server
+COPY --from=frontend /build/dist /app/dist
+
+# Create data directory and default config
+RUN mkdir -p /data/gallery /data/thumbnails && \
+    echo '{"comfyui_path":"/opt/comfyui","venv_path":"/opt/comfyui/.venv","auto_start":true,"setup_complete":true,"browser_mode":true,"ui_server_port":3200,"lan_enabled":true,"server_mode":"autolaunch"}' \
+    > /data/config.json
+
+WORKDIR /app
+EXPOSE 3200
+VOLUME ["/data"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:3200/health || exit 1
+
+ENTRYPOINT ["/app/mooshieui-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  mooshieui:
+    build: .
+    image: ghcr.io/mooshieblob1/mooshieui:latest
+    ports:
+      - "${MOOSHIEUI_PORT:-3200}:3200"
+    volumes:
+      - mooshie-data:/data
+      - ${MODELS_PATH:-./models}:/data/models
+    environment:
+      - MOOSHIEUI_DATA_DIR=/data
+      - NVIDIA_VISIBLE_DEVICES=all
+      - RUST_LOG=${RUST_LOG:-info}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  # Optional: Cloudflare Tunnel sidecar for secure remote access.
+  # Uncomment and set CLOUDFLARE_TUNNEL_TOKEN in .env to enable.
+  #
+  # cloudflared:
+  #   image: cloudflare/cloudflared:latest
+  #   command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+  #   network_mode: "service:mooshieui"
+  #   restart: unless-stopped
+
+volumes:
+  mooshie-data:

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mooshieui-config
+  namespace: mooshieui
+data:
+  config.json: |
+    {
+      "comfyui_path": "/opt/comfyui",
+      "venv_path": "/opt/comfyui/.venv",
+      "auto_start": true,
+      "setup_complete": true,
+      "browser_mode": true,
+      "ui_server_port": 3200,
+      "lan_enabled": true,
+      "server_mode": "autolaunch",
+      "vram_mode": "normal",
+      "default_sampler": "euler_cfg_pp",
+      "default_scheduler": "sgm_uniform",
+      "default_steps": 20,
+      "default_cfg": 1.4,
+      "default_width": 1024,
+      "default_height": 1024
+    }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mooshieui
+  namespace: mooshieui
+  labels:
+    app: mooshieui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mooshieui
+  strategy:
+    type: Recreate          # GPU workload — no rolling update
+  template:
+    metadata:
+      labels:
+        app: mooshieui
+    spec:
+      containers:
+        # ── MooshieUI server ──
+        - name: mooshieui
+          image: ghcr.io/mooshieblob1/mooshieui:latest
+          ports:
+            - containerPort: 3200
+              name: http
+          env:
+            - name: MOOSHIEUI_DATA_DIR
+              value: /data
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: RUST_LOG
+              value: info
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: models
+              mountPath: /data/models
+            - name: config
+              mountPath: /data/config.json
+              subPath: config.json
+          resources:
+            limits:
+              nvidia.com/gpu.shared: "1"
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3200
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3200
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+
+        # ── Cloudflare Tunnel sidecar (optional — remove if not needed) ──
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-tunnel
+                  key: token
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: mooshieui-data
+        - name: models
+          persistentVolumeClaim:
+            claimName: mooshieui-models
+        - name: config
+          configMap:
+            name: mooshieui-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooshieui
+  namespace: mooshieui
+spec:
+  selector:
+    app: mooshieui
+  ports:
+    - port: 3200
+      targetPort: 3200
+      name: http
+  type: ClusterIP

--- a/k8s/namespace-pvc.yaml
+++ b/k8s/namespace-pvc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mooshieui
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mooshieui-data
+  namespace: mooshieui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+---
+# Optional: separate PVC for models if you want to share across pods
+# or use a larger / different storage class.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mooshieui-models
+  namespace: mooshieui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,14 @@
+# Create this secret before deploying:
+#   kubectl -n mooshieui create secret generic cloudflare-tunnel \
+#     --from-literal=token=YOUR_TUNNEL_TOKEN
+#
+# Or apply this template after filling in the base64-encoded token:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-tunnel
+  namespace: mooshieui
+type: Opaque
+data:
+  # echo -n 'YOUR_TOKEN' | base64
+  token: ""

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT"
 
@@ -8,15 +8,38 @@ license = "MIT"
 name = "comfyui_desktop_lib"
 crate-type = ["lib", "cdylib", "staticlib"]
 
+[[bin]]
+name = "mooshieui-server"
+path = "src/server_main.rs"
+required-features = ["server"]
+
+[features]
+default = ["desktop"]
+desktop = [
+    "dep:tauri",
+    "dep:tauri-build",
+    "dep:tauri-plugin-store",
+    "dep:tauri-plugin-shell",
+    "dep:tauri-plugin-dialog",
+    "dep:tauri-plugin-fs",
+    "dep:tauri-plugin-clipboard-manager",
+    "dep:tauri-plugin-updater",
+    "dep:tauri-plugin-process",
+    "dep:webkit2gtk",
+    "dep:ort",
+    "dep:csv",
+]
+server = []
+
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2", features = [], optional = true }
 
 [dependencies]
-tauri = { version = "2", features = ["image-png"] }
-tauri-plugin-store = "2"
-tauri-plugin-shell = "2"
-tauri-plugin-dialog = "2"
-tauri-plugin-fs = "2"
+tauri = { version = "2", features = ["image-png"], optional = true }
+tauri-plugin-store = { version = "2", optional = true }
+tauri-plugin-shell = { version = "2", optional = true }
+tauri-plugin-dialog = { version = "2", optional = true }
+tauri-plugin-fs = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 reqwest = { version = "0.12", features = ["json", "multipart"] }
@@ -33,14 +56,14 @@ rand = "0.10"
 base64 = "0.22"
 dirs = "6"
 sha2 = "0.10"
-tauri-plugin-clipboard-manager = "2"
-tauri-plugin-updater = "2"
-tauri-plugin-process = "2"
+tauri-plugin-clipboard-manager = { version = "2", optional = true }
+tauri-plugin-updater = { version = "2", optional = true }
+tauri-plugin-process = { version = "2", optional = true }
 png = "0.18"
 flate2 = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
-ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "tls-native", "api-24", "load-dynamic"] }
-csv = "1"
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "tracing", "tls-native", "api-24", "load-dynamic"], optional = true }
+csv = { version = "1", optional = true }
 axum = { version = "0.8", features = ["tokio"] }
 tower-http = { version = "0.6", features = ["fs", "cors"] }
 mime_guess = "2"
@@ -50,7 +73,7 @@ hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-webkit2gtk = "=2.0.2"
+webkit2gtk = { version = "=2.0.2", optional = true }
 tar = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    #[cfg(feature = "desktop")]
     tauri_build::build();
 }

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -272,6 +272,7 @@ impl AppState {
     /// emitting `download:progress` events with byte-level progress.
     /// If `dest_dir_override` is provided, the file is written there instead
     /// of the default `{comfyui_path}/models/{category}` path.
+    #[cfg(feature = "desktop")]
     pub async fn download_model_file(
         &self,
         app: &tauri::AppHandle,

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -1,12 +1,14 @@
 use base64::Engine;
 use futures_util::StreamExt;
 use std::time::Instant;
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter};
 use tokio_tungstenite::connect_async;
 
 use crate::error::AppError;
 use crate::state::AppState;
 
+#[cfg(feature = "desktop")]
 pub async fn connect_websocket(
     app_handle: AppHandle,
     state: &AppState,

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+#[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, State};
 
 use crate::comfyui::types::*;
@@ -69,6 +70,7 @@ pub struct CivitaiSearchParams {
     pub api_key: Option<String>,
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_models(
     state: State<'_, Arc<AppState>>,
@@ -77,21 +79,25 @@ pub async fn get_models(
     state.get_models_list(&category).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_samplers(state: State<'_, Arc<AppState>>) -> Result<SamplerInfo, AppError> {
     state.get_samplers_and_schedulers().await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_embeddings(state: State<'_, Arc<AppState>>) -> Result<Vec<String>, AppError> {
     state.get_embeddings_list().await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_queue(state: State<'_, Arc<AppState>>) -> Result<QueueInfo, AppError> {
     state.get_queue_info().await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_history(
     state: State<'_, Arc<AppState>>,
@@ -100,11 +106,13 @@ pub async fn get_history(
     state.get_history_for(&prompt_id).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn interrupt_generation(state: State<'_, Arc<AppState>>) -> Result<(), AppError> {
     state.interrupt().await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn delete_queue_item(
     state: State<'_, Arc<AppState>>,
@@ -113,6 +121,7 @@ pub async fn delete_queue_item(
     state.delete_queue_items(vec![prompt_id]).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn upload_image(
     state: State<'_, Arc<AppState>>,
@@ -121,6 +130,7 @@ pub async fn upload_image(
     state.upload_image_file(&image_path).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn upload_image_bytes(
     state: State<'_, Arc<AppState>>,
@@ -130,6 +140,7 @@ pub async fn upload_image_bytes(
     state.upload_image_from_bytes(image_bytes, filename).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_output_image(
     state: State<'_, Arc<AppState>>,
@@ -139,6 +150,7 @@ pub async fn get_output_image(
     state.get_output_image_bytes(&filename, &subfolder).await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_client_id(state: State<'_, Arc<AppState>>) -> Result<String, AppError> {
     Ok(state.client_id.clone())
@@ -153,6 +165,7 @@ pub struct ModelInstallDir {
 /// Returns all directories where a model of the given category can be installed.
 /// Always includes the primary app directory; also includes any extra_model_paths
 /// subdirectories for the category that already exist on disk.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_model_install_dirs(
     state: State<'_, Arc<AppState>>,
@@ -205,6 +218,7 @@ pub async fn get_model_install_dirs(
 }
 
 /// Opens a directory in the OS file explorer.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn open_directory(path: String) -> Result<(), AppError> {
     let dir = std::path::Path::new(&path);
@@ -241,6 +255,7 @@ pub async fn open_directory(path: String) -> Result<(), AppError> {
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn download_model(
     app: AppHandle,
@@ -263,6 +278,7 @@ pub async fn download_model(
         .await
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn save_image_file(image_bytes: Vec<u8>, path: String) -> Result<(), AppError> {
     std::fs::write(&path, &image_bytes)?;
@@ -271,6 +287,7 @@ pub async fn save_image_file(image_bytes: Vec<u8>, path: String) -> Result<(), A
 
 /// Embed metadata into raw PNG bytes and return the result — no disk save.
 /// Used when copying a freshly-generated image before it has been persisted to gallery.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn embed_png_metadata_bytes(
     image_bytes: Vec<u8>,
@@ -282,6 +299,7 @@ pub async fn embed_png_metadata_bytes(
     crate::metadata::embed_png_metadata(&image_bytes, &metadata, mode).map_err(AppError::Other)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn save_to_gallery(
     state: State<'_, Arc<AppState>>,
@@ -304,6 +322,7 @@ pub async fn save_to_gallery(
 }
 
 /// Save raw image bytes (from WebSocket) directly to the gallery with optional embedded metadata.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn save_to_gallery_bytes(
     image_bytes: Vec<u8>,
@@ -396,6 +415,7 @@ pub fn save_to_gallery_inner(
     Ok(gallery_filename)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_image_metadata(
     filename: String,
@@ -407,6 +427,7 @@ pub async fn read_image_metadata(
     crate::metadata::read_png_metadata(&bytes).map_err(AppError::Other)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_image_metadata_bytes(
     image_bytes: Vec<u8>,
@@ -414,6 +435,7 @@ pub async fn read_image_metadata_bytes(
     crate::metadata::read_png_metadata(&image_bytes).map_err(AppError::Other)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_image_metadata_path(
     path: String,
@@ -422,6 +444,7 @@ pub async fn read_image_metadata_path(
     crate::metadata::read_png_metadata(&bytes).map_err(AppError::Other)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn list_gallery_images() -> Result<Vec<String>, AppError> {
     let dir = crate::config::gallery_dir()
@@ -448,6 +471,7 @@ pub async fn list_gallery_images() -> Result<Vec<String>, AppError> {
     Ok(files.into_iter().map(|(_, name)| name).collect())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn list_gallery_image_entries() -> Result<Vec<GalleryImageEntry>, AppError> {
     let dir = crate::config::gallery_dir()
@@ -487,6 +511,7 @@ pub async fn list_gallery_image_entries() -> Result<Vec<GalleryImageEntry>, AppE
     Ok(files)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn load_gallery_image(filename: String) -> Result<Vec<u8>, AppError> {
     if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
@@ -524,6 +549,7 @@ pub fn generate_thumbnail(
     Ok(buf.into_inner())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_gallery_image_path(filename: String) -> Result<String, AppError> {
     let dir = crate::config::gallery_dir()
@@ -538,6 +564,7 @@ pub async fn get_gallery_image_path(filename: String) -> Result<String, AppError
     Ok(path.to_string_lossy().into_owned())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn delete_gallery_image(filename: String) -> Result<(), AppError> {
     let dir = crate::config::gallery_dir()
@@ -549,6 +576,7 @@ pub async fn delete_gallery_image(filename: String) -> Result<(), AppError> {
     Ok(())
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn rename_gallery_image(
     old_filename: String,
@@ -751,6 +779,7 @@ fn native_clipboard_write(image_bytes: &[u8], mime_type: &str) -> Result<(), App
 }
 
 /// Copy raw image bytes (PNG/JPEG/WebP) to the system clipboard.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn copy_bytes_to_clipboard(bytes: Vec<u8>, ext: String) -> Result<(), AppError> {
     let mime = infer_image_mime(&bytes, Some(&ext));
@@ -758,6 +787,7 @@ pub async fn copy_bytes_to_clipboard(bytes: Vec<u8>, ext: String) -> Result<(), 
 }
 
 /// Copy an image file to the system clipboard.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn copy_image_to_clipboard(file_path: String) -> Result<(), AppError> {
     let path = std::path::Path::new(&file_path);
@@ -792,6 +822,7 @@ pub async fn copy_image_to_clipboard(file_path: String) -> Result<(), AppError> 
 }
 
 /// Check if a ComfyUI node class is available (used to detect custom node packages).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn check_node_available(
     state: State<'_, Arc<AppState>>,
@@ -825,6 +856,7 @@ pub fn resolve_uv_bin_pub(venv_path: &str) -> std::path::PathBuf {
 }
 
 /// Check if a custom node package is installed on disk (directory exists in custom_nodes/).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn is_custom_node_installed(
     state: State<'_, Arc<AppState>>,
@@ -839,6 +871,7 @@ pub async fn is_custom_node_installed(
 
 /// Install a custom node from a git repository into ComfyUI's custom_nodes directory.
 /// Emits `install:progress` events with { node_name, step, message, done } for live progress.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn install_custom_node(
     app: AppHandle,
@@ -1000,6 +1033,7 @@ pub async fn install_custom_node(
 /// Install a pip package into the ComfyUI virtual environment.
 /// Used to lazily install dependencies that are only needed for optional features
 /// (e.g. `ultralytics` for face fix).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn install_pip_package(
     state: State<'_, Arc<AppState>>,
@@ -1045,6 +1079,7 @@ pub async fn install_pip_package(
 /// Search for a model file by SHA256 hash (full or AutoV2) within a model category directory.
 /// Returns the filename if found, or null if no match.
 /// Note: this hashes each file in the directory, so it may take a while for large collections.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn find_model_by_hash(
     state: State<'_, Arc<AppState>>,
@@ -1096,6 +1131,7 @@ pub async fn find_model_by_hash(
 
 /// Compute the full SHA256 hash of a model file (uppercase hex, CivitAI-compatible).
 /// Also returns the AutoV2 hash (first 10 chars).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn hash_model_file(
     state: State<'_, Arc<AppState>>,
@@ -1121,6 +1157,7 @@ pub async fn hash_model_file(
 
 /// Look up a model on CivitAI by its hash (SHA256 or AutoV2).
 /// Returns the CivitAI model version info if found.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn civitai_lookup_hash(
     state: State<'_, Arc<AppState>>,
@@ -1157,6 +1194,7 @@ pub async fn civitai_lookup_hash(
     Ok(data)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn civitai_search_models(
     state: State<'_, Arc<AppState>>,
@@ -1240,6 +1278,7 @@ pub async fn civitai_search_models(
     Ok(data)
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn civitai_list_architectures(
     state: State<'_, Arc<AppState>>,
@@ -1380,6 +1419,7 @@ pub async fn civitai_list_architectures(
 /// Read the ModelSpec metadata from a safetensors file header.
 /// Returns a map of modelspec fields (without the "modelspec." prefix) if present,
 /// or null if the file has no ModelSpec metadata.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_modelspec(
     state: State<'_, Arc<AppState>>,
@@ -1618,6 +1658,7 @@ fn resolve_model_path(
 
 /// Fetch combined LoRA info: hash the file, look up on CivitAI, read ModelSpec.
 /// Returns structured info for the LoRA gallery panel.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_lora_civitai_info(
     state: State<'_, Arc<AppState>>,
@@ -1802,6 +1843,7 @@ pub async fn get_lora_civitai_info(
 /// are populated even when a local sidecar preview exists.
 /// Sidecar search order: `{stem}.png`, `{stem}.jpg`, `{stem}.jpeg`,
 /// `{stem}.preview.png`, `{stem}.preview.jpg` (same directory as the model file).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_checkpoint_civitai_info(
     state: State<'_, Arc<AppState>>,
@@ -2024,6 +2066,7 @@ pub struct ReleaseNote {
     pub published_at: String,
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn fetch_release_notes(
     state: State<'_, Arc<AppState>>,
@@ -2081,6 +2124,7 @@ pub struct ImportResult {
 /// Copies each image file (PNG/JPG/WebP) into the gallery directory,
 /// preserving file modification time in the gallery filename for sorting.
 /// Skips files that already exist in the gallery (by original filename).
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn import_image_directory(
     directory: String,
@@ -2204,6 +2248,7 @@ fn collect_image_files_recursive(
 /// - App config (sanitized)
 /// - Basic system/platform info
 /// - Rust-side log path references
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn export_logs(
     state: State<'_, Arc<AppState>>,
@@ -2350,6 +2395,7 @@ fn detect_image_mime(bytes: &[u8]) -> &'static str {
 /// Returns the image as a `"data:<mime>;base64,..."` string so the WebView can
 /// display it without making its own unauthenticated request to CivitAI.
 /// Cache TTL is 7 days; stale or missing entries are refreshed transparently.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn fetch_cached_image(
     state: State<'_, Arc<AppState>>,
@@ -2429,6 +2475,7 @@ pub async fn fetch_cached_image(
 
 /// Read an image from the native clipboard and return PNG bytes.
 /// Bypasses WebView clipboard restrictions that prevent `navigator.clipboard.read()` from working.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_clipboard_image(app: AppHandle) -> Result<Vec<u8>, AppError> {
     use tauri_plugin_clipboard_manager::ClipboardExt;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,11 @@
 pub mod api;
+#[cfg(feature = "desktop")]
 pub mod config;
+#[cfg(feature = "desktop")]
 pub mod interrogator;
+#[cfg(feature = "desktop")]
 pub mod server;
+#[cfg(feature = "desktop")]
 pub mod websocket;
+#[cfg(feature = "desktop")]
 pub mod workflow;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,8 +3,10 @@ pub mod comfyui;
 pub mod commands;
 pub mod config;
 pub mod error;
+#[cfg(feature = "desktop")]
 pub mod interrogator;
 pub mod metadata;
+#[cfg(feature = "desktop")]
 pub mod setup;
 pub mod state;
 pub mod temp_images;
@@ -15,7 +17,6 @@ use std::sync::Arc;
 
 use config::load_persisted_config;
 use state::AppState;
-use tauri::{Manager, RunEvent};
 
 /// Fix Wayland rendering in AppImage builds.
 ///
@@ -28,7 +29,7 @@ use tauri::{Manager, RunEvent};
 ///   3. Re-executing the process with the corrected environment.
 ///
 /// A sentinel env var `_MOOSHIEUI_WAYLAND_FIXED` prevents infinite re-exec.
-#[cfg(target_os = "linux")]
+#[cfg(all(feature = "desktop", target_os = "linux"))]
 fn fix_wayland_appimage_env() {
     // Only relevant inside an AppImage on a Wayland session, and only once.
     if std::env::var("APPIMAGE").is_err()
@@ -83,8 +84,11 @@ fn fix_wayland_appimage_env() {
     eprintln!("Failed to re-exec for Wayland fix: {}", err);
 }
 
+#[cfg(feature = "desktop")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    use tauri::{Manager, RunEvent};
+
     // Fix WebKitGTK scroll jank and rendering glitches on NVIDIA + Wayland.
     // The DMA-BUF renderer is broken with NVIDIA proprietary drivers.
     #[cfg(target_os = "linux")]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(feature = "desktop")]
     comfyui_desktop_lib::run();
+
+    #[cfg(not(feature = "desktop"))]
+    eprintln!("This binary requires the 'desktop' feature. Use mooshieui-server for headless mode.");
 }

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -1,0 +1,91 @@
+//! Headless MooshieUI server — no Tauri, no GUI.
+//!
+//! Serves the Svelte frontend via axum, manages ComfyUI as a child process,
+//! and relays WebSocket events to SSE clients. Designed for Docker / K8s.
+
+use std::sync::Arc;
+
+use comfyui_desktop_lib::comfyui::{process, websocket};
+use comfyui_desktop_lib::config::load_persisted_config;
+use comfyui_desktop_lib::state::AppState;
+use comfyui_desktop_lib::{temp_images, webserver};
+
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    log::info!("MooshieUI Server starting...");
+
+    let config = load_persisted_config();
+    let port = config.ui_server_port;
+    let auto_start = config.auto_start;
+    let state = Arc::new(AppState::new(config));
+
+    // Clean up and create temp image directory
+    temp_images::init();
+
+    // Start the web server (always LAN-enabled in server mode)
+    let server_state = state.clone();
+    let server_handle = tokio::spawn(async move {
+        webserver::start_server(server_state, port, true).await;
+    });
+
+    log::info!("Web server listening on 0.0.0.0:{}", port);
+
+    // Auto-start ComfyUI if configured
+    if auto_start {
+        log::info!("Auto-starting ComfyUI...");
+        match process::start_comfyui_process(&state).await {
+            Ok(result) => {
+                log::info!("ComfyUI start result: {:?}", result);
+
+                // Wait for ComfyUI to become ready
+                match process::wait_for_ready(&state, 120).await {
+                    Ok(()) => {
+                        log::info!("ComfyUI server is ready");
+                        let event_tx = state.event_tx.clone();
+                        if let Err(e) =
+                            websocket::connect_websocket_headless(&state, event_tx).await
+                        {
+                            log::error!("Failed to connect WebSocket: {}", e);
+                        }
+                        state.broadcast(
+                            "comfyui:server_ready",
+                            serde_json::json!(null),
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("ComfyUI failed to become ready: {}", e);
+                        state.broadcast(
+                            "comfyui:server_error",
+                            serde_json::json!({
+                                "error": e.to_string(),
+                                "crashed": e.to_string().contains("exited with"),
+                            }),
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to start ComfyUI: {}", e);
+            }
+        }
+    }
+
+    // Wait for shutdown signal
+    tokio::signal::ctrl_c()
+        .await
+        .expect("Failed to listen for ctrl-c");
+    log::info!("Shutdown signal received, cleaning up...");
+
+    // Kill ComfyUI process
+    let mut proc = state.comfyui_process.lock().await;
+    if let Some(ref mut child) = *proc {
+        log::info!("Shutting down ComfyUI process...");
+        let _ = child.start_kill();
+        *proc = None;
+    }
+
+    server_handle.abort();
+    log::info!("MooshieUI Server stopped.");
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,9 +6,11 @@ use tokio::sync::{broadcast, Mutex, Notify, RwLock};
 use tokio::task::JoinHandle;
 
 use crate::config::AppConfig;
+#[cfg(feature = "desktop")]
 use crate::interrogator::InterrogatorState;
 
 /// Stored Tauri AppHandle so the headless web server can control the window.
+#[cfg(feature = "desktop")]
 pub type TauriAppHandle = tauri::AppHandle;
 
 /// An event that can be sent to both Tauri and browser SSE clients.
@@ -227,12 +229,14 @@ pub struct AppState {
     pub ws_handle: Mutex<Option<JoinHandle<()>>>,
     pub client_id: String,
     pub http_client: reqwest::Client,
+    #[cfg(feature = "desktop")]
     pub interrogator: Arc<RwLock<InterrogatorState>>,
     /// Broadcast channel for SSE events in browser mode.
     pub event_tx: broadcast::Sender<BroadcastEvent>,
     /// Timestamp of last heartbeat from browser client.
     pub last_heartbeat: Mutex<std::time::Instant>,
     /// Tauri AppHandle — set after app setup so the web server can show/hide the window.
+    #[cfg(feature = "desktop")]
     pub app_handle: Mutex<Option<TauriAppHandle>>,
     /// Set to true when switching from browser mode to app mode.
     /// Prevents the heartbeat watchdog from killing the process.
@@ -252,9 +256,11 @@ impl AppState {
             ws_handle: Mutex::new(None),
             client_id: uuid::Uuid::new_v4().to_string(),
             http_client: reqwest::Client::new(),
+            #[cfg(feature = "desktop")]
             interrogator: Arc::new(RwLock::new(InterrogatorState::new())),
             event_tx,
             last_heartbeat: Mutex::new(std::time::Instant::now()),
+            #[cfg(feature = "desktop")]
             app_handle: Mutex::new(None),
             app_mode_active: std::sync::atomic::AtomicBool::new(false),
             web_server_running: std::sync::atomic::AtomicBool::new(false),

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -199,6 +199,8 @@ pub async fn start_server(
         )
         .route("/internal-api/_auth/set_role", post(auth_set_role_handler))
         .route("/internal-api/_auth/lan_info", get(auth_lan_info_handler))
+        // Health check (unauthenticated, for K8s probes)
+        .route("/health", get(health_handler))
         // SSE event stream
         .route("/internal-api/_events", get(sse_handler))
         // Heartbeat endpoints
@@ -447,6 +449,19 @@ async fn serve_static(dist_dir: PathBuf, req: axum::extract::Request) -> Respons
         }
         Err(_) => (StatusCode::NOT_FOUND, "Not Found").into_response(),
     }
+}
+
+/// Health check endpoint for K8s liveness/readiness probes.
+/// No authentication required.
+async fn health_handler(
+    AxumState(state): AxumState<SharedState>,
+) -> Json<serde_json::Value> {
+    let comfyui_running = state.app.comfyui_process.lock().await.is_some();
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "comfyui_running": comfyui_running,
+    }))
 }
 
 /// SSE endpoint — streams backend events to browser clients.
@@ -801,42 +816,48 @@ async fn dispatch_command(
             Ok(serde_json::json!(null))
         }
         "switch_to_app_mode" => {
-            // Step 1: Save config
-            let mut cfg = state.config.write().await;
-            cfg.browser_mode = false;
-            config::save_config(&cfg).map_err(|e| e)?;
-            drop(cfg);
-
-            // Step 2: Disarm heartbeat watchdog
-            state
-                .app_mode_active
-                .store(true, std::sync::atomic::Ordering::SeqCst);
-
-            // Step 3: Show the existing hidden Tauri window.
-            // The window was only hidden (not destroyed) by switch_to_browser_mode,
-            // so it still has the fully-loaded app. Just make it visible again.
-            let handle_guard = state.app_handle.lock().await;
-            if let Some(ref app_handle) = *handle_guard {
-                use tauri::Manager;
-                if let Some(win) = app_handle.get_webview_window("main") {
-                    // Reload the page first — the hidden webview's JS context
-                    // gets stale (suspended timers, dead WebSocket connections)
-                    // so we need a fresh init.
-                    let _ = win.eval("location.reload()");
-                    let _ = win.show();
-                    let _ = win.unminimize();
-                    let _ = win.set_focus();
-                    log::info!("switch_to_app_mode: reloaded and showed existing window");
-                } else {
-                    log::error!("switch_to_app_mode: no 'main' window found");
-                    return Err("No app window found — please restart the application".into());
-                }
-            } else {
-                log::error!("switch_to_app_mode: AppHandle not available");
-                return Err("AppHandle not available — please restart the application".into());
+            #[cfg(not(feature = "desktop"))]
+            {
+                return Err("switch_to_app_mode is only available in desktop mode".into());
             }
+            #[cfg(feature = "desktop")]
+            {
+                // Step 1: Save config
+                let mut cfg = state.config.write().await;
+                cfg.browser_mode = false;
+                config::save_config(&cfg).map_err(|e| e)?;
+                drop(cfg);
 
-            Ok(serde_json::json!(null))
+                // Step 2: Disarm heartbeat watchdog
+                state
+                    .app_mode_active
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+
+                // Step 3: Show the existing hidden Tauri window.
+                let handle_guard = state.app_handle.lock().await;
+                if let Some(ref app_handle) = *handle_guard {
+                    use tauri::Manager;
+                    if let Some(win) = app_handle.get_webview_window("main") {
+                        let _ = win.eval("location.reload()");
+                        let _ = win.show();
+                        let _ = win.unminimize();
+                        let _ = win.set_focus();
+                        log::info!("switch_to_app_mode: reloaded and showed existing window");
+                    } else {
+                        log::error!("switch_to_app_mode: no 'main' window found");
+                        return Err(
+                            "No app window found — please restart the application".into()
+                        );
+                    }
+                } else {
+                    log::error!("switch_to_app_mode: AppHandle not available");
+                    return Err(
+                        "AppHandle not available — please restart the application".into()
+                    );
+                }
+
+                Ok(serde_json::json!(null))
+            }
         }
         "get_gallery_path" => {
             let dir = user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
@@ -1322,16 +1343,15 @@ async fn dispatch_command(
         "read_image_metadata_bytes" => {
             let image_bytes: Vec<u8> = serde_json::from_value(args["imageBytes"].clone())
                 .map_err(|e| format!("Invalid imageBytes: {}", e))?;
-            let result = commands::api::read_image_metadata_bytes(image_bytes)
-                .await
-                .map_err(|e| e.to_string())?;
+            let result =
+                crate::metadata::read_png_metadata(&image_bytes).map_err(|e| e.to_string())?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "read_image_metadata_path" => {
             let path = args["path"].as_str().ok_or("Missing path")?.to_string();
-            let result = commands::api::read_image_metadata_path(path)
-                .await
-                .map_err(|e| e.to_string())?;
+            let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+            let result =
+                crate::metadata::read_png_metadata(&bytes).map_err(|e| e.to_string())?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "embed_png_metadata_bytes" => {
@@ -1344,10 +1364,11 @@ async fn dispatch_command(
                 .get("metadataMode")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            let result =
-                commands::api::embed_png_metadata_bytes(image_bytes, metadata, metadata_mode)
-                    .await
-                    .map_err(|e| e.to_string())?;
+            let mode = crate::metadata::MetadataMode::from_str(
+                metadata_mode.as_deref().unwrap_or("text_chunk"),
+            );
+            let result = crate::metadata::embed_png_metadata(&image_bytes, &metadata, mode)
+                .map_err(|e| e.to_string())?;
             Ok(serde_json::json!(result))
         }
 
@@ -1880,39 +1901,51 @@ async fn dispatch_command(
             Ok(serde_json::json!(null))
         }
 
-        // --- Interrogator ---
-        "interrogate_image" => {
-            let image_base64 = args["imageBase64"]
-                .as_str()
-                .ok_or("Missing imageBase64")?
-                .to_string();
-            use base64::Engine;
-            let image_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&image_base64)
-                .map_err(|e| format!("Invalid base64: {}", e))?;
-            let result = run_interrogation_headless(&state, image_bytes).await?;
-            serde_json::to_value(result).map_err(|e| e.to_string())
-        }
-        "interrogate_image_path" => {
-            let path = args["path"].as_str().ok_or("Missing path")?.to_string();
-            let image_bytes =
-                std::fs::read(&path).map_err(|e| format!("Failed to read image: {}", e))?;
-            let result = run_interrogation_headless(&state, image_bytes).await?;
-            serde_json::to_value(result).map_err(|e| e.to_string())
-        }
-        "interrogate_gallery_image" => {
-            let filename = args["filename"]
-                .as_str()
-                .ok_or("Missing filename")?
-                .to_string();
-            if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
-                return Err("Invalid filename".to_string());
+        // --- Interrogator (requires desktop feature: ONNX Runtime + model files) ---
+        "interrogate_image" | "interrogate_image_path" | "interrogate_gallery_image" => {
+            #[cfg(not(feature = "desktop"))]
+            {
+                return Err("Interrogation is not available in headless server mode".to_string());
             }
-            let dir = crate::config::gallery_dir().ok_or("Cannot find gallery directory")?;
-            let path = dir.join(&filename);
-            let image_bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
-            let result = run_interrogation_headless(&state, image_bytes).await?;
-            serde_json::to_value(result).map_err(|e| e.to_string())
+            #[cfg(feature = "desktop")]
+            {
+                let image_bytes = match command {
+                    "interrogate_image" => {
+                        let image_base64 = args["imageBase64"]
+                            .as_str()
+                            .ok_or("Missing imageBase64")?
+                            .to_string();
+                        use base64::Engine;
+                        base64::engine::general_purpose::STANDARD
+                            .decode(&image_base64)
+                            .map_err(|e| format!("Invalid base64: {}", e))?
+                    }
+                    "interrogate_image_path" => {
+                        let path = args["path"].as_str().ok_or("Missing path")?.to_string();
+                        std::fs::read(&path)
+                            .map_err(|e| format!("Failed to read image: {}", e))?
+                    }
+                    "interrogate_gallery_image" => {
+                        let filename = args["filename"]
+                            .as_str()
+                            .ok_or("Missing filename")?
+                            .to_string();
+                        if filename.contains('/')
+                            || filename.contains('\\')
+                            || filename.contains("..")
+                        {
+                            return Err("Invalid filename".to_string());
+                        }
+                        let dir = crate::config::gallery_dir()
+                            .ok_or("Cannot find gallery directory")?;
+                        let path = dir.join(&filename);
+                        std::fs::read(&path).map_err(|e| e.to_string())?
+                    }
+                    _ => unreachable!(),
+                };
+                let result = run_interrogation_headless(&state, image_bytes).await?;
+                serde_json::to_value(result).map_err(|e| e.to_string())
+            }
         }
         "interrogate_clipboard" => Err(
             "interrogate_clipboard not available in browser mode (no clipboard access)".to_string(),
@@ -1966,23 +1999,37 @@ async fn dispatch_command(
 
         // --- Clipboard ---
         "copy_image_to_clipboard" => {
-            let file_path = args["filePath"]
-                .as_str()
-                .ok_or("Missing filePath")?
-                .to_string();
-            crate::commands::api::copy_image_to_clipboard(file_path)
-                .await
-                .map_err(|e| e.to_string())?;
-            Ok(serde_json::json!(null))
+            #[cfg(feature = "desktop")]
+            {
+                let file_path = args["filePath"]
+                    .as_str()
+                    .ok_or("Missing filePath")?
+                    .to_string();
+                crate::commands::api::copy_image_to_clipboard(file_path)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(null))
+            }
+            #[cfg(not(feature = "desktop"))]
+            {
+                Err("Clipboard is not available in headless server mode".to_string())
+            }
         }
         "copy_bytes_to_clipboard" => {
-            let bytes: Vec<u8> = serde_json::from_value(args["bytes"].clone())
-                .map_err(|e| format!("Invalid bytes: {}", e))?;
-            let ext = args["ext"].as_str().ok_or("Missing ext")?.to_string();
-            crate::commands::api::copy_bytes_to_clipboard(bytes, ext)
-                .await
-                .map_err(|e| e.to_string())?;
-            Ok(serde_json::json!(null))
+            #[cfg(feature = "desktop")]
+            {
+                let bytes: Vec<u8> = serde_json::from_value(args["bytes"].clone())
+                    .map_err(|e| format!("Invalid bytes: {}", e))?;
+                let ext = args["ext"].as_str().ok_or("Missing ext")?.to_string();
+                crate::commands::api::copy_bytes_to_clipboard(bytes, ext)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok(serde_json::json!(null))
+            }
+            #[cfg(not(feature = "desktop"))]
+            {
+                Err("Clipboard is not available in headless server mode".to_string())
+            }
         }
         "read_clipboard_image" => {
             Err("read_clipboard_image is not yet available in browser mode".to_string())
@@ -2002,6 +2049,7 @@ async fn dispatch_command(
 
 /// Run interrogation without AppHandle (browser mode).
 /// Emits progress via the broadcast channel instead of Tauri events.
+#[cfg(feature = "desktop")]
 async fn run_interrogation_headless(
     state: &Arc<AppState>,
     image_bytes: Vec<u8>,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Adds a headless server binary (`mooshieui-server`) that runs without Tauri/GUI, designed for Docker and Kubernetes deployment.

## Changes

### Cargo Feature Gates
- All Tauri deps gated behind `desktop` feature (default)  
- New `server` feature + `mooshieui-server` binary target
- 46 `#[tauri::command]` functions cfg-gated; pure helpers remain shared

### New Files
- **`src-tauri/src/server_main.rs`** — headless entry point (env_logger, auto-start ComfyUI, graceful shutdown)
- **`Dockerfile`** — 3-stage build (node:20 → rust:1-bookworm → nvidia/cuda:12.6.3-runtime)
- **`docker-compose.yml`** — GPU reservations, volumes, optional cloudflared sidecar
- **`.env.example`** — port, models path, log level, tunnel token
- **`k8s/`** — namespace, PVCs, configmap, secret, deployment + ClusterIP service

### Modified Files  
- `webserver.rs` — `GET /health` endpoint (no auth, for K8s probes), cfg-gated clipboard/interrogation/mode-switch
- `release.yml` — `build-server` job (ubuntu-22.04, no webkit), `docker-publish` job (GHCR via Buildx)
- Version bump: 0.7.1 → 0.7.2

### Build Verification
- ✅ `cargo check --no-default-features --features server --bin mooshieui-server` — compiles clean
- ✅ `cargo check` (desktop/default) — no regressions