### PR TITLE
v0.7.6: Pip path fix, mod account creation, browser clipboard fallback

### DIFF
--- a/BOT_REVIEW_TRIAGE.md
+++ b/BOT_REVIEW_TRIAGE.md
@@ -1,0 +1,177 @@
+# Bot Review Triage
+
+Updated: 2026-04-10
+
+Purpose: convert Gemini Code Assist and Copilot PR review comments into a practical action list for MooshieUI's actual deployment model: hosted over WAN for known, trusted users and moderators, not anonymous public users.
+
+## How To Use This File
+
+- `Fix soon`: real bugs or security/correctness issues that still matter under the current trust model.
+- `Keep intentionally`: reviewer concern is understandable, but the current behavior is an intentional operator feature.
+- `Low priority`: real issue, but not urgent.
+- `Ignore / stale`: review comment is no longer relevant or was based on incomplete PR context.
+
+## Fix Soon
+
+### Auth and credentials
+
+- Replace SHA-256 password hashing with Argon2id or bcrypt.
+  - Current code still uses unsalted SHA-256 in `src-tauri/src/auth.rs`.
+  - This is a real issue even for trusted WAN users.
+
+- Remove checked-in default admin passwords.
+  - `.env.example` still contains `MOOSHIEUI_ADMIN_PASS=changeme`.
+  - `k8s/secret.yaml` still contains the base64 for `changeme`.
+  - These are easy deployment footguns.
+
+- Add session expiry / rotation.
+  - Session tokens are persisted to `sessions.json` without TTL.
+  - This is weaker than necessary for any remotely reachable auth system.
+
+- Fix browser auth storage mismatch.
+  - `setAuthUser()` and `getAuthUser()` still read/write different storage backends in some flows.
+  - This can mix per-user client state when switching remember-me behavior.
+
+### Real correctness bugs
+
+- Fix RGBA conversion in `src-tauri/src/comfyui/mooshie_nodes.py`.
+  - Current code assigns `rgba[:, :, :3] = img_np`.
+  - If `img_np` is already RGBA, this can throw due to channel mismatch.
+  - Safe fix: assign `img_np[:, :, :3]`.
+
+- Fix prompt scheduling base text handling in `src/lib/utils/promptSchedule.ts`.
+  - Scheduled text is still being added back into `baseText`.
+  - That means scheduled prompt text can apply globally and within the scheduled range, which is incorrect.
+
+- Fix storage/admin exemption logic in `src-tauri/src/webserver.rs`.
+  - Authenticated admin accounts are still treated differently from localhost admin.
+  - Storage limits and expiry still appear to apply to admin user directories.
+
+- Add timeout or bounded wait to output image finalization in `src/App.svelte`.
+  - `Promise.allSettled(fetches)` still has no timeout.
+  - A stuck image fetch can leave a generation hanging.
+
+- Fix update banner timing in `src/lib/components/updater/UpdateNotification.svelte`.
+  - Browser update check still runs one-shot on mount.
+  - If auth/role resolution happens later, admin/mod users can miss the banner.
+
+### Docker / deployment correctness
+
+- Fix the Docker PyTorch version and wheel index.
+  - `Dockerfile` still uses `TORCH_VERSION=2.7.1`.
+  - It still points to `cu126`.
+  - Both are likely invalid and should be corrected before relying on that image.
+
+## Fix Soon If Touching The Area
+
+### Async runtime blocking
+
+- Replace major synchronous filesystem work inside async handlers in `src-tauri/src/webserver.rs`.
+  - This remains one of the most consistently valid reviewer themes.
+  - Examples still include gallery listing, metadata reading, storage info, expiry cleanup, and path-based image operations.
+  - These are not theoretical; they can hurt responsiveness under normal use.
+
+### Export and logging safety
+
+- Keep `export_logs`, but redact secrets before writing.
+  - The feature is useful for trusted remote operators.
+  - Dumping config with secrets intact is still sloppy and should be cleaned up.
+
+### Accessibility and UI polish
+
+- Add `aria-modal`, `aria-labelledby`, and `aria-describedby` to the storage modal in `src/lib/components/settings/SettingsPage.svelte`.
+  - This is a real accessibility issue, just not urgent.
+
+- Fix `wrap-break-word` in `PromptTextarea.svelte`.
+  - It does not look like a valid Tailwind class.
+  - Replace with `break-words`.
+
+## Keep Intentionally
+
+These were flagged by reviewers, but they align with the product's actual operating model.
+
+### Moderator/operator capabilities
+
+- Keep `install_pip_package` available to trusted moderators.
+  - Face Fix depends on remote installation of `ultralytics`.
+  - This is an intentional operator capability, not an accidental privilege escalation.
+  - If desired later, narrow it to an allowlist rather than removing it entirely.
+
+- Keep `download_model` available for remote operators.
+  - Remote model installation is core product behavior.
+  - Reviewer concern only makes sense under a hostile multi-tenant assumption.
+
+- Keep `update_config` available to trusted remote operators if that is the intended role model.
+  - This is configuration delegation, not necessarily a vulnerability.
+  - Only revisit if moderators are meant to be lower-trust than they are today.
+
+### Maybe keep, but harden
+
+- `export_logs`
+  - Keep feature.
+  - Redact secrets.
+
+- SSE token in query string for EventSource
+  - Not ideal.
+  - For trusted HTTPS deployments, this is lower severity than reviewers implied.
+  - Improve later if convenient, but not top priority.
+
+## Low Priority
+
+### i18n cleanup
+
+- Translate gallery expiry/storage strings in all non-English locale files.
+- Add `gallery.toast.right_click_copy` to all locales.
+  - This is real but not urgent.
+
+### Auth / code cleanup items
+
+- Log errors from `save_sessions()` instead of ignoring them silently.
+- Consider implementing `Default` for `AuthState` only if it becomes useful.
+- Simplify `map_or` usages if touched.
+- Improve `flush_last_online()` so it does not keep stale activity forever.
+
+### Misc frontend polish
+
+- Fix lightbox null-guard around `selectedImage` in `gallery.svelte.ts`.
+- Consider optimizing any repeated reactive filtering for large galleries.
+
+## Ignore / Stale
+
+### No longer relevant or already addressed
+
+- Missing `connect_websocket_headless`
+  - Stale review context. The function exists now.
+
+- Face Fix supply-chain complaint about unpinned ultralytics
+  - Already fixed. Current code pins `ultralytics==8.4.34`.
+
+- Preview/output prompt isolation concerns from older reviews
+  - Mostly addressed in current `App.svelte` with prompt filtering.
+
+- v0.4.9 release-note mismatch complaints
+  - Historical PR-scope noise. Repo now contains the referenced assets.
+
+## Suggested Tomorrow Order
+
+1. Password hashing
+2. Remove default credentials from example/deployment files
+3. Fix RGBA channel bug
+4. Fix Docker PyTorch version/index
+5. Fix admin storage/expiry exemption logic
+6. Add timeout around output-image fetch wait
+7. Start converting biggest blocking `std::fs` paths to `tokio::fs` or `spawn_blocking`
+8. Redact secrets from exported logs
+9. Fix browser auth storage mismatch
+10. Clean up i18n and accessibility leftovers
+
+## Notes On Reviewer Quality
+
+- Gemini was mostly directionally correct on real bugs.
+- The main pattern of overreach was assuming anonymous/public-host threat models instead of trusted remote operators.
+- The most trustworthy review themes were:
+  - password handling
+  - default credentials
+  - sync I/O in async handlers
+  - Docker/runtime correctness
+  - concrete code bugs like the RGBA assignment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v0.7.6
+
+### Pip Install Fix
+- **Fixed pip path resolution** — custom node and pip package installs failed with "No such file or directory (os error 2)" when the `uv` tool wasn't available. The fallback pip path was constructed with string formatting instead of proper OS path joining, breaking on paths with spaces or unusual separators. All 4 affected locations now use `PathBuf::join()`.
+
+### Moderator Account Creation
+- **Moderators can now create accounts** — the "Add Account" button was only visible to admins despite the backend already permitting moderators to create accounts. The button now appears in the moderator account management section.
+
+### Browser-Mode Clipboard Copy
+- **Image copy works on headless servers** — copying images in browser mode failed on servers without `xclip`/`wl-copy` installed. The copy flow now falls through from server-side clipboard to the browser's native Clipboard API (available over HTTPS), so copy works without any tools installed on the server.
+
+### UI Polish
+- **Username tooltip on hover** — account list entries now show the full username on mouseover, so long names truncated by narrow windows are still readable.
+
+---
+
 ## What's New in v0.7.5
 
 ### Generation Reliability Fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v0.7.6
