### PR TITLE
v0.8.1: Fix reconciler alias resolution, activity-guarded reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v0.8.1
+
+### Reconciler Alias Resolution Fix
+- **Queue query aggregates all GPU workers** — the `get_queue` handler now queries every GPU worker's ComfyUI queue instead of only the primary, ensuring prompts on any worker are visible to the frontend reconciler.
+- **Prompt ID alias resolution in queue responses** — real ComfyUI prompt IDs are now translated back to the `gen-*` placeholder IDs the frontend tracks, preventing the reconciler from falsely concluding a running prompt has vanished.
+
+### Activity-Guarded Reconciler
+- **30-second activity window** — prompts that received an SSE event (executing, progress) within the last 30 seconds are never reconciled, even if the queue query momentarily misses them. This prevents tab-switching within the app from killing in-progress generations.
+- **Proper cleanup** — the activity timestamp map is cleaned up on prompt completion and error, preventing unbounded memory growth.
+
+---
+
 ## What's New in v0.8.0
 
 ### Non-Blocking Generation (Cloudflare 524 Fix)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v0.8.1
+
+### Reconciler Alias Resolution Fix
+- **Queue query aggregates all GPU workers** — the `get_queue` handler now queries every GPU worker's ComfyUI queue instead of only the primary, ensuring prompts on any worker are visible to the frontend reconciler.
+- **Prompt ID alias resolution in queue responses** — real ComfyUI prompt IDs are now translated back to the `gen-*` placeholder IDs the frontend tracks, preventing the reconciler from falsely concluding a running prompt has vanished.
+
+### Activity-Guarded Reconciler
+- **30-second activity window** — prompts that received an SSE event (executing, progress) within the last 30 seconds are never reconciled, even if the queue query momentarily misses them. This prevents tab-switching within the app from killing in-progress generations.
+- **Proper cleanup** — the activity timestamp map is cleaned up on prompt completion and error, preventing unbounded memory growth.
+
+---
+
 ## What's New in v0.8.0
 
 ### Non-Blocking Generation (Cloudflare 524 Fix)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1326,8 +1326,44 @@ async fn dispatch_command(
             Ok(serde_json::json!(result))
         }
         "get_queue" => {
-            let result = state.get_queue_info().await.map_err(|e| e.to_string())?;
-            serde_json::to_value(result).map_err(|e| e.to_string())
+            // Aggregate queues from ALL GPU workers so the frontend reconciler
+            // can see prompts regardless of which worker is executing them.
+            let mut running: Vec<serde_json::Value> = Vec::new();
+            let mut pending: Vec<serde_json::Value> = Vec::new();
+            for worker in &state.gpu_manager.workers {
+                let url = format!("{}/queue", worker.base_url);
+                if let Ok(resp) = state.http_client.get(&url).send().await {
+                    if let Ok(val) = resp.json::<serde_json::Value>().await {
+                        if let Some(arr) = val.get("queue_running").and_then(|v| v.as_array()) {
+                            running.extend(arr.iter().cloned());
+                        }
+                        if let Some(arr) = val.get("queue_pending").and_then(|v| v.as_array()) {
+                            pending.extend(arr.iter().cloned());
+                        }
+                    }
+                }
+            }
+            // Resolve aliases: replace real ComfyUI prompt IDs with the
+            // placeholder gen-* IDs the frontend knows about.
+            let resolve = |entries: &mut Vec<serde_json::Value>| {
+                for entry in entries.iter_mut() {
+                    // ComfyUI queue entries are arrays: [index, prompt_id, ...]
+                    if let Some(arr) = entry.as_array_mut() {
+                        if let Some(pid) = arr.get(1).and_then(|v| v.as_str()) {
+                            let resolved = state.prompt_queue.resolve_alias(pid);
+                            if resolved != pid {
+                                arr[1] = serde_json::Value::String(resolved);
+                            }
+                        }
+                    }
+                }
+            };
+            resolve(&mut running);
+            resolve(&mut pending);
+            Ok(serde_json::json!({
+                "queue_running": running,
+                "queue_pending": pending,
+            }))
         }
         "get_history" => {
             let prompt_id = args["promptId"].as_str().ok_or("Missing promptId")?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -51,6 +51,8 @@
     await Promise.race([Promise.allSettled(fetches), timeout]);
   }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
