### PR TITLE
v0.8.6: Bot review fixes, SHA256 integrity, release workflow triage

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -102,16 +102,42 @@ npm run build
 
 3. **Wait for CI** — poll `github-pull-request_pullRequestStatusChecks` until the "GlassWorm Infection Audit" check shows `state: "success"`. Wait 30 seconds between polls. Timeout after 5 minutes.
 
-4. **Merge the PR** using `mcp_github_merge_pull_request` with `merge_method: "squash"`.
+4. **Triage and address bot review comments** — after CI passes, wait 60 seconds for automated reviewers (`gemini-code-assist[bot]`, `copilot-pull-request-reviewer[bot]`) to post, then fetch all review comments with `mcp_github_pull_request_read` (`method: "get_review_comments"`).
 
-5. **Sync local main:**
+   **Assessment — do NOT blindly trust bot suggestions.** For each comment, classify it:
+
+   | Category | Action | Examples |
+   |----------|--------|---------|
+   | **Correctness / Safety** | Fix it | Error propagation bugs, MIME type mismatches, missing integrity checks, silent data loss |
+   | **Consistency** | Fix it | Title-case inconsistency in user-visible strings, naming convention violations |
+   | **Defensive hardening** | Fix if trivial | `.trim().is_empty()` instead of `.is_empty()`, edge-case guards |
+   | **Premature abstraction** | Skip | "Centralize X into a shared config" when only 2 call-sites exist |
+   | **Stylistic / informational** | Skip | Praise, nitpicks, suggestions that don't improve correctness or safety |
+   | **Factually wrong** | Skip and note why | Bot misunderstands the API contract, browser Clipboard API constraints, etc. |
+
+   **Workflow:**
+   - Read each comment, read the referenced file to verify the bot's claim is accurate
+   - Present a summary table to the user: comment, file, verdict (fix / skip), and one-line rationale
+   - Apply only the fixes classified as Fix
+   - If any fixes were made, commit and push:
+     ```powershell
+     git add -A
+     git -c core.hooksPath=/dev/null commit -m "address bot review feedback"
+     git -c core.hooksPath=/dev/null push origin release/vX.Y.Z
+     ```
+   - Wait for CI to pass again (same polling as step 3) before proceeding to merge
+   - If there are no actionable comments, proceed directly to merge
+
+5. **Merge the PR** using `mcp_github_merge_pull_request` with `merge_method: "squash"`.
+
+6. **Sync local main:**
    ```powershell
    git checkout main
    git fetch origin main
    git reset --hard origin/main
    ```
 
-### 6. Tag and push
+### 7. Tag and push
 
 > **CRITICAL**: Tag protection rules prevent deleting or force-updating tags once pushed. Only push the tag after the PR is merged and main is synced.
 
@@ -125,11 +151,11 @@ The `v*` tag triggers the **Build & Release** GitHub Actions workflow which:
 2. Generates `latest.json` updater manifest with signatures
 3. Creates a **GitHub Release** with download table + only the current version's section from `RELEASE_NOTES.md`
 
-### 7. Verify CI started
+### 8. Verify CI started
 
 After pushing the tag, confirm the release workflow started by checking with the GitHub API or telling the user to check `https://github.com/Mooshieblob1/MooshieUI/actions`.
 
-### 8. Fallback: workflow_dispatch
+### 9. Fallback: workflow_dispatch
 
 If the tag push is rejected (e.g. tag already exists due to a previous attempt), or if the tag-triggered workflow fails, use **workflow_dispatch** as a fallback:
 
@@ -144,7 +170,7 @@ Invoke-RestMethod -Uri "https://api.github.com/repos/Mooshieblob1/MooshieUI/acti
 
 This triggers the same Build & Release workflow from the current `main` HEAD.
 
-### 9. Clean up
+### 10. Clean up
 
 Delete the release branch (remote only):
 ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v0.8.6