+
+### Pip Install Fix
+- **Fixed pip path resolution** — custom node and pip package installs failed with "No such file or directory (os error 2)" when the `uv` tool wasn't available. The fallback pip path was constructed with string formatting instead of proper OS path joining, breaking on paths with spaces or unusual separators. All 4 affected locations now use `PathBuf::join()`.
+
+### Moderator Account Creation
+- **Moderators can now create accounts** — the "Add Account" button was only visible to admins despite the backend already permitting moderators to create accounts. The button now appears in the moderator account management section.
+
+### Browser-Mode Clipboard Copy
+- **Image copy works on headless servers** — copying images in browser mode failed on servers without `xclip`/`wl-copy` installed. The copy flow now falls through from server-side clipboard to the browser's native Clipboard API (available over HTTPS), so copy works without any tools installed on the server.
+
+### UI Polish
+- **Username tooltip on hover** — account list entries now show the full username on mouseover, so long names truncated by narrow windows are still readable.
+
+---
+
 ## What's New in v0.7.5
 
 ### Generation Reliability Fix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -974,10 +974,11 @@ pub async fn install_custom_node(
                 .spawn()
                 .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
         } else {
+            let venv_base = std::path::Path::new(&config.venv_path);
             #[cfg(target_os = "windows")]
-            let pip_path = format!("{}/Scripts/pip.exe", config.venv_path);
+            let pip_path = venv_base.join("Scripts").join("pip.exe");
             #[cfg(not(target_os = "windows"))]
-            let pip_path = format!("{}/bin/pip", config.venv_path);
+            let pip_path = venv_base.join("bin").join("pip");
 
             tokio::process::Command::new(&pip_path)
                 .args(["install", "-r", &req_file.to_string_lossy()])
@@ -1060,10 +1061,11 @@ pub async fn install_pip_package(
             .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
     } else {
         // Fallback to venv pip
+        let venv_base = std::path::Path::new(&config.venv_path);
         #[cfg(target_os = "windows")]
-        let pip_path = format!("{}/Scripts/pip.exe", config.venv_path);
+        let pip_path = venv_base.join("Scripts").join("pip.exe");
         #[cfg(not(target_os = "windows"))]
-        let pip_path = format!("{}/bin/pip", config.venv_path);
+        let pip_path = venv_base.join("bin").join("pip");
 
         tokio::process::Command::new(&pip_path)
             .args(["install", &package])

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1707,10 +1707,11 @@ async fn dispatch_command(
                         .await
                         .map_err(|e| format!("uv pip install failed: {}", e))?
                 } else {
+                    let venv_base = std::path::Path::new(&venv_path);
                     #[cfg(target_os = "windows")]
-                    let pip_path = format!("{}/Scripts/pip.exe", venv_path);
+                    let pip_path = venv_base.join("Scripts").join("pip.exe");
                     #[cfg(not(target_os = "windows"))]
-                    let pip_path = format!("{}/bin/pip", venv_path);
+                    let pip_path = venv_base.join("bin").join("pip");
                     tokio::process::Command::new(&pip_path)
                         .args(["install", "-r", &req_file.to_string_lossy()])
                         .status()
@@ -1753,10 +1754,11 @@ async fn dispatch_command(
                     .await
                     .map_err(|e| format!("uv pip install failed to start: {}", e))?
             } else {
+                let venv_base = std::path::Path::new(&venv_path);
                 #[cfg(target_os = "windows")]
-                let pip_path = format!("{}/Scripts/pip.exe", venv_path);
+                let pip_path = venv_base.join("Scripts").join("pip.exe");
                 #[cfg(not(target_os = "windows"))]
-                let pip_path = format!("{}/bin/pip", venv_path);
+                let pip_path = venv_base.join("bin").join("pip");
                 tokio::process::Command::new(&pip_path)
                     .args(["install", &package])
                     .output()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -975,7 +975,7 @@
                           <div class="flex items-center justify-between bg-neutral-800 rounded-lg px-3 py-2">
                             <div class="flex items-center gap-2 min-w-0">
                               <span class="inline-block w-2 h-2 rounded-full shrink-0 {account.online ? 'bg-green-500' : 'bg-neutral-600'}"></span>
-                              <span class="text-sm text-neutral-200 truncate">{account.username}</span>
+                              <span class="text-sm text-neutral-200 truncate" title={account.username}>{account.username}</span>
                               {#if account.role === "moderator"}
                                 <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/30 text-indigo-300 font-medium shrink-0">Mod</span>
                               {/if}
@@ -1067,7 +1067,7 @@
                     <div class="flex items-center justify-between bg-neutral-800 rounded-lg px-3 py-2">
                       <div class="flex items-center gap-2 min-w-0">
                         <span class="inline-block w-2 h-2 rounded-full shrink-0 {account.online ? 'bg-green-500' : 'bg-neutral-600'}"></span>
-                        <span class="text-sm text-neutral-200 truncate">{account.username}</span>
+                        <span class="text-sm text-neutral-200 truncate" title={account.username}>{account.username}</span>
                         {#if account.role === "moderator"}
                           <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/30 text-indigo-300 font-medium shrink-0">Mod</span>
                         {/if}
@@ -1113,6 +1113,13 @@
             {:else}
               <p class="text-xs text-neutral-500">No accounts found.</p>
             {/if}
+
+            <!-- Add account button (moderators can create accounts too) -->
+            <button
+              class="w-full px-3 py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer {lanAuthBusy ? 'bg-neutral-700 text-neutral-500' : 'bg-indigo-600 hover:bg-indigo-500 text-white'}"
+              disabled={lanAuthBusy}
+              onclick={() => { lanNewUser = ''; lanNewPass = ''; lanAuthError = null; showAddAccountModal = true; }}
+            >+ Add Account</button>
 
             {#if lanAuthError}
               <p class="text-xs text-red-400 mt-1">{lanAuthError}</p>

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -504,17 +504,22 @@ class GalleryStore {
           }
         }
         // Step 1: Try server-side native clipboard (preserves full PNG with metadata).
+        // May fail on headless servers without xclip/wl-copy — fall through to browser API.
         if (galleryFilename) {
-          const path = await getGalleryImagePath(galleryFilename);
-          await copyImageToClipboard(path);
-          this.showToast(locale.t("gallery.toast.copied"), "success");
-          return;
-        }
-        // Step 2: Try browser Clipboard API with fullImageUrl (HTTPS / localhost only).
-        const imgUrl = image.fullImageUrl || image.url;
-        if (imgUrl && navigator.clipboard?.write) {
           try {
-            const resp = await fetch(imgUrl);
+            const path = await getGalleryImagePath(galleryFilename);
+            await copyImageToClipboard(path);
+            this.showToast(locale.t("gallery.toast.copied"), "success");
+            return;
+          } catch {
+            // Server-side clipboard unavailable — fall through to browser API
+          }
+        }
+        // Step 2: Try browser Clipboard API with gallery URL or fullImageUrl.
+        const fetchUrl = image.fullImageUrl || image.url;
+        if (fetchUrl && navigator.clipboard?.write) {
+          try {
+            const resp = await fetch(fetchUrl);
             const blob = await resp.blob();
             const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
             await navigator.clipboard.write([new ClipboardItem({ [pngBlob.type]: pngBlob })]);


### PR DESCRIPTION
## v0.7.6

### Pip Install Fix
- Fixed pip path resolution — custom node and pip package installs failed with "No such file or directory (os error 2)" when `uv` wasn't available. Fallback pip paths now use `PathBuf::join()` instead of `format!()`.

### Moderator Account Creation
- "Add Account" button now visible to moderators, matching the backend permissions.

### Browser-Mode Clipboard Copy
- Image copy now falls through from server-side clipboard (xclip/wl-copy) to browser Clipboard API on headless servers.

### UI Polish
- Username tooltip on hover in account lists for truncated names.

**Files changed:** `src-tauri/src/commands/api.rs`, `src-tauri/src/webserver.rs`, `src/lib/components/settings/SettingsPage.svelte`, `src/lib/stores/gallery.svelte.ts`, `RELEASE_NOTES.md`, `CHANGELOG.md`, `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`