### PR TITLE
v0.7.9: Multi-GPU worker backend, GPU status panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## What's New in v0.7.9
+
+### Multi-GPU Worker Backend
+- **SwarmUI-style multi-GPU dispatch** — new `GpuManager` distributes generation prompts across multiple ComfyUI worker processes, each pinned to a specific GPU via `CUDA_VISIBLE_DEVICES`. Workers are selected using LRU (least-recently-used) scheduling with atomic reservation to prevent double-dispatch.
+- **Per-worker process lifecycle** — each GPU worker spawns its own ComfyUI subprocess on a dedicated port with independent health checks, WebSocket connections, and graceful shutdown.
+- **Auto-detection and configuration** — `detect_gpus()` queries `nvidia-smi` to discover available GPUs; `auto_configure_workers()` generates a default `gpu_workers` config array. Workers can be individually enabled/disabled with custom labels and VRAM modes.
+- **Transparent fallback** — when only one worker is configured, the system behaves identically to the previous single-process model with zero overhead.
+
+### GPU Status Panel (Settings)
+- **Live GPU monitoring** — new "GPU Workers" section in Settings displays real-time stats for every GPU: VRAM usage bar, GPU utilization %, temperature, power draw, and worker status badges (idle/running/starting/error).
+- **Visible to all users** — the GPU panel is not admin-gated, so every user can see system GPU health without needing `nvidia-smi` access.
+- **Auto-refresh** — stats poll every 5 seconds via `nvidia-smi` merged with internal worker status.
+- **Dual-mode support** — works in both Tauri desktop and browser/server mode via a dedicated `GET /internal-api/_gpu_stats` endpoint.
+
+### Backend Infrastructure
+- **Worker-aware prompt queue** — `PromptQueue` now tracks which worker is handling each prompt, enabling correct idle/error state transitions on completion.
+- **Configurable GPU workers** — `AppConfig` gains a `gpu_workers` array (`GpuWorkerConfig` structs) with `gpu_index`, `port`, `enabled`, `label`, and `vram_mode` per worker.
+- **Server mode multi-worker startup** — `mooshieui-server` starts all configured workers in parallel with health-check gates before accepting requests.
+
+---
+
 ## What's New in v0.7.8
 
 ### Model Hub Access Control

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+## What's New in v0.7.9
+
+### Multi-GPU Worker Backend
+- **SwarmUI-style multi-GPU dispatch** — new `GpuManager` distributes generation prompts across multiple ComfyUI worker processes, each pinned to a specific GPU via `CUDA_VISIBLE_DEVICES`. Workers are selected using LRU (least-recently-used) scheduling with atomic reservation to prevent double-dispatch.
+- **Per-worker process lifecycle** — each GPU worker spawns its own ComfyUI subprocess on a dedicated port with independent health checks, WebSocket connections, and graceful shutdown.
+- **Auto-detection and configuration** — `detect_gpus()` queries `nvidia-smi` to discover available GPUs; `auto_configure_workers()` generates a default `gpu_workers` config array. Workers can be individually enabled/disabled with custom labels and VRAM modes.
+- **Transparent fallback** — when only one worker is configured, the system behaves identically to the previous single-process model with zero overhead.
+
+### GPU Status Panel (Settings)
+- **Live GPU monitoring** — new "GPU Workers" section in Settings displays real-time stats for every GPU: VRAM usage bar, GPU utilization %, temperature, power draw, and worker status badges (idle/running/starting/error).
+- **Visible to all users** — the GPU panel is not admin-gated, so every user can see system GPU health without needing `nvidia-smi` access.
+- **Auto-refresh** — stats poll every 5 seconds via `nvidia-smi` merged with internal worker status.
+- **Dual-mode support** — works in both Tauri desktop and browser/server mode via a dedicated `GET /internal-api/_gpu_stats` endpoint.
+
+### Backend Infrastructure
+- **Worker-aware prompt queue** — `PromptQueue` now tracks which worker is handling each prompt, enabling correct idle/error state transitions on completion.
+- **Configurable GPU workers** — `AppConfig` gains a `gpu_workers` array (`GpuWorkerConfig` structs) with `gpu_index`, `port`, `enabled`, `label`, and `vram_mode` per worker.
+- **Server mode multi-worker startup** — `mooshieui-server` starts all configured workers in parallel with health-check gates before accepting requests.
+
+---
+
 ## What's New in v0.7.8
 
 ### Model Hub Access Control

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.8"
+version = "0.7.9"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/gpu_manager.rs
+++ b/src-tauri/src/comfyui/gpu_manager.rs
@@ -1,0 +1,492 @@
+//! Multi-GPU worker manager — distributes ComfyUI prompts across N GPU backends.
+//!
+//! Adapted from SwarmUI's `BackendHandler` pattern:
+//! - Each GPU gets its own ComfyUI process on a dedicated port
+//! - A dispatch loop assigns queued prompts to idle workers
+//! - Workers are reserved atomically (one prompt at a time per GPU)
+//! - If a worker errors, it's marked as failed and skipped
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Child;
+use tokio::sync::{Mutex, Notify, RwLock};
+use tokio::task::JoinHandle;
+
+use crate::config::{AppConfig, GpuWorkerConfig};
+use crate::error::AppError;
+
+/// Status of a GPU worker backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkerStatus {
+    /// Not started yet.
+    Stopped,
+    /// Starting up (process spawned, waiting for HTTP ready).
+    Starting,
+    /// Ready and idle — can accept a prompt.
+    Idle,
+    /// Currently executing a prompt.
+    Running,
+    /// Process crashed or failed to start.
+    Error,
+    /// Administratively disabled.
+    Disabled,
+}
+
+/// A single GPU worker — owns one ComfyUI process.
+pub struct GpuWorker {
+    /// Worker ID (0-indexed, matches gpu_workers config index).
+    pub id: u32,
+    /// GPU index (CUDA_VISIBLE_DEVICES value).
+    pub gpu_index: u32,
+    /// Port this ComfyUI instance listens on.
+    pub port: u16,
+    /// HTTP base URL for this worker's ComfyUI API.
+    pub base_url: String,
+    /// Current status.
+    pub status: RwLock<WorkerStatus>,
+    /// Whether this worker is currently reserved (executing a prompt).
+    pub reserved: AtomicBool,
+    /// Timestamp (millis since epoch) of last time this worker was released.
+    pub last_released: AtomicU64,
+    /// The child process handle.
+    pub process: Mutex<Option<Child>>,
+    /// WebSocket task handle for this worker.
+    pub ws_handle: Mutex<Option<JoinHandle<()>>>,
+    /// Friendly label (e.g. GPU name from nvidia-smi).
+    pub label: String,
+    /// VRAM mode override for this specific worker (falls back to global).
+    pub vram_mode: Option<String>,
+}
+
+impl GpuWorker {
+    pub fn new(id: u32, cfg: &GpuWorkerConfig, base_port: u16) -> Self {
+        let port = cfg.port.unwrap_or(base_port + id as u16);
+        Self {
+            id,
+            gpu_index: cfg.gpu_index,
+            port,
+            base_url: format!("http://127.0.0.1:{}", port),
+            status: RwLock::new(if cfg.enabled {
+                WorkerStatus::Stopped
+            } else {
+                WorkerStatus::Disabled
+            }),
+            reserved: AtomicBool::new(false),
+            last_released: AtomicU64::new(0),
+            process: Mutex::new(None),
+            ws_handle: Mutex::new(None),
+            label: cfg
+                .label
+                .clone()
+                .unwrap_or_else(|| format!("GPU {}", cfg.gpu_index)),
+            vram_mode: cfg.vram_mode.clone(),
+        }
+    }
+
+    /// Whether this worker can accept a new prompt right now.
+    pub async fn is_available(&self) -> bool {
+        let status = *self.status.read().await;
+        status == WorkerStatus::Idle && !self.reserved.load(Ordering::Acquire)
+    }
+
+    /// Reserve this worker for a prompt. Returns false if already reserved.
+    pub fn try_reserve(&self) -> bool {
+        self.reserved
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Release this worker after prompt completion/error.
+    pub fn release(&self) {
+        self.reserved.store(false, Ordering::Release);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        self.last_released.store(now, Ordering::Release);
+    }
+}
+
+/// Manages N GPU workers and distributes prompts across them.
+pub struct GpuManager {
+    /// All workers, indexed by worker ID.
+    pub workers: Vec<Arc<GpuWorker>>,
+    /// Notified when a worker becomes available (prompt finished).
+    pub worker_available: Notify,
+    /// Shared HTTP client for all workers.
+    pub http_client: reqwest::Client,
+}
+
+impl GpuManager {
+    /// Create a new manager from config. If no gpu_workers are configured,
+    /// creates a single default worker on the configured port.
+    pub fn new(config: &AppConfig, http_client: reqwest::Client) -> Self {
+        let workers = if config.gpu_workers.is_empty() {
+            // Backward compat: single worker on the existing port
+            let default_cfg = GpuWorkerConfig {
+                gpu_index: 0,
+                port: Some(config.server_port),
+                enabled: true,
+                label: None,
+                vram_mode: None,
+            };
+            vec![Arc::new(GpuWorker::new(
+                0,
+                &default_cfg,
+                config.server_port,
+            ))]
+        } else {
+            config
+                .gpu_workers
+                .iter()
+                .enumerate()
+                .map(|(i, cfg)| Arc::new(GpuWorker::new(i as u32, cfg, config.server_port)))
+                .collect()
+        };
+
+        Self {
+            workers,
+            worker_available: Notify::new(),
+            http_client,
+        }
+    }
+
+    /// Get the number of enabled workers.
+    pub async fn enabled_count(&self) -> usize {
+        let mut count = 0;
+        for w in &self.workers {
+            if *w.status.read().await != WorkerStatus::Disabled {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Find the best available worker for a new prompt.
+    /// Prefers idle workers, with ties broken by least-recently-used.
+    pub async fn find_available(&self) -> Option<Arc<GpuWorker>> {
+        let mut best: Option<Arc<GpuWorker>> = None;
+        let mut best_time: u64 = u64::MAX;
+
+        for worker in &self.workers {
+            if !worker.is_available().await {
+                continue;
+            }
+            let released = worker.last_released.load(Ordering::Acquire);
+            if released < best_time {
+                best_time = released;
+                best = Some(Arc::clone(worker));
+            }
+        }
+
+        best
+    }
+
+    /// Wait for any worker to become available, with timeout.
+    /// Returns the worker, or None on timeout.
+    pub async fn wait_for_available(&self, timeout: Duration) -> Option<Arc<GpuWorker>> {
+        // Fast path: check immediately
+        if let Some(w) = self.find_available().await {
+            return Some(w);
+        }
+
+        // Wait for notification
+        match tokio::time::timeout(timeout, self.worker_available.notified()).await {
+            Ok(()) => self.find_available().await,
+            Err(_) => None,
+        }
+    }
+
+    /// Submit a prompt to the best available worker.
+    /// Blocks until a worker is free (up to timeout).
+    /// Returns (worker_id, prompt_response) on success.
+    pub async fn submit_prompt(
+        &self,
+        workflow: serde_json::Value,
+        client_id: &str,
+        timeout: Duration,
+    ) -> Result<(u32, crate::comfyui::types::PromptResponse), AppError> {
+        let worker = self
+            .wait_for_available(timeout)
+            .await
+            .ok_or_else(|| AppError::Other("All GPU workers are busy — try again later".into()))?;
+
+        if !worker.try_reserve() {
+            // Race condition: another request grabbed it. Retry once.
+            let worker = self.find_available().await.ok_or_else(|| {
+                AppError::Other("All GPU workers are busy — try again later".into())
+            })?;
+            if !worker.try_reserve() {
+                return Err(AppError::Other(
+                    "All GPU workers are busy — try again later".into(),
+                ));
+            }
+            return self.do_submit(&worker, workflow, client_id).await;
+        }
+
+        self.do_submit(&worker, workflow, client_id).await
+    }
+
+    /// Actually POST the prompt to a specific worker.
+    async fn do_submit(
+        &self,
+        worker: &Arc<GpuWorker>,
+        workflow: serde_json::Value,
+        client_id: &str,
+    ) -> Result<(u32, crate::comfyui::types::PromptResponse), AppError> {
+        {
+            let mut status = worker.status.write().await;
+            *status = WorkerStatus::Running;
+        }
+
+        let body = serde_json::json!({
+            "prompt": workflow,
+            "client_id": client_id,
+        });
+
+        let url = format!("{}/prompt", worker.base_url);
+        let resp = self.http_client.post(&url).json(&body).send().await;
+
+        match resp {
+            Ok(r) if r.status().is_success() => {
+                let prompt_resp: crate::comfyui::types::PromptResponse = r.json().await?;
+                // Worker stays Running — will be released when execution completes
+                // (via WebSocket execution_complete event)
+                Ok((worker.id, prompt_resp))
+            }
+            Ok(r) => {
+                worker.release();
+                {
+                    let mut status = worker.status.write().await;
+                    *status = WorkerStatus::Idle;
+                }
+                self.worker_available.notify_one();
+                let status_code = r.status().as_u16();
+                let body = r.text().await.unwrap_or_default();
+                Err(AppError::ApiError {
+                    status: status_code,
+                    message: body,
+                })
+            }
+            Err(e) => {
+                worker.release();
+                {
+                    let mut status = worker.status.write().await;
+                    *status = WorkerStatus::Error;
+                }
+                self.worker_available.notify_one();
+                Err(AppError::ConnectionFailed(format!(
+                    "Worker {} (GPU {}): {}",
+                    worker.id, worker.gpu_index, e
+                )))
+            }
+        }
+    }
+
+    /// Mark a worker as idle after its prompt finishes (called from WS event handler).
+    pub async fn mark_worker_idle(&self, worker_id: u32) {
+        if let Some(worker) = self.workers.get(worker_id as usize) {
+            worker.release();
+            {
+                let mut status = worker.status.write().await;
+                if *status == WorkerStatus::Running {
+                    *status = WorkerStatus::Idle;
+                }
+            }
+            self.worker_available.notify_one();
+        }
+    }
+
+    /// Mark a worker as errored (called from WS on execution_error).
+    pub async fn mark_worker_error_then_idle(&self, worker_id: u32) {
+        if let Some(worker) = self.workers.get(worker_id as usize) {
+            worker.release();
+            {
+                let mut status = worker.status.write().await;
+                // Mark idle so it can try the next prompt — the error is transient
+                // (e.g. OOM on one prompt doesn't mean the GPU is dead).
+                *status = WorkerStatus::Idle;
+            }
+            self.worker_available.notify_one();
+        }
+    }
+
+    /// Find which worker is handling a given prompt by checking each worker's queue.
+    pub async fn worker_for_prompt(&self, _prompt_id: &str) -> Option<u32> {
+        // The prompt→worker mapping is tracked externally (in PromptQueue).
+        // This is a fallback that checks which worker is currently running.
+        for worker in &self.workers {
+            let status = *worker.status.read().await;
+            if status == WorkerStatus::Running && worker.reserved.load(Ordering::Acquire) {
+                return Some(worker.id);
+            }
+        }
+        None
+    }
+
+    /// Get status summary for all workers (for frontend display).
+    pub async fn worker_statuses(&self) -> Vec<WorkerStatusInfo> {
+        let mut out = Vec::with_capacity(self.workers.len());
+        for w in &self.workers {
+            out.push(WorkerStatusInfo {
+                id: w.id,
+                gpu_index: w.gpu_index,
+                label: w.label.clone(),
+                port: w.port,
+                status: *w.status.read().await,
+                reserved: w.reserved.load(Ordering::Acquire),
+            });
+        }
+        out
+    }
+
+    /// Perform an API GET on the first available or specified worker.
+    pub async fn api_get(&self, path: &str) -> Result<serde_json::Value, AppError> {
+        // Use the first idle (or any running) worker for read-only API calls
+        let worker = self
+            .first_ready_worker()
+            .await
+            .ok_or_else(|| AppError::ConnectionFailed("No GPU workers are ready".into()))?;
+        let url = format!("{}{}", worker.base_url, path);
+        let resp = self.http_client.get(&url).send().await?;
+        if !resp.status().is_success() {
+            return Err(AppError::ApiError {
+                status: resp.status().as_u16(),
+                message: resp.text().await.unwrap_or_default(),
+            });
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// Perform an API POST on the first available or specified worker.
+    pub async fn api_post(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value, AppError> {
+        let worker = self
+            .first_ready_worker()
+            .await
+            .ok_or_else(|| AppError::ConnectionFailed("No GPU workers are ready".into()))?;
+        let url = format!("{}{}", worker.base_url, path);
+        let resp = self.http_client.post(&url).json(body).send().await?;
+        if !resp.status().is_success() {
+            return Err(AppError::ApiError {
+                status: resp.status().as_u16(),
+                message: resp.text().await.unwrap_or_default(),
+            });
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// Interrupt generation on a specific worker or all workers.
+    pub async fn interrupt(&self, worker_id: Option<u32>) -> Result<(), AppError> {
+        match worker_id {
+            Some(id) => {
+                if let Some(w) = self.workers.get(id as usize) {
+                    let url = format!("{}/interrupt", w.base_url);
+                    self.http_client.post(&url).send().await?;
+                }
+            }
+            None => {
+                for w in &self.workers {
+                    let status = *w.status.read().await;
+                    if status == WorkerStatus::Running {
+                        let url = format!("{}/interrupt", w.base_url);
+                        let _ = self.http_client.post(&url).send().await;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the first worker that is idle or running (for model/sampler queries).
+    async fn first_ready_worker(&self) -> Option<Arc<GpuWorker>> {
+        for w in &self.workers {
+            let status = *w.status.read().await;
+            if status == WorkerStatus::Idle || status == WorkerStatus::Running {
+                return Some(Arc::clone(w));
+            }
+        }
+        None
+    }
+
+    /// Check if we're in single-worker mode (backward-compat, no gpu_workers configured).
+    pub fn is_single_worker(&self) -> bool {
+        self.workers.len() == 1
+    }
+}
+
+/// Serializable status info for frontend.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WorkerStatusInfo {
+    pub id: u32,
+    pub gpu_index: u32,
+    pub label: String,
+    pub port: u16,
+    pub status: WorkerStatus,
+    pub reserved: bool,
+}
+
+/// Detect available NVIDIA GPUs via nvidia-smi.
+/// Returns Vec<(index, name, vram_mb)>.
+pub fn detect_gpus() -> Vec<(u32, String, u64)> {
+    let output = std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=index,name,memory.total",
+            "--format=csv,noheader,nounits",
+        ])
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            stdout
+                .lines()
+                .filter_map(|line| {
+                    let parts: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
+                    if parts.len() >= 3 {
+                        let idx = parts[0].parse::<u32>().ok()?;
+                        let name = parts[1].to_string();
+                        let vram = parts[2].parse::<u64>().ok()?;
+                        Some((idx, name, vram))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
+/// Auto-generate worker configs from detected GPUs.
+/// Each GPU gets its own worker with sequential ports starting from base_port.
+pub fn auto_configure_workers(base_port: u16) -> Vec<GpuWorkerConfig> {
+    let gpus = detect_gpus();
+    if gpus.is_empty() {
+        return vec![];
+    }
+    gpus.iter()
+        .map(|(idx, name, vram)| {
+            let vram_mode = if *vram >= 40_000 {
+                Some("high".to_string())
+            } else if *vram >= 8_000 {
+                None // Use default
+            } else {
+                Some("low".to_string())
+            };
+            GpuWorkerConfig {
+                gpu_index: *idx,
+                port: Some(base_port + *idx as u16),
+                enabled: true,
+                label: Some(name.clone()),
+                vram_mode,
+            }
+        })
+        .collect()
+}

--- a/src-tauri/src/comfyui/mod.rs
+++ b/src-tauri/src/comfyui/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod gpu_manager;
 pub mod nodes;
 pub mod process;
 pub mod types;

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -655,3 +655,362 @@ async fn kill_process_on_port(port: u16) {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Multi-GPU worker process management
+// ---------------------------------------------------------------------------
+
+use crate::comfyui::gpu_manager::{GpuWorker, WorkerStatus};
+use std::sync::Arc;
+
+/// Start a ComfyUI process for a specific GPU worker.
+/// Sets CUDA_VISIBLE_DEVICES to pin the process to the worker's GPU.
+pub async fn start_worker_process(
+    state: &AppState,
+    worker: &Arc<GpuWorker>,
+) -> Result<(), AppError> {
+    let config = state.config.read().await;
+
+    // Deploy custom nodes (same as single-process path)
+    if !config.comfyui_path.is_empty() {
+        let main_exists = std::path::Path::new(&config.comfyui_path)
+            .join("main.py")
+            .exists();
+        if main_exists {
+            super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
+                .map_err(AppError::ProcessSpawnFailed)?;
+        }
+    }
+
+    if config.server_mode != ServerMode::AutoLaunch {
+        return Ok(());
+    }
+
+    // Check if something is already listening on the worker's port
+    let health_url = format!("{}/system_stats", worker.base_url);
+    if state.http_client.get(&health_url).send().await.is_ok() {
+        log::info!(
+            "Worker {} (GPU {}): ComfyUI already running at {}",
+            worker.id,
+            worker.gpu_index,
+            worker.base_url,
+        );
+        {
+            let mut status = worker.status.write().await;
+            *status = WorkerStatus::Idle;
+        }
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    let python_path = format!("{}/Scripts/python.exe", config.venv_path);
+    #[cfg(not(target_os = "windows"))]
+    let python_path = format!("{}/bin/python", config.venv_path);
+    let main_path = format!("{}/main.py", config.comfyui_path);
+
+    if config.venv_path.is_empty() || !std::path::Path::new(&python_path).exists() {
+        return Err(AppError::ProcessSpawnFailed(format!(
+            "Python not found at '{}'. Run setup first.",
+            python_path
+        )));
+    }
+    if config.comfyui_path.is_empty() || !std::path::Path::new(&main_path).exists() {
+        return Err(AppError::ProcessSpawnFailed(format!(
+            "ComfyUI main.py not found at '{}'.",
+            main_path
+        )));
+    }
+
+    log::info!(
+        "Worker {} (GPU {}): Spawning ComfyUI on port {}",
+        worker.id,
+        worker.gpu_index,
+        worker.port,
+    );
+
+    {
+        let mut status = worker.status.write().await;
+        *status = WorkerStatus::Starting;
+    }
+
+    let mut cmd = tokio::process::Command::new(&python_path);
+    cmd.arg(&main_path)
+        .arg("--listen")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg(worker.port.to_string());
+
+    cmd.arg("--preview-method").arg("auto");
+
+    // VRAM mode: worker-specific override > global config
+    let vram_mode = worker
+        .vram_mode
+        .as_deref()
+        .unwrap_or(config.vram_mode.as_str());
+    match vram_mode {
+        "high" => {
+            cmd.arg("--highvram");
+        }
+        "low" => {
+            cmd.arg("--lowvram");
+        }
+        "none" => {
+            cmd.arg("--novram");
+        }
+        _ => {}
+    }
+
+    // bf16 VAE for Blackwell
+    let has_vae_flag = config.extra_args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "--bf16-vae" | "--fp16-vae" | "--fp32-vae" | "--cpu-vae"
+        )
+    });
+    if !has_vae_flag && has_blackwell_gpu() {
+        cmd.arg("--bf16-vae");
+    }
+
+    // Extra model paths (reuse the main YAML if the single-process path wrote it)
+    let main_yaml = std::env::temp_dir().join("mooshieui_extra_model_paths.yaml");
+    if main_yaml.exists() {
+        cmd.arg("--extra-model-paths-config").arg(&main_yaml);
+    }
+
+    for arg in &config.extra_args {
+        cmd.arg(arg);
+    }
+
+    // Pin to specific GPU
+    cmd.env("CUDA_VISIBLE_DEVICES", worker.gpu_index.to_string());
+
+    // AppImage cleanup on Linux
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var("APPIMAGE").is_ok() {
+            cmd.env_remove("LD_LIBRARY_PATH");
+            cmd.env_remove("LD_PRELOAD");
+            cmd.env_remove("PYTHONHOME");
+            cmd.env_remove("PYTHONPATH");
+            cmd.env_remove("PYTHONDONTWRITEBYTECODE");
+            cmd.env_remove("GDK_BACKEND");
+            if let Ok(path) = std::env::var("PATH") {
+                let filtered: Vec<&str> = path
+                    .split(':')
+                    .filter(|p| !p.contains("/tmp/.mount_"))
+                    .collect();
+                cmd.env("PATH", filtered.join(":"));
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        #[allow(unused_imports)]
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000);
+    }
+
+    let log_path =
+        std::env::temp_dir().join(format!("comfyui-desktop-worker{}-stderr.log", worker.id));
+    let log_file = std::fs::File::create(&log_path).ok();
+    log::info!("Worker {} log: {}", worker.id, log_path.display());
+
+    cmd.stdout(std::process::Stdio::null())
+        .stderr(match log_file {
+            Some(f) => std::process::Stdio::from(f),
+            None => std::process::Stdio::null(),
+        })
+        .kill_on_drop(!config.keep_alive);
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| AppError::ProcessSpawnFailed(e.to_string()))?;
+
+    *worker.process.lock().await = Some(child);
+    Ok(())
+}
+
+/// Wait for a worker's ComfyUI process to become ready.
+pub async fn wait_for_worker_ready(
+    state: &AppState,
+    worker: &Arc<GpuWorker>,
+    timeout_secs: u64,
+) -> Result<(), AppError> {
+    let url = format!("{}/system_stats", worker.base_url);
+    let iterations = timeout_secs * 2;
+
+    for i in 0..iterations {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        if state.http_client.get(&url).send().await.is_ok() {
+            let mut status = worker.status.write().await;
+            *status = WorkerStatus::Idle;
+            log::info!(
+                "Worker {} (GPU {}): ready on port {}",
+                worker.id,
+                worker.gpu_index,
+                worker.port
+            );
+            return Ok(());
+        }
+
+        // Check for crash
+        if i % 4 == 3 {
+            let mut process = worker.process.lock().await;
+            if let Some(ref mut child) = *process {
+                match child.try_wait() {
+                    Ok(Some(exit_status)) => {
+                        *process = None;
+                        let mut status = worker.status.write().await;
+                        *status = WorkerStatus::Error;
+                        let log_path = std::env::temp_dir()
+                            .join(format!("comfyui-desktop-worker{}-stderr.log", worker.id));
+                        let log_excerpt =
+                            std::fs::read_to_string(&log_path).ok().map(|content| {
+                                let lines: Vec<&str> = content.lines().collect();
+                                let start = lines.len().saturating_sub(20);
+                                lines[start..].join("\n")
+                            });
+                        let msg = match log_excerpt {
+                            Some(log) => format!(
+                                "Worker {} (GPU {}): process exited with {} — {}",
+                                worker.id, worker.gpu_index, exit_status, log
+                            ),
+                            None => format!(
+                                "Worker {} (GPU {}): process exited with {}",
+                                worker.id, worker.gpu_index, exit_status
+                            ),
+                        };
+                        return Err(AppError::ProcessSpawnFailed(msg));
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        log::warn!("Worker {}: Failed to check process: {}", worker.id, e);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut status = worker.status.write().await;
+    *status = WorkerStatus::Error;
+    Err(AppError::ConnectionFailed(format!(
+        "Worker {} (GPU {}): did not start within {} seconds",
+        worker.id, worker.gpu_index, timeout_secs
+    )))
+}
+
+/// Stop a specific worker's ComfyUI process.
+pub async fn stop_worker_process(worker: &Arc<GpuWorker>) -> Result<(), AppError> {
+    // Abort WebSocket task
+    {
+        let mut ws = worker.ws_handle.lock().await;
+        if let Some(h) = ws.take() {
+            h.abort();
+        }
+    }
+
+    // Kill child process
+    {
+        let mut process = worker.process.lock().await;
+        if let Some(ref mut child) = *process {
+            child.kill().await.ok();
+            let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+            *process = None;
+        }
+    }
+
+    // Kill anything lingering on the port
+    kill_process_on_port(worker.port).await;
+
+    let mut status = worker.status.write().await;
+    *status = WorkerStatus::Stopped;
+
+    log::info!("Worker {} (GPU {}): stopped", worker.id, worker.gpu_index);
+    Ok(())
+}
+
+/// Start all enabled workers.
+pub async fn start_all_workers(state: &AppState) -> Vec<(u32, Result<(), AppError>)> {
+    let mut results = Vec::new();
+    for worker in &state.gpu_manager.workers {
+        let status = *worker.status.read().await;
+        if status == WorkerStatus::Disabled {
+            continue;
+        }
+        let res = start_worker_process(state, worker).await;
+        results.push((worker.id, res));
+    }
+    results
+}
+
+/// Wait for all starting workers to become ready (in parallel).
+pub async fn wait_all_workers_ready(state: &AppState, timeout_secs: u64) {
+    let mut handles = Vec::new();
+
+    for worker in &state.gpu_manager.workers {
+        let status = *worker.status.read().await;
+        if status != WorkerStatus::Starting {
+            continue;
+        }
+
+        let w = Arc::clone(worker);
+        let http_client = state.http_client.clone();
+        let base_url = w.base_url.clone();
+        let worker_id = w.id;
+        let gpu_index = w.gpu_index;
+        let port = w.port;
+
+        let handle = tokio::spawn(async move {
+            let url = format!("{}/system_stats", base_url);
+            let iterations = timeout_secs * 2;
+            for i in 0..iterations {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                if http_client.get(&url).send().await.is_ok() {
+                    let mut status = w.status.write().await;
+                    *status = WorkerStatus::Idle;
+                    log::info!(
+                        "Worker {} (GPU {}): ready on port {}",
+                        worker_id,
+                        gpu_index,
+                        port
+                    );
+                    return Ok(worker_id);
+                }
+                if i % 4 == 3 {
+                    let mut process = w.process.lock().await;
+                    if let Some(ref mut child) = *process {
+                        if let Ok(Some(_)) = child.try_wait() {
+                            *process = None;
+                            let mut status = w.status.write().await;
+                            *status = WorkerStatus::Error;
+                            return Err(worker_id);
+                        }
+                    }
+                }
+            }
+            let mut status = w.status.write().await;
+            *status = WorkerStatus::Error;
+            Err(worker_id)
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(id)) => log::info!("Worker {} is ready", id),
+            Ok(Err(id)) => log::error!("Worker {} failed to become ready", id),
+            Err(e) => log::error!("Worker ready-wait task panicked: {}", e),
+        }
+    }
+}
+
+/// Stop all workers.
+pub async fn stop_all_workers(state: &AppState) {
+    for worker in &state.gpu_manager.workers {
+        if let Err(e) = stop_worker_process(worker).await {
+            log::error!("Failed to stop worker {}: {}", worker.id, e);
+        }
+    }
+}

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -452,3 +452,203 @@ pub async fn disconnect_websocket(state: &AppState) -> Result<(), AppError> {
     }
     Ok(())
 }
+
+/// Connect a WebSocket to a specific GPU worker's ComfyUI instance.
+/// Events are broadcast to the shared event_tx channel.
+/// The task handle is stored in the worker so it can be aborted on shutdown.
+pub async fn connect_websocket_for_worker(
+    state: &AppState,
+    worker: &std::sync::Arc<super::gpu_manager::GpuWorker>,
+    event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
+) -> Result<(), AppError> {
+    // Disconnect existing WS for this worker
+    {
+        let mut handle = worker.ws_handle.lock().await;
+        if let Some(h) = handle.take() {
+            h.abort();
+        }
+    }
+
+    let ws_url = worker
+        .base_url
+        .replace("http://", "ws://")
+        .replace("https://", "wss://");
+    let ws_url = format!("{}/ws?clientId={}", ws_url, state.client_id);
+
+    let worker_id = worker.id;
+    let tx = event_tx;
+
+    let task = tokio::spawn(async move {
+        let emit = |event: &str, payload: serde_json::Value| {
+            let _ = tx.send(crate::state::BroadcastEvent {
+                event: event.to_string(),
+                payload,
+            });
+        };
+        let result = connect_async(&ws_url).await;
+        let (ws_stream, _) = match result {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("Worker {} WebSocket connection failed: {}", worker_id, e);
+                emit(
+                    "comfyui:connection",
+                    serde_json::json!({"connected": false, "worker_id": worker_id}),
+                );
+                return;
+            }
+        };
+
+        log::info!("Worker {} WebSocket connected", worker_id);
+        emit(
+            "comfyui:connection",
+            serde_json::json!({"connected": true, "worker_id": worker_id}),
+        );
+
+        let (_, mut read) = ws_stream.split();
+        let mut current_prompt_id: Option<String> = None;
+
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                        let event_type = parsed["type"].as_str().unwrap_or("unknown");
+                        let data = &parsed["data"];
+
+                        if let Some(prompt_id) = data["prompt_id"].as_str() {
+                            match event_type {
+                                "execution_start" => {
+                                    current_prompt_id = Some(prompt_id.to_string());
+                                }
+                                "executing" => {
+                                    if data["node"].is_null() {
+                                        if current_prompt_id.as_deref() == Some(prompt_id) {
+                                            current_prompt_id = None;
+                                        }
+                                    } else {
+                                        current_prompt_id = Some(prompt_id.to_string());
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        let event_name = format!("comfyui:{}", event_type);
+                        emit(&event_name, data.clone());
+                    }
+                }
+                Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
+                    if data.len() < 4 {
+                        continue;
+                    }
+                    let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                    if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
+                        continue;
+                    }
+                    match event_type {
+                        1 | 2 => {
+                            if data.len() < 8 {
+                                continue;
+                            }
+                            let format_type =
+                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+                            let format = if format_type == 2 { "png" } else { "jpeg" };
+                            let ext = if format_type == 2 { "png" } else { "jpg" };
+                            let image_data = &data[8..];
+                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
+
+                            let payload = if let Some(temp_filename) =
+                                crate::temp_images::save(image_data, ext)
+                            {
+                                serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
+                            } else {
+                                let b64 =
+                                    base64::engine::general_purpose::STANDARD.encode(image_data);
+                                serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str })
+                            };
+                            emit("comfyui:preview", payload);
+                        }
+                        4 => {
+                            if data.len() < 8 {
+                                continue;
+                            }
+                            let meta_len =
+                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
+                            let image_start = 8 + meta_len;
+                            if image_start < data.len() {
+                                let image_data = &data[image_start..];
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+
+                                let payload = if let Some(temp_filename) =
+                                    crate::temp_images::save(image_data, "jpg")
+                                {
+                                    serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                } else {
+                                    let b64 = base64::engine::general_purpose::STANDARD
+                                        .encode(image_data);
+                                    serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str })
+                                };
+                                emit("comfyui:preview", payload);
+                            }
+                        }
+                        100 => {
+                            if data.len() < 8 {
+                                continue;
+                            }
+                            let format_tag =
+                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+                            let started = Instant::now();
+                            let bit_depth = if format_tag == 2 { 16 } else { 8 };
+                            let image_data = &data[8..];
+                            let encode_ms = started.elapsed().as_millis() as u64;
+                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
+
+                            let payload = if let Some(temp_filename) =
+                                crate::temp_images::save(image_data, "png")
+                            {
+                                serde_json::json!({
+                                    "temp_filename": temp_filename,
+                                    "bit_depth": bit_depth,
+                                    "image_bytes": image_data.len(),
+                                    "encode_ms": encode_ms,
+                                    "prompt_id": prompt_id_str,
+                                })
+                            } else {
+                                let b64 =
+                                    base64::engine::general_purpose::STANDARD.encode(image_data);
+                                serde_json::json!({
+                                    "image": b64,
+                                    "bit_depth": bit_depth,
+                                    "image_bytes": image_data.len(),
+                                    "encode_ms": encode_ms,
+                                    "prompt_id": prompt_id_str,
+                                })
+                            };
+                            emit("comfyui:output_image", payload);
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
+                    log::warn!("Worker {} WebSocket closed", worker_id);
+                    emit(
+                        "comfyui:connection",
+                        serde_json::json!({"connected": false, "worker_id": worker_id}),
+                    );
+                    break;
+                }
+                Err(e) => {
+                    log::error!("Worker {} WebSocket error: {}", worker_id, e);
+                    emit(
+                        "comfyui:connection",
+                        serde_json::json!({"connected": false, "worker_id": worker_id}),
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    *worker.ws_handle.lock().await = Some(task);
+    Ok(())
+}

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2641,3 +2641,110 @@ pub async fn read_clipboard_image(app: AppHandle) -> Result<Vec<u8>, AppError> {
 
     Ok(png_bytes)
 }
+
+// ---------------------------------------------------------------------------
+// GPU stats — live nvidia-smi data + worker status
+// ---------------------------------------------------------------------------
+
+/// Per-GPU stats returned to the frontend.
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuStats {
+    /// GPU index (matches CUDA device order)
+    pub index: u32,
+    /// GPU name (e.g. "NVIDIA RTX 3090 Ti")
+    pub name: String,
+    /// VRAM used in MiB
+    pub vram_used_mb: u64,
+    /// VRAM total in MiB
+    pub vram_total_mb: u64,
+    /// GPU utilization percentage (0–100)
+    pub gpu_util: u32,
+    /// GPU temperature in Celsius
+    pub temperature: u32,
+    /// Power draw in watts
+    pub power_draw_w: u32,
+    /// Worker status (if a MooshieUI worker is assigned to this GPU)
+    pub worker: Option<GpuWorkerInfo>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GpuWorkerInfo {
+    pub worker_id: u32,
+    pub port: u16,
+    pub status: String,
+    pub reserved: bool,
+    pub label: String,
+}
+
+/// Query live GPU stats from nvidia-smi.
+fn query_nvidia_smi_stats() -> Result<Vec<GpuStats>, AppError> {
+    let output = std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=index,name,memory.used,memory.total,utilization.gpu,temperature.gpu,power.draw",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .map_err(|e| AppError::Other(format!("nvidia-smi not found: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AppError::Other(format!("nvidia-smi failed: {}", stderr)));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut gpus = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split(',').map(|s| s.trim()).collect();
+        if parts.len() < 7 {
+            continue;
+        }
+        let index = parts[0].parse::<u32>().unwrap_or(0);
+        let name = parts[1].to_string();
+        let vram_used = parts[2].parse::<f64>().unwrap_or(0.0) as u64;
+        let vram_total = parts[3].parse::<f64>().unwrap_or(0.0) as u64;
+        let gpu_util = parts[4].parse::<u32>().unwrap_or(0);
+        let temperature = parts[5].parse::<u32>().unwrap_or(0);
+        let power_draw = parts[6].parse::<f64>().unwrap_or(0.0) as u32;
+
+        gpus.push(GpuStats {
+            index,
+            name,
+            vram_used_mb: vram_used,
+            vram_total_mb: vram_total,
+            gpu_util,
+            temperature,
+            power_draw_w: power_draw,
+            worker: None,
+        });
+    }
+
+    Ok(gpus)
+}
+
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn get_gpu_stats(state: State<'_, Arc<AppState>>) -> Result<Vec<GpuStats>, AppError> {
+    get_gpu_stats_inner(&state).await
+}
+
+/// Shared implementation used by both Tauri command and REST handler.
+pub async fn get_gpu_stats_inner(state: &AppState) -> Result<Vec<GpuStats>, AppError> {
+    let mut gpus = query_nvidia_smi_stats()?;
+
+    // Merge worker status info
+    let statuses = state.gpu_manager.worker_statuses().await;
+    for ws in &statuses {
+        if let Some(gpu) = gpus.iter_mut().find(|g| g.index == ws.gpu_index) {
+            gpu.worker = Some(GpuWorkerInfo {
+                worker_id: ws.id,
+                port: ws.port,
+                status: format!("{:?}", ws.status).to_lowercase(),
+                reserved: ws.reserved,
+                label: ws.label.clone(),
+            });
+        }
+    }
+
+    Ok(gpus)
+}

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -32,13 +32,20 @@ pub async fn generate(
             serde_json::to_string_pretty(&workflow).unwrap_or_default()
         );
     }
-    let response = state
-        .queue_prompt_request(workflow, &state.client_id)
+
+    // Route through GPU manager for multi-GPU distribution
+    let timeout = std::time::Duration::from_secs(300);
+    let (worker_id, response) = state
+        .gpu_manager
+        .submit_prompt(workflow, &state.client_id, timeout)
         .await?;
 
     // Track the Tauri (host) prompt in the shared queue so LAN users see
     // an accurate queue position.  None = admin / host user.
     state.prompt_queue.insert(&response.prompt_id, None);
+    state
+        .prompt_queue
+        .set_worker(&response.prompt_id, worker_id);
     state.broadcast_queue_positions();
 
     Ok(GenerateResponse {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,6 +1,26 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Per-GPU worker configuration for multi-GPU setups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpuWorkerConfig {
+    /// CUDA device index (maps to CUDA_VISIBLE_DEVICES).
+    pub gpu_index: u32,
+    /// Port for this worker's ComfyUI instance. Auto-assigned if None.
+    pub port: Option<u16>,
+    /// Whether this worker is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Human-readable label (e.g. "RTX 4090").
+    pub label: Option<String>,
+    /// VRAM mode override ("high", "normal", "low", "none"). Falls back to global.
+    pub vram_mode: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppConfig {
@@ -44,6 +64,9 @@ pub struct AppConfig {
     pub ui_server_port: u16,
     /// Enable LAN access (bind to 0.0.0.0 instead of 127.0.0.1). Only effective in browser mode.
     pub lan_enabled: bool,
+    /// Multi-GPU worker configs. When empty, single-worker mode (backward compat).
+    #[serde(default)]
+    pub gpu_workers: Vec<GpuWorkerConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -85,6 +108,7 @@ impl Default for AppConfig {
             browser_mode: false,
             ui_server_port: 3200,
             lan_enabled: false,
+            gpu_workers: vec![],
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,6 +375,7 @@ pub fn run() {
             commands::interrogator::interrogate_clipboard,
             commands::api::fetch_cached_image,
             commands::api::read_clipboard_image,
+            commands::api::get_gpu_stats,
             setup::check_setup,
             setup::detect_gpu,
             setup::run_setup,

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -84,37 +84,72 @@ async fn main() {
 
     // Auto-start ComfyUI if configured
     if auto_start {
-        log::info!("Auto-starting ComfyUI...");
-        match process::start_comfyui_process(&state).await {
-            Ok(result) => {
-                log::info!("ComfyUI start result: {:?}", result);
+        let multi_gpu = !state.gpu_manager.is_single_worker();
 
-                // Wait for ComfyUI to become ready
-                match process::wait_for_ready(&state, 120).await {
-                    Ok(()) => {
-                        log::info!("ComfyUI server is ready");
-                        let event_tx = state.event_tx.clone();
-                        if let Err(e) =
-                            websocket::connect_websocket_headless(&state, event_tx).await
-                        {
-                            log::error!("Failed to connect WebSocket: {}", e);
-                        }
-                        state.broadcast("comfyui:server_ready", serde_json::json!(null));
-                    }
-                    Err(e) => {
-                        log::error!("ComfyUI failed to become ready: {}", e);
-                        state.broadcast(
-                            "comfyui:server_error",
-                            serde_json::json!({
-                                "error": e.to_string(),
-                                "crashed": e.to_string().contains("exited with"),
-                            }),
-                        );
+        if multi_gpu {
+            // Multi-GPU mode: start all configured workers
+            log::info!(
+                "Auto-starting ComfyUI on {} GPU workers...",
+                state.gpu_manager.workers.len()
+            );
+            let results = process::start_all_workers(&state).await;
+            for (wid, res) in &results {
+                if let Err(e) = res {
+                    log::error!("Worker {} failed to start: {}", wid, e);
+                }
+            }
+
+            // Wait for all workers to become ready (in parallel)
+            process::wait_all_workers_ready(&state, 120).await;
+
+            // Connect WebSocket for each ready worker
+            for worker in &state.gpu_manager.workers {
+                let status = *worker.status.read().await;
+                if status == comfyui_desktop_lib::comfyui::gpu_manager::WorkerStatus::Idle {
+                    let event_tx = state.event_tx.clone();
+                    if let Err(e) =
+                        websocket::connect_websocket_for_worker(&state, worker, event_tx).await
+                    {
+                        log::error!("Worker {} WebSocket failed: {}", worker.id, e);
                     }
                 }
             }
-            Err(e) => {
-                log::error!("Failed to start ComfyUI: {}", e);
+
+            state.broadcast("comfyui:server_ready", serde_json::json!(null));
+        } else {
+            // Single-worker mode (backward compat)
+            log::info!("Auto-starting ComfyUI...");
+            match process::start_comfyui_process(&state).await {
+                Ok(result) => {
+                    log::info!("ComfyUI start result: {:?}", result);
+
+                    // Wait for ComfyUI to become ready
+                    match process::wait_for_ready(&state, 120).await {
+                        Ok(()) => {
+                            log::info!("ComfyUI server is ready");
+                            let event_tx = state.event_tx.clone();
+                            if let Err(e) =
+                                websocket::connect_websocket_headless(&state, event_tx).await
+                            {
+                                log::error!("Failed to connect WebSocket: {}", e);
+                            }
+                            state.broadcast("comfyui:server_ready", serde_json::json!(null));
+                        }
+                        Err(e) => {
+                            log::error!("ComfyUI failed to become ready: {}", e);
+                            state.broadcast(
+                                "comfyui:server_error",
+                                serde_json::json!({
+                                    "error": e.to_string(),
+                                    "crashed": e.to_string().contains("exited with"),
+                                }),
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::error!("Failed to start ComfyUI: {}", e);
+                }
             }
         }
     }
@@ -125,12 +160,17 @@ async fn main() {
         .expect("Failed to listen for ctrl-c");
     log::info!("Shutdown signal received, cleaning up...");
 
-    // Kill ComfyUI process
-    let mut proc = state.comfyui_process.lock().await;
-    if let Some(ref mut child) = *proc {
-        log::info!("Shutting down ComfyUI process...");
-        let _ = child.start_kill();
-        *proc = None;
+    // Kill ComfyUI process(es)
+    if !state.gpu_manager.is_single_worker() {
+        log::info!("Shutting down all GPU workers...");
+        process::stop_all_workers(&state).await;
+    } else {
+        let mut proc = state.comfyui_process.lock().await;
+        if let Some(ref mut child) = *proc {
+            log::info!("Shutting down ComfyUI process...");
+            let _ = child.start_kill();
+            *proc = None;
+        }
     }
 
     server_handle.abort();

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,6 +5,7 @@ use tokio::process::Child;
 use tokio::sync::{broadcast, Mutex, Notify, RwLock};
 use tokio::task::JoinHandle;
 
+use crate::comfyui::gpu_manager::GpuManager;
 use crate::config::AppConfig;
 #[cfg(any(feature = "desktop", feature = "server"))]
 use crate::interrogator::InterrogatorState;
@@ -39,6 +40,8 @@ pub struct HeldPrompt {
 pub struct PromptQueue {
     /// prompt_id → username (None = admin/local)
     owners: std::sync::RwLock<HashMap<String, Option<String>>>,
+    /// prompt_id → worker_id that is executing this prompt.
+    worker_map: std::sync::RwLock<HashMap<String, u32>>,
     /// Ordered list of (prompt_id, username) for queue position tracking
     pub(crate) queue: std::sync::RwLock<Vec<(String, Option<String>)>>,
     /// Prompts waiting to be submitted to ComfyUI (fair queue held prompts).
@@ -51,6 +54,7 @@ impl PromptQueue {
     pub fn new() -> Self {
         Self {
             owners: std::sync::RwLock::new(HashMap::new()),
+            worker_map: std::sync::RwLock::new(HashMap::new()),
             queue: std::sync::RwLock::new(Vec::new()),
             held: std::sync::Mutex::new(Vec::new()),
             drain_notify: Notify::new(),
@@ -133,21 +137,38 @@ impl PromptQueue {
 
     /// Remove a completed/errored prompt from the position queue.
     /// Keeps the ownership mapping so in-flight SSE events can still be filtered.
-    pub fn finish(&self, prompt_id: &str) {
+    /// Returns the worker_id that was handling this prompt (if tracked).
+    pub fn finish(&self, prompt_id: &str) -> Option<u32> {
+        let worker_id = self.worker_map.write().unwrap().remove(prompt_id);
         self.queue
             .write()
             .unwrap()
             .retain(|(id, _)| id != prompt_id);
+        worker_id
     }
 
     /// Remove a prompt entirely (position + ownership).
     /// Only used for explicit cancellation, not completion.
     pub fn remove(&self, prompt_id: &str) {
         self.owners.write().unwrap().remove(prompt_id);
+        self.worker_map.write().unwrap().remove(prompt_id);
         self.queue
             .write()
             .unwrap()
             .retain(|(id, _)| id != prompt_id);
+    }
+
+    /// Record which worker is handling a prompt.
+    pub fn set_worker(&self, prompt_id: &str, worker_id: u32) {
+        self.worker_map
+            .write()
+            .unwrap()
+            .insert(prompt_id.to_string(), worker_id);
+    }
+
+    /// Get the worker handling a prompt.
+    pub fn worker_of(&self, prompt_id: &str) -> Option<u32> {
+        self.worker_map.read().unwrap().get(prompt_id).copied()
     }
 
     /// Check if a prompt_id belongs to a specific user.
@@ -245,17 +266,21 @@ pub struct AppState {
     pub web_server_running: std::sync::atomic::AtomicBool,
     /// Multi-user generation queue — tracks prompt ownership and position.
     pub prompt_queue: PromptQueue,
+    /// Multi-GPU worker manager — distributes prompts across N GPU backends.
+    pub gpu_manager: GpuManager,
 }
 
 impl AppState {
     pub fn new(config: AppConfig) -> Self {
         let (event_tx, _) = broadcast::channel(1024);
+        let http_client = reqwest::Client::new();
+        let gpu_manager = GpuManager::new(&config, http_client.clone());
         Self {
             config: RwLock::new(config),
             comfyui_process: Mutex::new(None),
             ws_handle: Mutex::new(None),
             client_id: uuid::Uuid::new_v4().to_string(),
-            http_client: reqwest::Client::new(),
+            http_client,
             #[cfg(any(feature = "desktop", feature = "server"))]
             interrogator: Arc::new(RwLock::new(InterrogatorState::new())),
             event_tx,
@@ -265,6 +290,7 @@ impl AppState {
             app_mode_active: std::sync::atomic::AtomicBool::new(false),
             web_server_running: std::sync::atomic::AtomicBool::new(false),
             prompt_queue: PromptQueue::new(),
+            gpu_manager,
         }
     }
 

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -261,6 +261,8 @@ pub async fn start_server(
             "/internal-api/_embed_temp_metadata",
             post(embed_temp_metadata_handler),
         )
+        // GPU stats — available to all authenticated users
+        .route("/internal-api/_gpu_stats", get(gpu_stats_handler))
         // Generic IPC command proxy
         .route("/internal-api/{command}", post(command_handler))
         // Static file serving (frontend)
@@ -306,7 +308,10 @@ pub async fn start_server(
                                             &pid[..8.min(pid.len())],
                                             owner.as_deref().unwrap_or("admin"),
                                         );
-                                        cleanup_state.prompt_queue.finish(&pid);
+                                        // Release the GPU worker that handled this prompt
+                                        if let Some(wid) = cleanup_state.prompt_queue.finish(&pid) {
+                                            cleanup_state.gpu_manager.mark_worker_idle(wid).await;
+                                        }
                                         cleanup_state.broadcast_queue_positions();
                                         // Signal the drain reactor to submit next held prompt
                                         cleanup_state.prompt_queue.drain_notify.notify_one();
@@ -321,7 +326,13 @@ pub async fn start_server(
                                         &pid[..8.min(pid.len())],
                                         owner.as_deref().unwrap_or("admin"),
                                     );
-                                    cleanup_state.prompt_queue.finish(&pid);
+                                    // Release the GPU worker (error is transient, mark idle)
+                                    if let Some(wid) = cleanup_state.prompt_queue.finish(&pid) {
+                                        cleanup_state
+                                            .gpu_manager
+                                            .mark_worker_error_then_idle(wid)
+                                            .await;
+                                    }
                                     cleanup_state.broadcast_queue_positions();
                                     // Signal the drain reactor to submit next held prompt
                                     cleanup_state.prompt_queue.drain_notify.notify_one();
@@ -350,13 +361,16 @@ pub async fn start_server(
                 drain_state.prompt_queue.drain_notify.notified().await;
                 // Submit one held prompt per completion signal.
                 if let Some(hp) = drain_state.prompt_queue.take_next_held() {
+                    let timeout = std::time::Duration::from_secs(300);
                     let res = drain_state
-                        .queue_prompt_request(hp.workflow, &drain_state.client_id)
+                        .gpu_manager
+                        .submit_prompt(hp.workflow, &drain_state.client_id, timeout)
                         .await;
                     match res {
-                        Ok(response) => {
-                            // Signal the waiting handler with the result.
-                            // The handler will replace the placeholder in the queue.
+                        Ok((worker_id, response)) => {
+                            drain_state
+                                .prompt_queue
+                                .set_worker(&response.prompt_id, worker_id);
                             *hp.result.lock().await = Some(Ok((response.prompt_id, 0)));
                         }
                         Err(e) => {
@@ -952,6 +966,27 @@ async fn embed_temp_metadata_handler(
     }
 }
 
+/// GPU stats handler — returns nvidia-smi data merged with worker statuses.
+async fn gpu_stats_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    let role = resolve_role(&state, &headers, &remote);
+    if role == UserRole::Anonymous {
+        return unauthorized_response("Authentication required");
+    }
+
+    match crate::commands::api::get_gpu_stats_inner(&state.app).await {
+        Ok(stats) => axum::Json(stats).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to get GPU stats: {}", e),
+        )
+            .into_response(),
+    }
+}
+
 /// Generic command handler — proxies IPC commands via HTTP POST.
 ///
 /// The frontend sends `POST /internal-api/{command}` with a JSON body
@@ -1413,12 +1448,17 @@ async fn dispatch_command(
                 }))
             } else {
                 // Direct submission (admin or user's first prompt)
-                let response = state
-                    .queue_prompt_request(workflow, &state.client_id)
+                let timeout = std::time::Duration::from_secs(300);
+                let (worker_id, response) = state
+                    .gpu_manager
+                    .submit_prompt(workflow, &state.client_id, timeout)
                     .await
                     .map_err(|e| e.to_string())?;
 
                 state.prompt_queue.insert(&response.prompt_id, user);
+                state
+                    .prompt_queue
+                    .set_worker(&response.prompt_id, worker_id);
 
                 state.broadcast_queue_positions();
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/settings/GpuStatusPanel.svelte
+++ b/src/lib/components/settings/GpuStatusPanel.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { getGpuStats } from "../../utils/api.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import type { GpuStats } from "../../types/index.js";
+
+  let gpus = $state<GpuStats[]>([]);
+  let error = $state<string | null>(null);
+  let loading = $state(true);
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  async function refresh() {
+    try {
+      gpus = await getGpuStats();
+      error = null;
+    } catch (e: any) {
+      error = e?.message ?? "Failed to fetch GPU stats";
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    refresh();
+    timer = setInterval(refresh, 5000);
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  });
+
+  function vramPercent(gpu: GpuStats): number {
+    if (!gpu.vram_total_mb) return 0;
+    return Math.round((gpu.vram_used_mb / gpu.vram_total_mb) * 100);
+  }
+
+  function statusColor(status: string | undefined): string {
+    if (!status) return "bg-neutral-600";
+    if (status === "running") return "bg-green-500";
+    if (status === "idle") return "bg-indigo-500";
+    if (status === "starting") return "bg-amber-500";
+    if (status === "error") return "bg-red-500";
+    return "bg-neutral-600";
+  }
+
+  function statusLabel(status: string | undefined): string {
+    if (!status) return "No worker";
+    if (status === "running") return "Running";
+    if (status === "idle") return "Idle";
+    if (status === "starting") return "Starting";
+    if (status === "error") return "Error";
+    return status;
+  }
+
+  function vramBarColor(pct: number): string {
+    if (pct > 90) return "bg-red-500";
+    if (pct > 70) return "bg-amber-500";
+    return "bg-indigo-500";
+  }
+
+  function tempColor(temp: number): string {
+    if (temp > 85) return "text-red-400";
+    if (temp > 70) return "text-amber-400";
+    return "text-neutral-300";
+  }
+</script>
+
+{#if loading}
+  <div class="flex items-center gap-2 text-neutral-500 text-sm py-3">
+    <svg class="w-4 h-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+    </svg>
+    Loading GPU info…
+  </div>
+{:else if error}
+  <div class="text-sm text-red-400 py-2">{error}</div>
+{:else if gpus.length === 0}
+  <div class="text-sm text-neutral-500 py-2">No GPUs detected</div>
+{:else}
+  <div class="space-y-3">
+    {#each gpus as gpu (gpu.index)}
+      <div class="bg-neutral-800/60 border border-neutral-700/50 rounded-lg p-4 space-y-3">
+        <!-- Header: GPU name + worker status badge -->
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-neutral-100">GPU {gpu.index}</span>
+            <span class="text-xs text-neutral-400 truncate max-w-[200px]">{gpu.name}</span>
+          </div>
+          <div class="flex items-center gap-2">
+            {#if gpu.worker}
+              <span class="inline-flex items-center gap-1.5 text-xs text-neutral-300">
+                <span class="w-2 h-2 rounded-full {statusColor(gpu.worker.status)}"></span>
+                {statusLabel(gpu.worker.status)}
+                {#if gpu.worker.reserved}
+                  <span class="text-amber-400 text-[10px]">(busy)</span>
+                {/if}
+              </span>
+            {:else}
+              <span class="inline-flex items-center gap-1.5 text-xs text-neutral-500">
+                <span class="w-2 h-2 rounded-full bg-neutral-600"></span>
+                No worker
+              </span>
+            {/if}
+          </div>
+        </div>
+
+        <!-- VRAM bar -->
+        <div>
+          <div class="flex items-center justify-between text-[11px] mb-1">
+            <span class="text-neutral-400">VRAM</span>
+            <span class="text-neutral-300">{gpu.vram_used_mb} / {gpu.vram_total_mb} MiB ({vramPercent(gpu)}%)</span>
+          </div>
+          <div class="w-full h-2 bg-neutral-700 rounded-full overflow-hidden">
+            <div
+              class="h-full rounded-full transition-all duration-500 {vramBarColor(vramPercent(gpu))}"
+              style="width: {vramPercent(gpu)}%"
+            ></div>
+          </div>
+        </div>
+
+        <!-- Stats row -->
+        <div class="flex items-center gap-4 text-[11px]">
+          <div class="flex items-center gap-1.5">
+            <span class="text-neutral-500">Utilization</span>
+            <span class="text-neutral-200 font-medium">{gpu.gpu_util}%</span>
+          </div>
+          <div class="flex items-center gap-1.5">
+            <span class="text-neutral-500">Temp</span>
+            <span class="font-medium {tempColor(gpu.temperature)}">{gpu.temperature}°C</span>
+          </div>
+          <div class="flex items-center gap-1.5">
+            <span class="text-neutral-500">Power</span>
+            <span class="text-neutral-200 font-medium">{gpu.power_draw_w}W</span>
+          </div>
+          {#if gpu.worker?.label}
+            <div class="flex items-center gap-1.5 ml-auto">
+              <span class="text-neutral-500">Worker</span>
+              <span class="text-neutral-300">{gpu.worker.label} (:{gpu.worker.port})</span>
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+  <p class="text-[10px] text-neutral-600 mt-2">Auto-refreshes every 5 seconds</p>
+{/if}

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -10,6 +10,7 @@
   import { locale, LOCALE_OPTIONS } from "../../stores/locale.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import OpenModelFolders from "./OpenModelFolders.svelte";
+  import GpuStatusPanel from "./GpuStatusPanel.svelte";
   import { ipcInvoke, ipcListen, isTauri, isBrowserMode, authHeaders } from "../../utils/ipc.js";
   import { onMount } from "svelte";
   import { marked } from "marked";
@@ -701,6 +702,7 @@
     { key: "connection", label: "Connection", keywords: "server mode url port remote autolaunch" },
     { key: "appearance", label: "Appearance", keywords: "theme dark light font scale size style presets fooocus" },
     { key: "performance", label: "Performance", keywords: "vram mode high low normal keep alive close quality tags auto" },
+    { key: "gpu", label: "GPU Workers", keywords: "gpu vram worker backend multi status utilization temperature power nvidia" },
     { key: "paths", label: "Paths", keywords: "comfyui install venv python cli arguments extra args shared model directory models" },
     { key: "gallery", label: "Gallery", keywords: "import images output directory swarmui comfyui external folder manual save mode save directory" },
     { key: "autocomplete", label: "Autocomplete", keywords: "tags taglist suggestions results url upload csv json danbooru" },
@@ -1504,6 +1506,25 @@
           </div>
           {/if}
           {/if}
+          </div>
+          {/if}
+        </section>
+        {/if}
+
+        <!-- GPU Workers (visible to all users) -->
+        {#if sectionVisible("gpu")}
+        <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
+          <button
+            class="w-full flex items-center justify-between p-5 text-sm font-medium text-neutral-200 hover:bg-neutral-800/50 transition-colors cursor-pointer"
+            onclick={() => (collapsed.gpu = !collapsed.gpu)}
+          >
+            GPU Workers
+            <svg class="w-4 h-4 text-neutral-500 transition-transform {collapsed.gpu ? '-rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </button>
+
+          {#if !collapsed.gpu}
+          <div class="px-5 pb-5">
+            <GpuStatusPanel />
           </div>
           {/if}
         </section>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -174,3 +174,22 @@ export interface InterrogationResult {
   copyright_tags: TagResult[];
   rating_tags: TagResult[];
 }
+
+export interface GpuWorkerInfo {
+  worker_id: number;
+  port: number;
+  status: string;
+  reserved: boolean;
+  label: string;
+}
+
+export interface GpuStats {
+  index: number;
+  name: string;
+  vram_used_mb: number;
+  vram_total_mb: number;
+  gpu_util: number;
+  temperature: number;
+  power_draw_w: number;
+  worker: GpuWorkerInfo | null;
+}

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,9 +1,10 @@
-import { ipcInvoke, isBrowserMode } from "./ipc.js";
+import { ipcInvoke, isBrowserMode, isTauri } from "./ipc.js";
 import { locale } from "../stores/locale.svelte.js";
 import type {
   AppConfig,
   GalleryImageEntry,
   GenerationParams,
+  GpuStats,
   InterrogationResult,
   OutputImage,
   QueueInfo,
@@ -573,4 +574,18 @@ export async function readClipboardImageSafe(): Promise<number[]> {
 
 export async function exportLogs(destination: string): Promise<void> {
   return ipcInvoke("export_logs", { destination });
+}
+
+export async function getGpuStats(): Promise<GpuStats[]> {
+  if (isTauri) {
+    return ipcInvoke("get_gpu_stats");
+  }
+  if (!isBrowserMode) return [];
+  const { getAuthToken } = await import("./ipc.js");
+  const headers: Record<string, string> = {};
+  const token = getAuthToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const resp = await fetch("/internal-api/_gpu_stats", { headers });
+  if (!resp.ok) throw new Error(await resp.text());
+  return resp.json();
 }


### PR DESCRIPTION
## v0.7.9

### Multi-GPU Worker Backend
- SwarmUI-style `GpuManager` for multi-GPU prompt dispatch with LRU scheduling
- Per-worker ComfyUI subprocess pinned to specific GPUs via `CUDA_VISIBLE_DEVICES`
- Auto-detection via `nvidia-smi` with configurable `gpu_workers` array in AppConfig
- Transparent single-worker fallback when only one GPU is configured

### GPU Status Panel (Settings)
- Live GPU monitoring: VRAM usage bar, GPU utilization %, temperature, power draw
- Worker status badges (idle/running/starting/error) with busy indicator
- Visible to all users (not admin-gated)
- Auto-refreshes every 5 seconds
- Dual-mode: Tauri command + `GET /internal-api/_gpu_stats` REST endpoint

### Backend Infrastructure
- Worker-aware `PromptQueue` tracks which worker handles each prompt
- `GpuWorkerConfig` struct with `gpu_index`, `port`, `enabled`, `label`, `vram_mode`
- Server mode (`mooshieui-server`) starts all workers in parallel with health-check gates

### Files Changed (21 files, +1590 / -51)
- **New**: `gpu_manager.rs`, `GpuStatusPanel.svelte`
- **Modified**: process.rs, websocket.rs, api.rs, workflow.rs, config.rs, lib.rs, server_main.rs, state.rs, webserver.rs, SettingsPage.svelte, types/index.ts, api.ts, version files, release notes