### PR TITLE
v0.7.7: Full i18n coverage, browser clipboard improvements, Docker OpenCV fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v0.7.7
+
+### Full i18n Coverage
+- **40+ hardcoded English strings localized** — toast messages, context menu labels, panel collapse/expand titles, drop overlay texts, alt attributes, ON/OFF toggles, ControlNet install status messages, and clipboard errors are now all routed through the `locale.t()` system with translations for all 11 supported languages (English, German, Spanish, French, Italian, Japanese, Korean, Portuguese, Russian, Chinese, Traditional Chinese).
+
+### Browser-Mode Clipboard Improvements
+- **Interrogate from clipboard in browser mode** — the "Interrogate Clipboard" feature now works on headless servers by reading images directly via the Web Clipboard API instead of relying on the unavailable Tauri clipboard command.
+- **`readClipboardImageSafe` fallback** — new clipboard utility that automatically falls through from the native Tauri command to the browser Clipboard API, used by both ControlNet image paste and generation input paste.
+- **Simplified gallery clipboard flow** — removed redundant `navigator.clipboard?.write` feature-detection guard in favor of the unified `writeBlobToClipboard` helper, which already handles insecure-context fallback internally.
+
+### Bug Fixes
+- **Face fix model hash updated** — the YOLOv8n face detection model SHA-256 hash was corrected to match the current upstream file, preventing false integrity failures during download.
+- **Docker OpenCV fix** — added `opencv-python-headless` to the Docker build so ControlNet preprocessors that depend on OpenCV work out of the box.
+
+---
+
 ## What's New in v0.7.6
 
 ### Pip Install Fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
     uv pip install torch==${TORCH_VERSION} torchvision torchaudio \
         --index-url https://download.pytorch.org/whl/cu126 && \
     uv pip install -r ${COMFYUI_PATH}/requirements.txt && \
+    uv pip install opencv-python-headless && \
     uv pip install ultralytics==8.4.34
 
 # Copy custom nodes (auto-deployed by the binary on startup, but also

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v0.7.7
+
+### Full i18n Coverage
+- **40+ hardcoded English strings localized** — toast messages, context menu labels, panel collapse/expand titles, drop overlay texts, alt attributes, ON/OFF toggles, ControlNet install status messages, and clipboard errors are now all routed through the `locale.t()` system with translations for all 11 supported languages (English, German, Spanish, French, Italian, Japanese, Korean, Portuguese, Russian, Chinese, Traditional Chinese).
+
+### Browser-Mode Clipboard Improvements
+- **Interrogate from clipboard in browser mode** — the "Interrogate Clipboard" feature now works on headless servers by reading images directly via the Web Clipboard API instead of relying on the unavailable Tauri clipboard command.
+- **`readClipboardImageSafe` fallback** — new clipboard utility that automatically falls through from the native Tauri command to the browser Clipboard API, used by both ControlNet image paste and generation input paste.
+- **Simplified gallery clipboard flow** — removed redundant `navigator.clipboard?.write` feature-detection guard in favor of the unified `writeBlobToClipboard` helper, which already handles insecure-context fallback internally.
+
+### Bug Fixes
+- **Face fix model hash updated** — the YOLOv8n face detection model SHA-256 hash was corrected to match the current upstream file, preventing false integrity failures during download.
+- **Docker OpenCV fix** — added `opencv-python-headless` to the Docker build so ControlNet preprocessors that depend on OpenCV work out of the box.
+
+---
+
 ## What's New in v0.7.6
 
 ### Pip Install Fix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/ControlNetSettings.svelte
+++ b/src/lib/components/generation/ControlNetSettings.svelte
@@ -7,7 +7,7 @@
     downloadModel,
     uploadImage,
     uploadImageBytes,
-    readClipboardImage,
+    readClipboardImageSafe,
     checkNodeAvailable,
     isCustomNodeInstalled,
     installCustomNode,
@@ -115,7 +115,7 @@
           await downloadModel(model.url, "controlnet", model.filename);
           await models.refresh();
         } catch (e) {
-          downloadError = `Download failed: ${e}`;
+          downloadError = locale.t('generation.controlnet.download_failed', { error: String(e) });
           generation.controlnetModel = null;
         } finally {
           downloading = null;
@@ -159,7 +159,7 @@
 
   async function handleImagePaste() {
     try {
-      const bytes = await readClipboardImage();
+      const bytes = await readClipboardImageSafe();
       uploadingImage = true;
       const result = await uploadImageBytes(bytes, "pasted_image.png");
       generation.controlnetImage = result.name;
@@ -216,7 +216,7 @@
     installing = true;
     installError = null;
     installStep = "clone";
-    installMessage = "Starting installation...";
+    installMessage = locale.t('generation.controlnet.install_starting');
     try {
       await installCustomNode(
         "https://github.com/Fannovel16/comfyui_controlnet_aux.git",
@@ -225,18 +225,18 @@
 
       // Restart ComfyUI to load new nodes
       installStep = "restart";
-      installMessage = "Stopping ComfyUI...";
+      installMessage = locale.t('generation.controlnet.install_stopping');
       connection.connected = false;
       await stopComfyui();
 
-      installMessage = "Starting ComfyUI with new nodes...";
+      installMessage = locale.t('generation.controlnet.install_starting_nodes');
       await startComfyui();
 
       // Wait for the server to actually be ready via the event system
-      installMessage = "Waiting for ComfyUI to become ready...";
+      installMessage = locale.t('generation.controlnet.install_waiting_ready');
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
-          reject(new Error("ComfyUI did not become ready within 120 seconds"));
+          reject(new Error(locale.t('generation.controlnet.install_timeout')));
         }, 120_000);
 
         const unlistenReady = ipcListen("comfyui:server_ready", () => {
@@ -250,13 +250,13 @@
           clearTimeout(timeout);
           unlistenReady.then((fn) => fn());
           unlistenError.then((fn) => fn());
-          reject(new Error(event.payload?.error || "ComfyUI failed to start"));
+          reject(new Error(event.payload?.error || locale.t('generation.controlnet.install_start_failed')));
         });
       });
 
       // Server is ready — check if the node is now available
       installStep = "verify";
-      installMessage = "Verifying preprocessor nodes...";
+      installMessage = locale.t('generation.controlnet.install_verifying');
       try {
         preprocessorAvailable = await checkNodeAvailable("CannyEdgePreprocessor");
       } catch {
@@ -267,7 +267,7 @@
       installStep = "";
       installMessage = "";
     } catch (e) {
-      installError = `Install failed: ${e}`;
+      installError = locale.t('generation.controlnet.install_failed', { error: String(e) });
       installing = false;
       installStep = "";
       installMessage = "";
@@ -503,7 +503,7 @@
             <div class="relative rounded-lg overflow-hidden bg-neutral-800 border border-neutral-700">
               <img
                 src={imagePreviewUrl}
-                alt="Control image"
+                alt={locale.t('generation.controlnet.control_image_alt')}
                 class="w-full max-h-48 object-contain"
               />
               <div class="absolute top-1.5 right-1.5">

--- a/src/lib/components/generation/FaceFixSettings.svelte
+++ b/src/lib/components/generation/FaceFixSettings.svelte
@@ -27,7 +27,7 @@
       label: "YOLOv8n Face (Lightweight)",
       filename: "face_yolov8n.pt",
       url: "https://huggingface.co/Bingsu/adetailer/resolve/main/face_yolov8n.pt",
-      sha256: "d1126adb762a2a935e6a9780395360ba6a223144ee012777342d4258180c3e93",
+      sha256: "70b640f8f60b1cf0dcc72f30caf3da9495eb2fb6509da48c53374ad6806e6a9c",
     },
   ];
 

--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -19,7 +19,7 @@
   import CanvasEditor from "../canvas/CanvasEditor.svelte";
   import LayerPanel from "../canvas/layers/LayerPanel.svelte";
   import { canvas } from "../../stores/canvas.svelte.js";
-  import { uploadImage, uploadImageBytes, loadGalleryImage, getOutputImage, readClipboardImage } from "../../utils/api.js";
+  import { uploadImage, uploadImageBytes, loadGalleryImage, getOutputImage, readClipboardImageSafe } from "../../utils/api.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
   import type { OutputImage, InterrogationResult } from "../../types/index.js";
