### PR TITLE
v0.8.7: Logout button, fix browser-mode pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## What's New in v0.8.7
+
+### Logout Button
+
+- **Logout in Settings** — browser-mode users now have a "Log Out" button in the Account section of Settings. Clicking it invalidates the server-side session token and returns to the login screen. Localized in all 11 languages.
+- **Backend logout endpoint** — new `POST /internal-api/_auth/logout` route properly invalidates the session token on the server, not just the browser.
+
+### Bug Fix
+
+- **Face Detailer pip install error in browser mode** — `FaceFixSettings.svelte` no longer attempts to run `installPipPackage()` in browser mode, which previously failed with "No such file or directory" because `pip`/`uv` don't exist on the web server. The `isBrowserMode` guard already existed in `GenerateButton.svelte` but was missing from the settings component.
+
+---
+
 ## What's New in v0.8.6
 
 ### Bot Review Fixes (from v0.8.5 PR feedback)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## What's New in v0.8.7
+
+### Logout Button
+
+- **Logout in Settings** — browser-mode users now have a "Log Out" button in the Account section of Settings. Clicking it invalidates the server-side session token and returns to the login screen. Localized in all 11 languages.
+- **Backend logout endpoint** — new `POST /internal-api/_auth/logout` route properly invalidates the session token on the server, not just the browser.
+
+### Bug Fix
+
+- **Face Detailer pip install error in browser mode** — `FaceFixSettings.svelte` no longer attempts to run `installPipPackage()` in browser mode, which previously failed with "No such file or directory" because `pip`/`uv` don't exist on the web server. The `isBrowserMode` guard already existed in `GenerateButton.svelte` but was missing from the settings component.
+
+---
+
 ## What's New in v0.8.6
 
 ### Bot Review Fixes (from v0.8.5 PR feedback)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -222,6 +222,7 @@ pub async fn start_server(
             "/internal-api/_auth/set_modelhub_access",
             post(auth_set_modelhub_access_handler),
         )
+        .route("/internal-api/_auth/logout", post(auth_logout_handler))
         .route("/internal-api/_auth/lan_info", get(auth_lan_info_handler))
         // Storage management
         .route("/internal-api/_storage/info", get(storage_info_handler))
