### PR TITLE
v0.8.2: Fix lightbox blob URL staleness after tab switch, fix upscale method label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v0.8.2
+
+### Bug Fixes
+- **Fix lightbox images breaking after tab switch** — images in the modal view (lightbox) and bottom panel gallery would fail to load with `ERR_FILE_NOT_FOUND` after switching browser tabs, because the in-memory blob URLs became stale. The lightbox now always loads persisted images fresh from disk, with the session blob shown as an instant placeholder. Blob URLs created for lightbox display are properly tracked and revoked on close, eliminating memory leaks.
+- **Fix upscale method label showing raw locale key** — the upscale settings "Method" dropdown displayed the raw key `generation.upscale.method_label` instead of the translated label. Corrected to use the existing `generation.upscale.method` locale key.
+
+---
+
 ## What's New in v0.6.9 — The "Nice" Update
 
 ### Compare Grid Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v0.8.2
+
+### Bug Fixes
+- **Fix lightbox images breaking after tab switch** — images in the modal view (lightbox) and bottom panel gallery would fail to load with `ERR_FILE_NOT_FOUND` after switching browser tabs, because the in-memory blob URLs became stale. The lightbox now always loads persisted images fresh from disk, with the session blob shown as an instant placeholder. Blob URLs created for lightbox display are properly tracked and revoked on close, eliminating memory leaks.
+- **Fix upscale method label showing raw locale key** — the upscale settings "Method" dropdown displayed the raw key `generation.upscale.method_label` instead of the translated label. Corrected to use the existing `generation.upscale.method` locale key.
+
+---
+
 ## What's New in v0.6.9 — The "Nice" Update
 
 ### Compare Grid Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.6.9",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.6.9"
+version = "0.8.2"
 dependencies = [
  "base64 0.22.1",
  "csv",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.6.9"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.6.9",
+  "version": "0.8.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/UpscaleSettings.svelte
+++ b/src/lib/components/generation/UpscaleSettings.svelte
@@ -145,7 +145,7 @@
   {#if generation.upscaleEnabled}
     <!-- Method -->
     <div>
-      <label class="block text-xs text-neutral-400 mb-1">{locale.t('generation.upscale.method_label')}<InfoTip text={locale.t('generation.upscale.method_tip')} /></label>
+      <label class="block text-xs text-neutral-400 mb-1">{locale.t('generation.upscale.method')}<InfoTip text={locale.t('generation.upscale.method_tip')} /></label>
       <select
         bind:value={generation.upscaleMethod}
         class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -35,6 +35,8 @@ class GalleryStore {
   boardAssignments = $state<Record<string, string>>({});
   customBoards = $state<string[]>([]);
   private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Blob URL created by loadFullImage for the current lightbox — revoked on close/replace. */
+  private _loadedLightboxUrl: string | null = null;
 
   constructor() {
     this.loadBoardAssignments();
@@ -124,24 +126,33 @@ class GalleryStore {
   }
 
   async openLightbox(image: OutputImage) {
+    // Revoke any blob URL we created in a previous loadFullImage call
+    if (this._loadedLightboxUrl) {
+      URL.revokeObjectURL(this._loadedLightboxUrl);
+      this._loadedLightboxUrl = null;
+    }
     this.selectedImage = image;
     this.lightboxOpen = true;
-    if (image.url) {
-      // Session images already have a full-res blob URL
-      this.lightboxUrl = image.url;
-      this.lightboxLoading = false;
-    } else if (image.gallery_filename) {
-      // Persisted images — load full-res from disk
-      this.lightboxUrl = null;
+    if (image.gallery_filename) {
+      // Persisted images — always load full-res from disk so we never rely on a
+      // potentially-stale session blob URL (which can be revoked by rescan, etc.).
+      // Show the session blob URL immediately as a low-latency placeholder.
+      this.lightboxUrl = image.url ?? null;
       this.lightboxLoading = true;
       try {
         const fullUrl = await this.loadFullImage(image.gallery_filename);
+        this._loadedLightboxUrl = fullUrl;
         this.lightboxUrl = fullUrl;
       } catch (e) {
         console.error("Failed to load full image:", e);
+        // Keep image.url as fallback if disk load fails
       } finally {
         this.lightboxLoading = false;
       }
+    } else if (image.url) {
+      // Pure session image not yet persisted — use the in-memory blob URL directly
+      this.lightboxUrl = image.url;
+      this.lightboxLoading = false;
     }
   }
 
@@ -153,6 +164,10 @@ class GalleryStore {
   }
 
   closeLightbox() {
+    if (this._loadedLightboxUrl) {
+      URL.revokeObjectURL(this._loadedLightboxUrl);
+      this._loadedLightboxUrl = null;
+    }
     this.lightboxOpen = false;
     this.selectedImage = null;
     this.lightboxUrl = null;
@@ -460,6 +475,8 @@ class GalleryStore {
       }
 
       if (migrated > 0) {
+        // Close the lightbox before revoking blobs to avoid showing broken blob URLs
+        this.closeLightbox();
         for (const image of this.images) {
           if (image.url) URL.revokeObjectURL(image.url);
         }


### PR DESCRIPTION
## v0.8.2 Bug Fixes

- **Fix lightbox images breaking after tab switch** — images in the modal view (lightbox) and bottom panel gallery would fail to load with `ERR_FILE_NOT_FOUND` after switching browser tabs. The lightbox now always loads persisted images fresh from disk, with the session blob shown as an instant placeholder. Blob URLs created for lightbox display are properly tracked and revoked on close, eliminating memory leaks.
- **Fix upscale method label showing raw locale key** — the upscale settings "Method" dropdown displayed the raw key `generation.upscale.method_label` instead of the translated label. Corrected to use the existing `generation.upscale.method` locale key.