+
+### Bot Review Fixes (from v0.8.5 PR feedback)
+
+- **Rust API error propagation** — `api_post()` in both `client.rs` and `gpu_manager.rs` now uses `?` instead of `unwrap_or_default()` when reading response text, so transport/body-read errors properly propagate instead of being silently swallowed as empty responses.
+- **Whitespace-tolerant empty body check** — `text.trim().is_empty()` replaces `text.is_empty()` so whitespace-only responses from ComfyUI endpoints (e.g. `/interrupt`, `/free`) are correctly treated as empty rather than failing JSON parse.
+- **Clipboard MIME type consistency** — Canvas fallback in `copyBlobToClipboard()` now explicitly resets `mimeType` to `"image/png"` so the clipboard item's declared type always matches the actual PNG bytes produced by the canvas.
+- **Face detector SHA256 verification** — `GenerateButton.svelte` now passes the expected SHA256 hash when downloading the default Anzhc YOLO11n Face Seg model, matching the integrity verification already used in `FaceFixSettings.svelte`.
+- **Title case fix** — "face detailer" → "Face Detailer" in the downloading message across 5 locale files (en, fr, it, pt, es) for consistency with the rest of the UI.
+
+### Release Workflow Improvement
+
+- **Bot review triage step** — The `/release` prompt now includes a structured assessment framework for bot review comments (gemini-code-assist, Copilot) with classification categories, rather than blindly trusting all suggestions.
+
+---
+
 ## What's New in v0.8.5
 
 ### UI Terminology & Tips Improvements

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v0.8.6
+
+### Bot Review Fixes (from v0.8.5 PR feedback)
+
+- **Rust API error propagation** — `api_post()` in both `client.rs` and `gpu_manager.rs` now uses `?` instead of `unwrap_or_default()` when reading response text, so transport/body-read errors properly propagate instead of being silently swallowed as empty responses.
+- **Whitespace-tolerant empty body check** — `text.trim().is_empty()` replaces `text.is_empty()` so whitespace-only responses from ComfyUI endpoints (e.g. `/interrupt`, `/free`) are correctly treated as empty rather than failing JSON parse.
+- **Clipboard MIME type consistency** — Canvas fallback in `copyBlobToClipboard()` now explicitly resets `mimeType` to `"image/png"` so the clipboard item's declared type always matches the actual PNG bytes produced by the canvas.
+- **Face detector SHA256 verification** — `GenerateButton.svelte` now passes the expected SHA256 hash when downloading the default Anzhc YOLO11n Face Seg model, matching the integrity verification already used in `FaceFixSettings.svelte`.
+- **Title case fix** — "face detailer" → "Face Detailer" in the downloading message across 5 locale files (en, fr, it, pt, es) for consistency with the rest of the UI.
+
+### Release Workflow Improvement
+
+- **Bot review triage step** — The `/release` prompt now includes a structured assessment framework for bot review comments (gemini-code-assist, Copilot) with classification categories, rather than blindly trusting all suggestions.
+
+---
+
 ## What's New in v0.8.5
 
 ### UI Terminology & Tips Improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -45,8 +45,8 @@ impl AppState {
                 message: resp.text().await.unwrap_or_default(),
             });
         }
-        let text = resp.text().await.unwrap_or_default();
-        if text.is_empty() {
+        let text = resp.text().await?;
+        if text.trim().is_empty() {
             return Ok(Value::Null);
         }
         Ok(serde_json::from_str(&text)?)

--- a/src-tauri/src/comfyui/gpu_manager.rs
+++ b/src-tauri/src/comfyui/gpu_manager.rs
@@ -379,8 +379,8 @@ impl GpuManager {
                 message: resp.text().await.unwrap_or_default(),
             });
         }