@@ -2965,6 +2966,17 @@ async fn run_interrogation_headless(
 struct AuthRequest {
     username: String,
     password: String,
+}
+
+/// POST /internal-api/_auth/logout — invalidate the current session token.
+async fn auth_logout_handler(
+    AxumState(state): AxumState<SharedState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(token) = extract_token(&headers) {
+        state.auth.logout(&token);
+    }
+    (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
 }
 
 /// POST /internal-api/_auth/login — authenticate and return a session token.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/FaceFixSettings.svelte
+++ b/src/lib/components/generation/FaceFixSettings.svelte
@@ -3,6 +3,7 @@
   import { models } from "../../stores/models.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
   import { downloadModel, installPipPackage } from "../../utils/api.js";
+  import { isBrowserMode } from "../../utils/ipc.js";
   import { ipcListen } from "../../utils/ipc.js";
   import { onMount } from "svelte";
   import InfoTip from "../ui/InfoTip.svelte";
@@ -95,7 +96,9 @@
       try {
         await downloadModel(rec.url, "ultralytics", rec.filename, undefined, rec.sha256);
         // Ensure ultralytics Python package is installed (required by MooshieFaceDetailer)
-        await installPipPackage("ultralytics==8.4.34");
+        if (!isBrowserMode) {
+          await installPipPackage("ultralytics==8.4.34");
+        }
         await models.refresh();
       } catch (e) {
         downloadError = `Download failed: ${e}`;

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -11,7 +11,7 @@
   import { gallery } from "../../stores/gallery.svelte.js";
   import OpenModelFolders from "./OpenModelFolders.svelte";
   import GpuStatusPanel from "./GpuStatusPanel.svelte";
-  import { ipcInvoke, ipcListen, isTauri, isBrowserMode, authHeaders } from "../../utils/ipc.js";
+  import { ipcInvoke, ipcListen, isTauri, isBrowserMode, authHeaders, clearAuthToken } from "../../utils/ipc.js";
   import { onMount } from "svelte";
   import { marked } from "marked";
 
@@ -2195,6 +2195,17 @@
                 {cpBusy ? "Saving..." : "Change Password"}
               </button>
             </div>
+            <hr class="border-neutral-800" />
+            <button
+              class="w-full py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer bg-red-600/20 hover:bg-red-600/40 text-red-300 border border-red-800/50"
+              onclick={async () => {
+                try { await fetch("/internal-api/_auth/logout", { method: "POST", headers: authHeaders() }); } catch {}
+                clearAuthToken();
+                window.location.reload();
+              }}
+            >
+              {locale.t('settings.account.logout')}
+            </button>
           </div>
         </section>
         {/if}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -217,6 +217,8 @@ const de: Record<string, string> = {
   "settings.interrogator.general_threshold": "Allgemeiner Tag-Schwellwert",
   "settings.interrogator.character_threshold": "Charakter-Tag-Schwellwert",
 
+  "settings.account.logout": "Abmelden",
+
   "settings.about.title": "Über",
   "settings.about.version": "Version",
   "settings.about.check_updates": "Nach Updates suchen",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -230,6 +230,9 @@ const en: Record<string, string> = {
   "settings.interrogator.general_threshold": "General Tag Threshold",
   "settings.interrogator.character_threshold": "Character Tag Threshold",
 
+  // Account
+  "settings.account.logout": "Log Out",
+
   // About section
   "settings.about.title": "About",
   "settings.about.version": "Version",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -224,6 +224,8 @@ const es: Record<string, string> = {
   "settings.interrogator.general_threshold": "Umbral de etiquetas generales",
   "settings.interrogator.character_threshold": "Umbral de etiquetas de personaje",
 
+  "settings.account.logout": "Cerrar sesión",
+
   // Acerca de
   "settings.about.title": "Acerca de",
   "settings.about.version": "Versión",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -224,6 +224,8 @@ const fr: Record<string, string> = {
   "settings.interrogator.general_threshold": "Seuil des tags généraux",
   "settings.interrogator.character_threshold": "Seuil des tags de personnage",
 
+  "settings.account.logout": "Se déconnecter",
+
   // Section À propos
   "settings.about.title": "À propos",
   "settings.about.version": "Version",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -217,6 +217,8 @@ const it: Record<string, string> = {
   "settings.interrogator.general_threshold": "Soglia tag generali",
   "settings.interrogator.character_threshold": "Soglia tag personaggi",
 
+  "settings.account.logout": "Esci",
+
   "settings.about.title": "Informazioni",
   "settings.about.version": "Versione",
   "settings.about.check_updates": "Controlla aggiornamenti",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -224,6 +224,8 @@ const ja: Record<string, string> = {
   "settings.interrogator.general_threshold": "一般タグ閾値",
   "settings.interrogator.character_threshold": "キャラクタータグ閾値",
 
+  "settings.account.logout": "ログアウト",
+
   // このアプリについて
   "settings.about.title": "このアプリについて",
   "settings.about.version": "バージョン",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -217,6 +217,8 @@ const ko: Record<string, string> = {
   "settings.interrogator.general_threshold": "일반 태그 임계값",
   "settings.interrogator.character_threshold": "캐릭터 태그 임계값",
 
+  "settings.account.logout": "로그아웃",
+
   "settings.about.title": "정보",
   "settings.about.version": "버전",
   "settings.about.check_updates": "업데이트 확인",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -217,6 +217,8 @@ const pt: Record<string, string> = {
   "settings.interrogator.general_threshold": "Limite de Tag Geral",
   "settings.interrogator.character_threshold": "Limite de Tag de Personagem",
 
+  "settings.account.logout": "Sair",
+
   "settings.about.title": "Sobre",
   "settings.about.version": "Versão",
   "settings.about.check_updates": "Verificar Atualizações",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -217,6 +217,8 @@ const ru: Record<string, string> = {
   "settings.interrogator.general_threshold": "Порог общих тегов",
   "settings.interrogator.character_threshold": "Порог тегов персонажей",
 
+  "settings.account.logout": "Выйти",
+
   "settings.about.title": "О программе",
   "settings.about.version": "Версия",
   "settings.about.check_updates": "Проверить обновления",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -217,6 +217,8 @@ const zhTw: Record<string, string> = {
   "settings.interrogator.general_threshold": "通用標籤閾值",
   "settings.interrogator.character_threshold": "角色標籤閾值",
 
+  "settings.account.logout": "登出",
+
   "settings.about.title": "關於",
   "settings.about.version": "版本",
   "settings.about.check_updates": "檢查更新",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -217,6 +217,8 @@ const zh: Record<string, string> = {
   "settings.interrogator.general_threshold": "通用标签阈值",
   "settings.interrogator.character_threshold": "角色标签阈值",
 
+  "settings.account.logout": "退出登录",
+
   "settings.about.title": "关于",
   "settings.about.version": "版本",
   "settings.about.check_updates": "检查更新",


### PR DESCRIPTION
## v0.8.7

### Logout Button
- Browser-mode users now have a "Log Out" button in the Account section of Settings
- New `POST /internal-api/_auth/logout` backend endpoint invalidates the server-side session token
- Localized in all 11 languages

### Bug Fix
- `FaceFixSettings.svelte` no longer calls `installPipPackage()` in browser mode (was causing 500 error: "pip install failed to start: No such file or directory")