@@ -571,7 +571,7 @@
 
   async function handleImagePaste() {
     try {
-      const bytes = await readClipboardImage();
+      const bytes = await readClipboardImageSafe();
       uploading = true;
       const normalized = await normalizeImageBytes(bytes, "pasted_image.png");
 
@@ -591,7 +591,7 @@
 
   async function handleMaskPaste() {
     try {
-      const bytes = await readClipboardImage();
+      const bytes = await readClipboardImageSafe();
       uploading = true;
       const blob = new Blob([new Uint8Array(bytes)], { type: "image/png" });
       if (maskPreviewUrl) URL.revokeObjectURL(maskPreviewUrl);
@@ -637,10 +637,10 @@
       generation.inputImage = response.name;
       generation.mode = "img2img";
       generation.upscaleEnabled = true;
-      gallery.showToast("Image loaded for upscaling", "success");
+      gallery.showToast(locale.t('generation.toast.loaded_upscale'), "success");
     } catch (e) {
       console.error("Failed to set up upscale:", e);
-      gallery.showToast("Failed to load image", "error");
+      gallery.showToast(locale.t('generation.toast.failed_load'), "error");
     }
   }
 
@@ -669,10 +669,10 @@
         canvas.initCanvas(generation.width, generation.height);
       }
 
-      gallery.showToast("Image loaded for inpainting", "success");
+      gallery.showToast(locale.t('generation.toast.loaded_inpaint'), "success");
     } catch (e) {
       console.error("Failed to set up inpainting:", e);
-      gallery.showToast("Failed to load image", "error");
+      gallery.showToast(locale.t('generation.toast.failed_load'), "error");
     }
   }
 
@@ -700,15 +700,15 @@
     const image = ctxMenuImage;
     if (!image) return [];
     return [
-      { label: "Get Image Tags", action: () => interrogateSessionImage(image) },
+      { label: locale.t('generation.ctx.get_tags'), action: () => interrogateSessionImage(image) },
       { label: "", action: () => {}, separator: true },
-      { label: "Upscale", action: () => upscaleImage(image) },
-      { label: "Inpaint", action: () => inpaintImage(image) },
+      { label: locale.t('generation.ctx.upscale'), action: () => upscaleImage(image) },
+      { label: locale.t('generation.ctx.inpaint'), action: () => inpaintImage(image) },
       { label: "", action: () => {}, separator: true },
-      { label: "Save As", action: () => gallery.saveImageAs(image) },
-      { label: "Copy", action: () => gallery.copyToClipboard(image) },
+      { label: locale.t('generation.ctx.save_as'), action: () => gallery.saveImageAs(image) },
+      { label: locale.t('generation.ctx.copy'), action: () => gallery.copyToClipboard(image) },
       { label: "", action: () => {}, separator: true },
-      { label: "Delete", action: () => gallery.deleteImage(image), destructive: true },
+      { label: locale.t('generation.ctx.delete'), action: () => gallery.deleteImage(image), destructive: true },
     ];
   });
 
@@ -1093,7 +1093,7 @@
             await handleMetadataImportPath(imgPath, importTarget);
           } catch (err) {
             console.error("Tauri drag-drop metadata import failed:", err);
-            gallery.showToast("Failed to read dropped image", "error");
+            gallery.showToast(locale.t('generation.toast.failed_drop'), "error");
           }
           return;
         }
@@ -1225,7 +1225,7 @@
         <button
           class="flex-1 flex items-center justify-between py-2 pr-3 text-xs text-neutral-300 hover:text-neutral-100 focus:outline-none"
           onclick={() => (dimensionsSectionOpen = !dimensionsSectionOpen)}
