### PR TITLE
v0.9.0: fix flashing console window, add --disable-auto-launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## What's New in v0.9.0
+
+### Fix: Flashing Console Window on Windows
+- **Eliminated the flickering window** that appeared every 5 seconds while the GPU Status panel was open. `nvidia-smi.exe` was being spawned without the `CREATE_NO_WINDOW` flag, causing Windows to briefly show a console window each cycle.
+- Applied `CREATE_NO_WINDOW` to all subprocess spawns in the Windows build: `nvidia-smi`, `detect_compute_capability`, export-logs diagnostics (python/nvidia-smi), and the PowerShell clipboard reader.
+
+### ComfyUI No Longer Opens a Browser Window
+- Added `--disable-auto-launch` to every ComfyUI process spawn (single-GPU and multi-GPU worker paths). ComfyUI previously attempted to open a browser tab on startup; MooshieUI is the frontend so this was unnecessary.
+
+---
+
 ## What's New in v0.8.9
 
 ### Attention Backend Selection

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+## What's New in v0.9.0
+
+### Fix: Flashing Console Window on Windows
+- **Eliminated the flickering window** that appeared every 5 seconds while the GPU Status panel was open. `nvidia-smi.exe` was being spawned without the `CREATE_NO_WINDOW` flag, causing Windows to briefly show a console window each cycle.
+- Applied `CREATE_NO_WINDOW` to all subprocess spawns in the Windows build: `nvidia-smi`, `detect_compute_capability`, export-logs diagnostics (python/nvidia-smi), and the PowerShell clipboard reader.
+
+### ComfyUI No Longer Opens a Browser Window
+- Added `--disable-auto-launch` to every ComfyUI process spawn (single-GPU and multi-GPU worker paths). ComfyUI previously attempted to open a browser tab on startup; MooshieUI is the frontend so this was unnecessary.
+
+---
+
 ## What's New in v0.8.9
 
 ### Attention Backend Selection

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.8.9"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -254,7 +254,8 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
         .arg("--listen")
         .arg("127.0.0.1")
         .arg("--port")
-        .arg(config.server_port.to_string());
+        .arg(config.server_port.to_string())
+        .arg("--disable-auto-launch"); // MooshieUI is the frontend — no browser needed
 
     // Enable latent previews over WebSocket
     cmd.arg("--preview-method").arg("auto");
