### PR TITLE
v0.7.5: SSE race condition fix, right-click copy metadata, clipboard reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v0.7.5
+
+### Generation Reliability Fix
+- **SSE race condition resolved** — fixed a timing bug where the `output_image` handler (async HTTP fetch) could lose the race against the synchronous `executing: node=null` completion event, causing generated images to silently disappear despite successful execution. In-flight image fetches are now tracked and awaited before finalizing output.
+
+### Right-Click Copy with Metadata
+- **MooshieSaveImage outputs RGBA** — the custom ComfyUI output node now produces RGBA PNGs (alpha=255) instead of RGB, ensuring the alpha channel is available for stealth metadata embedding
+- **Server-side metadata embedding** — new `_embed_temp_metadata` endpoint allows the browser to embed stealth alpha metadata into temp images without serializing multi-MB image data over JSON
+- **Automatic blob URL upgrade** — in browser mode, generated images are displayed immediately and then silently upgraded with metadata-embedded versions in the background, so right-click → Copy Image includes stealth alpha metadata from the start
+
+### Clipboard & Lightbox Reliability
+- **Persist promise tracking** — gallery image persistence is now tracked with per-image promises, eliminating race conditions where clipboard copy or lightbox display tried to use gallery URLs before the image was saved
+- **Lightbox URL upgrade** — lightbox now shows the blob URL immediately and upgrades to the gallery URL once persistence completes, instead of waiting or showing a broken reference
+
+---
+
 ## What's New in v0.7.4
 
 ### Image Storage Limits & Expiry

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
     . ${COMFYUI_PATH}/.venv/bin/activate && \
     uv pip install torch==${TORCH_VERSION} torchvision torchaudio \
         --index-url https://download.pytorch.org/whl/cu126 && \
-    uv pip install -r ${COMFYUI_PATH}/requirements.txt
+    uv pip install -r ${COMFYUI_PATH}/requirements.txt && \
+    uv pip install ultralytics==8.4.34
 
 # Copy custom nodes (auto-deployed by the binary on startup, but also
 # pre-copy them so they're available even if the binary doesn't run the
@@ -96,12 +97,18 @@ COPY comfyui-nodes/nodes_sdxl_flux2vae.py ${COMFYUI_PATH}/custom_nodes/
 COPY comfyui-nodes/nodes_sdxl_flux2vae_combined.py ${COMFYUI_PATH}/custom_nodes/
 COPY comfyui-nodes/nanosaur_support/ ${COMFYUI_PATH}/custom_nodes/nanosaur_support/
 
-# Copy server binary and frontend
+# Copy server binary, frontend, and entrypoint
 COPY --from=builder /build/src-tauri/target/release/mooshieui-server /app/mooshieui-server
 COPY --from=frontend /build/dist /app/dist
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
-# Create data directory and default config
-RUN mkdir -p /data/gallery /data/thumbnails && \
+# Create data directory and default config.
+# Symlink ComfyUI's models directory to the persistent /data/models volume
+# so that downloaded models survive container recreation.
+RUN mkdir -p /data/gallery /data/thumbnails /data/models && \
+    rm -rf ${COMFYUI_PATH}/models && \
+    ln -s /data/models ${COMFYUI_PATH}/models && \
     echo '{"comfyui_path":"/opt/comfyui","venv_path":"/opt/comfyui/.venv","auto_start":true,"setup_complete":true,"browser_mode":true,"ui_server_port":3200,"lan_enabled":true,"server_mode":"autolaunch"}' \
     > /data/config.json
 
