### PR TITLE
fix: image not displaying after generation in browser mode (v0.8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v0.8.3
+
+### Bug Fixes
+
+- **Fix image not displaying after generation (browser mode)** — two related bugs caused `ERR_FILE_NOT_FOUND` for generated images when running through Cloudflare/browser mode:
+  1. **Backend alias race condition** — the cleanup reactor removed the prompt ID alias mapping before SSE streams could resolve it for the `node: null` completion event. Alias cleanup is now deferred by 5 seconds.
+  2. **Stale blob URL in PreviewImage** — `embedTempMetadata` replaced and revoked the output image's blob URL without updating `progress.lastOutputImage` or `modeLastOutput`. Now updates all progress store references before revoking.
+
+---
+
 ## What's New in v0.8.2
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v0.8.3
+
+### Bug Fixes
+
+- **Fix image not displaying after generation (browser mode)** — two related bugs caused `ERR_FILE_NOT_FOUND` for generated images when running through Cloudflare/browser mode:
+  1. **Backend alias race condition** — the cleanup reactor removed the prompt ID alias mapping before SSE streams could resolve it for the `node: null` completion event. The frontend received the raw ComfyUI prompt_id, rejected it, and relied on the 15-second reconciler fallback. Alias cleanup is now deferred by 5 seconds so all SSE streams forward the correct `gen-*` placeholder ID.
+  2. **Stale blob URL in PreviewImage** — `embedTempMetadata` replaced and revoked the output image's blob URL without updating `progress.lastOutputImage` or `modeLastOutput`. The `PreviewImage` component's `$derived` then attempted to load the revoked URL. Now updates all progress store references before revoking, and triggers `sessionImages` reactivity so gallery thumbnails also pick up the new URL.
+
+---
+
 ## What's New in v0.8.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -313,7 +313,18 @@ pub async fn start_server(
                                         if let Some(wid) = cleanup_state.prompt_queue.finish(&pid) {
                                             cleanup_state.gpu_manager.mark_worker_idle(wid).await;
                                         }
-                                        cleanup_state.prompt_queue.cleanup_alias(&pid);
+                                        // Delay alias cleanup so SSE streams have time to
+                                        // resolve the alias for this same event.  Without the
+                                        // delay, the SSE filter_map can race with this reactor
+                                        // and forward the raw ComfyUI prompt_id instead of the
+                                        // gen-* placeholder the frontend expects.
+                                        let alias_pid = pid.clone();
+                                        let alias_state = cleanup_state.clone();
+                                        tokio::spawn(async move {
+                                            tokio::time::sleep(std::time::Duration::from_secs(5))
+                                                .await;
+                                            alias_state.prompt_queue.cleanup_alias(&alias_pid);
+                                        });
                                         cleanup_state.broadcast_queue_positions();
                                         // Signal the drain reactor to submit next held prompt
                                         cleanup_state.prompt_queue.drain_notify.notify_one();
@@ -335,7 +346,12 @@ pub async fn start_server(
                                             .mark_worker_error_then_idle(wid)
                                             .await;
                                     }
-                                    cleanup_state.prompt_queue.cleanup_alias(&pid);
+                                    let alias_pid = pid.clone();
+                                    let alias_state = cleanup_state.clone();
+                                    tokio::spawn(async move {
+                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                                        alias_state.prompt_queue.cleanup_alias(&alias_pid);
+                                    });
                                     cleanup_state.broadcast_queue_positions();
                                     // Signal the drain reactor to submit next held prompt
                                     cleanup_state.prompt_queue.drain_notify.notify_one();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1117,7 +1117,15 @@
         gallery.lightboxUrl = newUrl;
       }
 
-      if (oldUrl) URL.revokeObjectURL(oldUrl);
+      // Update progress store references so PreviewImage doesn't try to
+      // load the revoked blob URL via displayImage / lastOutputImage.
+      if (oldUrl) {
+        progress.replaceOutputUrl(oldUrl, newUrl);
+        URL.revokeObjectURL(oldUrl);
+      }
+
+      // Trigger Svelte reactivity so lazyThumbnail actions pick up the new URL
+      gallery.sessionImages = [...gallery.sessionImages];
     } catch (e) {
       // Non-critical — the image is still visible, just without embedded metadata
       console.warn("[embedTempMetadata] failed:", e);

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -120,6 +120,23 @@ class ProgressStore {
     this.lastOutputImage = image;
   }
 
+  /** Replace a blob URL in lastOutputImage/modeLastOutput (used by embedTempMetadata). */
+  replaceOutputUrl(oldUrl: string, newUrl: string) {
+    if (this.lastOutputImage === oldUrl) {
+      this.lastOutputImage = newUrl;
+    }
+    let changed = false;
+    for (const [mode, url] of Object.entries(this.modeLastOutput)) {
+      if (url === oldUrl) {
+        (this.modeLastOutput as Record<string, string | null>)[mode] = newUrl;
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.modeLastOutput = { ...this.modeLastOutput };
+    }
+  }
+
   /** Called when a progress event arrives — detects pass transitions */
   updateProgress(step: number, max: number, node: string | null) {
     if (node && node !== this._lastProgressNode) {


### PR DESCRIPTION
## Release v0.8.3\n\n### Fix: Image not displaying after generation (browser mode)\n\nTwo related bugs caused `ERR_FILE_NOT_FOUND` for generated images when running through Cloudflare/browser mode:\n\n#### 1. Backend alias race condition (`webserver.rs`)\nThe cleanup reactor removed the prompt ID alias mapping (`cleanup_alias`) immediately when the `node: null` executing event fired. SSE streams processing the same event could race and find the alias already gone, forwarding the raw ComfyUI prompt_id instead of the `gen-*` placeholder. The frontend rejected the unrecognized ID and fell through to the 15-second reconciler.\n\n**Fix:** Defer `cleanup_alias` by 5 seconds via `tokio::spawn` + `tokio::time::sleep`, giving all SSE streams time to resolve the alias.\n\n#### 2. Stale blob URL in PreviewImage (`App.svelte` + `progress.svelte.ts`)\n`embedTempMetadata` replaced an output image's blob URL with a metadata-embedded version and revoked the old one — but `progress.lastOutputImage` and `progress.modeLastOutput` still referenced the revoked URL. The `PreviewImage` component's `$derived(previewSrc)` then tried to load it.\n\n**Fix:** Added `progress.replaceOutputUrl(oldUrl, newUrl)` that updates both `lastOutputImage` and `modeLastOutput`. Called before `revokeObjectURL`. Also triggers `gallery.sessionImages` reactivity so `lazyThumbnail` actions pick up the new URL.\n\n### Changed Files\n- `src-tauri/src/webserver.rs` — deferred alias cleanup (both success and error paths)\n- `src/App.svelte` — embedTempMetadata updates progress refs + triggers reactivity\n- `src/lib/stores/progress.svelte.ts` — new `replaceOutputUrl` method\n- Version bump 0.8.2 → 0.8.3\n- Release notes & changelog