+  /** Timestamp of the most recent SSE event per prompt — prevents false reconciliation. */
+  let promptLastActivity = new Map<string, number>();
 
   // Lightbox zoom state — only scale needs reactivity (used in template conditionals)
   let lbScale = 1;
@@ -1365,6 +1367,7 @@
         // Filter by prompt_id — reject events for other users' prompts
         if (data.prompt_id && !progress.pendingPrompts.some((p: any) => p.promptId === data.prompt_id)) return;
         if (data.prompt_id && progress.activePromptId && data.prompt_id !== progress.activePromptId) return;
+        if (data.prompt_id) promptLastActivity.set(data.prompt_id, Date.now());
         if (data.prompt_id && !progress.activePromptId) {
           progress.setActivePrompt(data.prompt_id);
         }
@@ -1492,6 +1495,8 @@
         if (data.prompt_id && !progress.pendingPrompts.some((p: any) => p.promptId === data.prompt_id)) {
           return;
         }
+        // Record activity so the reconciler knows this prompt is alive
+        if (data.prompt_id) promptLastActivity.set(data.prompt_id, Date.now());
         if (data.node === null) {
           if (!progress.isGenerating) return;
           const promptId = data.prompt_id;
@@ -1508,6 +1513,7 @@
           }
 
           const item = progress.completePrompt(promptId);
+          promptLastActivity.delete(promptId);
           if (item) {
             const images = pendingOutputImages.get(promptId) ?? [];
             pendingOutputImages.delete(promptId);
@@ -1534,12 +1540,14 @@
         if (data.prompt_id) {
           pendingOutputImages.delete(data.prompt_id);
           pendingOutputFetches.delete(data.prompt_id);
+          promptLastActivity.delete(data.prompt_id);
           progress.removePrompt(data.prompt_id);
           compare.clearGridBatch();
         } else {
           // No prompt_id — clear everything
           pendingOutputImages.clear();
           pendingOutputFetches.clear();
+          promptLastActivity.clear();
           progress.cancelAll();
           compare.clearGridBatch();
         }
@@ -1564,7 +1572,13 @@
             : (item as any)?.prompt_id;
           if (pid) allPromptIds.add(pid);
         }
+        const now = Date.now();
         for (const p of progress.pendingPrompts) {
+          // Skip prompts that received an SSE event within the last 30s —
+          // they're clearly still alive even if the queue query missed them.
+          const lastEvent = promptLastActivity.get(p.promptId) ?? 0;
+          if (now - lastEvent < 30_000) continue;
+
           if (!allPromptIds.has(p.promptId)) {
             console.warn(`[reconcile] Prompt ${p.promptId} no longer in ComfyUI queue — completing`);
             // Wait for any in-flight output_image fetches
@@ -1574,6 +1588,7 @@
               pendingOutputFetches.delete(p.promptId);
             }
             const item = progress.completePrompt(p.promptId);
+            promptLastActivity.delete(p.promptId);
             if (item) {
               const images = pendingOutputImages.get(p.promptId) ?? [];
               pendingOutputImages.delete(p.promptId);


### PR DESCRIPTION
# v0.8.1 Release\n\n## Fixes\n\n### Reconciler Alias Resolution Fix\n- `get_queue` handler now aggregates queues from **all** GPU workers instead of only the primary\n- Real ComfyUI prompt IDs are resolved to `gen-*` placeholder IDs in queue responses so the frontend reconciler correctly identifies running prompts\n\n### Activity-Guarded Reconciler\n- Prompts receiving SSE events within the last 30s are exempt from reconciliation\n- Prevents in-app tab switching (Settings, Gallery) from killing in-progress generations\n- Activity map cleaned up on prompt completion/error\n\n## Root Cause\nSwitching between tabs within MooshieUI while generating would trigger the stuck-generation reconciler. Because `get_queue` returned raw ComfyUI prompt IDs (not the `gen-*` aliases the frontend tracks), the reconciler falsely concluded the prompt had vanished and prematurely completed it — losing the output image and leaving the GPU worker reserved.\n\n## Files Changed\n- `src-tauri/src/webserver.rs` — multi-worker queue aggregation + alias resolution\n- `src/App.svelte` — `promptLastActivity` map, activity guards in event handlers + reconciler"