-        let text = resp.text().await.unwrap_or_default();
-        if text.is_empty() {
+        let text = resp.text().await?;
+        if text.trim().is_empty() {
             return Ok(serde_json::Value::Null);
         }
         Ok(serde_json::from_str(&text)?)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -58,14 +58,20 @@
         const detector = generation.facefixDetector || "Anzhc Face seg 640 v4 y11n.pt";
         if (!models.ultralyticsModels.includes(detector)) {
           gallery.showToast(locale.t('generation.downloading_facefix'), "info");
-          const detectorUrls: Record<string, string> = {
-            "Anzhc Face seg 640 v4 y11n.pt": "https://huggingface.co/Anzhc/Anzhcs_YOLOs/resolve/0319daeae9ae40752c2fb3904069cb35cc61d2ec/Anzhc%20Face%20seg%20640%20v4%20y11n.pt",
+          const detectorMeta: Record<string, { url: string; sha256?: string }> = {
+            "Anzhc Face seg 640 v4 y11n.pt": {
+              url: "https://huggingface.co/Anzhc/Anzhcs_YOLOs/resolve/0319daeae9ae40752c2fb3904069cb35cc61d2ec/Anzhc%20Face%20seg%20640%20v4%20y11n.pt",
+              sha256: "1e77ad7bd349babd8a4a90478bfc965348642b63a8d95d3b43ee13db42fd0a64",
+            },
           };
-          const url = detectorUrls[detector] ?? `https://huggingface.co/Bingsu/adetailer/resolve/main/${detector}`;
+          const meta = detectorMeta[detector];
+          const url = meta?.url ?? `https://huggingface.co/Bingsu/adetailer/resolve/main/${detector}`;
           await downloadModel(
             url,
             "ultralytics",
             detector,
+            undefined,
+            meta?.sha256,
           );
           generation.facefixDetector = detector;
           await models.refresh();

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -491,7 +491,7 @@ const en: Record<string, string> = {
   "generation.error_no_checkpoint": "Select a checkpoint first",
   "generation.error_no_image": "Inpainting needs an input image. Upload one or use a staged image.",
   "generation.error_no_mask": "Inpainting needs a mask. Paint a mask in Canvas Editor or upload one.",
-  "generation.downloading_facefix": "Downloading face detailer model...",
+  "generation.downloading_facefix": "Downloading Face Detailer model...",
 
   // Session context menu
   "generation.ctx.get_tags": "Get Image Tags",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -484,7 +484,7 @@ const es: Record<string, string> = {
   "generation.error_no_checkpoint": "Selecciona un checkpoint primero",
   "generation.error_no_image": "El inpainting necesita una imagen de entrada. Sube una o usa una imagen preparada.",
   "generation.error_no_mask": "El inpainting necesita una máscara. Pinta una máscara en el Editor de lienzo o sube una.",
-  "generation.downloading_facefix": "Descargando modelo face detailer...",
+  "generation.downloading_facefix": "Descargando modelo Face Detailer...",
 
   // Session context menu
   "generation.ctx.get_tags": "Obtener etiquetas",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -483,7 +483,7 @@ const fr: Record<string, string> = {
   "generation.error_no_checkpoint": "Sélectionnez d'abord un checkpoint",
   "generation.error_no_image": "L'inpainting nécessite une image d'entrée. Téléversez-en une ou utilisez une image préparée.",
   "generation.error_no_mask": "L'inpainting nécessite un masque. Peignez un masque dans l'éditeur de canevas ou téléversez-en un.",
-  "generation.downloading_facefix": "Téléchargement du modèle face detailer...",
+  "generation.downloading_facefix": "Téléchargement du modèle Face Detailer...",
 
   // Session context menu
   "generation.ctx.get_tags": "Obtenir les tags",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -462,7 +462,7 @@ const it: Record<string, string> = {
   "generation.error_no_checkpoint": "Seleziona prima un checkpoint",
   "generation.error_no_image": "L'inpainting richiede un'immagine di input. Caricane una o usa un'immagine preparata.",
   "generation.error_no_mask": "L'inpainting richiede una maschera. Disegna una maschera nel Canvas Editor o caricane una.",
-  "generation.downloading_facefix": "Download modello face detailer...",
+  "generation.downloading_facefix": "Download modello Face Detailer...",
 
   // Session context menu
   "generation.ctx.get_tags": "Ottieni tag immagine",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -462,7 +462,7 @@ const pt: Record<string, string> = {
   "generation.error_no_checkpoint": "Selecione um checkpoint primeiro",
   "generation.error_no_image": "Inpainting precisa de uma imagem de entrada. Envie uma ou use uma imagem preparada.",
   "generation.error_no_mask": "Inpainting precisa de uma máscara. Pinte uma no Editor de Canvas ou envie uma.",
-  "generation.downloading_facefix": "Baixando modelo face detailer...",
+  "generation.downloading_facefix": "Baixando modelo Face Detailer...",
 
   // Session context menu
   "generation.ctx.get_tags": "Obter tags da imagem",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -615,6 +615,7 @@ class GalleryStore {
         // fetch on blob: URLs can be blocked by CSP (e.g. Cloudflare proxy).
         // Fall back to drawing through <img> + canvas to extract PNG bytes.
         bytes = await this._blobUrlToPngBytes(blobUrl);
+        mimeType = "image/png";
       }
 
       if (metadata) {


### PR DESCRIPTION
## v0.8.6

### Bot Review Fixes (from v0.8.5 PR feedback)

- **Rust API error propagation** — `api_post()` uses `?` instead of `unwrap_or_default()` for response text reads
- **Whitespace-tolerant empty body check** — `text.trim().is_empty()` replaces `text.is_empty()`
- **Clipboard MIME type consistency** — Canvas fallback resets `mimeType` to `"image/png"`
- **Face detector SHA256 verification** — `GenerateButton.svelte` passes expected SHA256 for Anzhc model downloads
- **Title case fix** — "face detailer" → "Face Detailer" in downloading message across 5 locales

### Release Workflow Improvement

- **Bot review triage step** — `/release` prompt includes structured assessment framework for bot review comments with classification categories