### PR TITLE
v0.8.4: Quality tags settings accessible to all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v0.8.4
+
+### Quality Tags for All Users
+
+- **Quality tags settings accessible to all users** — the auto quality tags controls (toggle, customization, per-model tag editing for Anima/Illustrious/Nanosaur) were previously hidden inside the admin-only Performance section. They are now in their own standalone "Quality Tags" section visible to all users, regardless of role.
+
+---
+
 ## What's New in v0.8.3
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v0.8.4
+
+### Quality Tags for All Users
+
+- **Quality tags settings accessible to all users** — the auto quality tags controls (toggle, customization, per-model tag editing for Anima/Illustrious/Nanosaur) were previously hidden inside the admin-only Performance section. They are now in their own standalone "Quality Tags" section visible to all users, regardless of role.
+
+---
+
 ## What's New in v0.8.3
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -701,7 +701,8 @@
   const sections = [
     { key: "connection", label: "Connection", keywords: "server mode url port remote autolaunch" },
     { key: "appearance", label: "Appearance", keywords: "theme dark light font scale size style presets fooocus" },
-    { key: "performance", label: "Performance", keywords: "vram mode high low normal keep alive close quality tags auto" },
+    { key: "performance", label: "Performance", keywords: "vram mode high low normal keep alive close" },
+    { key: "quality", label: "Quality Tags", keywords: "quality tags auto masterpiece best quality anima illustrious noobai pony nanosaur positive negative prompt" },
     { key: "gpu", label: "GPU Workers", keywords: "gpu vram worker backend multi status utilization temperature power nvidia" },
     { key: "paths", label: "Paths", keywords: "comfyui install venv python cli arguments extra args shared model directory models" },
     { key: "gallery", label: "Gallery", keywords: "import images output directory swarmui comfyui external folder manual save mode save directory" },
@@ -1362,6 +1363,24 @@
             </div>
           </div>
 
+          </div>
+          {/if}
+        </section>
+        {/if}
+
+        <!-- Quality Tags (visible to all users) -->
+        {#if sectionVisible("quality")}
+        <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
+          <button
+            class="w-full flex items-center justify-between p-5 text-sm font-medium text-neutral-200 hover:bg-neutral-800/50 transition-colors cursor-pointer"
+            onclick={() => (collapsed.quality = !collapsed.quality)}
+          >
+            {locale.t('settings.performance.auto_quality_tags')}
+            <svg class="w-4 h-4 text-neutral-500 transition-transform {collapsed.quality ? '-rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </button>
+
+          {#if !collapsed.quality}
+          <div class="px-5 pb-5 space-y-4">
           <div class="flex items-start gap-3">
             <input
               type="checkbox"


### PR DESCRIPTION
## Changes

- **Quality tags settings accessible to all users** — the auto quality tags controls (toggle, customization, per-model tag editing for Anima/Illustrious/Nanosaur) were previously hidden inside the admin-only Performance section. They are now in their own standalone "Quality Tags" section visible to all users, regardless of role.

## Files Changed

- `src/lib/components/settings/SettingsPage.svelte` — extracted quality tags controls into new section
- `package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` — version bump to 0.8.4
- `RELEASE_NOTES.md` / `CHANGELOG.md` — v0.8.4 release notes