### PR TITLE
v0.7.8: Model Hub access control, upscaler migration, security hardening, native clipboard read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## What's New in v0.7.8
+
+### Model Hub Access Control
+- **Per-user Model Hub permission** — new `can_use_modelhub` field on account records lets admins toggle Model Hub access per user. Backend enforces gating on all model-hub commands; frontend hides the nav button when access is denied.
+- **Account actions modal** — admin and moderator account lists now surface action buttons (role change, delete, storage limit, Model Hub toggle) behind a cog-icon modal instead of inline buttons.
+
+### Upscaler Model Migration
+- **Safetensored upscaler models** — upscaler dropdown now recommends 7 models from the `AshtakaOOf/safetensored-upscalers` HuggingFace repo: SPAN 2×/4×, OmniSR 2×/3×/4×, and DAT 4×. Each entry includes a short description.
+- **Scale-factor regex updated** — `extractScaleFromModel` now handles prefix-style names (e.g., `2x_OmniSR`) in addition to suffix patterns.
+
+### Security Hardening
+- **Command ACL expansion** — `save_image_file` and `upload_image` added to `ADMIN_ONLY_COMMANDS`, preventing non-admin users from writing arbitrary files.
+- **Path traversal sanitization** — `save_to_gallery_in_dir` now strips directory separators, dots, and backslashes from `prompt_id` and extracts only the basename from filenames before joining paths.
+- **Mod privilege-escalation guard** — moderators can no longer set storage limits on admin accounts.
+- **Blob URL memory-leak fixes** — preview and lightbox blob URLs are now revoked when replaced or closed, preventing unbounded memory growth.
+- **Clipboard copy response check** — `copyBlobToClipboard` now verifies `resp.ok` before reading the blob.
+- **Prompt-schedule regex tightened** — weight patterns narrowed from `[\d.]+` to `\d+(?:\.\d+)?` to reject malformed values like `1.2.3`.
+- **Autocomplete `<fromto>` fix** — `getCurrentTagFragment` now detects `<fromto>` blocks and avoids splitting on commas inside them.
+
+### Clipboard Read for HTTP Contexts
+- **Native OS clipboard read** — when the browser Clipboard API is unavailable (HTTP, non-secure contexts), clipboard image reads fall back to server-side native tools (`wl-paste`/`xclip` on Linux, `osascript` on macOS, PowerShell on Windows).
+
+### Docker
+- **FaceDetailer libxcb fix** — added `libxcb1` to the Docker image so FaceDetailer's OpenCV dependency loads without missing-library errors.
+
+### Dependencies
+- Merged 7 Dependabot PRs — `@tauri-apps/plugin-updater` 2.10.1, `serde` 1.0.219, `serde_json` 1.0.140, `reqwest` 0.12.15, `tokio` 1.44.2, `uuid` 1.16.0, `tauri-plugin-updater` 2.7.0.
+
+---
+
 ## What's New in v0.7.7
 
 ### Full i18n Coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN touch src-tauri/src/lib.rs src-tauri/src/server_main.rs src-tauri/src/main.r
 FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
 
 ARG COMFYUI_VERSION=master
-ARG TORCH_VERSION=2.7.1
+ARG TORCH_VERSION=2.11.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     MOOSHIEUI_DATA_DIR=/data \
@@ -70,6 +70,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12 python3.12-venv python3-pip \
     git curl ca-certificates \
+    libxcb1 libglib2.0-0 libgl1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (fast Python package manager)
@@ -86,8 +87,8 @@ RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
     uv pip install torch==${TORCH_VERSION} torchvision torchaudio \
         --index-url https://download.pytorch.org/whl/cu126 && \
     uv pip install -r ${COMFYUI_PATH}/requirements.txt && \
-    uv pip install opencv-python-headless && \
-    uv pip install ultralytics==8.4.34
+    uv pip install ultralytics==8.4.34 && \
+    uv pip install --force-reinstall --no-deps opencv-python-headless
 
 # Copy custom nodes (auto-deployed by the binary on startup, but also
 # pre-copy them so they're available even if the binary doesn't run the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+## What's New in v0.7.8
+
+### Model Hub Access Control
+- **Per-user Model Hub permission** — new `can_use_modelhub` field on account records lets admins toggle Model Hub access per user. Backend enforces gating on all model-hub commands; frontend hides the nav button when access is denied.
+- **Account actions modal** — admin and moderator account lists now surface action buttons (role change, delete, storage limit, Model Hub toggle) behind a cog-icon modal instead of inline buttons.
+
+### Upscaler Model Migration
+- **Safetensored upscaler models** — upscaler dropdown now recommends 7 models from the `AshtakaOOf/safetensored-upscalers` HuggingFace repo: SPAN 2×/4×, OmniSR 2×/3×/4×, and DAT 4×. Each entry includes a short description.
+- **Scale-factor regex updated** — `extractScaleFromModel` now handles prefix-style names (e.g., `2x_OmniSR`) in addition to suffix patterns.
+
+### Security Hardening
+- **Command ACL expansion** — `save_image_file` and `upload_image` added to `ADMIN_ONLY_COMMANDS`, preventing non-admin users from writing arbitrary files.
+- **Path traversal sanitization** — `save_to_gallery_in_dir` now strips directory separators, dots, and backslashes from `prompt_id` and extracts only the basename from filenames before joining paths.
+- **Mod privilege-escalation guard** — moderators can no longer set storage limits on admin accounts.
+- **Blob URL memory-leak fixes** — preview and lightbox blob URLs are now revoked when replaced or closed, preventing unbounded memory growth.
+- **Clipboard copy response check** — `copyBlobToClipboard` now verifies `resp.ok` before reading the blob.
+- **Prompt-schedule regex tightened** — weight patterns narrowed from `[\d.]+` to `\d+(?:\.\d+)?` to reject malformed values like `1.2.3`.
+- **Autocomplete `<fromto>` fix** — `getCurrentTagFragment` now detects `<fromto>` blocks and avoids splitting on commas inside them.
+
+### Clipboard Read for HTTP Contexts
+- **Native OS clipboard read** — when the browser Clipboard API is unavailable (HTTP, non-secure contexts), clipboard image reads fall back to server-side native tools (`wl-paste`/`xclip` on Linux, `osascript` on macOS, PowerShell on Windows).
+
+### Docker
+- **FaceDetailer libxcb fix** — added `libxcb1` to the Docker image so FaceDetailer's OpenCV dependency loads without missing-library errors.
+
+### Dependencies
+- Merged 7 Dependabot PRs — `@tauri-apps/plugin-updater` 2.10.1, `serde` 1.0.219, `serde_json` 1.0.140, `reqwest` 0.12.15, `tokio` 1.44.2, `uuid` 1.16.0, `tauri-plugin-updater` 2.7.0.
+
+---
+
 ## What's New in v0.7.7
 
 ### Full i18n Coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - MOOSHIEUI_DATA_DIR=/data
       - MOOSHIEUI_ADMIN_USER=${MOOSHIEUI_ADMIN_USER:-admin}
-      - MOOSHIEUI_ADMIN_PASS=${MOOSHIEUI_ADMIN_PASS:?Set MOOSHIEUI_ADMIN_PASS in .env}
+      - MOOSHIEUI_ADMIN_PASS=${MOOSHIEUI_ADMIN_PASS:-changeme}
       - NVIDIA_VISIBLE_DEVICES=all
       - RUST_LOG=${RUST_LOG:-info}
     deploy:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,28 @@
 #!/bin/sh
 set -e
 