@@ -750,7 +751,8 @@ pub async fn start_worker_process(
         .arg("--listen")
         .arg("127.0.0.1")
         .arg("--port")
-        .arg(worker.port.to_string());
+        .arg(worker.port.to_string())
+        .arg("--disable-auto-launch"); // MooshieUI is the frontend — no browser needed
 
     cmd.arg("--preview-method").arg("auto");
 

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -875,6 +875,7 @@ fn native_clipboard_read() -> Result<Vec<u8>, AppError> {
 
     #[cfg(target_os = "windows")]
     {
+        use std::os::windows::process::CommandExt;
         use std::process::{Command, Stdio};
 
         let tmp_path = std::env::temp_dir().join("mooshie_clipboard_read.png");
@@ -886,6 +887,7 @@ fn native_clipboard_read() -> Result<Vec<u8>, AppError> {
             .args(["-NoProfile", "-Command", &script])
             .stdin(Stdio::null())
             .stderr(Stdio::piped())
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
             .status()
             .map_err(|e| AppError::Other(format!("PowerShell clipboard read failed: {}", e)))?;
 
@@ -2536,13 +2538,20 @@ pub async fn export_logs(
 
     // GPU info (NVIDIA)
     let _ = writeln!(output, "=== GPU Info ===");
-    match std::process::Command::new("nvidia-smi")
-        .args([
+    let nvidia_smi_out = {
+        let mut cmd = std::process::Command::new("nvidia-smi");
+        cmd.args([
             "--query-gpu=name,driver_version,memory.total,compute_cap",
             "--format=csv,noheader",
-        ])
-        .output()
-    {
+        ]);
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
+        cmd.output()
+    };
+    match nvidia_smi_out {
         Ok(o) if o.status.success() => {
             let _ = write!(output, "{}", String::from_utf8_lossy(&o.stdout));
         }
@@ -2566,20 +2575,31 @@ pub async fn export_logs(
                 }
             };
             if python_path.exists() {
-                if let Ok(o) = std::process::Command::new(&python_path)
-                    .args(["--version"])
-                    .output()
+                #[cfg(target_os = "windows")]
+                let hide: u32 = 0x08000000; // CREATE_NO_WINDOW
+
+                let mut py_ver_cmd = std::process::Command::new(&python_path);
+                py_ver_cmd.args(["--version"]);
+                #[cfg(target_os = "windows")]
                 {
+                    use std::os::windows::process::CommandExt;
+                    py_ver_cmd.creation_flags(hide);
+                }
+                if let Ok(o) = py_ver_cmd.output() {
                     let _ = write!(output, "Python: {}", String::from_utf8_lossy(&o.stdout));
                     if !o.stderr.is_empty() {
                         let _ = write!(output, "{}", String::from_utf8_lossy(&o.stderr));
                     }
                 }
                 // Get torch version
-                if let Ok(o) = std::process::Command::new(&python_path)
-                    .args(["-c", "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}'); print(f'CUDA version: {torch.version.cuda}') if torch.cuda.is_available() else None"])
-                    .output()
+                let mut torch_cmd = std::process::Command::new(&python_path);
+                torch_cmd.args(["-c", "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA available: {torch.cuda.is_available()}'); print(f'CUDA version: {torch.version.cuda}') if torch.cuda.is_available() else None"]);
+                #[cfg(target_os = "windows")]
                 {
+                    use std::os::windows::process::CommandExt;
+                    torch_cmd.creation_flags(hide);
+                }
+                if let Ok(o) = torch_cmd.output() {
                     if o.status.success() {
                         let _ = write!(output, "{}", String::from_utf8_lossy(&o.stdout));
                     }
@@ -2779,11 +2799,17 @@ pub struct GpuWorkerInfo {
 
 /// Query live GPU stats from nvidia-smi.
 fn query_nvidia_smi_stats() -> Result<Vec<GpuStats>, AppError> {
-    let output = std::process::Command::new("nvidia-smi")
-        .args([
-            "--query-gpu=index,name,memory.used,memory.total,utilization.gpu,temperature.gpu,power.draw",
-            "--format=csv,noheader,nounits",
-        ])
+    let mut cmd = std::process::Command::new("nvidia-smi");
+    cmd.args([
+        "--query-gpu=index,name,memory.used,memory.total,utilization.gpu,temperature.gpu,power.draw",
+        "--format=csv,noheader,nounits",
+    ]);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    let output = cmd
         .output()
         .map_err(|e| AppError::Other(format!("nvidia-smi not found: {}", e)))?;
 
@@ -2920,10 +2946,14 @@ pub async fn check_attention_backend(
 
 /// Detect the highest NVIDIA GPU compute capability (e.g. 8.6 for RTX 3080).
 fn detect_compute_capability() -> Option<f32> {
-    let output = std::process::Command::new("nvidia-smi")
-        .args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"])
-        .output()
-        .ok()?;
+    let mut cmd = std::process::Command::new("nvidia-smi");
+    cmd.args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"]);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    let output = cmd.output().ok()?;
 
     if !output.status.success() {
         return None;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v0.9.0

### Fix: Flashing Console Window on Windows
- **Eliminated the flickering window** that appeared every 5 seconds while the GPU Status panel was open. `nvidia-smi.exe` was being spawned without the `CREATE_NO_WINDOW` flag, causing Windows to briefly show a console window each cycle.
- Applied `CREATE_NO_WINDOW` (`0x08000000`) to all subprocess spawns in the Windows build: `nvidia-smi` in `query_nvidia_smi_stats` (the primary offender called every 5s), `detect_compute_capability`, export-logs diagnostics (python/nvidia-smi), and the PowerShell clipboard reader.

### ComfyUI No Longer Opens a Browser Window
- Added `--disable-auto-launch` to every ComfyUI process spawn (single-GPU and multi-GPU worker paths). ComfyUI previously attempted to open a browser tab on startup; MooshieUI is the frontend so this was unnecessary and could cause a brief window flash on each ComfyUI launch.

### Code Quality
- Ran `cargo fmt` to fix formatting on the new Windows process flag blocks.