@@ -112,4 +119,5 @@ VOLUME ["/data"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:3200/health || exit 1
 
-ENTRYPOINT ["/app/mooshieui-server"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/mooshieui-server"]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v0.7.5
+
+### Generation Reliability Fix
+- **SSE race condition resolved** — fixed a timing bug where the `output_image` handler (async HTTP fetch) could lose the race against the synchronous `executing: node=null` completion event, causing generated images to silently disappear despite successful execution. In-flight image fetches are now tracked and awaited before finalizing output.
+
+### Right-Click Copy with Metadata
+- **MooshieSaveImage outputs RGBA** — the custom ComfyUI output node now produces RGBA PNGs (alpha=255) instead of RGB, ensuring the alpha channel is available for stealth metadata embedding
+- **Server-side metadata embedding** — new `_embed_temp_metadata` endpoint allows the browser to embed stealth alpha metadata into temp images without serializing multi-MB image data over JSON
+- **Automatic blob URL upgrade** — in browser mode, generated images are displayed immediately and then silently upgraded with metadata-embedded versions in the background, so right-click → Copy Image includes stealth alpha metadata from the start
+
+### Clipboard & Lightbox Reliability
+- **Persist promise tracking** — gallery image persistence is now tracked with per-image promises, eliminating race conditions where clipboard copy or lightbox display tried to use gallery URLs before the image was saved
+- **Lightbox URL upgrade** — lightbox now shows the blob URL immediately and upgrades to the gallery URL once persistence completes, instead of waiting or showing a broken reference
+
+---
+
 ## What's New in v0.7.4
 
 ### Image Storage Limits & Expiry

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Ensure the persistent models directory exists.
+mkdir -p /data/models
+
+# Replace ComfyUI's models/ with a symlink to the persistent volume.
+# This ensures downloaded models survive container recreation.
+# The symlink may have been broken by a volume overlay.
+if [ ! -L "${COMFYUI_PATH}/models" ] || [ "$(readlink "${COMFYUI_PATH}/models")" != "/data/models" ]; then
+    rm -rf "${COMFYUI_PATH}/models"
+    ln -s /data/models "${COMFYUI_PATH}/models"
+fi
+
+# Copy default ComfyUI model subdirectory structure if the volume is fresh.
+# This is needed because ComfyUI expects certain subdirectories to exist.
+for subdir in checkpoints clip clip_vision configs controlnet diffusers diffusion_models embeddings gligen hypernetworks loras photomaker style_models unet upscale_models vae vae_approx ultralytics; do
+    mkdir -p "/data/models/${subdir}"
+done
+
+exec "$@"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "MIT"
+default-run = "comfyui-desktop"
 
 [lib]
 name = "comfyui_desktop_lib"

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -12,8 +12,8 @@ use std::sync::RwLock;
 
 use crate::config;
 
-/// Default storage limit per user: 2 GB.
-const DEFAULT_STORAGE_LIMIT: u64 = 2 * 1024 * 1024 * 1024;
+/// Default storage limit per user: 1 GB.
+const DEFAULT_STORAGE_LIMIT: u64 = 1024 * 1024 * 1024;
 
 /// Default image expiry: 7 days in seconds.
 pub const DEFAULT_EXPIRY_SECS: u64 = 7 * 24 * 60 * 60;
@@ -56,10 +56,11 @@ pub struct AuthDatabase {
     pub accounts: Vec<Account>,
 }
 
-/// In-memory auth state.
+/// Auth state with persistent sessions.
 pub struct AuthState {
     db: RwLock<AuthDatabase>,
-    /// Active session tokens → username.
+    /// Active session tokens → username. Persisted to disk so tokens survive
+    /// server restarts (enables "remember me").
     sessions: RwLock<HashMap<String, String>>,
     /// Per-user last activity timestamp (username → Instant).
     last_activity: RwLock<HashMap<String, std::time::Instant>>,
@@ -68,9 +69,14 @@ pub struct AuthState {
 impl AuthState {
     pub fn new() -> Self {
         let db = load_auth_db().unwrap_or_default();
+        let mut sessions = load_sessions().unwrap_or_default();
+        // Prune sessions for accounts that no longer exist
+        let valid_usernames: std::collections::HashSet<&str> =
+            db.accounts.iter().map(|a| a.username.as_str()).collect();
+        sessions.retain(|_, u| valid_usernames.contains(u.as_str()));
         Self {
             db: RwLock::new(db),
-            sessions: RwLock::new(HashMap::new()),
+            sessions: RwLock::new(sessions),
             last_activity: RwLock::new(HashMap::new()),
         }
     }
@@ -126,10 +132,11 @@ impl AuthState {
 
         let must_change = account.must_change_password;
         let token = generate_token();
-        self.sessions
-            .write()
-            .unwrap()
-            .insert(token.clone(), username.to_string());
+        {
+            let mut sessions = self.sessions.write().unwrap();
+            sessions.insert(token.clone(), username.to_string());
+            let _ = save_sessions(&sessions);
+        }
         Ok((token, must_change))
     }
 
@@ -141,7 +148,9 @@ impl AuthState {
 
     /// Invalidate a session token.
     pub fn logout(&self, token: &str) {
-        self.sessions.write().unwrap().remove(token);
+        let mut sessions = self.sessions.write().unwrap();
+        sessions.remove(token);
+        let _ = save_sessions(&sessions);
     }
 
     /// List all account usernames.
@@ -196,6 +205,7 @@ impl AuthState {
         // Also remove any active sessions for this user
         let mut sessions = self.sessions.write().unwrap();
         sessions.retain(|_, u| u != username);
+        let _ = save_sessions(&sessions);
         Ok(())
     }
 
@@ -268,6 +278,7 @@ impl AuthState {
         // Revoke existing sessions for this user so they must re-login
         let mut sessions = self.sessions.write().unwrap();
         sessions.retain(|_, u| u != username);
+        let _ = save_sessions(&sessions);
         Ok(())
     }
 
@@ -301,12 +312,12 @@ impl AuthState {
         }
     }
 
-    /// List all users with their role, online/offline status, and timestamps.
+    /// List all users with their role, online/offline status, timestamps, and storage limit.
     /// A user is "online" if their last activity was within `threshold`.
     pub fn list_users_status(
         &self,
         threshold: std::time::Duration,
-    ) -> Vec<(String, String, bool, String, Option<String>)> {
+    ) -> Vec<(String, String, bool, String, Option<String>, u64)> {
         let db = self.db.read().unwrap();
         let activity = self.last_activity.read().unwrap();
         db.accounts
@@ -321,6 +332,7 @@ impl AuthState {
                     online,
                     a.created_at.clone(),
                     a.last_online.clone(),
+                    a.storage_limit_bytes,
                 )
             })
             .collect()
@@ -359,6 +371,31 @@ fn save_auth_db(db: &AuthDatabase) -> Result<(), String> {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(db).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+// --- Session persistence ---
+
+fn sessions_db_path() -> Option<PathBuf> {
+    config::app_data_dir().map(|d| d.join("sessions.json"))
+}
+
+fn load_sessions() -> Result<HashMap<String, String>, String> {
+    let path = sessions_db_path().ok_or("No app data dir")?;
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&content).map_err(|e| e.to_string())
+}
+
+fn save_sessions(sessions: &HashMap<String, String>) -> Result<(), String> {
+    let path = sessions_db_path().ok_or("No app data dir")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let json = serde_json::to_string_pretty(sessions).map_err(|e| e.to_string())?;
     std::fs::write(&path, json).map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/comfyui/mooshie_nodes.py
+++ b/src-tauri/src/comfyui/mooshie_nodes.py
@@ -282,7 +282,14 @@ class MooshieSaveImage:
             else:
                 fmt_tag = self.FMT_PNG_8
                 img_np = (255.0 * frame).clip(0, 255).astype(np.uint8)
-                img = Image.fromarray(img_np)
+                # Output RGBA (alpha=255) so the PNG has an alpha channel.
+                # This lets the Rust metadata embedder write stealth-alpha
+                # data directly, and ensures right-click → Copy Image from
+                # the browser gets an image with an alpha layer.
+                h, w, c = img_np.shape
+                rgba = np.full((h, w, 4), 255, dtype=np.uint8)
+                rgba[:, :, :3] = img_np
+                img = Image.fromarray(rgba, "RGBA")
                 buf = io.BytesIO()
                 img.save(buf, format="PNG")
                 png_bytes = buf.getvalue()

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -663,7 +663,9 @@ fn native_clipboard_write(image_bytes: &[u8], mime_type: &str) -> Result<(), App
                 .args(args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::null())
-                .stderr(Stdio::piped())
+                // stderr must be null — xclip/wl-copy fork a background daemon
+                // that inherits piped fds, causing wait_with_output to hang forever.
+                .stderr(Stdio::null())
                 .spawn()
                 .map_err(|e| format!("{} spawn failed: {}", program, e))?;
 
@@ -672,21 +674,17 @@ fn native_clipboard_write(image_bytes: &[u8], mime_type: &str) -> Result<(), App
                     .write_all(image_bytes)
                     .map_err(|e| format!("{} stdin write failed: {}", program, e))?;
             }
+            // Close stdin so the clipboard tool knows we're done writing.
+            drop(child.stdin.take());
 
-            let output = child
-                .wait_with_output()
+            let status = child
+                .wait()
                 .map_err(|e| format!("{} wait failed: {}", program, e))?;
 
-            if output.status.success() {
+            if status.success() {
                 Ok(())
             } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                Err(format!(
-                    "{} exited with {}: {}",
-                    program,
-                    output.status,
-                    stderr.trim()
-                ))
+                Err(format!("{} exited with {}", program, status))
             }
         };
 
@@ -776,6 +774,16 @@ fn native_clipboard_write(image_bytes: &[u8], mime_type: &str) -> Result<(), App
     }
 
     Ok(())
+}
+
+/// Public wrapper for `native_clipboard_write` — used by the web server.
+pub fn native_clipboard_write_pub(image_bytes: &[u8], mime_type: &str) -> Result<(), AppError> {
+    native_clipboard_write(image_bytes, mime_type)
+}
+
+/// Public wrapper for `infer_image_mime` — used by the web server.
+pub fn infer_image_mime_pub(bytes: &[u8], ext_hint: Option<&str>) -> &'static str {
+    infer_image_mime(bytes, ext_hint)
 }
 
 /// Copy raw image bytes (PNG/JPEG/WebP) to the system clipboard.

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -110,7 +110,6 @@ const ADMIN_ONLY_COMMANDS: &[&str] = &[
     "switch_to_app_mode",
     "set_gallery_path",
     "install_custom_node",
-    "install_pip_package",
     "import_image_directory",
     "open_directory",
     "move_installation",
@@ -119,7 +118,12 @@ const ADMIN_ONLY_COMMANDS: &[&str] = &[
 
 /// Commands that moderators (and admins) can execute.
 /// These involve server control and configuration but no filesystem access.
-const MODERATOR_COMMANDS: &[&str] = &["update_config", "stop_comfyui", "export_logs"];
+const MODERATOR_COMMANDS: &[&str] = &[
+    "update_config",
+    "stop_comfyui",
+    "export_logs",
+    "install_pip_package",
+];
 
 /// Check command permission level.
 /// Returns the minimum role required to execute the command.
@@ -224,6 +228,11 @@ pub async fn start_server(
         .route(
             "/internal-api/_temp_image/{filename}",
             get(temp_image_handler),
+        )
+        // Embed metadata into a temp image and return a new temp URL
+        .route(
+            "/internal-api/_embed_temp_metadata",
+            post(embed_temp_metadata_handler),
         )
         // Generic IPC command proxy
         .route("/internal-api/{command}", post(command_handler))
@@ -841,8 +850,8 @@ async fn temp_image_handler(
             } else {
                 "image/jpeg"
             };
-            // Delete after serving — one-shot delivery
-            crate::temp_images::remove(&filename);
+            // Don't delete immediately — the image may be needed later for
+            // save_to_gallery_temp.  Periodic cleanup handles expiry.
             (
                 StatusCode::OK,
                 [
@@ -854,6 +863,65 @@ async fn temp_image_handler(
                 .into_response()
         }
         None => (StatusCode::NOT_FOUND, "Temp image not found").into_response(),
+    }
+}
+
+/// Embed metadata into an existing temp image and return a new temp filename.
+/// Avoids the slow JSON number-array round-trip: the image bytes stay on the
+/// server side; only the compact metadata JSON crosses the wire.
+async fn embed_temp_metadata_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let role = resolve_role(&state, &headers, &remote);
+    if role == UserRole::Anonymous {
+        return unauthorized_response("Authentication required");
+    }
+
+    let args: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid JSON").into_response(),
+    };
+
+    let temp_filename = match args["tempFilename"].as_str() {
+        Some(f) => f,
+        None => return (StatusCode::BAD_REQUEST, "Missing tempFilename").into_response(),
+    };
+
+    let metadata: std::collections::HashMap<String, String> =
+        match serde_json::from_value(args["metadata"].clone()) {
+            Ok(m) => m,
+            Err(_) => return (StatusCode::BAD_REQUEST, "Invalid metadata").into_response(),
+        };
+
+    let metadata_mode = args["metadataMode"].as_str().unwrap_or("stealth");
+
+    let bytes = match crate::temp_images::load(temp_filename) {
+        Some(b) => b,
+        None => return (StatusCode::NOT_FOUND, "Temp image not found").into_response(),
+    };
+
+    let embed_mode = crate::metadata::MetadataMode::from_str(metadata_mode);
+    let embedded = match crate::metadata::embed_png_metadata(&bytes, &metadata, embed_mode) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("embed_temp_metadata failed: {}", e);
+            return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response();
+        }
+    };
+
+    match crate::temp_images::save(&embedded, "png") {
+        Some(new_filename) => {
+            let json = serde_json::json!({ "tempFilename": new_filename });
+            axum::Json(json).into_response()
+        }
+        None => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to save embedded image",
+        )
+            .into_response(),
     }
 }
 
