### PR TITLE
fix: sync @tauri-apps/plugin-fs npm to 2.5.0 (match Cargo crate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "comfyui-desktop",
-  "version": "0.7.7",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "0.7.7",
+      "version": "0.7.9",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",
-        "@tauri-apps/plugin-fs": "^2",
+        "@tauri-apps/plugin-fs": "^2.5.0",
         "@tauri-apps/plugin-process": "^2",
         "@tauri-apps/plugin-shell": "^2",
         "@tauri-apps/plugin-store": "^2",
@@ -1503,12 +1503,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-fs": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.5.tgz",
-      "integrity": "sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.0.tgz",
+      "integrity": "sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tauri-apps/plugin-process": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2",
-    "@tauri-apps/plugin-fs": "^2",
+    "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-store": "^2",


### PR DESCRIPTION
Fix v0.7.9 build failure: Tauri detected version mismatch between `tauri-plugin-fs` Rust crate (2.5.0, bumped by Dependabot) and `@tauri-apps/plugin-fs` npm package (2.4.5).

Updated `@tauri-apps/plugin-fs` to 2.5.0 to match.