-          title={dimensionsSectionOpen ? "Collapse Dimensions" : "Expand Dimensions"}
+          title={dimensionsSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.dimensions.title') }) : locale.t('common.expand', { section: locale.t('generation.dimensions.title') })}
         >
           <span class="font-medium">{locale.t('generation.dimensions.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {dimensionsSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1239,7 +1239,7 @@
       {#if metadataDropTarget === "dimensions"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import dimensions
+            {locale.t('common.drop_to_import', { section: locale.t('generation.dimensions.title') })}
           </span>
         </div>
       {/if}
@@ -1258,7 +1258,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (promptsSectionOpen = !promptsSectionOpen)}
-          title={promptsSectionOpen ? "Collapse Prompts" : "Expand Prompts"}
+          title={promptsSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.prompts.title') }) : locale.t('common.expand', { section: locale.t('generation.prompts.title') })}
         >
           <span class="font-medium">{locale.t('generation.prompts.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {promptsSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1272,7 +1272,7 @@
       {#if metadataDropTarget === "prompts"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import prompts
+            {locale.t('common.drop_to_import', { section: locale.t('generation.prompts.title') })}
           </span>
         </div>
       {/if}
@@ -1286,7 +1286,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (interrogateSectionOpen = !interrogateSectionOpen)}
-          title={interrogateSectionOpen ? "Collapse Interrogate Image" : "Expand Interrogate Image"}
+          title={interrogateSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.interrogate.title') }) : locale.t('common.expand', { section: locale.t('generation.interrogate.title') })}
         >
           <span class="flex items-center gap-1.5 font-medium">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
@@ -1310,7 +1310,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (imageSectionOpen = !imageSectionOpen)}
-          title={imageSectionOpen ? "Collapse Image Inputs" : "Expand Image Inputs"}
+          title={imageSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.image.title') }) : locale.t('common.expand', { section: locale.t('generation.image.title') })}
         >
           <span class="font-medium">{locale.t('generation.image.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {imageSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1337,7 +1337,7 @@
               <div class="relative group">
                 <img
                   src={imagePreviewUrl}
-                  alt="Input"
+                  alt={locale.t('generation.image.input')}
                   class="w-full rounded-lg border border-neutral-700 object-contain max-h-40"
                 />
                 <button
@@ -1432,7 +1432,7 @@
                 <div class="relative group">
                   <img
                     src={maskPreviewUrl}
-                    alt="Mask"
+                    alt={locale.t('generation.inpaint.mask')}
                     class="w-full rounded-lg border border-neutral-700 object-contain max-h-40"
                   />
                   <button
@@ -1510,7 +1510,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (layersSectionOpen = !layersSectionOpen)}
-          title={layersSectionOpen ? "Collapse Inpainting & Layers" : "Expand Inpainting & Layers"}
+          title={layersSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.inpaint.title') }) : locale.t('common.expand', { section: locale.t('generation.inpaint.title') })}
         >
           <span class="font-medium">{locale.t('generation.inpaint.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {layersSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1570,7 +1570,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (controlsSectionOpen = !controlsSectionOpen)}
-          title={controlsSectionOpen ? "Collapse Generation Settings" : "Expand Generation Settings"}
+          title={controlsSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.settings.title') }) : locale.t('common.expand', { section: locale.t('generation.settings.title') })}
         >
           <span class="font-medium">{locale.t('generation.settings.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {controlsSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1604,7 +1604,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (modelSectionOpen = !modelSectionOpen)}
-          title={modelSectionOpen ? "Collapse Model" : "Expand Model"}
+          title={modelSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.model.title') }) : locale.t('common.expand', { section: locale.t('generation.model.title') })}
         >
           <span class="font-medium">{locale.t('generation.model.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {modelSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1618,7 +1618,7 @@
       {#if metadataDropTarget === "model"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import model settings
+            {locale.t('common.drop_to_import', { section: locale.t('generation.model.title') })}
           </span>
         </div>
       {/if}
@@ -1637,7 +1637,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (samplerSectionOpen = !samplerSectionOpen)}
-          title={samplerSectionOpen ? "Collapse Sampler" : "Expand Sampler"}
+          title={samplerSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.sampler.title') }) : locale.t('common.expand', { section: locale.t('generation.sampler.title') })}
         >
           <span class="font-medium">{locale.t('generation.sampler.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {samplerSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1651,7 +1651,7 @@
       {#if metadataDropTarget === "sampler"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import sampler settings
+            {locale.t('common.drop_to_import', { section: locale.t('generation.sampler.title') })}
           </span>
         </div>
       {/if}
@@ -1665,7 +1665,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (controlnetSectionOpen = !controlnetSectionOpen)}
-          title={controlnetSectionOpen ? "Collapse ControlNet" : "Expand ControlNet"}
+          title={controlnetSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.controlnet.title') }) : locale.t('common.expand', { section: locale.t('generation.controlnet.title') })}
         >
           <span class="font-medium">{locale.t('generation.controlnet.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {controlnetSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1691,7 +1691,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (facefixSectionOpen = !facefixSectionOpen)}
-          title={facefixSectionOpen ? "Collapse Face Fix" : "Expand Face Fix"}
+          title={facefixSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.facefix.title') }) : locale.t('common.expand', { section: locale.t('generation.facefix.title') })}
         >
           <span class="font-medium">{locale.t('generation.facefix.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {facefixSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1705,7 +1705,7 @@
       {#if metadataDropTarget === "facefix"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import face fix settings
+            {locale.t('common.drop_to_import', { section: locale.t('generation.facefix.title') })}
           </span>
         </div>
       {/if}
@@ -1724,7 +1724,7 @@
         <button
           class="flex-1 px-3 py-2 flex items-center justify-between text-xs text-neutral-300 hover:text-neutral-100 transition-colors"
           onclick={() => (postSectionOpen = !postSectionOpen)}
-          title={postSectionOpen ? "Collapse Upscale" : "Expand Upscale"}
+          title={postSectionOpen ? locale.t('common.collapse', { section: locale.t('generation.upscale.title') }) : locale.t('common.expand', { section: locale.t('generation.upscale.title') })}
         >
           <span class="font-medium">{locale.t('generation.upscale.title')}</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {postSectionOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -1738,7 +1738,7 @@
       {#if metadataDropTarget === "upscaleHistory"}
         <div class="absolute inset-0 flex items-center justify-center pointer-events-none z-10 rounded-lg bg-indigo-500/10 border-2 border-dashed border-indigo-400/60">
           <span class="text-xs font-medium text-indigo-300 bg-neutral-900/80 px-3 py-1.5 rounded-full">
-            Drop to import upscale settings
+            {locale.t('common.drop_to_import', { section: locale.t('generation.upscale.title') })}
           </span>
         </div>
       {/if}
@@ -1830,7 +1830,7 @@
                   {locale.t('generation.inpaint.canvas_editor')}
                 </span>
                 <span class="text-[10px] {canvas.isCanvasMode ? 'text-indigo-400' : 'text-neutral-500'}">
-                  {canvas.isCanvasMode ? 'ON' : 'OFF'}
+                  {canvas.isCanvasMode ? locale.t('common.on') : locale.t('common.off')}
                 </span>
               </button>
             {/if}
@@ -1868,7 +1868,7 @@
           class="absolute top-1/2 -translate-y-1/2 left-0 z-20 w-6 h-12 flex items-center justify-center rounded-r border border-l-0 transition-colors {leftCollapsed
             ? 'bg-indigo-600 border-indigo-500/70 text-white hover:bg-indigo-500'
             : 'bg-neutral-800 border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700'}"
-          title={leftCollapsed ? "Expand left panel" : "Collapse left panel"}
+          title={leftCollapsed ? locale.t('generation.panel.expand_left') : locale.t('generation.panel.collapse_left')}
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 transition-transform {leftCollapsed ? 'rotate-180' : ''}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
@@ -1904,7 +1904,7 @@
             class="absolute left-1/2 -translate-x-1/2 bottom-0 z-20 h-6 w-12 flex items-center justify-center rounded-t border border-b-0 transition-colors {bottomCollapsed
               ? 'bg-indigo-600 border-indigo-500/70 text-white hover:bg-indigo-500'
               : 'bg-neutral-800 border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700'}"
-            title={bottomCollapsed ? "Expand bottom panel" : "Collapse bottom panel"}
+            title={bottomCollapsed ? locale.t('generation.panel.expand_bottom') : locale.t('generation.panel.collapse_bottom')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 transition-transform {bottomCollapsed ? 'rotate-180' : ''}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
           </button>
@@ -1935,7 +1935,7 @@
           class="absolute top-1/2 -translate-y-1/2 right-0 z-20 w-6 h-12 flex items-center justify-center rounded-l border border-r-0 transition-colors {rightCollapsed
             ? 'bg-indigo-600 border-indigo-500/70 text-white hover:bg-indigo-500'
             : 'bg-neutral-800 border-neutral-700 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-700'}"
-          title={rightCollapsed ? "Expand right panel" : "Collapse right panel"}
+          title={rightCollapsed ? locale.t('generation.panel.expand_right') : locale.t('generation.panel.collapse_right')}
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 transition-transform {rightCollapsed ? '' : 'rotate-180'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
@@ -1993,7 +1993,7 @@
                   {locale.t('generation.inpaint.canvas_editor')}
                 </span>
                 <span class="text-[10px] {canvas.isCanvasMode ? 'text-indigo-400' : 'text-neutral-500'}">
-                  {canvas.isCanvasMode ? 'ON' : 'OFF'}
+                  {canvas.isCanvasMode ? locale.t('common.on') : locale.t('common.off')}
                 </span>
               </button>
             {/if}

--- a/src/lib/components/generation/InterrogateSection.svelte
+++ b/src/lib/components/generation/InterrogateSection.svelte
@@ -4,7 +4,7 @@
   import InfoTip from "../ui/InfoTip.svelte";
   import InterrogateModal from "./InterrogateModal.svelte";
   import { interrogateImage, interrogateImagePath, interrogateClipboard } from "../../utils/api.js";
-  import { ipcListen, isTauri } from "../../utils/ipc.js";
+  import { ipcListen, isTauri, isBrowserMode } from "../../utils/ipc.js";
   import type { InterrogationResult } from "../../types/index.js";
 
   // Interrogation state
@@ -108,6 +108,43 @@
   }
 
   async function interrogateFromClipboard() {
+    // In browser mode, use the Web Clipboard API to read the image client-side,
+    // then send via interrogate_image (base64). The Tauri clipboard command is
+    // not available without the native shell.
+    if (isBrowserMode) {
+      try {
+        const items = await navigator.clipboard.read();
+        let imageBlob: Blob | null = null;
+        for (const item of items) {
+          for (const type of item.types) {
+            if (type.startsWith("image/")) {
+              imageBlob = await item.getType(type);
+              break;
+            }
+          }
+          if (imageBlob) break;
+        }
+        if (!imageBlob) {
+          showInterrogateModal = true;
+          interrogateError = locale.t('common.no_clipboard_image');
+          return;
+        }
+        const previewUrl = URL.createObjectURL(imageBlob);
+        const buffer = await imageBlob.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+          binary += String.fromCharCode(bytes[i]);
+        }
+        await interrogateBytes(btoa(binary), previewUrl);
+        return;
+      } catch (e) {
+        showInterrogateModal = true;
+        interrogateError = e instanceof Error ? e.message : String(e);
+        return;
+      }
+    }
+
     showInterrogateModal = true;
     interrogateLoading = true;
     interrogateResult = null;

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -30,6 +30,11 @@ const de: Record<string, string> = {
   "common.close": "Schließen",
   "common.or": "oder",
   "common.on": "An",
+  "common.off": "AUS",
+  "common.collapse": "{section} einklappen",
+  "common.expand": "{section} ausklappen",
+  "common.drop_to_import": "Zum Importieren ablegen: {section}",
+  "common.no_clipboard_image": "Kein Bild in der Zwischenablage gefunden",
   "common.detected": "Erkannt",
   "common.click_to_type": "Klicken, um einen Wert einzugeben",
 
@@ -277,6 +282,7 @@ const de: Record<string, string> = {
   "generation.dimensions.swap": "Breite/Höhe tauschen",
   "generation.dimensions.result": "Ergebnis",
   "generation.swap_panels": "Linkes/rechtes Panel tauschen",
+  "generation.settings.title": "Generierungseinstellungen",
 
   "generation.sampler.title": "Sampler",
   "generation.sampler.label": "Sampler",
@@ -457,6 +463,28 @@ const de: Record<string, string> = {
   "generation.error_no_image": "Inpainting benötigt ein Eingabebild. Laden Sie eins hoch oder verwenden Sie ein bereitgestelltes Bild.",
   "generation.error_no_mask": "Inpainting benötigt eine Maske. Zeichnen Sie eine im Canvas-Editor oder laden Sie eine hoch.",
   "generation.downloading_facefix": "Gesichtskorrektur-Modell wird heruntergeladen...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Bild-Tags abrufen",
+  "generation.ctx.upscale": "Hochskalieren",
+  "generation.ctx.inpaint": "Inpainting",
+  "generation.ctx.save_as": "Speichern unter",
+  "generation.ctx.copy": "Kopieren",
+  "generation.ctx.delete": "Löschen",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Bild zum Hochskalieren geladen",
+  "generation.toast.loaded_inpaint": "Bild für Inpainting geladen",
+  "generation.toast.failed_load": "Bild konnte nicht geladen werden",
+  "generation.toast.failed_drop": "Abgelegtes Bild konnte nicht gelesen werden",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Linkes Panel ausklappen",
+  "generation.panel.collapse_left": "Linkes Panel einklappen",
+  "generation.panel.expand_right": "Rechtes Panel ausklappen",
+  "generation.panel.collapse_right": "Rechtes Panel einklappen",
+  "generation.panel.expand_bottom": "Unteres Panel ausklappen",
+  "generation.panel.collapse_bottom": "Unteres Panel einklappen",
 
   "generation.interrogate.title": "Bildanalyse",
   "generation.interrogate.tip": "Analysiert ein Bild, um Tags (Charakter, Künstler, Allgemein) zu extrahieren. Bild ablegen, durchsuchen oder aus der Zwischenablage einfügen. Tags können direkt auf Prompts angewendet werden.",
@@ -870,6 +898,16 @@ const de: Record<string, string> = {
   "generation.controlnet.uploading": "Wird hochgeladen...",
   "generation.controlnet.start_percent_tip": "Wann ControlNet beginnt, die Generierung zu beeinflussen (0% = von Anfang an). Verzögerter Start fügt mehr Variation hinzu.",
   "generation.controlnet.end_percent_tip": "Wann ControlNet aufhört, die Generierung zu beeinflussen (100% = bis zum Ende). Frühes Beenden lässt das Modell Details frei verfeinern.",
+  "generation.controlnet.download_failed": "Download fehlgeschlagen: {error}",
+  "generation.controlnet.install_starting": "Installation wird gestartet...",
+  "generation.controlnet.install_stopping": "ComfyUI wird gestoppt...",
+  "generation.controlnet.install_starting_nodes": "ComfyUI mit neuen Knoten starten...",
+  "generation.controlnet.install_waiting_ready": "Warte auf Bereitschaft von ComfyUI...",
+  "generation.controlnet.install_timeout": "ComfyUI war innerhalb von 120 Sekunden nicht bereit",
+  "generation.controlnet.install_start_failed": "ComfyUI konnte nicht gestartet werden",
+  "generation.controlnet.install_verifying": "Präprozessor-Knoten werden überprüft...",
+  "generation.controlnet.install_failed": "Installation fehlgeschlagen: {error}",
+  "generation.controlnet.control_image_alt": "Kontrollbild",
   "generation.controlnet.preset_canny": "Canny-Kanten",
   "generation.controlnet.preset_canny_desc": "Erkennt Kanten — am besten zur Bewahrung von Struktur und Komposition",
   "generation.controlnet.preset_depth": "Tiefenkarte",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -30,6 +30,11 @@ const en: Record<string, string> = {
   "common.close": "Close",
   "common.or": "or",
   "common.on": "ON",
+  "common.off": "OFF",
+  "common.collapse": "Collapse {section}",
+  "common.expand": "Expand {section}",
+  "common.drop_to_import": "Drop to import {section}",
+  "common.no_clipboard_image": "No image found in clipboard",
   "common.detected": "detected",
   "common.click_to_type": "Click to type a value",
 
@@ -294,6 +299,7 @@ const en: Record<string, string> = {
   "generation.dimensions.swap": "Swap W/H",
   "generation.dimensions.result": "Result",
   "generation.swap_panels": "Swap left/right panels",
+  "generation.settings.title": "Generation Settings",
 
   // Sampler
   "generation.sampler.title": "Sampler",
@@ -485,6 +491,28 @@ const en: Record<string, string> = {
   "generation.error_no_image": "Inpainting needs an input image. Upload one or use a staged image.",
   "generation.error_no_mask": "Inpainting needs a mask. Paint a mask in Canvas Editor or upload one.",
   "generation.downloading_facefix": "Downloading face fix model...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Get Image Tags",
+  "generation.ctx.upscale": "Upscale",
+  "generation.ctx.inpaint": "Inpaint",
+  "generation.ctx.save_as": "Save As",
+  "generation.ctx.copy": "Copy",
+  "generation.ctx.delete": "Delete",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Image loaded for upscaling",
+  "generation.toast.loaded_inpaint": "Image loaded for inpainting",
+  "generation.toast.failed_load": "Failed to load image",
+  "generation.toast.failed_drop": "Failed to read dropped image",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Expand left panel",
+  "generation.panel.collapse_left": "Collapse left panel",
+  "generation.panel.expand_right": "Expand right panel",
+  "generation.panel.collapse_right": "Collapse right panel",
+  "generation.panel.expand_bottom": "Expand bottom panel",
+  "generation.panel.collapse_bottom": "Collapse bottom panel",
 
   // Interrogate modal
   "generation.interrogate.title": "Interrogate Image",
@@ -940,6 +968,16 @@ const en: Record<string, string> = {
   "generation.controlnet.uploading": "Uploading...",
   "generation.controlnet.start_percent_tip": "When ControlNet starts influencing the generation (0% = from the very beginning). Delaying the start can add more variation.",
   "generation.controlnet.end_percent_tip": "When ControlNet stops influencing the generation (100% = until the very end). Ending early lets the model refine details freely.",
+  "generation.controlnet.download_failed": "Download failed: {error}",
+  "generation.controlnet.install_starting": "Starting installation...",
+  "generation.controlnet.install_stopping": "Stopping ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Starting ComfyUI with new nodes...",
+  "generation.controlnet.install_waiting_ready": "Waiting for ComfyUI to become ready...",
+  "generation.controlnet.install_timeout": "ComfyUI did not become ready within 120 seconds",
+  "generation.controlnet.install_start_failed": "ComfyUI failed to start",
+  "generation.controlnet.install_verifying": "Verifying preprocessor nodes...",
+  "generation.controlnet.install_failed": "Install failed: {error}",
+  "generation.controlnet.control_image_alt": "Control image",
 
   "generation.controlnet.preset_canny": "Canny Edge",
   "generation.controlnet.preset_canny_desc": "Detects edges — best for preserving structure and composition",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -30,6 +30,11 @@ const es: Record<string, string> = {
   "common.close": "Cerrar",
   "common.or": "o",
   "common.on": "ON",
+  "common.off": "APAGADO",
+  "common.collapse": "Contraer {section}",
+  "common.expand": "Expandir {section}",
+  "common.drop_to_import": "Soltar para importar {section}",
+  "common.no_clipboard_image": "No se encontró imagen en el portapapeles",
   "common.detected": "detectado",
   "common.click_to_type": "Haz clic para escribir un valor",
 
@@ -289,6 +294,7 @@ const es: Record<string, string> = {
   "generation.dimensions.swap": "Intercambiar A/Al",
   "generation.dimensions.result": "Resultado",
   "generation.swap_panels": "Intercambiar paneles izquierdo/derecho",
+  "generation.settings.title": "Ajustes de generación",
 
   // Muestreador
   "generation.sampler.title": "Muestreador",
@@ -479,6 +485,28 @@ const es: Record<string, string> = {
   "generation.error_no_image": "El inpainting necesita una imagen de entrada. Sube una o usa una imagen preparada.",
   "generation.error_no_mask": "El inpainting necesita una máscara. Pinta una máscara en el Editor de lienzo o sube una.",
   "generation.downloading_facefix": "Descargando modelo de corrección facial...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Obtener etiquetas",
+  "generation.ctx.upscale": "Escalar",
+  "generation.ctx.inpaint": "Inpaint",
+  "generation.ctx.save_as": "Guardar como",
+  "generation.ctx.copy": "Copiar",
+  "generation.ctx.delete": "Eliminar",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Imagen cargada para escalar",
+  "generation.toast.loaded_inpaint": "Imagen cargada para inpainting",
+  "generation.toast.failed_load": "Error al cargar la imagen",
+  "generation.toast.failed_drop": "Error al leer la imagen soltada",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Expandir panel izquierdo",
+  "generation.panel.collapse_left": "Contraer panel izquierdo",
+  "generation.panel.expand_right": "Expandir panel derecho",
+  "generation.panel.collapse_right": "Contraer panel derecho",
+  "generation.panel.expand_bottom": "Expandir panel inferior",
+  "generation.panel.collapse_bottom": "Contraer panel inferior",
 
   // Modal de interrogación
   "generation.interrogate.title": "Interrogar imagen",
@@ -897,6 +925,16 @@ const es: Record<string, string> = {
   "generation.controlnet.uploading": "Subiendo...",
   "generation.controlnet.start_percent_tip": "Cuándo ControlNet comienza a influir en la generación (0% = desde el inicio). Retrasar el inicio añade más variación.",
   "generation.controlnet.end_percent_tip": "Cuándo ControlNet deja de influir en la generación (100% = hasta el final). Terminar antes permite al modelo refinar detalles libremente.",
+  "generation.controlnet.download_failed": "Descarga fallida: {error}",
+  "generation.controlnet.install_starting": "Iniciando instalación...",
+  "generation.controlnet.install_stopping": "Deteniendo ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Iniciando ComfyUI con nuevos nodos...",
+  "generation.controlnet.install_waiting_ready": "Esperando a que ComfyUI esté listo...",
+  "generation.controlnet.install_timeout": "ComfyUI no estuvo listo en 120 segundos",
+  "generation.controlnet.install_start_failed": "ComfyUI no pudo iniciarse",
+  "generation.controlnet.install_verifying": "Verificando nodos de preprocesador...",
+  "generation.controlnet.install_failed": "Instalación fallida: {error}",
+  "generation.controlnet.control_image_alt": "Imagen de control",
   "generation.controlnet.preset_canny": "Bordes Canny",
   "generation.controlnet.preset_canny_desc": "Detecta bordes — ideal para preservar estructura y composición",
   "generation.controlnet.preset_depth": "Mapa de profundidad",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -30,6 +30,11 @@ const fr: Record<string, string> = {
   "common.close": "Fermer",
   "common.or": "ou",
   "common.on": "ACTIVÉ",
+  "common.off": "DÉSACTIVÉ",
+  "common.collapse": "Réduire {section}",
+  "common.expand": "Développer {section}",
+  "common.drop_to_import": "Déposer pour importer {section}",
+  "common.no_clipboard_image": "Aucune image trouvée dans le presse-papiers",
   "common.detected": "détecté",
   "common.click_to_type": "Cliquez pour saisir une valeur",
 
@@ -289,6 +294,7 @@ const fr: Record<string, string> = {
   "generation.dimensions.swap": "Inverser L/H",
   "generation.dimensions.result": "Résultat",
   "generation.swap_panels": "Échanger les panneaux gauche/droite",
+  "generation.settings.title": "Paramètres de génération",
 
   // Échantillonneur
   "generation.sampler.title": "Échantillonneur",
@@ -478,6 +484,28 @@ const fr: Record<string, string> = {
   "generation.error_no_image": "L'inpainting nécessite une image d'entrée. Téléversez-en une ou utilisez une image préparée.",
   "generation.error_no_mask": "L'inpainting nécessite un masque. Peignez un masque dans l'éditeur de canevas ou téléversez-en un.",
   "generation.downloading_facefix": "Téléchargement du modèle de correction faciale...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Obtenir les tags",
+  "generation.ctx.upscale": "Agrandir",
+  "generation.ctx.inpaint": "Inpainting",
+  "generation.ctx.save_as": "Enregistrer sous",
+  "generation.ctx.copy": "Copier",
+  "generation.ctx.delete": "Supprimer",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Image chargée pour l\'agrandissement",
+  "generation.toast.loaded_inpaint": "Image chargée pour l\'inpainting",
+  "generation.toast.failed_load": "Échec du chargement de l\'image",
+  "generation.toast.failed_drop": "Échec de la lecture de l\'image déposée",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Développer le panneau gauche",
+  "generation.panel.collapse_left": "Réduire le panneau gauche",
+  "generation.panel.expand_right": "Développer le panneau droit",
+  "generation.panel.collapse_right": "Réduire le panneau droit",
+  "generation.panel.expand_bottom": "Développer le panneau inférieur",
+  "generation.panel.collapse_bottom": "Réduire le panneau inférieur",
 
   // Modal d'interrogation
   "generation.interrogate.title": "Interroger l'image",
@@ -895,6 +923,16 @@ const fr: Record<string, string> = {
   "generation.controlnet.uploading": "Téléversement...",
   "generation.controlnet.start_percent_tip": "Quand ControlNet commence à influencer la génération (0% = dès le début). Retarder le début ajoute plus de variation.",
   "generation.controlnet.end_percent_tip": "Quand ControlNet arrête d'influencer la génération (100% = jusqu'à la fin). Terminer tôt permet au modèle d'affiner les détails librement.",
+  "generation.controlnet.download_failed": "Échec du téléchargement : {error}",
+  "generation.controlnet.install_starting": "Démarrage de l\'installation...",
+  "generation.controlnet.install_stopping": "Arrêt de ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Démarrage de ComfyUI avec les nouveaux nœuds...",
+  "generation.controlnet.install_waiting_ready": "En attente de la disponibilité de ComfyUI...",
+  "generation.controlnet.install_timeout": "ComfyUI n\'est pas prêt après 120 secondes",
+  "generation.controlnet.install_start_failed": "Échec du démarrage de ComfyUI",
+  "generation.controlnet.install_verifying": "Vérification des nœuds de préprocesseur...",
+  "generation.controlnet.install_failed": "Échec de l\'installation : {error}",
+  "generation.controlnet.control_image_alt": "Image de contrôle",
   "generation.controlnet.preset_canny": "Contours Canny",
   "generation.controlnet.preset_canny_desc": "Détecte les contours — idéal pour préserver la structure et la composition",
   "generation.controlnet.preset_depth": "Carte de profondeur",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -30,6 +30,11 @@ const it: Record<string, string> = {
   "common.close": "Chiudi",
   "common.or": "o",
   "common.on": "Attivo",
+  "common.off": "DISATTIVATO",
+  "common.collapse": "Comprimi {section}",
+  "common.expand": "Espandi {section}",
+  "common.drop_to_import": "Rilascia per importare {section}",
+  "common.no_clipboard_image": "Nessuna immagine trovata negli appunti",
   "common.detected": "Rilevato",
   "common.click_to_type": "Clicca per digitare un valore",
 
@@ -277,6 +282,7 @@ const it: Record<string, string> = {
   "generation.dimensions.swap": "Scambia L/A",
   "generation.dimensions.result": "Risultato",
   "generation.swap_panels": "Scambia pannelli sinistra/destra",
+  "generation.settings.title": "Impostazioni di generazione",
 
   "generation.sampler.title": "Sampler",
   "generation.sampler.label": "Sampler",
@@ -457,6 +463,28 @@ const it: Record<string, string> = {
   "generation.error_no_image": "L'inpainting richiede un'immagine di input. Caricane una o usa un'immagine preparata.",
   "generation.error_no_mask": "L'inpainting richiede una maschera. Disegna una maschera nel Canvas Editor o caricane una.",
   "generation.downloading_facefix": "Download modello correzione visi...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Ottieni tag immagine",
+  "generation.ctx.upscale": "Ingrandisci",
+  "generation.ctx.inpaint": "Inpainting",
+  "generation.ctx.save_as": "Salva con nome",
+  "generation.ctx.copy": "Copia",
+  "generation.ctx.delete": "Elimina",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Immagine caricata per l\'ingrandimento",
+  "generation.toast.loaded_inpaint": "Immagine caricata per l\'inpainting",
+  "generation.toast.failed_load": "Impossibile caricare l\'immagine",
+  "generation.toast.failed_drop": "Impossibile leggere l\'immagine rilasciata",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Espandi pannello sinistro",
+  "generation.panel.collapse_left": "Comprimi pannello sinistro",
+  "generation.panel.expand_right": "Espandi pannello destro",
+  "generation.panel.collapse_right": "Comprimi pannello destro",
+  "generation.panel.expand_bottom": "Espandi pannello inferiore",
+  "generation.panel.collapse_bottom": "Comprimi pannello inferiore",
 
   "generation.interrogate.title": "Analizza immagine",
   "generation.interrogate.tip": "Analizza un'immagine per estrarre tag (personaggio, artista, generali). Trascina un'immagine, sfoglia i file o incolla dagli appunti. I tag possono essere applicati direttamente al prompt.",
@@ -868,6 +896,16 @@ const it: Record<string, string> = {
   "generation.controlnet.uploading": "Caricamento...",
   "generation.controlnet.start_percent_tip": "Quando ControlNet inizia a influenzare la generazione (0% = dall'inizio). Ritardare l'inizio aggiunge più variazione.",
   "generation.controlnet.end_percent_tip": "Quando ControlNet smette di influenzare la generazione (100% = fino alla fine). Terminare prima permette al modello di affinare i dettagli liberamente.",
+  "generation.controlnet.download_failed": "Download fallito: {error}",
+  "generation.controlnet.install_starting": "Avvio installazione...",
+  "generation.controlnet.install_stopping": "Arresto di ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Avvio di ComfyUI con nuovi nodi...",
+  "generation.controlnet.install_waiting_ready": "In attesa che ComfyUI sia pronto...",
+  "generation.controlnet.install_timeout": "ComfyUI non è stato pronto entro 120 secondi",
+  "generation.controlnet.install_start_failed": "Avvio di ComfyUI fallito",
+  "generation.controlnet.install_verifying": "Verifica dei nodi preprocessore...",
+  "generation.controlnet.install_failed": "Installazione fallita: {error}",
+  "generation.controlnet.control_image_alt": "Immagine di controllo",
   "generation.controlnet.preset_canny": "Bordi Canny",
   "generation.controlnet.preset_canny_desc": "Rileva i bordi — ideale per preservare struttura e composizione",
   "generation.controlnet.preset_depth": "Mappa di profondità",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -30,6 +30,11 @@ const ja: Record<string, string> = {
   "common.close": "閉じる",
   "common.or": "または",
   "common.on": "オン",
+  "common.off": "オフ",
+  "common.collapse": "{section}を折りたたむ",
+  "common.expand": "{section}を展開",
+  "common.drop_to_import": "ドロップして{section}をインポート",
+  "common.no_clipboard_image": "クリップボードに画像が見つかりません",
   "common.detected": "検出済み",
   "common.click_to_type": "クリックして値を入力",
 
@@ -289,6 +294,7 @@ const ja: Record<string, string> = {
   "generation.dimensions.swap": "幅と高さを入れ替え",
   "generation.dimensions.result": "結果",
   "generation.swap_panels": "左右パネルを入れ替える",
+  "generation.settings.title": "生成設定",
 
   // サンプラー
   "generation.sampler.title": "サンプラー",
@@ -478,6 +484,28 @@ const ja: Record<string, string> = {
   "generation.error_no_image": "インペインティングには入力画像が必要です。アップロードするかステージング画像を使用してください。",
   "generation.error_no_mask": "インペインティングにはマスクが必要です。キャンバスエディターでマスクを描くかアップロードしてください。",
   "generation.downloading_facefix": "顔修正モデルをダウンロード中...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "画像タグを取得",
+  "generation.ctx.upscale": "アップスケール",
+  "generation.ctx.inpaint": "インペイント",
+  "generation.ctx.save_as": "名前を付けて保存",
+  "generation.ctx.copy": "コピー",
+  "generation.ctx.delete": "削除",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "アップスケール用に画像を読み込みました",
+  "generation.toast.loaded_inpaint": "インペイント用に画像を読み込みました",
+  "generation.toast.failed_load": "画像の読み込みに失敗しました",
+  "generation.toast.failed_drop": "ドロップした画像の読み取りに失敗しました",
+
+  // Panel collapse
+  "generation.panel.expand_left": "左パネルを展開",
+  "generation.panel.collapse_left": "左パネルを折りたたむ",
+  "generation.panel.expand_right": "右パネルを展開",
+  "generation.panel.collapse_right": "右パネルを折りたたむ",
+  "generation.panel.expand_bottom": "下パネルを展開",
+  "generation.panel.collapse_bottom": "下パネルを折りたたむ",
 
   // 画像解析モーダル
   "generation.interrogate.title": "画像を解析",
@@ -893,6 +921,16 @@ const ja: Record<string, string> = {
   "generation.controlnet.uploading": "アップロード中...",
   "generation.controlnet.start_percent_tip": "ControlNetが生成に影響を与え始めるタイミング（0% = 最初から）。開始を遅らせるとバリエーションが増えます。",
   "generation.controlnet.end_percent_tip": "ControlNetが生成への影響を停止するタイミング（100% = 最後まで）。早く終了するとモデルが自由にディテールを調整できます。",
+  "generation.controlnet.download_failed": "ダウンロード失敗: {error}",
+  "generation.controlnet.install_starting": "インストールを開始中...",
+  "generation.controlnet.install_stopping": "ComfyUIを停止中...",
+  "generation.controlnet.install_starting_nodes": "新しいノードでComfyUIを起動中...",
+  "generation.controlnet.install_waiting_ready": "ComfyUIの準備を待機中...",
+  "generation.controlnet.install_timeout": "ComfyUIが120秒以内に準備できませんでした",
+  "generation.controlnet.install_start_failed": "ComfyUIの起動に失敗しました",
+  "generation.controlnet.install_verifying": "プリプロセッサノードを検証中...",
+  "generation.controlnet.install_failed": "インストール失敗: {error}",
+  "generation.controlnet.control_image_alt": "制御画像",
   "generation.controlnet.preset_canny": "Cannyエッジ",
   "generation.controlnet.preset_canny_desc": "エッジを検出 — 構造と構図の保持に最適",
   "generation.controlnet.preset_depth": "深度マップ",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -30,6 +30,11 @@ const ko: Record<string, string> = {
   "common.close": "닫기",
   "common.or": "또는",
   "common.on": "켜짐",
+  "common.off": "꺼짐",
+  "common.collapse": "{section} 접기",
+  "common.expand": "{section} 펼치기",
+  "common.drop_to_import": "{section} 가져오려면 놓기",
+  "common.no_clipboard_image": "클립보드에서 이미지를 찾을 수 없습니다",
   "common.detected": "감지됨",
   "common.click_to_type": "클릭하여 값 입력",
 
@@ -277,6 +282,7 @@ const ko: Record<string, string> = {
   "generation.dimensions.swap": "가로/세로 전환",
   "generation.dimensions.result": "결과",
   "generation.swap_panels": "왼쪽/오른쪽 패널 전환",
+  "generation.settings.title": "생성 설정",
 
   "generation.sampler.title": "샘플러",
   "generation.sampler.label": "샘플러",
@@ -457,6 +463,28 @@ const ko: Record<string, string> = {
   "generation.error_no_image": "인페인팅에는 입력 이미지가 필요합니다. 업로드하거나 스테이지 이미지를 사용하세요.",
   "generation.error_no_mask": "인페인팅에는 마스크가 필요합니다. 캔버스 에디터에서 마스크를 그리거나 업로드하세요.",
   "generation.downloading_facefix": "얼굴 보정 모델 다운로드 중...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "이미지 태그 가져오기",
+  "generation.ctx.upscale": "업스케일",
+  "generation.ctx.inpaint": "인페인트",
+  "generation.ctx.save_as": "다른 이름으로 저장",
+  "generation.ctx.copy": "복사",
+  "generation.ctx.delete": "삭제",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "업스케일용 이미지 로드됨",
+  "generation.toast.loaded_inpaint": "인페인트용 이미지 로드됨",
+  "generation.toast.failed_load": "이미지 로드 실패",
+  "generation.toast.failed_drop": "드롭된 이미지 읽기 실패",
+
+  // Panel collapse
+  "generation.panel.expand_left": "왼쪽 패널 펼치기",
+  "generation.panel.collapse_left": "왼쪽 패널 접기",
+  "generation.panel.expand_right": "오른쪽 패널 펼치기",
+  "generation.panel.collapse_right": "오른쪽 패널 접기",
+  "generation.panel.expand_bottom": "하단 패널 펼치기",
+  "generation.panel.collapse_bottom": "하단 패널 접기",
 
   "generation.interrogate.title": "이미지 분석",
   "generation.interrogate.tip": "이미지를 분석하여 태그(캐릭터, 아티스트, 일반)를 추출합니다. 이미지를 드롭하거나 파일을 찾거나 클립보드에서 붙여넣기하세요. 태그를 프롬프트에 직접 적용할 수 있습니다.",
@@ -868,6 +896,16 @@ const ko: Record<string, string> = {
   "generation.controlnet.uploading": "업로드 중...",
   "generation.controlnet.start_percent_tip": "ControlNet이 생성에 영향을 미치기 시작하는 시점 (0% = 처음부터). 시작을 늦추면 변화가 더 많아집니다.",
   "generation.controlnet.end_percent_tip": "ControlNet이 생성에 영향을 중단하는 시점 (100% = 끝까지). 일찍 종료하면 모델이 자유롭게 디테일을 조정합니다.",
+  "generation.controlnet.download_failed": "다운로드 실패: {error}",
+  "generation.controlnet.install_starting": "설치 시작 중...",
+  "generation.controlnet.install_stopping": "ComfyUI 중지 중...",
+  "generation.controlnet.install_starting_nodes": "새 노드로 ComfyUI 시작 중...",
+  "generation.controlnet.install_waiting_ready": "ComfyUI 준비 대기 중...",
+  "generation.controlnet.install_timeout": "ComfyUI가 120초 내에 준비되지 않았습니다",
+  "generation.controlnet.install_start_failed": "ComfyUI 시작 실패",
+  "generation.controlnet.install_verifying": "전처리기 노드 확인 중...",
+  "generation.controlnet.install_failed": "설치 실패: {error}",
+  "generation.controlnet.control_image_alt": "제어 이미지",
   "generation.controlnet.preset_canny": "Canny 엣지",
   "generation.controlnet.preset_canny_desc": "엣지 감지 — 구조와 구도 보존에 최적",
   "generation.controlnet.preset_depth": "깊이 맵",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -30,6 +30,11 @@ const pt: Record<string, string> = {
   "common.close": "Fechar",
   "common.or": "ou",
   "common.on": "Ligado",
+  "common.off": "DESLIGADO",
+  "common.collapse": "Recolher {section}",
+  "common.expand": "Expandir {section}",
+  "common.drop_to_import": "Soltar para importar {section}",
+  "common.no_clipboard_image": "Nenhuma imagem encontrada na área de transferência",
   "common.detected": "Detectado",
   "common.click_to_type": "Clique para digitar um valor",
 
@@ -277,6 +282,7 @@ const pt: Record<string, string> = {
   "generation.dimensions.swap": "Trocar L/A",
   "generation.dimensions.result": "Resultado",
   "generation.swap_panels": "Trocar painéis esquerdo/direito",
+  "generation.settings.title": "Configurações de geração",
 
   "generation.sampler.title": "Sampler",
   "generation.sampler.label": "Sampler",
@@ -457,6 +463,28 @@ const pt: Record<string, string> = {
   "generation.error_no_image": "Inpainting precisa de uma imagem de entrada. Envie uma ou use uma imagem preparada.",
   "generation.error_no_mask": "Inpainting precisa de uma máscara. Pinte uma no Editor de Canvas ou envie uma.",
   "generation.downloading_facefix": "Baixando modelo de correção facial...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Obter tags da imagem",
+  "generation.ctx.upscale": "Ampliar",
+  "generation.ctx.inpaint": "Inpainting",
+  "generation.ctx.save_as": "Salvar como",
+  "generation.ctx.copy": "Copiar",
+  "generation.ctx.delete": "Excluir",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Imagem carregada para ampliação",
+  "generation.toast.loaded_inpaint": "Imagem carregada para inpainting",
+  "generation.toast.failed_load": "Falha ao carregar imagem",
+  "generation.toast.failed_drop": "Falha ao ler imagem solta",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Expandir painel esquerdo",
+  "generation.panel.collapse_left": "Recolher painel esquerdo",
+  "generation.panel.expand_right": "Expandir painel direito",
+  "generation.panel.collapse_right": "Recolher painel direito",
+  "generation.panel.expand_bottom": "Expandir painel inferior",
+  "generation.panel.collapse_bottom": "Recolher painel inferior",
 
   "generation.interrogate.title": "Interrogar Imagem",
   "generation.interrogate.tip": "Analisa uma imagem para extrair tags (personagem, artista, geral). Solte uma imagem, procure nos seus arquivos ou cole da área de transferência. Tags podem ser aplicadas diretamente ao seu prompt.",
@@ -870,6 +898,16 @@ const pt: Record<string, string> = {
   "generation.controlnet.uploading": "Enviando...",
   "generation.controlnet.start_percent_tip": "Quando o ControlNet começa a influenciar a geração (0% = desde o início). Atrasar o início adiciona mais variação.",
   "generation.controlnet.end_percent_tip": "Quando o ControlNet para de influenciar a geração (100% = até o final). Terminar cedo permite que o modelo refine detalhes livremente.",
+  "generation.controlnet.download_failed": "Falha no download: {error}",
+  "generation.controlnet.install_starting": "Iniciando instalação...",
+  "generation.controlnet.install_stopping": "Parando ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Iniciando ComfyUI com novos nós...",
+  "generation.controlnet.install_waiting_ready": "Aguardando ComfyUI ficar pronto...",
+  "generation.controlnet.install_timeout": "ComfyUI não ficou pronto em 120 segundos",
+  "generation.controlnet.install_start_failed": "ComfyUI falhou ao iniciar",
+  "generation.controlnet.install_verifying": "Verificando nós do pré-processador...",
+  "generation.controlnet.install_failed": "Falha na instalação: {error}",
+  "generation.controlnet.control_image_alt": "Imagem de controle",
   "generation.controlnet.preset_canny": "Bordas Canny",
   "generation.controlnet.preset_canny_desc": "Detecta bordas — ideal para preservar estrutura e composição",
   "generation.controlnet.preset_depth": "Mapa de profundidade",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -30,6 +30,11 @@ const ru: Record<string, string> = {
   "common.close": "Закрыть",
   "common.or": "или",
   "common.on": "Вкл",
+  "common.off": "Выкл",
+  "common.collapse": "Свернуть {section}",
+  "common.expand": "Развернуть {section}",
+  "common.drop_to_import": "Перетащите для импорта {section}",
+  "common.no_clipboard_image": "Изображение не найдено в буфере обмена",
   "common.detected": "Обнаружено",
   "common.click_to_type": "Нажмите, чтобы ввести значение",
 
@@ -277,6 +282,7 @@ const ru: Record<string, string> = {
   "generation.dimensions.swap": "Поменять Ш/В",
   "generation.dimensions.result": "Результат",
   "generation.swap_panels": "Поменять левую/правую панели",
+  "generation.settings.title": "Настройки генерации",
 
   "generation.sampler.title": "Сэмплер",
   "generation.sampler.label": "Сэмплер",
@@ -457,6 +463,28 @@ const ru: Record<string, string> = {
   "generation.error_no_image": "Для инпейнтинга нужно входное изображение. Загрузите или используйте подготовленное.",
   "generation.error_no_mask": "Для инпейнтинга нужна маска. Нарисуйте маску в Холст-редакторе или загрузите.",
   "generation.downloading_facefix": "Скачивание модели коррекции лиц...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "Получить теги изображения",
+  "generation.ctx.upscale": "Увеличить",
+  "generation.ctx.inpaint": "Инпейнт",
+  "generation.ctx.save_as": "Сохранить как",
+  "generation.ctx.copy": "Копировать",
+  "generation.ctx.delete": "Удалить",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "Изображение загружено для увеличения",
+  "generation.toast.loaded_inpaint": "Изображение загружено для инпейнта",
+  "generation.toast.failed_load": "Не удалось загрузить изображение",
+  "generation.toast.failed_drop": "Не удалось прочитать перетащенное изображение",
+
+  // Panel collapse
+  "generation.panel.expand_left": "Развернуть левую панель",
+  "generation.panel.collapse_left": "Свернуть левую панель",
+  "generation.panel.expand_right": "Развернуть правую панель",
+  "generation.panel.collapse_right": "Свернуть правую панель",
+  "generation.panel.expand_bottom": "Развернуть нижнюю панель",
+  "generation.panel.collapse_bottom": "Свернуть нижнюю панель",
 
   "generation.interrogate.title": "Анализ изображения",
   "generation.interrogate.tip": "Анализирует изображение для извлечения тегов (персонаж, художник, общие). Перетащите изображение, выберите файл или вставьте из буфера обмена. Теги можно применить непосредственно к промпту.",
@@ -868,6 +896,16 @@ const ru: Record<string, string> = {
   "generation.controlnet.uploading": "Загрузка...",
   "generation.controlnet.start_percent_tip": "Когда ControlNet начинает влиять на генерацию (0% = с самого начала). Задержка начала добавляет больше вариаций.",
   "generation.controlnet.end_percent_tip": "Когда ControlNet прекращает влиять на генерацию (100% = до самого конца). Раннее завершение позволяет модели свободно дорабатывать детали.",
+  "generation.controlnet.download_failed": "Ошибка загрузки: {error}",
+  "generation.controlnet.install_starting": "Начало установки...",
+  "generation.controlnet.install_stopping": "Остановка ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "Запуск ComfyUI с новыми узлами...",
+  "generation.controlnet.install_waiting_ready": "Ожидание готовности ComfyUI...",
+  "generation.controlnet.install_timeout": "ComfyUI не стал доступен в течение 120 секунд",
+  "generation.controlnet.install_start_failed": "Не удалось запустить ComfyUI",
+  "generation.controlnet.install_verifying": "Проверка узлов препроцессора...",
+  "generation.controlnet.install_failed": "Ошибка установки: {error}",
+  "generation.controlnet.control_image_alt": "Контрольное изображение",
   "generation.controlnet.preset_canny": "Canny края",
   "generation.controlnet.preset_canny_desc": "Обнаруживает края — лучше всего для сохранения структуры и композиции",
   "generation.controlnet.preset_depth": "Карта глубины",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -30,6 +30,11 @@ const zhTw: Record<string, string> = {
   "common.close": "關閉",
   "common.or": "或",
   "common.on": "開啟",
+  "common.off": "關閉",
+  "common.collapse": "摺疊{section}",
+  "common.expand": "展開{section}",
+  "common.drop_to_import": "拖放以匯入{section}",
+  "common.no_clipboard_image": "剪貼簿中未找到圖片",
   "common.detected": "已偵測",
   "common.click_to_type": "點擊輸入值",
 
@@ -277,6 +282,7 @@ const zhTw: Record<string, string> = {
   "generation.dimensions.swap": "交換寬高",
   "generation.dimensions.result": "結果",
   "generation.swap_panels": "切換左右面板",
+  "generation.settings.title": "生成設定",
 
   "generation.sampler.title": "取樣器",
   "generation.sampler.label": "取樣器",
@@ -457,6 +463,28 @@ const zhTw: Record<string, string> = {
   "generation.error_no_image": "局部重繪需要輸入影像。請上傳或使用暫存影像。",
   "generation.error_no_mask": "局部重繪需要遮罩。請在畫布編輯器中繪製或上傳遮罩。",
   "generation.downloading_facefix": "正在下載臉部修復模型...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "取得圖片標籤",
+  "generation.ctx.upscale": "放大",
+  "generation.ctx.inpaint": "修復",
+  "generation.ctx.save_as": "另存為",
+  "generation.ctx.copy": "複製",
+  "generation.ctx.delete": "刪除",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "已載入圖片用於放大",
+  "generation.toast.loaded_inpaint": "已載入圖片用於修復",
+  "generation.toast.failed_load": "載入圖片失敗",
+  "generation.toast.failed_drop": "讀取拖放的圖片失敗",
+
+  // Panel collapse
+  "generation.panel.expand_left": "展開左側面板",
+  "generation.panel.collapse_left": "摺疊左側面板",
+  "generation.panel.expand_right": "展開右側面板",
+  "generation.panel.collapse_right": "摺疊右側面板",
+  "generation.panel.expand_bottom": "展開底部面板",
+  "generation.panel.collapse_bottom": "摺疊底部面板",
 
   "generation.interrogate.title": "影像分析",
   "generation.interrogate.tip": "分析影像以擷取標籤（角色、藝術家、通用）。拖放影像、瀏覽檔案或從剪貼簿貼上。標籤可直接套用到提示詞。",
@@ -868,6 +896,16 @@ const zhTw: Record<string, string> = {
   "generation.controlnet.uploading": "上傳中...",
   "generation.controlnet.start_percent_tip": "ControlNet 開始影響生成的時機（0% = 從一開始）。延遲開始可以增加更多變化。",
   "generation.controlnet.end_percent_tip": "ControlNet 停止影響生成的時機（100% = 直到最後）。提前結束讓模型自由地細化細節。",
+  "generation.controlnet.download_failed": "下載失敗：{error}",
+  "generation.controlnet.install_starting": "正在開始安裝...",
+  "generation.controlnet.install_stopping": "正在停止 ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "正在使用新節點啟動 ComfyUI...",
+  "generation.controlnet.install_waiting_ready": "等待 ComfyUI 就緒...",
+  "generation.controlnet.install_timeout": "ComfyUI 未在 120 秒內就緒",
+  "generation.controlnet.install_start_failed": "ComfyUI 啟動失敗",
+  "generation.controlnet.install_verifying": "正在驗證預處理器節點...",
+  "generation.controlnet.install_failed": "安裝失敗：{error}",
+  "generation.controlnet.control_image_alt": "控制圖像",
   "generation.controlnet.preset_canny": "Canny 邊緣",
   "generation.controlnet.preset_canny_desc": "偵測邊緣 — 最適合保留結構和構圖",
   "generation.controlnet.preset_depth": "深度圖",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -30,6 +30,11 @@ const zh: Record<string, string> = {
   "common.close": "关闭",
   "common.or": "或",
   "common.on": "开启",
+  "common.off": "关闭",
+  "common.collapse": "折叠{section}",
+  "common.expand": "展开{section}",
+  "common.drop_to_import": "拖放以导入{section}",
+  "common.no_clipboard_image": "剪贴板中未找到图片",
   "common.detected": "检测到",
   "common.click_to_type": "点击输入值",
 
@@ -277,6 +282,7 @@ const zh: Record<string, string> = {
   "generation.dimensions.swap": "交换宽高",
   "generation.dimensions.result": "结果",
   "generation.swap_panels": "切换左右面板",
+  "generation.settings.title": "生成设置",
 
   "generation.sampler.title": "采样器",
   "generation.sampler.label": "采样器",
@@ -457,6 +463,28 @@ const zh: Record<string, string> = {
   "generation.error_no_image": "局部重绘需要输入图像。请上传或使用暂存图像。",
   "generation.error_no_mask": "局部重绘需要蒙版。请在画布编辑器中绘制或上传蒙版。",
   "generation.downloading_facefix": "正在下载面部修复模型...",
+
+  // Session context menu
+  "generation.ctx.get_tags": "获取图片标签",
+  "generation.ctx.upscale": "放大",
+  "generation.ctx.inpaint": "修复",
+  "generation.ctx.save_as": "另存为",
+  "generation.ctx.copy": "复制",
+  "generation.ctx.delete": "删除",
+
+  // Session toast messages
+  "generation.toast.loaded_upscale": "已加载图片用于放大",
+  "generation.toast.loaded_inpaint": "已加载图片用于修复",
+  "generation.toast.failed_load": "加载图片失败",
+  "generation.toast.failed_drop": "读取拖放的图片失败",
+
+  // Panel collapse
+  "generation.panel.expand_left": "展开左侧面板",
+  "generation.panel.collapse_left": "折叠左侧面板",
+  "generation.panel.expand_right": "展开右侧面板",
+  "generation.panel.collapse_right": "折叠右侧面板",
+  "generation.panel.expand_bottom": "展开底部面板",
+  "generation.panel.collapse_bottom": "折叠底部面板",
 
   "generation.interrogate.title": "图像分析",
   "generation.interrogate.tip": "分析图像以提取标签（角色、艺术家、通用）。拖放图像、浏览文件或从剪贴板粘贴。标签可直接应用到提示词。",
@@ -868,6 +896,16 @@ const zh: Record<string, string> = {
   "generation.controlnet.uploading": "上传中...",
   "generation.controlnet.start_percent_tip": "ControlNet 开始影响生成的时机（0% = 从一开始）。延迟开始可以增加更多变化。",
   "generation.controlnet.end_percent_tip": "ControlNet 停止影响生成的时机（100% = 直到最后）。提前结束让模型自由地细化细节。",
+  "generation.controlnet.download_failed": "下载失败：{error}",
+  "generation.controlnet.install_starting": "正在开始安装...",
+  "generation.controlnet.install_stopping": "正在停止 ComfyUI...",
+  "generation.controlnet.install_starting_nodes": "正在使用新节点启动 ComfyUI...",
+  "generation.controlnet.install_waiting_ready": "等待 ComfyUI 就绪...",
+  "generation.controlnet.install_timeout": "ComfyUI 未在 120 秒内就绪",
+  "generation.controlnet.install_start_failed": "ComfyUI 启动失败",
+  "generation.controlnet.install_verifying": "正在验证预处理器节点...",
+  "generation.controlnet.install_failed": "安装失败：{error}",
+  "generation.controlnet.control_image_alt": "控制图像",
   "generation.controlnet.preset_canny": "Canny 边缘",
   "generation.controlnet.preset_canny_desc": "检测边缘 — 最适合保留结构和构图",
   "generation.controlnet.preset_depth": "深度图",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -515,21 +515,17 @@ class GalleryStore {
             // Server-side clipboard unavailable — fall through to browser API
           }
         }
-        // Step 2: Try browser Clipboard API with gallery URL or fullImageUrl.
+        // Step 2: Try browser Clipboard API, with server-side fallback for insecure (HTTP) contexts.
         const fetchUrl = image.fullImageUrl || image.url;
-        if (fetchUrl && navigator.clipboard?.write) {
-          try {
-            const resp = await fetch(fetchUrl);
-            const blob = await resp.blob();
-            const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
-            await navigator.clipboard.write([new ClipboardItem({ [pngBlob.type]: pngBlob })]);
-            this.showToast(locale.t("gallery.toast.copied"), "success");
-            return;
-          } catch {
-            // Clipboard API blocked (insecure context) — fall through
-          }
+        if (fetchUrl) {
+          const resp = await fetch(fetchUrl);
+          const blob = await resp.blob();
+          const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
+          await this.writeBlobToClipboard(pngBlob);
+          this.showToast(locale.t("gallery.toast.copied"), "success");
+          return;
         }
-        // Step 3: Image not saved yet.
+        // Step 3: Image genuinely not available yet (no URL or gallery file).
         this.showToast(locale.t("gallery.toast.not_saved_yet"), "info");
         return;
       }

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,4 +1,5 @@
-import { ipcInvoke } from "./ipc.js";
+import { ipcInvoke, isBrowserMode } from "./ipc.js";
+import { locale } from "../stores/locale.svelte.js";
 import type {
   AppConfig,
   GalleryImageEntry,
@@ -537,6 +538,29 @@ export async function interrogateClipboard(): Promise<InterrogationResult> {
 
 export async function readClipboardImage(): Promise<number[]> {
   return ipcInvoke("read_clipboard_image");
+}
+
+/**
+ * Read an image from the clipboard, with browser-mode fallback.
+ * In Tauri: uses the native clipboard command.
+ * In browser mode: uses the Web Clipboard API (navigator.clipboard.read()).
+ * Returns raw image bytes as a number array.
+ */
+export async function readClipboardImageSafe(): Promise<number[]> {
+  if (!isBrowserMode) {
+    return readClipboardImage();
+  }
+  const items = await navigator.clipboard.read();
+  for (const item of items) {
+    for (const type of item.types) {
+      if (type.startsWith("image/")) {
+        const blob = await item.getType(type);
+        const buffer = await blob.arrayBuffer();
+        return Array.from(new Uint8Array(buffer));
+      }
+    }
+  }
+  throw new Error(locale.t('common.no_clipboard_image'));
 }
 
 export async function exportLogs(destination: string): Promise<void> {


### PR DESCRIPTION
## What's New in v0.7.7

### Full i18n Coverage
- 40+ hardcoded English strings localized across GenerationPage, ControlNetSettings, InterrogateSection, and api.ts
- Toast messages, context menu labels, panel titles, drop overlays, alt attributes, ON/OFF toggles, and ControlNet install status messages all routed through `locale.t()`
- Translations added for all 11 supported languages (en, de, es, fr, it, ja, ko, pt, ru, zh, zh-tw)

### Browser-Mode Clipboard Improvements
- Interrogate from clipboard now works in browser mode via Web Clipboard API
- New `readClipboardImageSafe` utility with automatic Tauri → browser fallback
- Simplified gallery clipboard flow using unified `writeBlobToClipboard` helper

### Bug Fixes
- Face fix model (YOLOv8n) SHA-256 hash corrected to match current upstream
- Docker: added `opencv-python-headless` for ControlNet preprocessor support