@@ -1435,6 +1503,56 @@ async fn dispatch_command(
                 metadata.as_ref(),
                 metadata_mode.as_deref(),
             )?;
+            Ok(serde_json::json!(result))
+        }
+        "save_to_gallery_temp" => {
+            // Save from a temp image file (browser mode: image was already received
+            // via WebSocket and stored as a temp file on the server).
+            let temp_filename = args["tempFilename"]
+                .as_str()
+                .ok_or("Missing tempFilename")?
+                .to_string();
+            let filename = args["filename"].as_str().unwrap_or("image.png").to_string();
+            let prompt_id = args["promptId"].as_str().unwrap_or("").to_string();
+            let mode = args
+                .get("mode")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let metadata: Option<std::collections::HashMap<String, String>> = args
+                .get("metadata")
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            let metadata_mode = args
+                .get("metadataMode")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let bytes = crate::temp_images::load(&temp_filename)
+                .ok_or_else(|| format!("Temp image '{}' not found or expired", temp_filename))?;
+            let dir = user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
+            // Enforce storage limit for non-admin users
+            if let Some(name) = username {
+                let limit = auth.get_storage_limit(name);
+                if limit > 0 {
+                    let usage = dir_usage_bytes(&dir);
+                    if usage + bytes.len() as u64 > limit {
+                        return Err(format!(
+                            "Storage limit exceeded ({:.1} MB / {:.1} MB). Download your images and free space, or ask an admin to increase your limit.",
+                            usage as f64 / 1_048_576.0,
+                            limit as f64 / 1_048_576.0,
+                        ));
+                    }
+                }
+            }
+            let result = save_to_gallery_in_dir(
+                &dir,
+                &bytes,
+                &filename,
+                &prompt_id,
+                mode.as_deref(),
+                metadata.as_ref(),
+                metadata_mode.as_deref(),
+            )?;
+            // Clean up temp file after successful save
+            crate::temp_images::remove(&temp_filename);
             Ok(serde_json::json!(result))
         }
         "delete_gallery_image" => {
@@ -2485,37 +2603,32 @@ async fn dispatch_command(
 
         // --- Clipboard ---
         "copy_image_to_clipboard" => {
-            #[cfg(feature = "desktop")]
-            {
-                let file_path = args["filePath"]
-                    .as_str()
-                    .ok_or("Missing filePath")?
-                    .to_string();
-                crate::commands::api::copy_image_to_clipboard(file_path)
-                    .await
-                    .map_err(|e| e.to_string())?;
-                Ok(serde_json::json!(null))
+            let file_path = args["filePath"]
+                .as_str()
+                .ok_or("Missing filePath")?
+                .to_string();
+            let path = std::path::Path::new(&file_path);
+            if !path.exists() {
+                return Err(format!("File not found: {}", file_path));
             }
-            #[cfg(not(feature = "desktop"))]
-            {
-                Err("Clipboard is not available in headless server mode".to_string())
-            }
+            let bytes = std::fs::read(path).map_err(|e| format!("Read failed: {}", e))?;
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase());
+            let mime = crate::commands::api::infer_image_mime_pub(&bytes, ext.as_deref());
+            crate::commands::api::native_clipboard_write_pub(&bytes, mime)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::json!(null))
         }
         "copy_bytes_to_clipboard" => {
-            #[cfg(feature = "desktop")]
-            {
-                let bytes: Vec<u8> = serde_json::from_value(args["bytes"].clone())
-                    .map_err(|e| format!("Invalid bytes: {}", e))?;
-                let ext = args["ext"].as_str().ok_or("Missing ext")?.to_string();
-                crate::commands::api::copy_bytes_to_clipboard(bytes, ext)
-                    .await
-                    .map_err(|e| e.to_string())?;
-                Ok(serde_json::json!(null))
-            }
-            #[cfg(not(feature = "desktop"))]
-            {
-                Err("Clipboard is not available in headless server mode".to_string())
-            }
+            let bytes: Vec<u8> = serde_json::from_value(args["bytes"].clone())
+                .map_err(|e| format!("Invalid bytes: {}", e))?;
+            let ext = args["ext"].as_str().ok_or("Missing ext")?.to_string();
+            let mime = crate::commands::api::infer_image_mime_pub(&bytes, Some(&ext));
+            crate::commands::api::native_clipboard_write_pub(&bytes, mime)
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::json!(null))
         }
         "read_clipboard_image" => {
             Err("read_clipboard_image is not yet available in browser mode".to_string())
@@ -2706,15 +2819,18 @@ async fn auth_list_accounts_handler(
         .auth
         .list_users_status(online_threshold)
         .into_iter()
-        .map(|(username, role, online, created_at, last_online)| {
-            serde_json::json!({
-                "username": username,
-                "role": role,
-                "online": online,
-                "created_at": created_at,
-                "last_online": last_online,
-            })
-        })
+        .map(
+            |(username, role, online, created_at, last_online, storage_limit_bytes)| {
+                serde_json::json!({
+                    "username": username,
+                    "role": role,
+                    "online": online,
+                    "created_at": created_at,
+                    "last_online": last_online,
+                    "storage_limit_bytes": storage_limit_bytes,
+                })
+            },
+        )
         .collect();
     (
         StatusCode::OK,
@@ -2752,11 +2868,11 @@ async fn auth_delete_account_handler(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    // Moderators cannot delete admin accounts
+    // Moderators cannot delete admin or other moderator accounts
     if role == UserRole::Moderator {
         if let Some(target_role) = state.auth.get_account_role(username) {
-            if target_role == "admin" {
-                return forbidden_response("Moderators cannot delete admin accounts.");
+            if target_role == "admin" || target_role == "moderator" {
+                return forbidden_response("Moderators can only manage regular user accounts.");
             }
         }
     }
@@ -2861,6 +2977,16 @@ async fn auth_reset_password_handler(
                 .into_response();
         }
     };
+
+    // Moderators cannot reset passwords for admin or other moderator accounts
+    if role == UserRole::Moderator {
+        if let Some(target_role) = state.auth.get_account_role(username) {
+            if target_role == "admin" || target_role == "moderator" {
+                return forbidden_response("Moderators can only manage regular user accounts.");
+            }
+        }
+    }
+
     let temp_pass = match req.get("temp_password").and_then(|v| v.as_str()) {
         Some(p) => p,
         None => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { ipcInvoke, ipcListen, isTauri, isBrowserMode, startHeartbeat, getAuthToken, setAuthToken, setAuthUser, authHeaders } from "./lib/utils/ipc.js";
+  import { ipcInvoke, ipcListen, isTauri, isBrowserMode, startHeartbeat, getAuthToken, setAuthToken, setAuthUser, authHeaders, wasRememberMe } from "./lib/utils/ipc.js";
   import SetupWizard from "./lib/components/setup/SetupWizard.svelte";
   import GenerationPage from "./lib/components/generation/GenerationPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
@@ -41,7 +41,9 @@
   let lastProgressEventAt = 0;
 
   /** Images received via WebSocket during generation, keyed by prompt_id. */
-  let pendingOutputImages = new Map<string, Array<{ blob: Blob; url: string }>>();
+  let pendingOutputImages = new Map<string, Array<{ blob: Blob; url: string; tempFilename?: string }>>();
+  /** In-flight output_image fetch promises per prompt_id (for SSE race-condition avoidance). */
+  let pendingOutputFetches = new Map<string, Promise<void>[]>();
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
 
   // Lightbox zoom state — only scale needs reactivity (used in template conditionals)
@@ -412,6 +414,7 @@
   let loginPass = $state("");
   let loginError = $state<string | null>(null);
   let loginBusy = $state(false);
+  let rememberMe = $state(wasRememberMe());
   let mustChangePassword = $state(false);
   let newPass1 = $state("");
   let newPass2 = $state("");
@@ -459,7 +462,7 @@
         loginError = data.error ?? "Login failed.";
         return;
       }
-      setAuthToken(data.token);
+      setAuthToken(data.token, rememberMe);
       setAuthUser(loginUser.trim());
       // Re-check auth status to get the actual role (user vs moderator)
       const statusResp = await fetch("/internal-api/_auth/status", {
@@ -1015,7 +1018,7 @@
     mode: "txt2img" | "img2img" | "inpainting",
     wasUpscaled: boolean,
     params: GenerationParams | null,
-    images: Array<{ blob: Blob; url: string }>,
+    images: Array<{ blob: Blob; url: string; tempFilename?: string }>,
   ) {
     if (images.length === 0) return;
 
@@ -1038,9 +1041,75 @@
     for (const image of newImages) {
       image.metadata = metadata ?? null;
     }
-    // Pass blobs so persistImages can use the bytes-based API (no ComfyUI disk round-trip)
+
+    // In browser mode, embed metadata into the blob URLs immediately so that
+    // right-click → Copy Image has stealth alpha from the start (no waiting
+    // for persistImages to finish).  Uses the temp file path on the server to
+    // avoid serializing multi-MB images as JSON number arrays.
+    if (isBrowserMode && metadata) {
+      for (let i = 0; i < images.length; i++) {
+        const img = images[i]!;
+        const outputImage = newImages[i]!;
+        if (img.tempFilename) {
+          embedTempMetadata(img.tempFilename, metadata, outputImage);
+        }
+      }
+    }
+
+    // Pass blobs and temp filenames so persistImages can use the most efficient path
     const blobs = images.map((img) => img.blob);
-    gallery.persistImages(newImages, metadata, blobs, generation.metadataMode);
+    const tempFilenames = images.map((img) => img.tempFilename);
+    gallery.persistImages(newImages, metadata, blobs, generation.metadataMode, tempFilenames);
+  }
+
+  /**
+   * Embed metadata into a temp image on the server and upgrade the blob URL.
+   * Runs async in the background — the image is already visible (blob URL),
+   * this just replaces it with a metadata-embedded version.
+   */
+  async function embedTempMetadata(
+    tempFilename: string,
+    metadata: Record<string, string>,
+    image: OutputImage,
+  ) {
+    try {
+      const resp = await fetch("/internal-api/_embed_temp_metadata", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...authHeaders() },
+        body: JSON.stringify({
+          tempFilename,
+          metadata,
+          metadataMode: generation.metadataMode,
+        }),
+      });
+      if (!resp.ok) return;
+      const result = await resp.json();
+      const newTempFilename = result.tempFilename;
+      if (!newTempFilename) return;
+
+      // Fetch the metadata-embedded image as a new blob URL
+      const imgResp = await fetch(
+        `/internal-api/_temp_image/${encodeURIComponent(newTempFilename)}`,
+        { headers: authHeaders() },
+      );
+      if (!imgResp.ok) return;
+      const newBlob = await imgResp.blob();
+      const newUrl = URL.createObjectURL(newBlob);
+
+      // Revoke old blob URL and update the image
+      const oldUrl = image.url;
+      image.url = newUrl;
+
+      // If the lightbox is showing this image's old blob URL, upgrade it
+      if (gallery.lightboxOpen && gallery.lightboxUrl === oldUrl) {
+        gallery.lightboxUrl = newUrl;
+      }
+
+      if (oldUrl) URL.revokeObjectURL(oldUrl);
+    } catch (e) {
+      // Non-critical — the image is still visible, just without embedded metadata
+      console.warn("[embedTempMetadata] failed:", e);
+    }
   }
 
   /**
@@ -1326,12 +1395,18 @@
           progress.previewImage = `data:image/${data.format};base64,${data.image}`;
         }
       }),
-      ipcListen("comfyui:output_image", async (event: any) => {
-        // MooshieSaveImage sends final PNG bytes over WS — collect per prompt
+      ipcListen("comfyui:output_image", (event: any) => {
+        // MooshieSaveImage sends final PNG bytes over WS — collect per prompt.
+        // NOTE: The actual image fetch (for SSE/browser path) is async but we
+        // must register the promise *synchronously* so that the executing
+        // node=null handler can await it before consuming pendingOutputImages.
         const data = event.payload;
         if (!progress.isGenerating) return;
         // Filter by prompt_id — reject events for other users' prompts
         if (data.prompt_id && !progress.pendingPrompts.some((p: any) => p.promptId === data.prompt_id)) return;
+
+        const pid = data.prompt_id ?? progress.activePromptId;
+        if (!pid) return;
 
         if (data.bit_depth === 16) {
           const now = Date.now();
@@ -1341,7 +1416,7 @@
 
           if ((sinceProgressMs !== null && sinceProgressMs > 1500) || (encodeMs !== null && encodeMs > 250)) {
             console.warn("[16-bit diagnostics] output_image timing", {
-              promptId: data.prompt_id ?? progress.activePromptId,
+              promptId: pid,
               sinceProgressMs,
               encodeMs,
               imageBytes,
@@ -1352,44 +1427,52 @@
           }
         }
 
-        let blob: Blob;
-        let url: string;
+        // Start the (possibly async) image fetch and register its promise
+        // synchronously so the executing handler can await it.
+        const fetchPromise = (async () => {
+          let blob: Blob;
+          let url: string;
+          let tempFilename: string | undefined;
 
-        if (data.temp_filename) {
-          // SSE/browser path: fetch image from temp endpoint (avoids multi-MB SSE payloads)
-          try {
-            const resp = await fetch(`/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}`, {
-              headers: authHeaders(),
-            });
-            if (!resp.ok) {
-              console.error("[output_image] failed to fetch temp image:", resp.status);
+          if (data.temp_filename) {
+            tempFilename = data.temp_filename;
+            // SSE/browser path: fetch image from temp endpoint (avoids multi-MB SSE payloads)
+            try {
+              const resp = await fetch(`/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}`, {
+                headers: authHeaders(),
+              });
+              if (!resp.ok) {
+                console.error("[output_image] failed to fetch temp image:", resp.status);
+                return;
+              }
+              blob = await resp.blob();
+              url = URL.createObjectURL(blob);
+            } catch (e) {
+              console.error("[output_image] failed to fetch temp image:", e);
               return;
             }
-            blob = await resp.blob();
+          } else if (data.image) {
+            // Tauri path: decode inline base64
+            const raw = atob(data.image);
+            const bytes = new Uint8Array(raw.length);
+            for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+            blob = new Blob([bytes], { type: "image/png" });
             url = URL.createObjectURL(blob);
-          } catch (e) {
-            console.error("[output_image] failed to fetch temp image:", e);
+          } else {
+            console.warn("[output_image] event has neither temp_filename nor image");
             return;
           }
-        } else if (data.image) {
-          // Tauri path: decode inline base64
-          const raw = atob(data.image);
-          const bytes = new Uint8Array(raw.length);
-          for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
-          blob = new Blob([bytes], { type: "image/png" });
-          url = URL.createObjectURL(blob);
-        } else {
-          console.warn("[output_image] event has neither temp_filename nor image");
-          return;
-        }
 
-        const pid = data.prompt_id ?? progress.activePromptId;
-        if (!pid) return;
-        const arr = pendingOutputImages.get(pid) ?? [];
-        arr.push({ blob, url });
-        pendingOutputImages.set(pid, arr);
+          const arr = pendingOutputImages.get(pid) ?? [];
+          arr.push({ blob, url, tempFilename });
+          pendingOutputImages.set(pid, arr);
+        })();
+
+        const fetches = pendingOutputFetches.get(pid) ?? [];
+        fetches.push(fetchPromise);
+        pendingOutputFetches.set(pid, fetches);
       }),
-      ipcListen("comfyui:executing", (event: any) => {
+      ipcListen("comfyui:executing", async (event: any) => {
         const data = event.payload;
         console.log("Executing event:", data);
         // Ignore prompts not in our queue
@@ -1400,6 +1483,17 @@
           if (!progress.isGenerating) return;
           const promptId = data.prompt_id;
           if (!promptId) return;
+
+          // Wait for any in-flight output_image fetches to complete before
+          // consuming pendingOutputImages.  The output_image handler is async
+          // (fetches temp images over HTTP) and SSE events fire synchronously,
+          // so without this await the images map would be empty.
+          const fetches = pendingOutputFetches.get(promptId);
+          if (fetches && fetches.length > 0) {
+            await Promise.allSettled(fetches);
+            pendingOutputFetches.delete(promptId);
+          }
+
           const item = progress.completePrompt(promptId);
           if (item) {
             const images = pendingOutputImages.get(promptId) ?? [];
@@ -1426,11 +1520,13 @@
         const data = event.payload;
         if (data.prompt_id) {
           pendingOutputImages.delete(data.prompt_id);
+          pendingOutputFetches.delete(data.prompt_id);
           progress.removePrompt(data.prompt_id);
           compare.clearGridBatch();
         } else {
           // No prompt_id — clear everything
           pendingOutputImages.clear();
+          pendingOutputFetches.clear();
           progress.cancelAll();
           compare.clearGridBatch();
         }
@@ -1458,6 +1554,12 @@
         for (const p of progress.pendingPrompts) {
           if (!allPromptIds.has(p.promptId)) {
             console.warn(`[reconcile] Prompt ${p.promptId} no longer in ComfyUI queue — completing`);
+            // Wait for any in-flight output_image fetches
+            const fetches = pendingOutputFetches.get(p.promptId);
+            if (fetches && fetches.length > 0) {
+              await Promise.allSettled(fetches);
+              pendingOutputFetches.delete(p.promptId);
+            }
             const item = progress.completePrompt(p.promptId);
             if (item) {
               const images = pendingOutputImages.get(p.promptId) ?? [];
@@ -1621,6 +1723,14 @@
         class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:outline-none focus:border-indigo-500 transition-colors"
         onkeydown={(e) => { if (e.key === "Enter") handleLogin(); }}
       />
+      <label class="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          bind:checked={rememberMe}
+          class="w-4 h-4 rounded border-neutral-600 bg-neutral-800 text-indigo-500 focus:ring-indigo-500 focus:ring-offset-0 cursor-pointer"
+        />
+        <span class="text-sm text-neutral-400">Remember me</span>
+      </label>
       {#if loginError}
         <p class="text-xs text-red-400">{loginError}</p>
       {/if}

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -57,10 +57,6 @@
       if (generation.facefixEnabled) {
         const detector = generation.facefixDetector || "face_yolov8m.pt";
         if (!models.ultralyticsModels.includes(detector)) {
-          if (isBrowserMode) {
-            errorMsg = "Face fix model not installed. Ask the host to generate with face fix enabled once to set it up.";
-            return;
-          }
           gallery.showToast(locale.t('generation.downloading_facefix'), "info");
           await downloadModel(
             `https://huggingface.co/Bingsu/adetailer/resolve/main/${detector}`,

--- a/src/lib/components/generation/InterrogateModal.svelte
+++ b/src/lib/components/generation/InterrogateModal.svelte
@@ -205,7 +205,22 @@
       if (checkedCopyright[tag.name]) allTags.push(tag.name);
     }
 
-    await navigator.clipboard.writeText(allTags.join(", "));
+    const text = allTags.join(", ");
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch { /* fall through */ }
+    }
+    // Fallback for insecure (HTTP) contexts
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/src/lib/components/generation/LoraGallery.svelte
+++ b/src/lib/components/generation/LoraGallery.svelte
@@ -181,14 +181,14 @@
 
   function currentImageUrl(filename: string): string | null {
     const info = getInfo(filename);
-    if (!info?.civitai_images.length) return null;
+    if (!info?.civitai_images?.length) return null;
     const idx = imageIndex[filename] ?? 0;
     return info.civitai_images[idx]?.url ?? null;
   }
 
   function nextImage(filename: string) {
     const info = getInfo(filename);
-    if (!info?.civitai_images.length) return;
+    if (!info?.civitai_images?.length) return;
     const current = imageIndex[filename] ?? 0;
     const next = (current + 1) % info.civitai_images.length;
     imageIndex = { ...imageIndex, [filename]: next };
@@ -198,7 +198,7 @@
 
   function prevImage(filename: string) {
     const info = getInfo(filename);
-    if (!info?.civitai_images.length) return;
+    if (!info?.civitai_images?.length) return;
     const current = imageIndex[filename] ?? 0;
     const prev = current === 0 ? info.civitai_images.length - 1 : current - 1;
     imageIndex = { ...imageIndex, [filename]: prev };
@@ -288,7 +288,7 @@
         {@const error = errors[loraName]}
         {@const imgUrl = currentImageUrl(loraName)}
         {@const resolvedUrl = imgUrl ? (resolvedImages[imgUrl] ?? null) : null}
-        {@const imgCount = info?.civitai_images.length ?? 0}
+        {@const imgCount = info?.civitai_images?.length ?? 0}
         {@const imgIdx = imageIndex[loraName] ?? 0}
         {@const isSelected = selectedLora === loraName}
         {@const enabled = isLoraEnabled(loraName)}
@@ -410,9 +410,9 @@
             {/if}
 
             <!-- Trigger words -->
-            {#if info?.civitai_trigger_words.length || info?.modelspec_trigger_phrase}
+            {#if info?.civitai_trigger_words?.length || info?.modelspec_trigger_phrase}
               <div class="flex flex-wrap gap-1">
-                {#if info.civitai_trigger_words.length}
+                {#if info.civitai_trigger_words?.length}
                   {#each info.civitai_trigger_words as word}
                     <button
                       class="px-1.5 py-0.5 text-[10px] rounded bg-indigo-500/10 border border-indigo-500/30 text-indigo-300 hover:bg-indigo-500/20 hover:border-indigo-400/50 transition-colors"

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AppConfig } from "../../types/index.js";
-  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, getGalleryPath, setGalleryPath } from "../../utils/api.js";
+  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, getGalleryPath, setGalleryPath, setStorageLimit } from "../../utils/api.js";
   import type { ReleaseNote, ImportResult } from "../../utils/api.js";
   import { smoothScroll } from "../../utils/smoothScroll.js";
   import { connection } from "../../stores/connection.svelte.js";
@@ -60,7 +60,7 @@
   let switchingMode = $state(false);
 
   // LAN auth state
-  let lanAccounts = $state<{ username: string; role: string; online: boolean; created_at: string; last_online: string | null }[]>([]);
+  let lanAccounts = $state<{ username: string; role: string; online: boolean; created_at: string; last_online: string | null; storage_limit_bytes: number }[]>([]);
   let lanNewUser = $state("");
   let lanNewPass = $state("");
   let lanAuthError = $state<string | null>(null);
@@ -75,6 +75,39 @@
   let showDeleteModal = $state(false);
   let deleteTargetUser = $state("");
   let deleteKeepData = $state(true);
+
+  // Storage limit modal
+  let showStorageModal = $state(false);
+  let storageTargetUser = $state("");
+  let storageInputGB = $state("1");
+  let storageError = $state<string | null>(null);
+  let storageBusy = $state(false);
+
+  function formatBytes(bytes: number): string {
+    if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+    return `${(bytes / 1024).toFixed(0)} KB`;
+  }
+
+  async function applyStorageLimit() {
+    storageBusy = true;
+    storageError = null;
+    try {
+      const gb = parseFloat(storageInputGB);
+      if (isNaN(gb) || gb < 0.1 || gb > 100) {
+        storageError = "Enter a value between 0.1 and 100 GB.";
+        return;
+      }
+      const limitBytes = Math.round(gb * 1024 * 1024 * 1024);
+      await setStorageLimit(storageTargetUser, limitBytes);
+      showStorageModal = false;
+      await loadLanAccounts();
+    } catch (e: any) {
+      storageError = e.message || String(e);
+    } finally {
+      storageBusy = false;
+    }
+  }
 
   function relativeTime(iso: string | null): string {
     if (!iso) return "Never";
@@ -194,8 +227,8 @@
       // Normalise: backend now returns {username, role, online, created_at, last_online}
       lanAccounts = raw.map((a: any) =>
         typeof a === "string"
-          ? { username: a, role: "user", online: false, created_at: "", last_online: null }
-          : { username: a.username, role: a.role ?? "user", online: !!a.online, created_at: a.created_at ?? "", last_online: a.last_online ?? null }
+          ? { username: a, role: "user", online: false, created_at: "", last_online: null, storage_limit_bytes: 1024 * 1024 * 1024 }
+          : { username: a.username, role: a.role ?? "user", online: !!a.online, created_at: a.created_at ?? "", last_online: a.last_online ?? null, storage_limit_bytes: a.storage_limit_bytes ?? 1024 * 1024 * 1024 }
       );
     } catch {
       lanAccounts = [];
@@ -697,9 +730,9 @@
     }
   });
 
-  // Poll account list every 10s to refresh online/offline indicators (admin only).
+  // Poll account list every 10s to refresh online/offline indicators (admin/mod).
   $effect(() => {
-    if (!isBrowserMode || !isAdmin) return;
+    if (!isBrowserMode || !canManageServer) return;
     const id = setInterval(loadLanAccounts, 10_000);
     return () => clearInterval(id);
   });
@@ -946,6 +979,7 @@
                               {#if account.role === "moderator"}
                                 <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/30 text-indigo-300 font-medium shrink-0">Mod</span>
                               {/if}
+                              <span class="text-[10px] text-neutral-500 shrink-0">{formatBytes(account.storage_limit_bytes)}</span>
                               <span class="text-[10px] text-neutral-500 shrink-0" title={account.created_at ? `Joined: ${new Date(account.created_at).toLocaleDateString()}` : ''}>
                                 {account.created_at ? relativeTime(account.created_at) : ''}
                               </span>
@@ -961,6 +995,11 @@
                                 disabled={lanAuthBusy}
                                 onclick={() => toggleAccountRole(account.username, account.role)}
                               >{account.role === "moderator" ? "Revoke Mod" : "Make Mod"}</button>
+                              <button
+                                class="text-xs text-cyan-400 hover:text-cyan-300 cursor-pointer"
+                                disabled={lanAuthBusy}
+                                onclick={() => { storageTargetUser = account.username; storageInputGB = (account.storage_limit_bytes / (1024 * 1024 * 1024)).toFixed(1); storageError = null; showStorageModal = true; }}
+                              >Storage</button>
                               <button
                                 class="text-xs text-amber-400 hover:text-amber-300 cursor-pointer"
                                 disabled={lanAuthBusy}
@@ -993,8 +1032,97 @@
         </section>
         {/if}
 
+        <!-- Account Management (moderator in browser mode — admins see this inside the LAN section above) -->
+        {#if canManageServer && !isAdmin && isBrowserMode}
+        <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
+          <div class="p-5 space-y-3">
+            <h3 class="text-sm font-medium text-neutral-200">Account Management</h3>
+            <p class="text-xs text-neutral-500">Manage user accounts. You can reset passwords and remove accounts (except admin and moderator accounts).</p>
+
+            {#if lanAccounts.length > 0}
+              <div class="space-y-2">
+                <div class="flex items-center justify-between">
+                  <p class="text-xs text-neutral-400 font-medium">Accounts</p>
+                  <p class="text-[10px] text-neutral-500">{sortedAccounts.length} of {lanAccounts.length}</p>
+                </div>
+
+                <input
+                  type="text"
+                  placeholder="Search accounts…"
+                  bind:value={accountSearch}
+                  class="w-full px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700 text-xs text-neutral-200 placeholder-neutral-500 focus:outline-none focus:border-indigo-500"
+                />
+
+                <div class="flex gap-1">
+                  {#each [["name", "Name"], ["joined", "Joined"], ["last_online", "Last Online"]] as [key, label]}
+                    <button
+                      class="text-[10px] px-2 py-1 rounded cursor-pointer transition-colors {accountSort === key ? 'bg-indigo-600/30 text-indigo-300' : 'bg-neutral-800 text-neutral-400 hover:text-neutral-300'}"
+                      onclick={() => { if (accountSort === key) { accountSortAsc = !accountSortAsc; } else { accountSort = key as typeof accountSort; accountSortAsc = true; } }}
+                    >{label} {accountSort === key ? (accountSortAsc ? '↑' : '↓') : ''}</button>
+                  {/each}
+                </div>
+
+                <div class="max-h-[288px] overflow-y-auto space-y-1 pr-1">
+                  {#each sortedAccounts as account}
+                    <div class="flex items-center justify-between bg-neutral-800 rounded-lg px-3 py-2">
+                      <div class="flex items-center gap-2 min-w-0">
+                        <span class="inline-block w-2 h-2 rounded-full shrink-0 {account.online ? 'bg-green-500' : 'bg-neutral-600'}"></span>
+                        <span class="text-sm text-neutral-200 truncate">{account.username}</span>
+                        {#if account.role === "moderator"}
+                          <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/30 text-indigo-300 font-medium shrink-0">Mod</span>
+                        {/if}
+                        {#if account.role === "admin"}
+                          <span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-600/30 text-amber-300 font-medium shrink-0">Admin</span>
+                        {/if}
+                        {#if account.role === "user"}
+                          <span class="text-[10px] text-neutral-500 shrink-0">{formatBytes(account.storage_limit_bytes)}</span>
+                        {/if}
+                        <span class="text-[10px] text-neutral-500 shrink-0" title={account.created_at ? `Joined: ${new Date(account.created_at).toLocaleDateString()}` : ''}>
+                          {account.created_at ? relativeTime(account.created_at) : ''}
+                        </span>
+                        {#if !account.online && account.last_online}
+                          <span class="text-[10px] text-neutral-600 shrink-0" title={`Last online: ${new Date(account.last_online).toLocaleString()}`}>
+                            · {relativeTime(account.last_online)}
+                          </span>
+                        {/if}
+                      </div>
+                      <!-- Mods can only manage regular users — not admins or other mods -->
+                      {#if account.role === "user"}
+                        <div class="flex items-center gap-2 shrink-0 ml-2">
+                          <button
+                            class="text-xs text-cyan-400 hover:text-cyan-300 cursor-pointer"
+                            disabled={lanAuthBusy}
+                            onclick={() => { storageTargetUser = account.username; storageInputGB = (account.storage_limit_bytes / (1024 * 1024 * 1024)).toFixed(1); storageError = null; showStorageModal = true; }}
+                          >Storage</button>
+                          <button
+                            class="text-xs text-amber-400 hover:text-amber-300 cursor-pointer"
+                            disabled={lanAuthBusy}
+                            onclick={() => { resetTargetUser = account.username; resetTempPass = ''; resetError = null; resetSuccess = false; showResetPasswordModal = true; }}
+                          >Reset Password</button>
+                          <button
+                            class="text-xs text-red-400 hover:text-red-300 cursor-pointer"
+                            disabled={lanAuthBusy}
+                            onclick={() => { deleteTargetUser = account.username; deleteKeepData = true; showDeleteModal = true; }}
+                          >Remove</button>
+                        </div>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            {:else}
+              <p class="text-xs text-neutral-500">No accounts found.</p>
+            {/if}
+
+            {#if lanAuthError}
+              <p class="text-xs text-red-400 mt-1">{lanAuthError}</p>
+            {/if}
+          </div>
+        </section>
+        {/if}
+
         <!-- Connection (admin / moderator) -->
-        {#if canManageServer && sectionVisible("connection")}
+        {#if isAdmin && sectionVisible("connection")}
         <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
           <button
             class="w-full flex items-center justify-between p-5 text-sm font-medium text-neutral-200 hover:bg-neutral-800/50 transition-colors cursor-pointer"
@@ -1184,7 +1312,7 @@
         {/if}
 
         <!-- Performance (admin / moderator) -->
-        {#if canManageServer && sectionVisible("performance")}
+        {#if isAdmin && sectionVisible("performance")}
         <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
           <button
             class="w-full flex items-center justify-between p-5 text-sm font-medium text-neutral-200 hover:bg-neutral-800/50 transition-colors cursor-pointer"
@@ -1591,6 +1719,7 @@
           {#if !collapsed.gallery}
           <div class="px-5 pb-5 space-y-4">
 
+            {#if isAdmin}
             <!-- Gallery storage location -->
             <div>
               <label class="block text-xs text-neutral-400 mb-1">{locale.t('settings.gallery.storage_label')}</label>
@@ -1626,6 +1755,7 @@
                 <p class="mt-1.5 text-[11px] text-amber-400">{galleryPathMessage}</p>
               {/if}
             </div>
+            {/if}
 
             <!-- Manual save mode -->
             <div>
@@ -1644,7 +1774,7 @@
               <p class="text-[10px] text-neutral-500 mt-1 ml-6">{locale.t('settings.gallery.manual_save_desc')}</p>
             </div>
 
-            {#if generation.manualSaveMode}
+            {#if generation.manualSaveMode && isAdmin}
             <!-- Save directories -->
             <div>
               <div class="flex items-center justify-between mb-1.5">
@@ -1699,6 +1829,7 @@
             </div>
             {/if}
 
+            {#if isAdmin}
             <!-- Import from external directory -->
             <div>
               <label class="block text-xs text-neutral-400 mb-1">{locale.t('settings.gallery.import_label')}</label>
@@ -1740,6 +1871,7 @@
                 <strong class="text-neutral-300">{locale.t('settings.gallery.metadata_support').split(':')[0]}:</strong> {locale.t('settings.gallery.metadata_support').split(':').slice(1).join(':').trim()}
               </p>
             </div>
+            {/if}
           </div>
           {/if}
         </section>
@@ -1758,6 +1890,7 @@
 
           {#if !collapsed.autocomplete}
           <div class="px-5 pb-5 space-y-4">
+            {#if isAdmin}
             <!-- Current source -->
             <div>
               <label class="block text-xs text-neutral-400 mb-1">{locale.t('settings.autocomplete.tag_source')}</label>
@@ -1842,6 +1975,7 @@
               <div class="px-3 py-2 bg-red-900/30 border border-red-800/50 rounded-lg text-red-200 text-xs">
                 {autocomplete.error}
               </div>
+            {/if}
             {/if}
 
             <!-- Max results -->
@@ -2381,6 +2515,43 @@
         disabled={lanAuthBusy}
         onclick={async () => { await deleteLanAccount(deleteTargetUser, deleteKeepData); showDeleteModal = false; }}
       >Delete Account</button>
+    </div>
+  </div>
+</div>
+{/if}
+
+{#if showStorageModal}
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+  onclick={(e) => { if (e.target === e.currentTarget) showStorageModal = false; }}
+  onkeydown={(e) => { if (e.key === 'Escape') showStorageModal = false; }}
+  role="dialog"
+  tabindex="-1"
+>
+  <div class="bg-neutral-900 border border-neutral-700 rounded-xl p-5 w-80 space-y-3">
+    <h3 class="text-sm font-medium text-neutral-200">Storage Limit — {storageTargetUser}</h3>
+    <p class="text-xs text-neutral-400">Set the maximum gallery storage for this user (in GB).</p>
+    <input
+      type="number"
+      min="0.1"
+      max="100"
+      step="0.1"
+      bind:value={storageInputGB}
+      class="w-full px-3 py-2 rounded-lg bg-neutral-800 border border-neutral-700 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500"
+    />
+    {#if storageError}
+      <p class="text-xs text-red-400">{storageError}</p>
+    {/if}
+    <div class="flex justify-end gap-2 pt-1">
+      <button
+        class="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 text-neutral-400 rounded-lg text-xs transition-colors cursor-pointer"
+        onclick={() => { showStorageModal = false; }}
+      >Cancel</button>
+      <button
+        class="px-4 py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer {storageBusy ? 'bg-neutral-700 text-neutral-500' : 'bg-indigo-600 hover:bg-indigo-500 text-white'}"
+        disabled={storageBusy}
+        onclick={applyStorageLimit}
+      >Save</button>
     </div>
   </div>
 </div>

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -786,6 +786,7 @@ const en: Record<string, string> = {
   "gallery.toast.copied": "Copied to clipboard",
   "gallery.toast.copying": "Copying...",
   "gallery.toast.failed_copy": "Failed to copy",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "gallery.toast.rescan_migrated": "Re-scanned metadata: migrated {count} image(s)",
   "gallery.toast.rescan_none": "Re-scan complete: no legacy metadata to migrate",
   "gallery.toast.rescan_failed": "Re-scan failed",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -4,6 +4,7 @@ import {
   loadGalleryImage,
   saveToGallery,
   saveToGalleryBytes,
+  saveToGalleryTemp,
   deleteGalleryImage,
   renameGalleryImage,
   saveImageFile,
@@ -85,6 +86,17 @@ class GalleryStore {
   /** Storage info from the server (browser mode only). */
   storageInfo = $state<StorageInfo | null>(null);
   private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Per-image persist promises.  Resolves with the gallery filename once
+   * the image has been saved to disk and metadata embedded.  Created up-front
+   * in persistImages() so callers (copyToClipboard, openLightbox) can await
+   * completion even if persist hasn't finished yet.
+   */
+  private _persistPromises = new Map<string, Promise<string>>();
+
+  private _imageKey(img: { prompt_id: string; filename: string }) {
+    return `${img.prompt_id}::${img.filename}`;
+  }
 
   constructor() {
     this.loadBoardAssignments();
@@ -181,9 +193,19 @@ class GalleryStore {
       this.lightboxUrl = image.fullImageUrl;
       this.lightboxLoading = false;
     } else if (image.url) {
-      // Session images still have a blob URL (pre-persistence)
+      // Session images still have a blob URL (pre-persistence) — show it
+      // immediately, then upgrade to the gallery URL once persist finishes
+      // so right-click → Copy Image preserves stealth-alpha metadata.
       this.lightboxUrl = image.url;
       this.lightboxLoading = false;
+      const key = this._imageKey(image);
+      const pending = this._persistPromises.get(key);
+      if (pending) {
+        const galleryFilename = await pending;
+        if (galleryFilename && this.lightboxOpen && this._imageKey(this.selectedImage!) === key) {
+          this.lightboxUrl = await fullImageUrl(galleryFilename);
+        }
+      }
     } else if (image.gallery_filename) {
       // Persisted images without a fullImageUrl — load full-res from disk
       this.lightboxUrl = null;
@@ -228,20 +250,45 @@ class GalleryStore {
   /** Save generated images to the persistent gallery on disk.
    *  Skipped when manualSaveMode is on — user saves manually via saveImageToDir.
    *  If blobs are provided (from WebSocket delivery), use the bytes-based API
-   *  to avoid a round-trip to ComfyUI's output directory. */
+   *  to avoid a round-trip to ComfyUI's output directory.
+   *  In browser mode, tempFilenames are used to save directly from server temp storage. */
   async persistImages(
     images: OutputImage[],
     metadata?: Record<string, string>,
     blobs?: Blob[],
     metadataMode?: string,
+    tempFilenames?: (string | undefined)[],
   ) {
     if (generation.manualSaveMode) return;
+
+    // Create per-image persist promises up-front so copyToClipboard / openLightbox
+    // can await them even if this loop hasn't reached the image yet.
+    const resolvers: Array<(gf: string) => void> = [];
+    for (const img of images) {
+      let resolve!: (gf: string) => void;
+      const promise = new Promise<string>((r) => { resolve = r; });
+      this._persistPromises.set(this._imageKey(img), promise);
+      resolvers.push(resolve);
+    }
+
     for (let i = 0; i < images.length; i++) {
       const img = images[i]!;
       try {
         let galleryFilename: string;
         const blob = blobs?.[i];
-        if (blob) {
+        const tempFilename = tempFilenames?.[i];
+        // In browser mode, prefer temp-file save (zero extra data transfer —
+        // the full-res image already lives on the server as a temp file).
+        if (isBrowserMode && tempFilename) {
+          galleryFilename = await saveToGalleryTemp(
+            tempFilename,
+            img.filename,
+            img.prompt_id,
+            img.generation_mode,
+            metadata,
+            metadataMode,
+          );
+        } else if (blob && !isBrowserMode) {
           const buf = await blob.arrayBuffer();
           const bytes = Array.from(new Uint8Array(buf));
           galleryFilename = await saveToGalleryBytes(
@@ -265,8 +312,12 @@ class GalleryStore {
         img.gallery_filename = galleryFilename;
         img.thumbnailUrl = await thumbnailUrl(galleryFilename);
         img.fullImageUrl = await fullImageUrl(galleryFilename);
+        resolvers[i]!(galleryFilename);
       } catch (e) {
         console.error("Failed to save image to gallery:", e);
+        resolvers[i]!("");
+      } finally {
+        this._persistPromises.delete(this._imageKey(img));
       }
     }
     // Trigger reactivity so components re-render with newly assigned thumbnailUrls
@@ -442,32 +493,39 @@ class GalleryStore {
     this.showToast(locale.t("gallery.toast.copying"), "info", true);
     try {
       if (isBrowserMode) {
-        // Browser mode: fetch the image bytes and write to clipboard.
-        // Prefer the real backend URL (already has metadata embedded on disk).
-        let bytes: Uint8Array;
-        if (image.fullImageUrl) {
-          const resp = await fetch(image.fullImageUrl);
-          const buf = await resp.arrayBuffer();
-          bytes = new Uint8Array(buf);
-        } else if (image.url) {
-          const resp = await fetch(image.url);
-          const buf = await resp.arrayBuffer();
-          bytes = new Uint8Array(buf);
-          // Blob URLs don't have metadata embedded — add it
-          if (image.metadata) {
-            const embedded = await embedPngMetadataBytes(Array.from(bytes), image.metadata);
-            bytes = new Uint8Array(embedded);
+        // Browser mode: prefer gallery file (has metadata embedded).
+        // If persist hasn't finished yet, wait for it (shows "Copying…" meanwhile).
+        let galleryFilename = image.gallery_filename;
+        if (!galleryFilename) {
+          const key = this._imageKey(image);
+          const pending = this._persistPromises.get(key);
+          if (pending) {
+            galleryFilename = await pending;
           }
-        } else if (image.gallery_filename) {
-          const raw = await loadGalleryImage(image.gallery_filename);
-          bytes = new Uint8Array(raw);
-        } else {
-          this.showToast(locale.t("gallery.toast.not_saved_yet"), "info");
+        }
+        // Step 1: Try server-side native clipboard (preserves full PNG with metadata).
+        if (galleryFilename) {
+          const path = await getGalleryImagePath(galleryFilename);
+          await copyImageToClipboard(path);
+          this.showToast(locale.t("gallery.toast.copied"), "success");
           return;
         }
-        const blob = new Blob([bytes], { type: "image/png" });
-        await this.writeBlobToClipboard(blob);
-        this.showToast(locale.t("gallery.toast.copied"), "success");
+        // Step 2: Try browser Clipboard API with fullImageUrl (HTTPS / localhost only).
+        const imgUrl = image.fullImageUrl || image.url;
+        if (imgUrl && navigator.clipboard?.write) {
+          try {
+            const resp = await fetch(imgUrl);
+            const blob = await resp.blob();
+            const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
+            await navigator.clipboard.write([new ClipboardItem({ [pngBlob.type]: pngBlob })]);
+            this.showToast(locale.t("gallery.toast.copied"), "success");
+            return;
+          } catch {
+            // Clipboard API blocked (insecure context) — fall through
+          }
+        }
+        // Step 3: Image not saved yet.
+        this.showToast(locale.t("gallery.toast.not_saved_yet"), "info");
         return;
       }
       // Tauri mode: prefer native clipboard via file path
@@ -491,39 +549,26 @@ class GalleryStore {
   /** Write an image blob to the clipboard, with fallback for non-secure contexts (HTTP LAN). */
   private async writeBlobToClipboard(blob: Blob) {
     // navigator.clipboard.write requires a secure context (HTTPS or localhost).
-    // On LAN HTTP, fall back to creating a temporary canvas → execCommand.
     if (navigator.clipboard?.write) {
       try {
         await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
         return;
       } catch {
-        // Clipboard API blocked — fall through to canvas fallback
+        // Clipboard API blocked — fall through to server fallback
       }
     }
-    // Canvas fallback: draw image onto a canvas, use legacy copy
-    const img = new Image();
-    const url = URL.createObjectURL(blob);
-    await new Promise<void>((resolve, reject) => {
-      img.onload = () => resolve();
-      img.onerror = () => reject(new Error("Failed to load image for clipboard fallback"));
-      img.src = url;
-    });
-    const canvas = document.createElement("canvas");
-    canvas.width = img.naturalWidth;
-    canvas.height = img.naturalHeight;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) throw new Error("Canvas 2D context unavailable");
-    ctx.drawImage(img, 0, 0);
-    URL.revokeObjectURL(url);
-    // Try canvas.toBlob + clipboard.write (works in some contexts where ClipboardItem doesn't)
-    const pngBlob = await new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((b) => b ? resolve(b) : reject(new Error("toBlob failed")), "image/png");
-    });
-    if (navigator.clipboard?.write) {
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": pngBlob })]);
-    } else {
-      throw new Error("Clipboard API not available — copy not supported in this browser context");
+    // Browser Clipboard API unavailable (HTTP context) — route through backend
+    // which uses native OS clipboard tools (xclip/wl-copy/pbcopy/PowerShell).
+    if (isBrowserMode) {
+      const buf = await blob.arrayBuffer();
+      const bytes = Array.from(new Uint8Array(buf));
+      const ext = blob.type === "image/jpeg" ? "jpg"
+        : blob.type === "image/webp" ? "webp"
+        : "png";
+      await copyBytesToClipboard(bytes, ext);
+      return;
     }
+    throw new Error("Clipboard API not available — copy not supported in this browser context");
   }
 
   /** Copy a blob URL image to clipboard via native Tauri clipboard or browser Clipboard API. */

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -396,7 +396,7 @@ class GenerationStore {
     );
 
     const nextEntry: PromptHistoryEntry = {
-      id: existing?.id ?? crypto.randomUUID(),
+      id: existing?.id ?? (crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`),
       positivePrompt,
       negativePrompt,
       mode: this.mode,

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -267,6 +267,17 @@ export async function saveToGalleryBytes(
   return ipcInvoke("save_to_gallery_bytes", { imageBytes, filename, promptId, mode, metadata, metadataMode });
 }
 
+export async function saveToGalleryTemp(
+  tempFilename: string,
+  filename: string,
+  promptId: string,
+  mode?: "txt2img" | "img2img" | "inpainting",
+  metadata?: Record<string, string>,
+  metadataMode?: string,
+): Promise<string> {
+  return ipcInvoke("save_to_gallery_temp", { tempFilename, filename, promptId, mode, metadata, metadataMode });
+}
+
 export async function readImageMetadata(
   filename: string
 ): Promise<Record<string, string> | null> {

--- a/src/lib/utils/ipc.ts
+++ b/src/lib/utils/ipc.ts
@@ -24,26 +24,52 @@ type EventCallback = (event: { payload: any }) => void;
 
 const AUTH_TOKEN_KEY = "mooshie:auth_token";
 const AUTH_USER_KEY = "mooshie:auth_user";
+const AUTH_REMEMBER_KEY = "mooshie:remember_me";
 
-export function getAuthToken(): string | null {
-  return localStorage.getItem(AUTH_TOKEN_KEY);
+/** Returns the active storage backend (localStorage if "remember me", sessionStorage otherwise). */
+function authStorage(): Storage {
+  // If a token exists in localStorage, always use localStorage (user chose "remember me")
+  if (localStorage.getItem(AUTH_TOKEN_KEY)) return localStorage;
+  // If a token exists in sessionStorage, use that
+  if (sessionStorage.getItem(AUTH_TOKEN_KEY)) return sessionStorage;
+  // Default to sessionStorage (no remembered session)
+  return sessionStorage;
 }
 
-export function setAuthToken(token: string) {
-  localStorage.setItem(AUTH_TOKEN_KEY, token);
+export function getAuthToken(): string | null {
+  return localStorage.getItem(AUTH_TOKEN_KEY) ?? sessionStorage.getItem(AUTH_TOKEN_KEY);
+}
+
+export function setAuthToken(token: string, rememberMe = false) {
+  if (rememberMe) {
+    localStorage.setItem(AUTH_TOKEN_KEY, token);
+    localStorage.setItem(AUTH_REMEMBER_KEY, "1");
+    sessionStorage.removeItem(AUTH_TOKEN_KEY);
+  } else {
+    sessionStorage.setItem(AUTH_TOKEN_KEY, token);
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    localStorage.removeItem(AUTH_REMEMBER_KEY);
+  }
 }
 
 export function clearAuthToken() {
   localStorage.removeItem(AUTH_TOKEN_KEY);
+  localStorage.removeItem(AUTH_REMEMBER_KEY);
+  sessionStorage.removeItem(AUTH_TOKEN_KEY);
 }
 
 /** Store the currently logged-in username (for per-user localStorage isolation). */
 export function setAuthUser(username: string) {
-  localStorage.setItem(AUTH_USER_KEY, username);
+  authStorage().setItem(AUTH_USER_KEY, username);
 }
 
 export function getAuthUser(): string | null {
-  return localStorage.getItem(AUTH_USER_KEY);
+  return localStorage.getItem(AUTH_USER_KEY) ?? sessionStorage.getItem(AUTH_USER_KEY);
+}
+
+/** Returns true if the user previously selected "Remember me". */
+export function wasRememberMe(): boolean {
+  return localStorage.getItem(AUTH_REMEMBER_KEY) === "1";
 }
 
 /** Build headers with auth token if present. */


### PR DESCRIPTION
## What's New in v0.7.5

### Generation Reliability Fix
- **SSE race condition resolved** — fixed a timing bug where the async `output_image` handler lost the race against the synchronous `executing: node=null` completion event, causing generated images to silently disappear despite successful execution

### Right-Click Copy with Metadata
- **MooshieSaveImage outputs RGBA** — RGBA PNGs (alpha=255) instead of RGB, enabling stealth metadata embedding
- **Server-side metadata embedding** — new `_embed_temp_metadata` endpoint embeds stealth alpha metadata into temp images efficiently
- **Automatic blob URL upgrade** — browser-mode images are displayed immediately then silently upgraded with metadata-embedded versions

### Clipboard & Lightbox Reliability
- **Persist promise tracking** — per-image promise tracking eliminates race conditions in clipboard copy and lightbox display
- **Lightbox URL upgrade** — shows blob URL immediately, upgrades to gallery URL once persistence completes