### PR TITLE
chore: release v0.8.2 — fix upscale label & lightbox blob safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v0.8.2
+
+### Bug Fixes
+
+- **Fix upscale method label** — the upscale method dropdown was showing a raw locale key (`generation.upscale.method_label`) instead of the translated label. Corrected to use the existing `generation.upscale.method` key.
+- **Fix lightbox blob URL crash on metadata rescan** — `rescanMetadata()` now closes the lightbox before revoking session blob URLs, preventing `ERR_FILE_NOT_FOUND` errors when the lightbox was displaying a blob-backed image during a gallery rescan.
+
+---
+
 ## What's New in v0.8.1
 
 ### Reconciler Alias Resolution Fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v0.8.2
+
+### Bug Fixes
+
+- **Fix upscale method label** — the upscale method dropdown was showing a raw locale key (`generation.upscale.method_label`) instead of the translated label. Corrected to use the existing `generation.upscale.method` key.
+- **Fix lightbox blob URL crash on metadata rescan** — `rescanMetadata()` now closes the lightbox before revoking session blob URLs, preventing `ERR_FILE_NOT_FOUND` errors when the lightbox was displaying a blob-backed image during a gallery rescan.
+
+---
+
 ## What's New in v0.8.1
 
 ### Reconciler Alias Resolution Fix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/UpscaleSettings.svelte
+++ b/src/lib/components/generation/UpscaleSettings.svelte
@@ -180,7 +180,7 @@
   {#if generation.upscaleEnabled}
     <!-- Method -->
     <div>
-      <label class="block text-xs text-neutral-400 mb-1">{locale.t('generation.upscale.method_label')}<InfoTip text={locale.t('generation.upscale.method_tip')} /></label>
+      <label class="block text-xs text-neutral-400 mb-1">{locale.t('generation.upscale.method')}<InfoTip text={locale.t('generation.upscale.method_tip')} /></label>
       <select
         bind:value={generation.upscaleMethod}
         class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -673,6 +673,9 @@ class GalleryStore {
       }
 
       if (migrated > 0) {
+        // Close lightbox before revoking blob URLs — the lightbox may be
+        // displaying one of these blobs, which would cause ERR_FILE_NOT_FOUND.
+        if (this.lightboxOpen) this.closeLightbox();
         for (const image of this.images) {
           if (image.url) URL.revokeObjectURL(image.url);
         }


### PR DESCRIPTION
## Release v0.8.2\n\n### Bug Fixes\n\n- **Fix upscale method label** — the upscale method dropdown showed raw locale key `generation.upscale.method_label` instead of the translated label. Corrected to use the existing `generation.upscale.method` key.\n- **Fix lightbox blob URL crash on metadata rescan** — `rescanMetadata()` now closes the lightbox before revoking session blob URLs, preventing `ERR_FILE_NOT_FOUND` when the lightbox was displaying a blob-backed image during a gallery rescan.\n\n### Version Bump\n\n`0.8.1` → `0.8.2` in `package.json`, `Cargo.toml`, `tauri.conf.json`\n\n### Changed Files\n\n- `src/lib/components/generation/UpscaleSettings.svelte` — locale key fix\n- `src/lib/stores/gallery.svelte.ts` — close lightbox before blob revocation\n- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` — version bump\n- `RELEASE_NOTES.md`, `CHANGELOG.md` — v0.8.2 notes