+# ── Admin password guard ──
+# Validate admin env vars and warn about the default password.
+if [ -n "$MOOSHIEUI_ADMIN_USER" ] || [ -n "$MOOSHIEUI_ADMIN_PASS" ]; then
+    if [ -z "$MOOSHIEUI_ADMIN_USER" ] || [ -z "$MOOSHIEUI_ADMIN_PASS" ]; then
+        echo "ERROR: Both MOOSHIEUI_ADMIN_USER and MOOSHIEUI_ADMIN_PASS must be set." >&2
+        exit 1
+    fi
+    if [ ${#MOOSHIEUI_ADMIN_PASS} -lt 4 ]; then
+        echo "ERROR: MOOSHIEUI_ADMIN_PASS is too short (minimum 4 characters)." >&2
+        exit 1
+    fi
+    if [ "$MOOSHIEUI_ADMIN_PASS" = "changeme" ]; then
+        echo "" >&2
+        echo "========================================================" >&2
+        echo "  WARNING: Using default admin password 'changeme'." >&2
+        echo "  Change MOOSHIEUI_ADMIN_PASS before exposing this" >&2
+        echo "  server to the network!" >&2
+        echo "========================================================" >&2
+        echo "" >&2
+    fi
+fi
+
 # Ensure the persistent models directory exists.
 mkdir -p /data/models
 

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,4 +1,7 @@
 # Admin credentials — required on first run (users cannot self-register).
+# Change the password before deploying to production!
+#
+# Alternatively, create the secret imperatively:
 #   kubectl -n mooshieui create secret generic mooshieui-admin \
 #     --from-literal=username=admin \
 #     --from-literal=password=YOUR_PASSWORD
@@ -11,7 +14,7 @@ type: Opaque
 data:
   # echo -n 'admin' | base64
   username: YWRtaW4=
-  # echo -n 'changeme' | base64  ← REPLACE THIS
+  # echo -n 'changeme' | base64  —  CHANGE THIS before deploying!
   password: Y2hhbmdlbWU=
 ---
 # Cloudflare Tunnel token (optional — remove if not using cloudflared sidecar).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -139,6 +139,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -528,8 +549,9 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
+ "argon2",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -3025,6 +3047,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.7"
+version = "0.7.8"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"
@@ -57,6 +57,7 @@ rand = "0.10"
 base64 = "0.22"
 dirs = "6"
 sha2 = "0.10"
+argon2 = { version = "0.5", features = ["std"] }
 tauri-plugin-clipboard-manager = { version = "2", optional = true }
 tauri-plugin-updater = { version = "2", optional = true }
 tauri-plugin-process = { version = "2", optional = true }

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -1,8 +1,13 @@
 //! Local account authentication for LAN mode.
 //!
-//! Stores accounts in `{app_data_dir}/auth.json` with bcrypt-hashed passwords.
+//! Stores accounts in `{app_data_dir}/auth.json` with Argon2id-hashed passwords.
 //! Sessions are tracked via random bearer tokens held in memory.
+//!
+//! Legacy SHA-256 hashes (64 hex chars) are accepted on login and
+//! transparently upgraded to Argon2id.
 
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -18,6 +23,9 @@ const DEFAULT_STORAGE_LIMIT: u64 = 1024 * 1024 * 1024;
 /// Default image expiry: 7 days in seconds.
 pub const DEFAULT_EXPIRY_SECS: u64 = 7 * 24 * 60 * 60;
 
+/// Session TTL: 7 days.
+const SESSION_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+
 fn default_storage_limit() -> u64 {
     DEFAULT_STORAGE_LIMIT
 }
@@ -26,8 +34,8 @@ fn default_storage_limit() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Account {
     pub username: String,
-    /// SHA-256 hash of the password (hex-encoded). Not bcrypt for simplicity
-    /// in MVP — upgrade to argon2 later.
+    /// Argon2id hash (PHC string). Legacy accounts may still hold a 64-char
+    /// hex SHA-256 hash — these are verified and upgraded on login.
     pub password_hash: String,
     /// When true the user must pick a new password on next login.
     #[serde(default)]
@@ -44,6 +52,10 @@ pub struct Account {
     /// Maximum gallery storage in bytes. Default 2 GB. Admins/mods can expand.
     #[serde(default = "default_storage_limit")]
     pub storage_limit_bytes: u64,
+    /// Whether this user can access the Model Hub (download models from CivitAI).
+    /// Admins and moderators always have access; this flag controls user-role accounts.
+    #[serde(default)]
+    pub can_use_modelhub: bool,
 }
 
 fn default_role() -> String {
@@ -56,12 +68,21 @@ pub struct AuthDatabase {
     pub accounts: Vec<Account>,
 }
 
+/// A persisted session entry with TTL metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEntry {
+    pub username: String,
+    /// ISO 8601 timestamp when the session was created.
+    pub created_at: String,
+}
+
 /// Auth state with persistent sessions.
 pub struct AuthState {
     db: RwLock<AuthDatabase>,
-    /// Active session tokens → username. Persisted to disk so tokens survive
-    /// server restarts (enables "remember me").
-    sessions: RwLock<HashMap<String, String>>,
+    /// Active session tokens → session entry. Persisted to disk so tokens
+    /// survive server restarts (enables "remember me"). Expired entries are
+    /// pruned on load and periodically on validation.
+    sessions: RwLock<HashMap<String, SessionEntry>>,
     /// Per-user last activity timestamp (username → Instant).
     last_activity: RwLock<HashMap<String, std::time::Instant>>,
 }
@@ -73,7 +94,14 @@ impl AuthState {
         // Prune sessions for accounts that no longer exist
         let valid_usernames: std::collections::HashSet<&str> =
             db.accounts.iter().map(|a| a.username.as_str()).collect();
-        sessions.retain(|_, u| valid_usernames.contains(u.as_str()));
+        sessions.retain(|_, entry| valid_usernames.contains(entry.username.as_str()));
+        // Prune expired sessions
+        let now = Utc::now();
+        sessions.retain(|_, entry| {
+            chrono::DateTime::parse_from_rfc3339(&entry.created_at)
+                .map(|t| (now - t.with_timezone(&Utc)).num_seconds() < SESSION_TTL_SECS)
+                .unwrap_or(false) // drop entries with unparseable timestamps
+        });
         Self {
             db: RwLock::new(db),
             sessions: RwLock::new(sessions),
@@ -111,6 +139,7 @@ impl AuthState {
             created_at: Utc::now().to_rfc3339(),
             last_online: None,
             storage_limit_bytes: DEFAULT_STORAGE_LIMIT,
+            can_use_modelhub: false,
         });
         save_auth_db(&db)?;
         Ok(())
@@ -126,31 +155,70 @@ impl AuthState {
             .find(|a| a.username == username)
             .ok_or("Invalid username or password")?;
 
-        if account.password_hash != hash_password(password) {
+        if !verify_password(password, &account.password_hash) {
             return Err("Invalid username or password".to_string());
         }
 
         let must_change = account.must_change_password;
+
+        // Transparently upgrade legacy SHA-256 hash to Argon2id
+        if is_legacy_sha256(&account.password_hash) {
+            drop(db); // release read lock
+            let mut db = self.db.write().unwrap();
+            if let Some(acc) = db.accounts.iter_mut().find(|a| a.username == username) {
+                acc.password_hash = hash_password(password);
+                let _ = save_auth_db(&db);
+            }
+        }
+
         let token = generate_token();
         {
             let mut sessions = self.sessions.write().unwrap();
-            sessions.insert(token.clone(), username.to_string());
-            let _ = save_sessions(&sessions);
+            sessions.insert(
+                token.clone(),
+                SessionEntry {
+                    username: username.to_string(),
+                    created_at: Utc::now().to_rfc3339(),
+                },
+            );
+            if let Err(e) = save_sessions(&sessions) {
+                log::error!("Failed to persist sessions after login: {}", e);
+            }
         }
         Ok((token, must_change))
     }
 
-    /// Validate a session token. Returns the username if valid.
+    /// Validate a session token. Returns the username if valid and not expired.
     pub fn validate_token(&self, token: &str) -> Option<String> {
         let sessions = self.sessions.read().unwrap();
-        sessions.get(token).cloned()
+        if let Some(entry) = sessions.get(token) {
+            // Check TTL
+            let now = Utc::now();
+            let expired = chrono::DateTime::parse_from_rfc3339(&entry.created_at)
+                .map(|t| (now - t.with_timezone(&Utc)).num_seconds() >= SESSION_TTL_SECS)
+                .unwrap_or(true);
+            if expired {
+                drop(sessions);
+                let mut sessions = self.sessions.write().unwrap();
+                sessions.remove(token);
+                if let Err(e) = save_sessions(&sessions) {
+                    log::error!("Failed to persist sessions after TTL prune: {}", e);
+                }
+                return None;
+            }
+            Some(entry.username.clone())
+        } else {
+            None
+        }
     }
 
     /// Invalidate a session token.
     pub fn logout(&self, token: &str) {
         let mut sessions = self.sessions.write().unwrap();
         sessions.remove(token);
-        let _ = save_sessions(&sessions);
+        if let Err(e) = save_sessions(&sessions) {
+            log::error!("Failed to persist sessions after logout: {}", e);
+        }
     }
 
     /// List all account usernames.
@@ -193,6 +261,28 @@ impl AuthState {
         Ok(())
     }
 
+    /// Get the modelhub access flag for a user account.
+    pub fn get_modelhub_access(&self, username: &str) -> Option<bool> {
+        let db = self.db.read().unwrap();
+        db.accounts
+            .iter()
+            .find(|a| a.username == username)
+            .map(|a| a.can_use_modelhub)
+    }
+
+    /// Set the modelhub access flag for a user account.
+    pub fn set_modelhub_access(&self, username: &str, allowed: bool) -> Result<(), String> {
+        let mut db = self.db.write().unwrap();
+        let account = db
+            .accounts
+            .iter_mut()
+            .find(|a| a.username == username)
+            .ok_or("Account not found")?;
+        account.can_use_modelhub = allowed;
+        save_auth_db(&db)?;
+        Ok(())
+    }
+
     /// Delete an account by username.
     pub fn delete_account(&self, username: &str) -> Result<(), String> {
         let mut db = self.db.write().unwrap();
@@ -204,8 +294,10 @@ impl AuthState {
         save_auth_db(&db)?;
         // Also remove any active sessions for this user
         let mut sessions = self.sessions.write().unwrap();
-        sessions.retain(|_, u| u != username);
-        let _ = save_sessions(&sessions);
+        sessions.retain(|_, entry| entry.username != username);
+        if let Err(e) = save_sessions(&sessions) {
+            log::error!("Failed to persist sessions after account deletion: {}", e);
+        }
         Ok(())
     }
 
@@ -250,7 +342,7 @@ impl AuthState {
             .find(|a| a.username == username)
             .ok_or("Account not found")?;
 
-        if account.password_hash != hash_password(current_password) {
+        if !verify_password(current_password, &account.password_hash) {
             return Err("Current password is incorrect".to_string());
         }
         account.password_hash = hash_password(new_password);
@@ -277,8 +369,10 @@ impl AuthState {
         save_auth_db(&db)?;
         // Revoke existing sessions for this user so they must re-login
         let mut sessions = self.sessions.write().unwrap();
-        sessions.retain(|_, u| u != username);
-        let _ = save_sessions(&sessions);
+        sessions.retain(|_, entry| entry.username != username);
+        if let Err(e) = save_sessions(&sessions) {
+            log::error!("Failed to persist sessions after password reset: {}", e);
+        }
         Ok(())
     }
 
@@ -312,12 +406,12 @@ impl AuthState {
         }
     }
 
-    /// List all users with their role, online/offline status, timestamps, and storage limit.
+    /// List all users with their role, online/offline status, timestamps, storage limit, and modelhub access.
     /// A user is "online" if their last activity was within `threshold`.
     pub fn list_users_status(
         &self,
         threshold: std::time::Duration,
-    ) -> Vec<(String, String, bool, String, Option<String>, u64)> {
+    ) -> Vec<(String, String, bool, String, Option<String>, u64, bool)> {
         let db = self.db.read().unwrap();
         let activity = self.last_activity.read().unwrap();
         db.accounts
@@ -333,16 +427,46 @@ impl AuthState {
                     a.created_at.clone(),
                     a.last_online.clone(),
                     a.storage_limit_bytes,
+                    a.can_use_modelhub,
                 )
             })
             .collect()
     }
 }
 
+/// Returns true if the stored hash is a legacy 64-character hex SHA-256 string.
+fn is_legacy_sha256(hash: &str) -> bool {
+    hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Hash a password with Argon2id (returns a PHC-format string including salt).
 fn hash_password(password: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(password.as_bytes());
-    format!("{:x}", hasher.finalize())
+    let salt = SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    let argon2 = Argon2::default();
+    argon2
+        .hash_password(password.as_bytes(), &salt)
+        .expect("Argon2 hashing should not fail")
+        .to_string()
+}
+
+/// Verify a password against a stored hash.
+/// Supports both Argon2id (PHC string) and legacy SHA-256 (64 hex chars).
+fn verify_password(password: &str, stored_hash: &str) -> bool {
+    if is_legacy_sha256(stored_hash) {
+        // Legacy path: plain SHA-256 comparison
+        let mut hasher = Sha256::new();
+        hasher.update(password.as_bytes());
+        let computed = format!("{:x}", hasher.finalize());
+        computed == stored_hash
+    } else {
+        // Argon2id verification
+        match PasswordHash::new(stored_hash) {
+            Ok(parsed) => Argon2::default()
+                .verify_password(password.as_bytes(), &parsed)
+                .is_ok(),
+            Err(_) => false,
+        }
+    }
 }
 
 fn generate_token() -> String {
@@ -381,16 +505,37 @@ fn sessions_db_path() -> Option<PathBuf> {
     config::app_data_dir().map(|d| d.join("sessions.json"))
 }
 
-fn load_sessions() -> Result<HashMap<String, String>, String> {
+fn load_sessions() -> Result<HashMap<String, SessionEntry>, String> {
     let path = sessions_db_path().ok_or("No app data dir")?;
     if !path.exists() {
         return Ok(HashMap::new());
     }
     let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
-    serde_json::from_str(&content).map_err(|e| e.to_string())
+    // Try new format first (token → SessionEntry)
+    if let Ok(entries) = serde_json::from_str::<HashMap<String, SessionEntry>>(&content) {
+        return Ok(entries);
+    }
+    // Fall back to legacy format (token → username string) — migrate on load
+    if let Ok(legacy) = serde_json::from_str::<HashMap<String, String>>(&content) {
+        let now = Utc::now().to_rfc3339();
+        let migrated: HashMap<String, SessionEntry> = legacy
+            .into_iter()
+            .map(|(token, username)| {
+                (
+                    token,
+                    SessionEntry {
+                        username,
+                        created_at: now.clone(),
+                    },
+                )
+            })
+            .collect();
+        return Ok(migrated);
+    }
+    Err("Failed to parse sessions.json".to_string())
 }
 
-fn save_sessions(sessions: &HashMap<String, String>) -> Result<(), String> {
+fn save_sessions(sessions: &HashMap<String, SessionEntry>) -> Result<(), String> {
     let path = sessions_db_path().ok_or("No app data dir")?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;

--- a/src-tauri/src/comfyui/mooshie_nodes.py
+++ b/src-tauri/src/comfyui/mooshie_nodes.py
@@ -288,7 +288,7 @@ class MooshieSaveImage:
                 # the browser gets an image with an alpha layer.
                 h, w, c = img_np.shape
                 rgba = np.full((h, w, 4), 255, dtype=np.uint8)
-                rgba[:, :, :3] = img_np
+                rgba[:, :, :3] = img_np[:, :, :3]
                 img = Image.fromarray(rgba, "RGBA")
                 buf = io.BytesIO()
                 img.save(buf, format="PNG")

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -781,6 +781,128 @@ pub fn native_clipboard_write_pub(image_bytes: &[u8], mime_type: &str) -> Result
     native_clipboard_write(image_bytes, mime_type)
 }
 
+/// Read image data from the native OS clipboard as PNG bytes.
+/// Uses wl-paste/xclip on Linux, pbpaste on macOS, PowerShell on Windows.
+pub fn native_clipboard_read_pub() -> Result<Vec<u8>, AppError> {
+    native_clipboard_read()
+}
+
+fn native_clipboard_read() -> Result<Vec<u8>, AppError> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::process::{Command, Stdio};
+
+        let on_wayland = std::env::var("WAYLAND_DISPLAY").is_ok()
+            || std::env::var("XDG_SESSION_TYPE")
+                .map(|v| v == "wayland")
+                .unwrap_or(false);
+
+        let try_read = |program: &str, args: &[&str]| -> Result<Vec<u8>, String> {
+            let output = Command::new(program)
+                .args(args)
+                .stdin(Stdio::null())
+                .stderr(Stdio::piped())
+                .output()
+                .map_err(|e| format!("{} spawn failed: {}", program, e))?;
+
+            if output.status.success() && !output.stdout.is_empty() {
+                Ok(output.stdout)
+            } else {
+                Err(format!("{} failed or returned no data", program))
+            }
+        };
+
+        let (primary, primary_args, fallback, fallback_args): (&str, Vec<&str>, &str, Vec<&str>) =
+            if on_wayland {
+                (
+                    "wl-paste",
+                    vec!["--type", "image/png"],
+                    "xclip",
+                    vec!["-selection", "clipboard", "-t", "image/png", "-o"],
+                )
+            } else {
+                (
+                    "xclip",
+                    vec!["-selection", "clipboard", "-t", "image/png", "-o"],
+                    "wl-paste",
+                    vec!["--type", "image/png"],
+                )
+            };
+
+        match try_read(primary, &primary_args) {
+            Ok(bytes) => return Ok(bytes),
+            Err(primary_err) => match try_read(fallback, &fallback_args) {
+                Ok(bytes) => return Ok(bytes),
+                Err(fallback_err) => {
+                    return Err(AppError::Other(format!(
+                        "No image in clipboard ({}: {} | {}: {})",
+                        primary, primary_err, fallback, fallback_err
+                    )));
+                }
+            },
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::{Command, Stdio};
+
+        // Use osascript to check if clipboard has an image and write it to temp
+        let tmp_path = std::env::temp_dir().join("mooshie_clipboard_read.png");
+        let script = format!(
+            "set imgData to the clipboard as «class PNGf»\nset f to open for access POSIX file \"{}\" with write permission\nwrite imgData to f\nclose access f",
+            tmp_path.display()
+        );
+        let status = Command::new("osascript")
+            .args(["-e", &script])
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped())
+            .status()
+            .map_err(|e| AppError::Other(format!("osascript failed: {}", e)))?;
+
+        if status.success() {
+            let bytes = std::fs::read(&tmp_path).map_err(|e| {
+                AppError::Other(format!("Failed to read temp clipboard file: {}", e))
+            })?;
+            let _ = std::fs::remove_file(&tmp_path);
+            if !bytes.is_empty() {
+                return Ok(bytes);
+            }
+        }
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(AppError::Other("No image in clipboard".into()));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::process::{Command, Stdio};
+
+        let tmp_path = std::env::temp_dir().join("mooshie_clipboard_read.png");
+        let script = format!(
+            "$img = Get-Clipboard -Format Image; if ($img) {{ $img.Save('{}', [System.Drawing.Imaging.ImageFormat]::Png) }} else {{ exit 1 }}",
+            tmp_path.display()
+        );
+        let status = Command::new("powershell")
+            .args(["-NoProfile", "-Command", &script])
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped())
+            .status()
+            .map_err(|e| AppError::Other(format!("PowerShell clipboard read failed: {}", e)))?;
+
+        if status.success() {
+            let bytes = std::fs::read(&tmp_path).map_err(|e| {
+                AppError::Other(format!("Failed to read temp clipboard file: {}", e))
+            })?;
+            let _ = std::fs::remove_file(&tmp_path);
+            if !bytes.is_empty() {
+                return Ok(bytes);
+            }
+        }
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(AppError::Other("No image in clipboard".into()));
+    }
+}
+
 /// Public wrapper for `infer_image_mime` — used by the web server.
 pub fn infer_image_mime_pub(bytes: &[u8], ext_hint: Option<&str>) -> &'static str {
     infer_image_mime(bytes, ext_hint)
@@ -887,8 +1009,11 @@ pub async fn install_custom_node(
     git_url: String,
     node_name: String,
 ) -> Result<(), AppError> {
-    let config = state.config.read().await;
-    let custom_nodes_dir = std::path::Path::new(&config.comfyui_path).join("custom_nodes");
+    let (comfyui_path, venv_path) = {
+        let config = state.config.read().await;
+        (config.comfyui_path.clone(), config.venv_path.clone())
+    };
+    let custom_nodes_dir = std::path::Path::new(&comfyui_path).join("custom_nodes");
     let target_dir = custom_nodes_dir.join(&node_name);
 
     let emit_progress = |step: &str, message: &str, done: bool| {
@@ -963,18 +1088,18 @@ pub async fn install_custom_node(
     if req_file.exists() {
         emit_progress("pip", "Installing Python dependencies...", false);
 
-        let uv_path = resolve_uv_bin(&config.venv_path);
+        let uv_path = resolve_uv_bin(&venv_path);
 
         let mut pip_child = if uv_path.exists() {
             tokio::process::Command::new(&uv_path)
                 .args(["pip", "install", "-r", &req_file.to_string_lossy()])
-                .env("VIRTUAL_ENV", &config.venv_path)
+                .env("VIRTUAL_ENV", &venv_path)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
                 .spawn()
                 .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
         } else {
-            let venv_base = std::path::Path::new(&config.venv_path);
+            let venv_base = std::path::Path::new(&venv_path);
             #[cfg(target_os = "windows")]
             let pip_path = venv_base.join("Scripts").join("pip.exe");
             #[cfg(not(target_os = "windows"))]
@@ -1048,20 +1173,23 @@ pub async fn install_pip_package(
     state: State<'_, Arc<AppState>>,
     package: String,
 ) -> Result<(), AppError> {
-    let config = state.config.read().await;
+    let venv_path = {
+        let config = state.config.read().await;
+        config.venv_path.clone()
+    };
 
-    let uv_path = resolve_uv_bin(&config.venv_path);
+    let uv_path = resolve_uv_bin(&venv_path);
 
     let output = if uv_path.exists() {
         tokio::process::Command::new(&uv_path)
             .args(["pip", "install", &package])
-            .env("VIRTUAL_ENV", &config.venv_path)
+            .env("VIRTUAL_ENV", &venv_path)
             .output()
             .await
             .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
     } else {
         // Fallback to venv pip
-        let venv_base = std::path::Path::new(&config.venv_path);
+        let venv_base = std::path::Path::new(&venv_path);
         #[cfg(target_os = "windows")]
         let pip_path = venv_base.join("Scripts").join("pip.exe");
         #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -24,16 +24,22 @@ async fn main() {
 
     // Seed admin account from env vars if provided and not already created.
     // Usage: MOOSHIEUI_ADMIN_USER=blob MOOSHIEUI_ADMIN_PASS=secret
-    if let (Ok(user), Ok(pass)) = (
-        std::env::var("MOOSHIEUI_ADMIN_USER"),
-        std::env::var("MOOSHIEUI_ADMIN_PASS"),
-    ) {
-        if !user.trim().is_empty() && pass.len() >= 4 {
+    let admin_user = std::env::var("MOOSHIEUI_ADMIN_USER").ok();
+    let admin_pass = std::env::var("MOOSHIEUI_ADMIN_PASS").ok();
+
+    match (&admin_user, &admin_pass) {
+        (Some(user), Some(pass)) if !user.trim().is_empty() && pass.len() >= 4 => {
+            if pass == "changeme" {
+                log::warn!("============================================================");
+                log::warn!("  Using default admin password 'changeme'.");
+                log::warn!("  Change MOOSHIEUI_ADMIN_PASS before exposing this server!");
+                log::warn!("============================================================");
+            }
             let auth = AuthState::new();
-            match auth.create_account(&user, &pass) {
+            match auth.create_account(user, pass) {
                 Ok(()) => {
                     // Promote to admin so they have full access remotely (account management, settings, etc.)
-                    let _ = auth.set_account_role(&user, "admin");
+                    let _ = auth.set_account_role(user, "admin");
                     log::info!("Created admin account '{}' from environment", user);
                 }
                 Err(e) if e.contains("already exists") => {
@@ -43,6 +49,25 @@ async fn main() {
                     log::error!("Failed to create admin account: {}", e);
                 }
             }
+        }
+        (Some(_), Some(pass)) if pass.len() < 4 => {
+            log::error!(
+                "MOOSHIEUI_ADMIN_PASS is set but too short ({} chars, minimum 4). \
+                 No admin account was created — you will be locked out!",
+                pass.len()
+            );
+            std::process::exit(1);
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            log::error!(
+                "Both MOOSHIEUI_ADMIN_USER and MOOSHIEUI_ADMIN_PASS must be set together. \
+                 No admin account was created — you will be locked out!"
+            );
+            std::process::exit(1);
+        }
+        _ => {
+            // Neither env var set — desktop mode or pre-existing accounts.
+            log::debug!("No admin env vars set, skipping admin seeding");
         }
     }
 

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -99,7 +99,13 @@ fn resolve_username(state: &WebState, headers: &HeaderMap, remote: &SocketAddr) 
         return None; // admin — uses root gallery
     }
     if let Some(token) = extract_token(headers) {
-        return state.auth.validate_token(&token);
+        if let Some(username) = state.auth.validate_token(&token) {
+            // Authenticated admin accounts use the shared gallery, same as localhost
+            if state.auth.get_account_role(&username).as_deref() == Some("admin") {
+                return None;
+            }
+            return Some(username);
+        }
     }
     None
 }
@@ -114,6 +120,8 @@ const ADMIN_ONLY_COMMANDS: &[&str] = &[
     "open_directory",
     "move_installation",
     "read_image_metadata_path",
+    "save_image_file",
+    "upload_image",
 ];
 
 /// Commands that moderators (and admins) can execute.
@@ -124,6 +132,21 @@ const MODERATOR_COMMANDS: &[&str] = &[
     "export_logs",
     "install_pip_package",
 ];
+
+/// Model Hub commands that require explicit per-user access for regular users.
+const MODELHUB_COMMANDS: &[&str] = &[
+    "civitai_search_models",
+    "civitai_list_architectures",
+    "civitai_lookup_hash",
+    "download_model",
+    "get_model_install_dirs",
+    "get_lora_civitai_info",
+    "get_checkpoint_civitai_info",
+];
+
+fn is_modelhub_command(command: &str) -> bool {
+    MODELHUB_COMMANDS.contains(&command)
+}
 
 /// Check command permission level.
 /// Returns the minimum role required to execute the command.
@@ -195,6 +218,10 @@ pub async fn start_server(
             post(auth_reset_password_handler),
         )
         .route("/internal-api/_auth/set_role", post(auth_set_role_handler))
+        .route(
+            "/internal-api/_auth/set_modelhub_access",
+            post(auth_set_modelhub_access_handler),
+        )
         .route("/internal-api/_auth/lan_info", get(auth_lan_info_handler))
         // Storage management
         .route("/internal-api/_storage/info", get(storage_info_handler))
@@ -961,6 +988,17 @@ async fn command_handler(
     };
     if !allowed {
         return forbidden_response("You do not have permission for this action.");
+    }
+
+    // Model Hub commands require explicit access for regular users
+    if is_modelhub_command(&command) && role == UserRole::User {
+        let has_access = extract_token(&headers)
+            .and_then(|t| state.auth.validate_token(&t))
+            .and_then(|u| state.auth.get_modelhub_access(&u))
+            .unwrap_or(false);
+        if !has_access {
+            return forbidden_response("You do not have access to the Model Hub. Ask an admin or moderator to enable it for your account.");
+        }
     }
 
     // Resolve username for per-user gallery isolation
@@ -2633,7 +2671,11 @@ async fn dispatch_command(
             Ok(serde_json::json!(null))
         }
         "read_clipboard_image" => {
-            Err("read_clipboard_image is not yet available in browser mode".to_string())
+            let bytes =
+                crate::commands::api::native_clipboard_read_pub().map_err(|e| e.to_string())?;
+            let encoded: Vec<serde_json::Value> =
+                bytes.iter().map(|b| serde_json::json!(*b)).collect();
+            Ok(serde_json::Value::Array(encoded))
         }
 
         // For commands not yet mapped, return an error
@@ -2798,11 +2840,27 @@ async fn auth_status_handler(
         UserRole::User => "user",
         UserRole::Anonymous => "anonymous",
     };
+    // Admins/mods always have modelhub access; for users check the account flag
+    let can_use_modelhub = match role {
+        UserRole::Admin | UserRole::Moderator => true,
+        _ => {
+            if let Some(token) = extract_token(&headers) {
+                state
+                    .auth
+                    .validate_token(&token)
+                    .and_then(|u| state.auth.get_modelhub_access(&u))
+                    .unwrap_or(false)
+            } else {
+                false
+            }
+        }
+    };
     Json(serde_json::json!({
         "auth_required": state.lan_enabled,
         "has_accounts": state.auth.has_accounts(),
         "role": role_str,
         "lan_enabled": state.lan_enabled,
+        "can_use_modelhub": can_use_modelhub,
     }))
 }
 
@@ -2822,7 +2880,15 @@ async fn auth_list_accounts_handler(
         .list_users_status(online_threshold)
         .into_iter()
         .map(
-            |(username, role, online, created_at, last_online, storage_limit_bytes)| {
+            |(
+                username,
+                role,
+                online,
+                created_at,
+                last_online,
+                storage_limit_bytes,
+                can_use_modelhub,
+            )| {
                 serde_json::json!({
                     "username": username,
                     "role": role,
@@ -2830,6 +2896,7 @@ async fn auth_list_accounts_handler(
                     "created_at": created_at,
                     "last_online": last_online,
                     "storage_limit_bytes": storage_limit_bytes,
+                    "can_use_modelhub": can_use_modelhub,
                 })
             },
         )
@@ -3055,6 +3122,41 @@ async fn auth_set_role_handler(
     }
 }
 
+/// POST /internal-api/_auth/set_modelhub_access — admin/moderator toggles Model Hub access for a user.
+async fn auth_set_modelhub_access_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(req): Json<serde_json::Value>,
+) -> Response {
+    let role = resolve_role(&state, &headers, &remote);
+    if role != UserRole::Admin && role != UserRole::Moderator {
+        return forbidden_response("Only admins and moderators can change Model Hub access.");
+    }
+    let username = match req.get("username").and_then(|v| v.as_str()) {
+        Some(u) => u,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "Missing username" })),
+            )
+                .into_response();
+        }
+    };
+    let allowed = req
+        .get("allowed")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    match state.auth.set_modelhub_access(username, allowed) {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
 /// GET /internal-api/_auth/lan_info — return the machine's LAN IPs and port. Admin only.
 async fn auth_lan_info_handler(
     AxumState(state): AxumState<SharedState>,
@@ -3132,6 +3234,18 @@ fn save_to_gallery_in_dir(
 ) -> Result<String, String> {
     std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
 
+    // Sanitize client-controlled values to prevent path traversal
+    let safe_filename = std::path::Path::new(filename)
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    let safe_prompt_id = prompt_id.replace(['/', '\\', '.'], "_");
+
+    if safe_filename.is_empty() {
+        return Err("Invalid filename".to_string());
+    }
+
     let normalized_mode = match mode {
         Some("txt2img") => "txt2img",
         Some("img2img") => "img2img",
@@ -3139,7 +3253,7 @@ fn save_to_gallery_in_dir(
         _ => "unknown",
     };
 
-    let gallery_filename = format!("{}__{}__{}", prompt_id, normalized_mode, filename);
+    let gallery_filename = format!("{}__{}__{}", safe_prompt_id, normalized_mode, safe_filename);
     let path = dir.join(&gallery_filename);
 
     let raw_mode = metadata_mode.unwrap_or("text_chunk");
@@ -3300,6 +3414,16 @@ async fn storage_set_limit_handler(
                 .into_response();
         }
     };
+
+    // Moderators cannot change storage limits for admin accounts
+    if role == UserRole::Moderator {
+        if let Some(target_role) = state.auth.get_account_role(username) {
+            if target_role == "admin" {
+                return forbidden_response("Moderators cannot modify admin storage limits.");
+            }
+        }
+    }
+
     let limit_bytes = match req.get("limit_bytes").and_then(|v| v.as_u64()) {
         Some(l) => l,
         None => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -44,6 +44,12 @@
   let pendingOutputImages = new Map<string, Array<{ blob: Blob; url: string; tempFilename?: string }>>();
   /** In-flight output_image fetch promises per prompt_id (for SSE race-condition avoidance). */
   let pendingOutputFetches = new Map<string, Promise<void>[]>();
+  /** Wait for pending fetches with a hard time limit to prevent hanging. */
+  const FETCH_TIMEOUT_MS = 30_000;
+  async function awaitFetchesWithTimeout(fetches: Promise<void>[]): Promise<void> {
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, FETCH_TIMEOUT_MS));
+    await Promise.race([Promise.allSettled(fetches), timeout]);
+  }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
 
   // Lightbox zoom state — only scale needs reactivity (used in template conditionals)
@@ -410,6 +416,7 @@
   let authRequired = $state(false);
   let authChecked = $state(false);
   let userRole = $state<"admin" | "moderator" | "user" | "anonymous">("admin");
+  let canUseModelhub = $state(true);
   let loginUser = $state("");
   let loginPass = $state("");
   let loginError = $state<string | null>(null);
@@ -425,6 +432,7 @@
     if (!isBrowserMode) {
       authChecked = true;
       userRole = "admin";
+      canUseModelhub = true;
       return true;
     }
     try {
@@ -433,6 +441,7 @@
       });
       const data = await resp.json();
       userRole = data.role ?? "anonymous";
+      canUseModelhub = data.can_use_modelhub ?? false;
       if (data.role === "anonymous" && data.auth_required) {
         authRequired = true;
         authChecked = true;
@@ -470,6 +479,7 @@
       });
       const statusData = await statusResp.json();
       userRole = statusData.role ?? "user";
+      canUseModelhub = statusData.can_use_modelhub ?? false;
 
       // If the admin set a temporary password, force a change before proceeding
       if (data.must_change_password) {
@@ -1387,11 +1397,14 @@
             if (!resp.ok) return;
             const blob = await resp.blob();
             const url = URL.createObjectURL(blob);
+            // Revoke the previous preview blob URL to avoid memory leaks
+            if (progress.previewImage?.startsWith("blob:")) URL.revokeObjectURL(progress.previewImage);
             progress.previewImage = url;
           } catch (e) {
             console.warn("[preview] failed to fetch temp image:", e);
           }
         } else if (data.image) {
+          if (progress.previewImage?.startsWith("blob:")) URL.revokeObjectURL(progress.previewImage);
           progress.previewImage = `data:image/${data.format};base64,${data.image}`;
         }
       }),
@@ -1490,7 +1503,7 @@
           // so without this await the images map would be empty.
           const fetches = pendingOutputFetches.get(promptId);
           if (fetches && fetches.length > 0) {
-            await Promise.allSettled(fetches);
+            await awaitFetchesWithTimeout(fetches);
             pendingOutputFetches.delete(promptId);
           }
 
@@ -1557,7 +1570,7 @@
             // Wait for any in-flight output_image fetches
             const fetches = pendingOutputFetches.get(p.promptId);
             if (fetches && fetches.length > 0) {
-              await Promise.allSettled(fetches);
+              await awaitFetchesWithTimeout(fetches);
               pendingOutputFetches.delete(p.promptId);
             }
             const item = progress.completePrompt(p.promptId);
@@ -1826,7 +1839,7 @@
         /></svg
       >
     </button>
-    {#if userRole === "admin" || userRole === "moderator"}
+    {#if canUseModelhub}
     <button
       class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {currentPage ===
       'modelhub'

--- a/src/lib/components/generation/InterrogateSection.svelte
+++ b/src/lib/components/generation/InterrogateSection.svelte
@@ -3,7 +3,7 @@
   import { locale } from "../../stores/locale.svelte.js";
   import InfoTip from "../ui/InfoTip.svelte";
   import InterrogateModal from "./InterrogateModal.svelte";
-  import { interrogateImage, interrogateImagePath, interrogateClipboard } from "../../utils/api.js";
+  import { interrogateImage, interrogateImagePath, interrogateClipboard, readClipboardImage } from "../../utils/api.js";
   import { ipcListen, isTauri, isBrowserMode } from "../../utils/ipc.js";
   import type { InterrogationResult } from "../../types/index.js";
 
@@ -70,6 +70,7 @@
         const { readFile } = await import("@tauri-apps/plugin-fs");
         const bytes = await readFile(path);
         const blob = new Blob([bytes]);
+        if (interrogateImageUrl?.startsWith("blob:")) URL.revokeObjectURL(interrogateImageUrl);
         interrogateImageUrl = URL.createObjectURL(blob);
       } catch {
         interrogateImageUrl = null;
@@ -108,35 +109,61 @@
   }
 
   async function interrogateFromClipboard() {
-    // In browser mode, use the Web Clipboard API to read the image client-side,
-    // then send via interrogate_image (base64). The Tauri clipboard command is
-    // not available without the native shell.
+    // In browser mode, try the Web Clipboard API first (requires HTTPS),
+    // then fall back to the server-side native clipboard read.
     if (isBrowserMode) {
-      try {
-        const items = await navigator.clipboard.read();
-        let imageBlob: Blob | null = null;
-        for (const item of items) {
-          for (const type of item.types) {
-            if (type.startsWith("image/")) {
-              imageBlob = await item.getType(type);
-              break;
+      let imageBlob: Blob | null = null;
+
+      // Try browser Clipboard API first
+      if (navigator.clipboard?.read) {
+        try {
+          const items = await navigator.clipboard.read();
+          for (const item of items) {
+            for (const type of item.types) {
+              if (type.startsWith("image/")) {
+                imageBlob = await item.getType(type);
+                break;
+              }
             }
+            if (imageBlob) break;
           }
-          if (imageBlob) break;
+        } catch {
+          // Clipboard API blocked — fall through to server fallback
         }
-        if (!imageBlob) {
+      }
+
+      // Fallback: ask server to read from host OS clipboard
+      if (!imageBlob) {
+        try {
+          const bytes = await readClipboardImage();
+          if (!bytes || bytes.length === 0) {
+            showInterrogateModal = true;
+            interrogateError = locale.t('common.no_clipboard_image');
+            return;
+          }
+          imageBlob = new Blob([new Uint8Array(bytes)], { type: "image/png" });
+        } catch (e) {
           showInterrogateModal = true;
-          interrogateError = locale.t('common.no_clipboard_image');
+          interrogateError = e instanceof Error ? e.message : String(e);
           return;
         }
+      }
+
+      try {
+        // Revoke previous blob URL to prevent memory leak
+        if (interrogateImageUrl?.startsWith("blob:")) URL.revokeObjectURL(interrogateImageUrl);
         const previewUrl = URL.createObjectURL(imageBlob);
-        const buffer = await imageBlob.arrayBuffer();
-        const bytes = new Uint8Array(buffer);
-        let binary = "";
-        for (let i = 0; i < bytes.length; i++) {
-          binary += String.fromCharCode(bytes[i]);
-        }
-        await interrogateBytes(btoa(binary), previewUrl);
+        // Use FileReader for efficient base64 conversion
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const dataUrl = reader.result as string;
+            resolve(dataUrl.split(",")[1]);
+          };
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(imageBlob!);
+        });
+        await interrogateBytes(base64, previewUrl);
         return;
       } catch (e) {
         showInterrogateModal = true;

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -62,6 +62,25 @@
     const pos = textareaEl.selectionStart;
     const text = value;
 
+    // Check if cursor is inside a <fromto[...]...> block — if so, use block
+    // boundaries instead of comma-splitting (commas are part of fromto syntax).
+    const fromtoRe = /<fromto\[[^\]]*\]:[^>]*>/g;
+    let ftMatch: RegExpExecArray | null;
+    while ((ftMatch = fromtoRe.exec(text)) !== null) {
+      const ftStart = ftMatch.index;
+      const ftEnd = ftStart + ftMatch[0].length;
+      if (pos > ftStart && pos <= ftEnd) {
+        // Cursor is inside this fromto block — use the whole block as the fragment
+        const token = text.substring(ftStart, ftEnd);
+        const leadingWhitespace = token.match(/^\s*/)?.[0].length ?? 0;
+        const trailingWhitespace = token.match(/\s*$/)?.[0].length ?? 0;
+        const trimmedStart = ftStart + leadingWhitespace;
+        const trimmedEnd = Math.max(trimmedStart, ftEnd - trailingWhitespace);
+        const fragment = text.substring(trimmedStart, trimmedEnd);
+        return { fragment, start: ftStart, end: ftEnd, trimmedStart, trimmedEnd };
+      }
+    }
+
     // Find the start of the current tag (after the last comma before cursor)
     let start = text.lastIndexOf(",", pos - 1) + 1;
     // Find the end of the current tag (next comma after cursor, or end of string)
@@ -359,7 +378,7 @@
   {#if showBackdrop}
     <div
       bind:this={backdropEl}
-      class="absolute inset-0 pointer-events-none overflow-hidden rounded-lg px-3 py-2 text-sm whitespace-pre-wrap wrap-break-word border border-transparent"
+      class="absolute inset-0 pointer-events-none overflow-hidden rounded-lg px-3 py-2 text-sm whitespace-pre-wrap break-words border border-transparent"
       style="color: transparent; z-index: 0;"
     >{@html highlightedHtml}</div>
   {/if}

--- a/src/lib/components/generation/UpscaleSettings.svelte
+++ b/src/lib/components/generation/UpscaleSettings.svelte
@@ -13,18 +13,50 @@
     label: string;
     filename: string;
     url: string;
+    description: string;
   }
 
+  const HF_BASE = "https://huggingface.co/AshtakaOOf/safetensored-upscalers/resolve/main";
+
   const recommendedModels: RecommendedModel[] = [
+    // SPAN — fast, sharp, excellent general-purpose upscaler
     {
-      label: "Omni 2x (Recommended)",
-      filename: "OmniSR_X2_DIV2K.safetensors",
-      url: "https://huggingface.co/Acly/Omni-SR/resolve/main/OmniSR_X2_DIV2K.safetensors",
+      label: "SPAN 2x — Spanimation",
+      filename: "2x_ModernSpanimationV1.safetensors",
+      url: `${HF_BASE}/span/2x_ModernSpanimationV1.safetensors`,
+      description: "Fast 2x with clean lines and vivid colours. Great for anime and illustration.",
     },
     {
-      label: "Omni 4x (Recommended)",
+      label: "SPAN 4x — NomosUni",
+      filename: "4xNomosUni_span_multijpg.safetensors",
+      url: `${HF_BASE}/span/4xNomosUni_span_multijpg.safetensors`,
+      description: "Fast 4x all-rounder. Handles photos, art, and JPEG artifacts well.",
+    },
+    // OmniSR — lightweight, reliable, good balance of speed and quality
+    {
+      label: "OmniSR 2x",
+      filename: "OmniSR_X2_DIV2K.safetensors",
+      url: `${HF_BASE}/omnisr/OmniSR_X2_DIV2K.safetensors`,
+      description: "Tiny model (~1.6 MB). Quick and artifact-free 2x upscale.",
+    },
+    {
+      label: "OmniSR 3x",
+      filename: "OmniSR_X3_DIV2K.safetensors",
+      url: `${HF_BASE}/omnisr/OmniSR_X3_DIV2K.safetensors`,
+      description: "Tiny model (~1.7 MB). Balanced 3x upscale when 2x isn't enough and 4x is too much.",
+    },
+    {
+      label: "OmniSR 4x",
       filename: "OmniSR_X4_DIV2K.safetensors",
-      url: "https://huggingface.co/Acly/Omni-SR/resolve/main/OmniSR_X4_DIV2K.safetensors",
+      url: `${HF_BASE}/omnisr/OmniSR_X4_DIV2K.safetensors`,
+      description: "Tiny model (~1.7 MB). Quick 4x upscale with solid detail for its size.",
+    },
+    // DAT — slow but highest quality, best for final output
+    {
+      label: "DAT 4x — IllustrationJaNai",
+      filename: "4x_IllustrationJaNai_V1_DAT2_190k.safetensors",
+      url: `${HF_BASE}/dat/4x_IllustrationJaNai_V1_DAT2_190k.safetensors`,
+      description: "Slow but excellent quality. Best for illustrations and anime final prints (~140 MB).",
     },
   ];
 
@@ -41,9 +73,12 @@
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
   }
 
-  /** Extract scale factor from upscaler model names (e.g., "OmniSR_X4_DIV2K" → 4) */
+  /** Extract scale factor from upscaler model names (e.g., "OmniSR_X4_DIV2K" → 4, "2x_Modern..." → 2) */
   function extractScaleFromModel(filename: string): number | null {
-    const match = filename.match(/_X(\d+)[_\.]/i) || filename.match(/[_-](\d+)x[_\.]/i);
+    const match =
+      filename.match(/_X(\d+)[_.]/i) ||
+      filename.match(/[_-](\d+)x[_.]/i) ||
+      filename.match(/^(\d+)x[_A-Z]/i);
     return match ? parseInt(match[1], 10) : null;
   }
 
@@ -188,6 +223,9 @@
             <option value={opt.value}>{opt.label}</option>
           {/each}
         </select>
+        {#if generation.upscaleModel && recommendedModels.find(r => r.filename === generation.upscaleModel)?.description}
+          <p class="text-[11px] text-neutral-500 mt-1">{recommendedModels.find(r => r.filename === generation.upscaleModel)!.description}</p>
+        {/if}
         {#if downloading}
           <div class="mt-2 bg-neutral-800/80 rounded-lg px-3 py-2">
             <div class="flex items-center justify-between text-[11px] text-neutral-400 mb-1">

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -60,7 +60,7 @@
   let switchingMode = $state(false);
 
   // LAN auth state
-  let lanAccounts = $state<{ username: string; role: string; online: boolean; created_at: string; last_online: string | null; storage_limit_bytes: number }[]>([]);
+  let lanAccounts = $state<{ username: string; role: string; online: boolean; created_at: string; last_online: string | null; storage_limit_bytes: number; can_use_modelhub: boolean }[]>([]);
   let lanNewUser = $state("");
   let lanNewPass = $state("");
   let lanAuthError = $state<string | null>(null);
@@ -75,6 +75,10 @@
   let showDeleteModal = $state(false);
   let deleteTargetUser = $state("");
   let deleteKeepData = $state(true);
+
+  // Account actions modal (per-user)
+  let showAccountActionsModal = $state(false);
+  let actionsTargetAccount = $state<{ username: string; role: string; online: boolean; created_at: string; last_online: string | null; storage_limit_bytes: number; can_use_modelhub: boolean } | null>(null);
 
   // Storage limit modal
   let showStorageModal = $state(false);
@@ -308,6 +312,28 @@
       if (!resp.ok) {
         const data = await resp.json();
         lanAuthError = data.error ?? "Failed to update role.";
+      } else {
+        await loadLanAccounts();
+      }
+    } catch (e) {
+      lanAuthError = String(e);
+    } finally {
+      lanAuthBusy = false;
+    }
+  }
+
+  async function toggleModelhubAccess(username: string, currentValue: boolean) {
+    lanAuthBusy = true;
+    lanAuthError = null;
+    try {
+      const resp = await fetch("/internal-api/_auth/set_modelhub_access", {
+        method: "POST",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ username, allowed: !currentValue }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json();
+        lanAuthError = data.error ?? "Failed to update Model Hub access.";
       } else {
         await loadLanAccounts();
       }
@@ -989,28 +1015,13 @@
                                 </span>
                               {/if}
                             </div>
-                            <div class="flex items-center gap-2 shrink-0 ml-2">
-                              <button
-                                class="text-xs cursor-pointer {account.role === 'moderator' ? 'text-indigo-400 hover:text-indigo-300' : 'text-neutral-400 hover:text-neutral-300'}"
-                                disabled={lanAuthBusy}
-                                onclick={() => toggleAccountRole(account.username, account.role)}
-                              >{account.role === "moderator" ? "Revoke Mod" : "Make Mod"}</button>
-                              <button
-                                class="text-xs text-cyan-400 hover:text-cyan-300 cursor-pointer"
-                                disabled={lanAuthBusy}
-                                onclick={() => { storageTargetUser = account.username; storageInputGB = (account.storage_limit_bytes / (1024 * 1024 * 1024)).toFixed(1); storageError = null; showStorageModal = true; }}
-                              >Storage</button>
-                              <button
-                                class="text-xs text-amber-400 hover:text-amber-300 cursor-pointer"
-                                disabled={lanAuthBusy}
-                                onclick={() => { resetTargetUser = account.username; resetTempPass = ''; resetError = null; resetSuccess = false; showResetPasswordModal = true; }}
-                              >Reset Password</button>
-                              <button
-                                class="text-xs text-red-400 hover:text-red-300 cursor-pointer"
-                                disabled={lanAuthBusy}
-                                onclick={() => { deleteTargetUser = account.username; deleteKeepData = true; showDeleteModal = true; }}
-                              >Remove</button>
-                            </div>
+                            <button
+                              class="shrink-0 ml-2 p-1 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-200 transition-colors cursor-pointer"
+                              title="Manage {account.username}"
+                              onclick={() => { actionsTargetAccount = account; showAccountActionsModal = true; }}
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+                            </button>
                           </div>
                         {/each}
                       </div>
@@ -1086,25 +1097,14 @@
                           </span>
                         {/if}
                       </div>
-                      <!-- Mods can only manage regular users — not admins or other mods -->
                       {#if account.role === "user"}
-                        <div class="flex items-center gap-2 shrink-0 ml-2">
-                          <button
-                            class="text-xs text-cyan-400 hover:text-cyan-300 cursor-pointer"
-                            disabled={lanAuthBusy}
-                            onclick={() => { storageTargetUser = account.username; storageInputGB = (account.storage_limit_bytes / (1024 * 1024 * 1024)).toFixed(1); storageError = null; showStorageModal = true; }}
-                          >Storage</button>
-                          <button
-                            class="text-xs text-amber-400 hover:text-amber-300 cursor-pointer"
-                            disabled={lanAuthBusy}
-                            onclick={() => { resetTargetUser = account.username; resetTempPass = ''; resetError = null; resetSuccess = false; showResetPasswordModal = true; }}
-                          >Reset Password</button>
-                          <button
-                            class="text-xs text-red-400 hover:text-red-300 cursor-pointer"
-                            disabled={lanAuthBusy}
-                            onclick={() => { deleteTargetUser = account.username; deleteKeepData = true; showDeleteModal = true; }}
-                          >Remove</button>
-                        </div>
+                        <button
+                          class="shrink-0 ml-2 p-1 rounded hover:bg-neutral-700 text-neutral-400 hover:text-neutral-200 transition-colors cursor-pointer"
+                          title="Manage {account.username}"
+                          onclick={() => { actionsTargetAccount = account; showAccountActionsModal = true; }}
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"/></svg>
+                        </button>
                       {/if}
                     </div>
                   {/each}
@@ -2392,10 +2392,11 @@
   onkeydown={(e) => { if (e.key === 'Escape') showAddAccountModal = false; }}
   role="dialog"
   aria-modal="true"
+  aria-labelledby="add-account-title"
   tabindex="-1"
 >
   <div class="bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl w-full max-w-sm p-6 space-y-4">
-    <h3 class="text-sm font-medium text-neutral-100">Add LAN Account</h3>
+    <h3 id="add-account-title" class="text-sm font-medium text-neutral-100">Add LAN Account</h3>
     <div class="space-y-3">
       <div>
         <label class="block text-xs text-neutral-400 mb-1">Username</label>
@@ -2442,10 +2443,11 @@
   onkeydown={(e) => { if (e.key === 'Escape') showResetPasswordModal = false; }}
   role="dialog"
   aria-modal="true"
+  aria-labelledby="reset-password-title"
   tabindex="-1"
 >
   <div class="bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl w-full max-w-sm p-6 space-y-4">
-    <h3 class="text-sm font-medium text-neutral-100">Reset Password</h3>
+    <h3 id="reset-password-title" class="text-sm font-medium text-neutral-100">Reset Password</h3>
     <p class="text-xs text-neutral-400">Set a temporary password for <span class="text-neutral-200 font-medium">{resetTargetUser}</span>. They will be asked to choose a new password on their next login.</p>
     <div>
       <label class="block text-xs text-neutral-400 mb-1">Temporary Password</label>
@@ -2488,10 +2490,11 @@
   onkeydown={(e) => { if (e.key === 'Escape') showDeleteModal = false; }}
   role="dialog"
   aria-modal="true"
+  aria-labelledby="delete-account-title"
   tabindex="-1"
 >
   <div class="bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl w-full max-w-sm p-6 space-y-4">
-    <h3 class="text-sm font-medium text-neutral-100">Delete Account</h3>
+    <h3 id="delete-account-title" class="text-sm font-medium text-neutral-100">Delete Account</h3>
     <p class="text-xs text-neutral-400">Are you sure you want to delete <span class="text-neutral-200 font-medium">{deleteTargetUser}</span>?</p>
 
     <label class="flex items-start gap-2 cursor-pointer">
@@ -2559,6 +2562,65 @@
         disabled={storageBusy}
         onclick={applyStorageLimit}
       >Save</button>
+    </div>
+  </div>
+</div>
+{/if}
+
+<!-- Account Actions Modal -->
+{#if showAccountActionsModal && actionsTargetAccount}
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+  onclick={(e) => { if (e.target === e.currentTarget) showAccountActionsModal = false; }}
+  onkeydown={(e) => { if (e.key === 'Escape') showAccountActionsModal = false; }}
+  role="dialog"
+  aria-modal="true"
+  tabindex="-1"
+>
+  <div class="bg-neutral-900 border border-neutral-700 rounded-xl shadow-2xl w-full max-w-xs p-5 space-y-3">
+    <div class="flex items-center gap-2">
+      <span class="inline-block w-2 h-2 rounded-full shrink-0 {actionsTargetAccount.online ? 'bg-green-500' : 'bg-neutral-600'}"></span>
+      <h3 class="text-sm font-medium text-neutral-100 truncate">{actionsTargetAccount.username}</h3>
+      {#if actionsTargetAccount.role === "moderator"}
+        <span class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/30 text-indigo-300 font-medium shrink-0">Mod</span>
+      {/if}
+    </div>
+    <div class="flex flex-col gap-2">
+      {#if isAdmin}
+        <button
+          class="w-full px-3 py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer text-left {actionsTargetAccount.role === 'moderator' ? 'bg-indigo-600/20 text-indigo-300 hover:bg-indigo-600/30' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700'}"
+          disabled={lanAuthBusy}
+          onclick={() => { toggleAccountRole(actionsTargetAccount!.username, actionsTargetAccount!.role); showAccountActionsModal = false; }}
+        >{actionsTargetAccount.role === "moderator" ? "Revoke Moderator" : "Make Moderator"}</button>
+      {/if}
+      <button
+        class="w-full px-3 py-2 rounded-lg text-xs font-medium bg-neutral-800 text-cyan-400 hover:bg-neutral-700 transition-colors cursor-pointer text-left"
+        disabled={lanAuthBusy}
+        onclick={() => { storageTargetUser = actionsTargetAccount!.username; storageInputGB = (actionsTargetAccount!.storage_limit_bytes / (1024 * 1024 * 1024)).toFixed(1); storageError = null; showAccountActionsModal = false; showStorageModal = true; }}
+      >Storage Limit — {formatBytes(actionsTargetAccount.storage_limit_bytes)}</button>
+      {#if actionsTargetAccount.role === 'user'}
+      <button
+        class="w-full px-3 py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer text-left {actionsTargetAccount.can_use_modelhub ? 'bg-emerald-600/20 text-emerald-300 hover:bg-emerald-600/30' : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700'}"
+        disabled={lanAuthBusy}
+        onclick={() => { toggleModelhubAccess(actionsTargetAccount!.username, actionsTargetAccount!.can_use_modelhub); showAccountActionsModal = false; }}
+      >{actionsTargetAccount.can_use_modelhub ? "Revoke Model Hub Access" : "Grant Model Hub Access"}</button>
+      {/if}
+      <button
+        class="w-full px-3 py-2 rounded-lg text-xs font-medium bg-neutral-800 text-amber-400 hover:bg-neutral-700 transition-colors cursor-pointer text-left"
+        disabled={lanAuthBusy}
+        onclick={() => { resetTargetUser = actionsTargetAccount!.username; resetTempPass = ''; resetError = null; resetSuccess = false; showAccountActionsModal = false; showResetPasswordModal = true; }}
+      >Reset Password</button>
+      <button
+        class="w-full px-3 py-2 rounded-lg text-xs font-medium bg-neutral-800 text-red-400 hover:bg-neutral-700 transition-colors cursor-pointer text-left"
+        disabled={lanAuthBusy}
+        onclick={() => { deleteTargetUser = actionsTargetAccount!.username; deleteKeepData = true; showAccountActionsModal = false; showDeleteModal = true; }}
+      >Remove Account</button>
+    </div>
+    <div class="flex justify-end pt-1">
+      <button
+        class="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 text-neutral-400 rounded-lg text-xs transition-colors cursor-pointer"
+        onclick={() => { showAccountActionsModal = false; }}
+      >Close</button>
     </div>
   </div>
 </div>

--- a/src/lib/components/updater/UpdateNotification.svelte
+++ b/src/lib/components/updater/UpdateNotification.svelte
@@ -37,6 +37,38 @@
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
+  // Track whether we've already checked for server updates (browser mode).
+  // The role may resolve after mount, so we use $effect to react to canSeeUpdate.
+  let serverCheckDone = false;
+  $effect(() => {
+    if (isBrowserMode && canSeeUpdate && !serverCheckDone) {
+      serverCheckDone = true;
+      checkServerUpdate();
+    }
+  });
+
+  async function checkServerUpdate() {
+    await new Promise((r) => setTimeout(r, 3000));
+    try {
+      console.log(`[Updater] Checking server for updates (current: v${currentVersion})...`);
+      const resp = await fetch("/internal-api/_check_update", {
+        headers: authHeaders(),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data.update_available) {
+          version = data.latest_version;
+          updateState = "server_available";
+          console.log(`[Updater] Server update available: v${data.latest_version} (current: v${data.current_version})`);
+        } else {
+          console.log("[Updater] Server is up to date");
+        }
+      }
+    } catch (e) {
+      console.warn("[Updater] Server update check failed:", e);
+    }
+  }
+
   onMount(async () => {
     // Check if a previous update didn't apply correctly (desktop only)
     const pending = localStorage.getItem("mooshieui_pending_update");
@@ -71,26 +103,6 @@
         }
       } catch (e) {
         console.warn("[Updater] Update check failed:", e);
-      }
-    } else if (isBrowserMode && canSeeUpdate) {
-      // Server/browser mode: check via backend endpoint (admin/mod only)
-      try {
-        console.log(`[Updater] Checking server for updates (current: v${currentVersion})...`);
-        const resp = await fetch("/internal-api/_check_update", {
-          headers: authHeaders(),
-        });
-        if (resp.ok) {
-          const data = await resp.json();
-          if (data.update_available) {
-            version = data.latest_version;
-            updateState = "server_available";
-            console.log(`[Updater] Server update available: v${data.latest_version} (current: v${data.current_version})`);
-          } else {
-            console.log("[Updater] Server is up to date");
-          }
-        }
-      } catch (e) {
-        console.warn("[Updater] Server update check failed:", e);
       }
     }
   });

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -35,6 +35,7 @@ const en: Record<string, string> = {
   "common.expand": "Expand {section}",
   "common.drop_to_import": "Drop to import {section}",
   "common.no_clipboard_image": "No image found in clipboard",
+  "common.clipboard_unavailable": "Clipboard API is not available (requires HTTPS)",
   "common.detected": "detected",
   "common.click_to_type": "Click to type a value",
 

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -202,7 +202,7 @@ class GalleryStore {
       const pending = this._persistPromises.get(key);
       if (pending) {
         const galleryFilename = await pending;
-        if (galleryFilename && this.lightboxOpen && this._imageKey(this.selectedImage!) === key) {
+        if (galleryFilename && this.lightboxOpen && this.selectedImage && this._imageKey(this.selectedImage) === key) {
           this.lightboxUrl = await fullImageUrl(galleryFilename);
         }
       }
@@ -229,6 +229,7 @@ class GalleryStore {
   }
 
   closeLightbox() {
+    if (this.lightboxUrl?.startsWith("blob:")) URL.revokeObjectURL(this.lightboxUrl);
     this.lightboxOpen = false;
     this.selectedImage = null;
     this.lightboxUrl = null;
@@ -519,6 +520,10 @@ class GalleryStore {
         const fetchUrl = image.fullImageUrl || image.url;
         if (fetchUrl) {
           const resp = await fetch(fetchUrl);
+          if (!resp.ok) {
+            this.showToast(locale.t("gallery.toast.copy_failed") || "Failed to copy image", "error");
+            return;
+          }
           const blob = await resp.blob();
           const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
           await this.writeBlobToClipboard(pngBlob);
@@ -577,6 +582,7 @@ class GalleryStore {
     this.showToast(locale.t("gallery.toast.copying"), "info", true);
     try {
       const response = await fetch(blobUrl);
+      if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
       const blob = await response.blob();
       const arrayBuf = await blob.arrayBuffer();
       let bytes = Array.from(new Uint8Array(arrayBuf));

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -550,17 +550,25 @@ export async function readClipboardImageSafe(): Promise<number[]> {
   if (!isBrowserMode) {
     return readClipboardImage();
   }
-  const items = await navigator.clipboard.read();
-  for (const item of items) {
-    for (const type of item.types) {
-      if (type.startsWith("image/")) {
-        const blob = await item.getType(type);
-        const buffer = await blob.arrayBuffer();
-        return Array.from(new Uint8Array(buffer));
+  // Try the browser Clipboard API first (requires HTTPS or localhost)
+  if (navigator.clipboard?.read) {
+    try {
+      const items = await navigator.clipboard.read();
+      for (const item of items) {
+        for (const type of item.types) {
+          if (type.startsWith("image/")) {
+            const blob = await item.getType(type);
+            const buffer = await blob.arrayBuffer();
+            return [...new Uint8Array(buffer)];
+          }
+        }
       }
+    } catch {
+      // Clipboard API blocked — fall through to server fallback
     }
   }
-  throw new Error(locale.t('common.no_clipboard_image'));
+  // Fallback: ask the server to read from the host OS clipboard
+  return readClipboardImage();
 }
 
 export async function exportLogs(destination: string): Promise<void> {

--- a/src/lib/utils/ipc.ts
+++ b/src/lib/utils/ipc.ts
@@ -55,12 +55,18 @@ export function setAuthToken(token: string, rememberMe = false) {
 export function clearAuthToken() {
   localStorage.removeItem(AUTH_TOKEN_KEY);
   localStorage.removeItem(AUTH_REMEMBER_KEY);
+  localStorage.removeItem(AUTH_USER_KEY);
   sessionStorage.removeItem(AUTH_TOKEN_KEY);
+  sessionStorage.removeItem(AUTH_USER_KEY);
 }
 
 /** Store the currently logged-in username (for per-user localStorage isolation). */
 export function setAuthUser(username: string) {
-  authStorage().setItem(AUTH_USER_KEY, username);
+  const storage = authStorage();
+  storage.setItem(AUTH_USER_KEY, username);
+  // Clear from the other backend to prevent stale cross-user reads
+  const other = storage === localStorage ? sessionStorage : localStorage;
+  other.removeItem(AUTH_USER_KEY);
 }
 
 export function getAuthUser(): string | null {

--- a/src/lib/utils/promptSchedule.ts
+++ b/src/lib/utils/promptSchedule.ts
@@ -13,17 +13,18 @@ import type { PromptSegment } from "../types/index.js";
  *   Separators: comma, | or ||
  */
 const SCHEDULE_REGEX =
-  /<(from|to|range):([\d.]+)(?::([\d.]+))?>([\s\S]*?)<\/\1>/g;
+  /<(from|to|range):(\d+(?:\.\d+)?)(?::(\d+(?:\.\d+)?))?>([ \s\S]*?)<\/\1>/g;
 
 const SWARM_FROMTO_REGEX =
-  /<fromto\[([\d.]+)\]:([^>]+)>/g;
+  /<fromto\[(\d+(?:\.\d+)?)\]:([^>]+)>/g;
 
 /**
  * Combined regex matching both syntaxes.
  * Used for highlight rendering and tag detection (single-pass over text).
+ * Numeric values must be valid decimals (e.g. 0.5, 1) — not malformed like 1.2.3.
  */
 const COMBINED_REGEX =
-  /<(?:(from|to|range):([\d.]+)(?::([\d.]+))?>([\s\S]*?)<\/\1>|fromto\[([\d.]+)\]:([^>]+)>)/g;
+  /<(?:(from|to|range):(\d+(?:\.\d+)?)(?::(\d+(?:\.\d+)?))?>([ \s\S]*?)<\/\1>|fromto\[(\d+(?:\.\d+)?)\]:([^>]+)>)/g;
 
 export interface ParsedPrompt {
   baseText: string;
@@ -104,7 +105,7 @@ export function parseScheduledPrompt(raw: string): ParsedPrompt {
       }
 
       segments.push({ text, start, end });
-      baseText += innerText;
+      // Do NOT add innerText to baseText — it should only apply during [start, end]
     } else if (match[5]) {
       // SwarmUI fromto syntax: groups 5-6
       const timestepStr = match[5];


### PR DESCRIPTION
## v0.7.8\n\n### Model Hub Access Control\n- Per-user `can_use_modelhub` permission with backend enforcement and frontend gating\n- Account actions modal (cog icon) replaces inline buttons\n\n### Upscaler Model Migration\n- 7 models from `AshtakaOOf/safetensored-upscalers` (SPAN 2×/4×, OmniSR 2×/3×/4×, DAT 4×)\n- Scale-factor regex updated for prefix-style names\n\n### Security Hardening\n- `save_image_file` / `upload_image` added to admin-only ACL\n- Path traversal sanitization in gallery save\n- Mod privilege-escalation guard on storage limits\n- Blob URL memory-leak fixes (preview + lightbox)\n- `copyBlobToClipboard` response check\n- Prompt-schedule regex tightened\n- Autocomplete `<fromto>` block fix\n\n### Clipboard Read for HTTP Contexts\n- Native OS clipboard read fallback (wl-paste/xclip, osascript, PowerShell)\n\n### Docker\n- FaceDetailer libxcb fix\n\n### Dependencies\n- 7 Dependabot PRs merged"