### PR TITLE
v0.8.0: Non-blocking generation, stuck-worker watchdog, clipboard fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## What's New in v0.8.0
+
+### Non-Blocking Generation (Cloudflare 524 Fix)
+- **Instant HTTP response** — the `generate` command now returns a placeholder prompt ID immediately and submits to ComfyUI workers in the background. Previously the request blocked for up to 300 seconds waiting for a GPU worker, which caused Cloudflare 524 timeout errors on LAN/cloud deployments.
+- **Prompt ID alias system** — an alias layer maps ComfyUI's real prompt IDs back to the placeholder IDs the frontend received, so all SSE events (progress, preview, completion) are transparently rewritten. No frontend changes required.
+- **Background error handling** — if submission fails after the response was already sent, an `execution_error` event is emitted so the frontend clears the stuck generation state.
+
+### Stuck-Worker Watchdog
+- **Automatic recovery** — a periodic watchdog (every 60 seconds) detects GPU workers that have been reserved for longer than 10 minutes with no corresponding queue entry, and forcibly releases them back to idle. This prevents the "generate button does nothing" bug caused by missed WebSocket completion events.
+
+### Clipboard Copy Fix (Browser Mode)
+- **Server URL preferred over blob URLs** — the copy-to-clipboard flow now constructs a proper `/internal-api/_gallery/` URL when the image's `fullImageUrl` hasn't been set yet, instead of falling back to a blob URL that fails with `SecurityError` through Cloudflare's proxy.
+- **Graceful fetch fallback** — blob URL fetch errors are now caught and handled instead of throwing to the user.
+
+### Tauri Plugin Version Sync
+- **`@tauri-apps/plugin-fs` bumped to 2.5.0** — syncs the npm package with the Rust crate (Dependabot had bumped only the Rust side), fixing the CI build failure in v0.7.9.
+
+---
+
 ## What's New in v0.7.9
 
 ### Multi-GPU Worker Backend

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+## What's New in v0.8.0
+
+### Non-Blocking Generation (Cloudflare 524 Fix)
+- **Instant HTTP response** — the `generate` command now returns a placeholder prompt ID immediately and submits to ComfyUI workers in the background. Previously the request blocked for up to 300 seconds waiting for a GPU worker, which caused Cloudflare 524 timeout errors on LAN/cloud deployments.
+- **Prompt ID alias system** — an alias layer maps ComfyUI's real prompt IDs back to the placeholder IDs the frontend received, so all SSE events (progress, preview, completion) are transparently rewritten. No frontend changes required.
+- **Background error handling** — if submission fails after the response was already sent, an `execution_error` event is emitted so the frontend clears the stuck generation state.
+
+### Stuck-Worker Watchdog
+- **Automatic recovery** — a periodic watchdog (every 60 seconds) detects GPU workers that have been reserved for longer than 10 minutes with no corresponding queue entry, and forcibly releases them back to idle. This prevents the "generate button does nothing" bug caused by missed WebSocket completion events.
+
+### Clipboard Copy Fix (Browser Mode)
+- **Server URL preferred over blob URLs** — the copy-to-clipboard flow now constructs a proper `/internal-api/_gallery/` URL when the image's `fullImageUrl` hasn't been set yet, instead of falling back to a blob URL that fails with `SecurityError` through Cloudflare's proxy.
+- **Graceful fetch fallback** — blob URL fetch errors are now caught and handled instead of throwing to the user.
+
+### Tauri Plugin Version Sync
+- **`@tauri-apps/plugin-fs` bumped to 2.5.0** — syncs the npm package with the Rust crate (Dependabot had bumped only the Rust side), fixing the CI build failure in v0.7.9.
+
+---
+
 ## What's New in v0.7.9
 
 ### Multi-GPU Worker Backend

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.7.9"
+version = "0.8.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.7.9"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -866,12 +866,11 @@ pub async fn wait_for_worker_ready(
                         *status = WorkerStatus::Error;
                         let log_path = std::env::temp_dir()
                             .join(format!("comfyui-desktop-worker{}-stderr.log", worker.id));
-                        let log_excerpt =
-                            std::fs::read_to_string(&log_path).ok().map(|content| {
-                                let lines: Vec<&str> = content.lines().collect();
-                                let start = lines.len().saturating_sub(20);
-                                lines[start..].join("\n")
-                            });
+                        let log_excerpt = std::fs::read_to_string(&log_path).ok().map(|content| {
+                            let lines: Vec<&str> = content.lines().collect();
+                            let start = lines.len().saturating_sub(20);
+                            lines[start..].join("\n")
+                        });
                         let msg = match log_excerpt {
                             Some(log) => format!(
                                 "Worker {} (GPU {}): process exited with {} — {}",

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -21,14 +21,16 @@ pub struct BroadcastEvent {
     pub payload: serde_json::Value,
 }
 
-/// Result slot for a held prompt: (prompt_id, seed) or error message.
-pub type HeldPromptResult = Arc<Mutex<Option<Result<(String, i64), String>>>>;
+/// Result slot for a held prompt: (prompt_id, worker_id) or error message.
+pub type HeldPromptResult = Arc<Mutex<Option<Result<(String, u32), String>>>>;
 
 /// A prompt held locally, waiting to be submitted to ComfyUI.
 /// Used for fair queuing — only one prompt per user is submitted at a time.
 pub struct HeldPrompt {
     pub workflow: serde_json::Value,
     pub username: Option<String>,
+    /// The placeholder prompt_id returned to the client (for alias binding).
+    pub placeholder_id: String,
     /// Signalled when this prompt is submitted to ComfyUI.
     pub submitted: Arc<Notify>,
     /// Filled in by the submission reactor after `queue_prompt`.
@@ -48,6 +50,9 @@ pub struct PromptQueue {
     pub(crate) held: std::sync::Mutex<Vec<HeldPrompt>>,
     /// Notified when a held prompt should be submitted (after a completion).
     pub(crate) drain_notify: Notify,
+    /// Maps ComfyUI's real prompt_id → our placeholder prompt_id.
+    /// Used to translate WebSocket events so the frontend sees consistent IDs.
+    aliases: std::sync::RwLock<HashMap<String, String>>,
 }
 
 impl PromptQueue {
@@ -58,6 +63,7 @@ impl PromptQueue {
             queue: std::sync::RwLock::new(Vec::new()),
             held: std::sync::Mutex::new(Vec::new()),
             drain_notify: Notify::new(),
+            aliases: std::sync::RwLock::new(HashMap::new()),
         }
     }
 
@@ -171,6 +177,11 @@ impl PromptQueue {
         self.worker_map.read().unwrap().get(prompt_id).copied()
     }
 
+    /// Snapshot of the worker_map (prompt_id → worker_id) for read-only inspection.
+    pub fn worker_map_snapshot(&self) -> HashMap<String, u32> {
+        self.worker_map.read().unwrap().clone()
+    }
+
     /// Check if a prompt_id belongs to a specific user.
     /// Returns true if:
     /// - The prompt is untracked (submitted before queue tracking started)
@@ -241,6 +252,45 @@ impl PromptQueue {
         }
         // Just take the first held prompt — the insert order already ensures fairness.
         Some(held.remove(0))
+    }
+
+    /// Bind an alias: map ComfyUI's real prompt_id → our placeholder_id.
+    /// Also registers ownership for the real_id so SSE filtering works if
+    /// an event arrives before alias resolution.
+    pub fn bind_alias(&self, placeholder_id: &str, comfyui_id: &str) {
+        self.aliases
+            .write()
+            .unwrap()
+            .insert(comfyui_id.to_string(), placeholder_id.to_string());
+        // Copy ownership so is_owned_by works for the real id too
+        let username = self
+            .owners
+            .read()
+            .unwrap()
+            .get(placeholder_id)
+            .cloned()
+            .flatten();
+        self.owners
+            .write()
+            .unwrap()
+            .insert(comfyui_id.to_string(), username);
+    }
+
+    /// Resolve a prompt_id: if it's a ComfyUI real_id with a bound alias,
+    /// return the placeholder_id. Otherwise return the original id.
+    pub fn resolve_alias(&self, prompt_id: &str) -> String {
+        self.aliases
+            .read()
+            .unwrap()
+            .get(prompt_id)
+            .cloned()
+            .unwrap_or_else(|| prompt_id.to_string())
+    }
+
+    /// Clean up alias entries for a finished prompt.
+    pub fn cleanup_alias(&self, placeholder_id: &str) {
+        let mut aliases = self.aliases.write().unwrap();
+        aliases.retain(|_, v| v != placeholder_id);
     }
 }
 

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -291,11 +291,12 @@ pub async fn start_server(
             loop {
                 match cleanup_rx.recv().await {
                     Ok(evt) => {
+                        // Resolve alias: translate ComfyUI's real prompt_id to our placeholder
                         let prompt_id = evt
                             .payload
                             .get("prompt_id")
                             .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
+                            .map(|s| cleanup_state.prompt_queue.resolve_alias(s));
 
                         match evt.event.as_str() {
                             "comfyui:executing" => {
@@ -312,6 +313,7 @@ pub async fn start_server(
                                         if let Some(wid) = cleanup_state.prompt_queue.finish(&pid) {
                                             cleanup_state.gpu_manager.mark_worker_idle(wid).await;
                                         }
+                                        cleanup_state.prompt_queue.cleanup_alias(&pid);
                                         cleanup_state.broadcast_queue_positions();
                                         // Signal the drain reactor to submit next held prompt
                                         cleanup_state.prompt_queue.drain_notify.notify_one();
@@ -333,6 +335,7 @@ pub async fn start_server(
                                             .mark_worker_error_then_idle(wid)
                                             .await;
                                     }
+                                    cleanup_state.prompt_queue.cleanup_alias(&pid);
                                     cleanup_state.broadcast_queue_positions();
                                     // Signal the drain reactor to submit next held prompt
                                     cleanup_state.prompt_queue.drain_notify.notify_one();
@@ -368,10 +371,14 @@ pub async fn start_server(
                         .await;
                     match res {
                         Ok((worker_id, response)) => {
+                            // Bind alias immediately to prevent race with WebSocket events
                             drain_state
                                 .prompt_queue
-                                .set_worker(&response.prompt_id, worker_id);
-                            *hp.result.lock().await = Some(Ok((response.prompt_id, 0)));
+                                .bind_alias(&hp.placeholder_id, &response.prompt_id);
+                            drain_state
+                                .prompt_queue
+                                .set_worker(&hp.placeholder_id, worker_id);
+                            *hp.result.lock().await = Some(Ok((response.prompt_id, worker_id)));
                         }
                         Err(e) => {
                             *hp.result.lock().await =
@@ -392,6 +399,57 @@ pub async fn start_server(
             loop {
                 interval.tick().await;
                 flush_auth.flush_last_online();
+            }
+        });
+    }
+
+    // Stuck-worker watchdog — every 60s, check for workers that have been
+    // reserved (running) for longer than 10 minutes without a corresponding
+    // queue entry. This catches cases where the WebSocket completion event
+    // was missed, leaving a worker permanently stuck.
+    {
+        let watchdog_state = web_state.app.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            let max_stuck_secs = 600u64; // 10 minutes
+            loop {
+                interval.tick().await;
+                for worker in &watchdog_state.gpu_manager.workers {
+                    let status = *worker.status.read().await;
+                    let reserved = worker.reserved.load(std::sync::atomic::Ordering::Acquire);
+                    if status == crate::comfyui::gpu_manager::WorkerStatus::Running && reserved {
+                        // Check if any prompt in the queue is assigned to this worker
+                        let has_active_prompt = {
+                            let wmap = watchdog_state.prompt_queue.worker_map_snapshot();
+                            wmap.values().any(|&wid| wid == worker.id)
+                        };
+                        if !has_active_prompt {
+                            // Worker is reserved but has no tracked prompt — check how long
+                            let last_released = worker
+                                .last_released
+                                .load(std::sync::atomic::Ordering::Acquire);
+                            let now_ms = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_millis() as u64;
+                            // If last_released is 0, worker was never released (started stuck)
+                            let stuck_secs = if last_released == 0 {
+                                now_ms / 1000
+                            } else {
+                                (now_ms.saturating_sub(last_released)) / 1000
+                            };
+                            if stuck_secs > max_stuck_secs {
+                                log::warn!(
+                                    "[watchdog] Releasing stuck worker {} (GPU {}, stuck {}s, no queue entry)",
+                                    worker.id,
+                                    worker.gpu_index,
+                                    stuck_secs,
+                                );
+                                watchdog_state.gpu_manager.mark_worker_idle(worker.id).await;
+                            }
+                        }
+                    }
+                }
             }
         });
     }
@@ -664,23 +722,41 @@ async fn sse_handler(
         let prompt_queue = prompt_queue.clone();
         match result {
             Ok(evt) => {
-                // System events (no prompt_id) pass through to everyone
-                // Prompt-specific events are filtered by ownership
-                let prompt_id = evt
+                // Resolve alias: translate ComfyUI's real prompt_id to our placeholder
+                let raw_prompt_id = evt
                     .payload
                     .get("prompt_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                let resolved_id = raw_prompt_id
+                    .as_deref()
+                    .map(|pid| prompt_queue.prompt_queue.resolve_alias(pid));
 
-                if let Some(ref pid) = prompt_id {
+                // Filter by ownership using the resolved (placeholder) id
+                if let Some(ref pid) = resolved_id {
                     if !prompt_queue.prompt_queue.is_owned_by(pid, &sse_username) {
                         return None; // Not this user's prompt — skip
                     }
                 }
 
+                // Replace prompt_id in payload with resolved placeholder so the
+                // frontend sees the same ID it received from the generate response.
+                let payload =
+                    if let (Some(ref resolved), Some(ref raw)) = (&resolved_id, &raw_prompt_id) {
+                        if resolved != raw {
+                            let mut p = evt.payload.clone();
+                            p["prompt_id"] = serde_json::Value::String(resolved.clone());
+                            p
+                        } else {
+                            evt.payload
+                        }
+                    } else {
+                        evt.payload
+                    };
+
                 let json = serde_json::json!({
                     "event": evt.event,
-                    "payload": evt.payload,
+                    "payload": payload,
                 });
                 Some(Ok::<_, std::convert::Infallible>(
                     Event::default().data(json.to_string()),
@@ -1397,78 +1473,112 @@ async fn dispatch_command(
                 params.steps,
             );
 
-            // Fair queue: LAN users are throttled to one active prompt at a time.
-            // If user already has an active prompt, hold this one until a slot opens.
+            // Check needs_hold BEFORE inserting the placeholder
             let needs_hold = user.is_some() && state.prompt_queue.active_count_for_user(&user) > 0;
 
-            if needs_hold {
-                // Hold the prompt locally — it will be submitted by the drain reactor.
-                let submitted = Arc::new(tokio::sync::Notify::new());
-                let result_slot: crate::state::HeldPromptResult =
-                    Arc::new(tokio::sync::Mutex::new(None));
+            // Generate a placeholder prompt_id and insert it immediately.
+            // This allows us to return to the client right away (avoids Cloudflare 524 timeouts).
+            let placeholder_id = format!("gen-{}", uuid::Uuid::new_v4());
+            state.prompt_queue.insert(&placeholder_id, user.clone());
+            state.broadcast_queue_positions();
 
-                let held = crate::state::HeldPrompt {
-                    workflow,
-                    username: user.clone(),
-                    submitted: submitted.clone(),
-                    result: result_slot.clone(),
-                };
+            let queue_pos = state.prompt_queue.len().saturating_sub(1);
+            let queue_total = state.prompt_queue.len();
 
-                // Add to held queue and also insert a placeholder into the display queue
-                // so the user sees their position immediately.
-                let placeholder_id = format!("held-{}", uuid::Uuid::new_v4());
-                state.prompt_queue.insert(&placeholder_id, user.clone());
-                {
-                    let mut held_queue = state.prompt_queue.held.lock().unwrap();
-                    held_queue.push(held);
+            // Spawn background task to do the actual ComfyUI submission.
+            let bg_state = Arc::clone(&state);
+            let bg_placeholder = placeholder_id.clone();
+            tokio::spawn(async move {
+                if needs_hold {
+                    // Fair queue: hold this prompt until a slot opens for this user.
+                    let submitted = Arc::new(tokio::sync::Notify::new());
+                    let result_slot: crate::state::HeldPromptResult =
+                        Arc::new(tokio::sync::Mutex::new(None));
+
+                    let held = crate::state::HeldPrompt {
+                        workflow,
+                        username: user.clone(),
+                        placeholder_id: bg_placeholder.clone(),
+                        submitted: submitted.clone(),
+                        result: result_slot.clone(),
+                    };
+
+                    {
+                        let mut held_queue = bg_state.prompt_queue.held.lock().unwrap();
+                        held_queue.push(held);
+                    }
+                    bg_state.broadcast_queue_positions();
+
+                    // Wait until the drain reactor submits this prompt
+                    submitted.notified().await;
+
+                    // Retrieve the result — alias is already bound by the drain reactor
+                    let res = result_slot
+                        .lock()
+                        .await
+                        .take()
+                        .unwrap_or_else(|| Err("Held prompt was never submitted".into()));
+
+                    match res {
+                        Ok(_) => {
+                            bg_state.broadcast_queue_positions();
+                        }
+                        Err(e) => {
+                            log::error!(
+                                "[gen] held submission failed for {}: {}",
+                                bg_placeholder,
+                                e
+                            );
+                            bg_state.prompt_queue.finish(&bg_placeholder);
+                            bg_state.prompt_queue.cleanup_alias(&bg_placeholder);
+                            bg_state.broadcast_queue_positions();
+                            let _ = bg_state.event_tx.send(crate::state::BroadcastEvent {
+                                event: "comfyui:execution_error".to_string(),
+                                payload: serde_json::json!({
+                                    "prompt_id": bg_placeholder,
+                                    "error": e,
+                                }),
+                            });
+                        }
+                    }
+                } else {
+                    // Direct submission (admin or user's first prompt)
+                    let timeout = std::time::Duration::from_secs(300);
+                    match bg_state
+                        .gpu_manager
+                        .submit_prompt(workflow, &bg_state.client_id, timeout)
+                        .await
+                    {
+                        Ok((worker_id, response)) => {
+                            bg_state
+                                .prompt_queue
+                                .bind_alias(&bg_placeholder, &response.prompt_id);
+                            bg_state.prompt_queue.set_worker(&bg_placeholder, worker_id);
+                            bg_state.broadcast_queue_positions();
+                        }
+                        Err(e) => {
+                            log::error!("[gen] submission failed for {}: {}", bg_placeholder, e);
+                            bg_state.prompt_queue.finish(&bg_placeholder);
+                            bg_state.broadcast_queue_positions();
+                            let _ = bg_state.event_tx.send(crate::state::BroadcastEvent {
+                                event: "comfyui:execution_error".to_string(),
+                                payload: serde_json::json!({
+                                    "prompt_id": bg_placeholder,
+                                    "error": e.to_string(),
+                                }),
+                            });
+                        }
+                    }
                 }
-                state.broadcast_queue_positions();
+            });
 
-                // Wait until the drain reactor submits this prompt
-                submitted.notified().await;
-
-                // Retrieve the result
-                let res = result_slot
-                    .lock()
-                    .await
-                    .take()
-                    .unwrap_or_else(|| Err("Held prompt was never submitted".into()));
-                let (prompt_id, _) = res.map_err(|e| e)?;
-
-                // Remove placeholder and insert the real prompt_id
-                state.prompt_queue.finish(&placeholder_id);
-                state.prompt_queue.insert(&prompt_id, user);
-                state.broadcast_queue_positions();
-
-                Ok(serde_json::json!({
-                    "prompt_id": prompt_id,
-                    "seed": seed,
-                    "queue_position": state.prompt_queue.len() - 1,
-                    "queue_total": state.prompt_queue.len(),
-                }))
-            } else {
-                // Direct submission (admin or user's first prompt)
-                let timeout = std::time::Duration::from_secs(300);
-                let (worker_id, response) = state
-                    .gpu_manager
-                    .submit_prompt(workflow, &state.client_id, timeout)
-                    .await
-                    .map_err(|e| e.to_string())?;
-
-                state.prompt_queue.insert(&response.prompt_id, user);
-                state
-                    .prompt_queue
-                    .set_worker(&response.prompt_id, worker_id);
-
-                state.broadcast_queue_positions();
-
-                Ok(serde_json::json!({
-                    "prompt_id": response.prompt_id,
-                    "seed": seed,
-                    "queue_position": state.prompt_queue.len() - 1,
-                    "queue_total": state.prompt_queue.len(),
-                }))
-            }
+            // Return immediately — the frontend tracks progress via SSE/WebSocket events
+            Ok(serde_json::json!({
+                "prompt_id": placeholder_id,
+                "seed": seed,
+                "queue_position": queue_pos,
+                "queue_total": queue_total,
+            }))
         }
         "delete_queue_item" => {
             let prompt_id = args["promptId"].as_str().ok_or("Missing promptId")?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -517,18 +517,27 @@ class GalleryStore {
           }
         }
         // Step 2: Try browser Clipboard API, with server-side fallback for insecure (HTTP) contexts.
-        const fetchUrl = image.fullImageUrl || image.url;
+        // Prefer the server-served gallery URL over blob URLs (blob: URLs fail through Cloudflare proxy).
+        let fetchUrl = image.fullImageUrl;
+        if (!fetchUrl && galleryFilename) {
+          fetchUrl = await fullImageUrl(galleryFilename);
+        }
+        if (!fetchUrl) fetchUrl = image.url;
         if (fetchUrl) {
-          const resp = await fetch(fetchUrl);
-          if (!resp.ok) {
-            this.showToast(locale.t("gallery.toast.copy_failed") || "Failed to copy image", "error");
+          try {
+            const resp = await fetch(fetchUrl);
+            if (!resp.ok) {
+              this.showToast(locale.t("gallery.toast.copy_failed") || "Failed to copy image", "error");
+              return;
+            }
+            const blob = await resp.blob();
+            const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
+            await this.writeBlobToClipboard(pngBlob);
+            this.showToast(locale.t("gallery.toast.copied"), "success");
             return;
+          } catch {
+            // Blob URL fetch can fail with SecurityError through Cloudflare — fall through
           }
-          const blob = await resp.blob();
-          const pngBlob = blob.type.startsWith("image/") ? blob : new Blob([blob], { type: "image/png" });
-          await this.writeBlobToClipboard(pngBlob);
-          this.showToast(locale.t("gallery.toast.copied"), "success");
-          return;
         }
         // Step 3: Image genuinely not available yet (no URL or gallery file).
         this.showToast(locale.t("gallery.toast.not_saved_yet"), "info");


### PR DESCRIPTION
# v0.8.0 Release

## Changes

### Non-Blocking Generation (Cloudflare 524 Fix)
- Generate command now returns a placeholder prompt ID immediately and submits to ComfyUI workers in the background
- Alias system maps real ComfyUI prompt IDs back to placeholder IDs for transparent SSE event rewriting
- Background error handling emits `execution_error` event if submission fails post-response

### Stuck-Worker Watchdog
- Periodic watchdog (60s interval) detects GPU workers reserved >10 min with no queue entry
- Forcibly releases orphaned workers back to idle, preventing "generate does nothing" bug

### Clipboard Copy Fix (Browser Mode)
- Prefers `/internal-api/_gallery/` URL over blob URLs for clipboard copy through Cloudflare proxy
- Catches blob URL fetch errors gracefully instead of throwing SecurityError

### Tauri Plugin Version Sync
- `@tauri-apps/plugin-fs` npm bumped to 2.5.0 to match Rust crate (fixes CI build from v0.7.9)

## Files Changed
- `src-tauri/src/state.rs` — alias system, worker_map_snapshot
- `src-tauri/src/webserver.rs` — non-blocking generate, watchdog, alias resolution in SSE/cleanup/drain reactors
- `src/lib/stores/gallery.svelte.ts` — clipboard copy fix
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` — version bump 0.8.0
- `RELEASE_NOTES.md`, `CHANGELOG.md` — release documentation