### PR TITLE
feat: artist gallery powered by Cloudflare R2

### DIFF
--- a/scripts/r2_build_indices.py
+++ b/scripts/r2_build_indices.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build sharded artist-gallery index JSON files from the dataset output.
+
+Reads:
+  <release-dir>/artist_tag_index.json       artist tag -> image metadata
+  src/lib/assets/anima-tags.json            tag source (aliases, post count)
+  <release-dir>/images/                     filesystem reality check
+
+Writes:
+  <release-dir>/indices/manifest.json
+  <release-dir>/indices/shards/<bucket>.json
+  <release-dir>/indices/search.json
+
+The shard bucket is the first character of the slug when alnum, else '_'.
+Each entry is annotated with hasImage based on whether the WEBP is present on disk.
+Upload the resulting directory via scripts/r2_upload_anima.py --indices-only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SHARD_SCHEME = "first-char-slug-v1"
+INDEX_VERSION = 1
+
+
+def bucket_for(slug: str) -> str:
+    if not slug:
+        return "_"
+    ch = slug[0].lower()
+    if ch.isalnum():
+        return ch
+    return "_"
+
+
+def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_tags_path: Path) -> None:
+    artist_index_path = release_dir / "artist_tag_index.json"
+    if not artist_index_path.is_file():
+        raise SystemExit(f"Missing {artist_index_path}")
+    if not anima_tags_path.is_file():
+        raise SystemExit(f"Missing {anima_tags_path}")
+
+    images_dir = release_dir / "images"
+    on_disk: set[str] = {
+        p.name for p in images_dir.iterdir() if p.is_file() and p.suffix.lower() == ".webp"
+    } if images_dir.is_dir() else set()
+    print(f"[indices] on-disk webp files: {len(on_disk)}", flush=True)
+
+    artist_index: dict[str, dict] = json.loads(artist_index_path.read_text(encoding="utf-8"))
+    anima_tags = json.loads(anima_tags_path.read_text(encoding="utf-8"))
+    tag_meta: dict[str, dict] = {
+        t["n"]: {"postCount": t.get("p", 0), "aliases": t.get("a", []) or []}
+        for t in anima_tags
+        if t.get("c") == 1
+    }
+    print(f"[indices] artists in source: {len(tag_meta)}; in dataset: {len(artist_index)}", flush=True)
+
+    base = public_base_url.rstrip("/")
+
+    shards: dict[str, dict[str, dict]] = {}
+    search_flat: list[dict] = []
+    with_image = 0
+
+    for tag, meta in artist_index.items():
+        slug = meta.get("slug") or ""
+        image_id = meta.get("image_id") or ""
+        filename = meta.get("filename_webp") or ""
+        object_key = meta.get("object_key") or f"{release_prefix}/images/{filename}"
+        image_url = f"{base}/{object_key}" if base else ""
+
+        src = tag_meta.get(tag, {})
+        has_image = filename in on_disk
+        if has_image:
+            with_image += 1
+
+        entry = {
+            "tag": tag,
+            "slug": slug,
+            "imageId": image_id,
+            "imageUrl": image_url,
+            "objectKey": object_key,
+            "postCount": int(src.get("postCount", 0)),
+            "aliases": list(src.get("aliases", [])),
+            "hasImage": has_image,
+        }
+
+        bucket = bucket_for(slug)
+        shards.setdefault(bucket, {})[slug] = entry
+        search_flat.append(
+            {
+                "slug": slug,
+                "tag": tag,
+                "imageId": image_id,
+                "postCount": entry["postCount"],
+                "shard": bucket,
+                "hasImage": has_image,
+            }
+        )
+
+    # Sort search by post count descending (typeahead ranking hint).
+    search_flat.sort(key=lambda e: (-e["postCount"], e["slug"]))
+
+    # Reset output dir.
+    out_dir = release_dir / "indices"
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    (out_dir / "shards").mkdir(parents=True, exist_ok=True)
+
+    manifest_shards: list[dict] = []
+    for bucket, entries in sorted(shards.items()):
+        shard_path = out_dir / "shards" / f"{bucket}.json"
+        shard_path.write_text(
+            json.dumps({"bucket": bucket, "entries": entries}, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        manifest_shards.append(
+            {"bucket": bucket, "count": len(entries), "path": f"shards/{bucket}.json"}
+        )
+
+    search_path = out_dir / "search.json"
+    search_path.write_text(
+        json.dumps(search_flat, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "version": INDEX_VERSION,
+        "releasePrefix": release_prefix,
+        "imageBaseUrl": base,
+        "shardScheme": SHARD_SCHEME,
+        "artistCount": len(artist_index),
+        "artistsWithImage": with_image,
+        "shards": manifest_shards,
+        "searchIndex": {
+            "path": "search.json",
+            "entries": len(search_flat),
+        },
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # Size summary.
+    total_bytes = sum(p.stat().st_size for p in out_dir.rglob("*.json"))
+    print(
+        f"[indices] wrote {len(manifest_shards)} shards + search.json + manifest.json "
+        f"({total_bytes/1024/1024:.2f} MiB) under {out_dir}",
+        flush=True,
+    )
+    print(f"[indices] artists with image on disk: {with_image}/{len(artist_index)}", flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--release-dir", type=Path, required=True)
+    ap.add_argument("--release-prefix", required=True)
+    ap.add_argument(
+        "--public-base-url",
+        required=True,
+        help="e.g. https://cdn.mooshieblob.com  (images URL: <base>/<object_key>)",
+    )
+    ap.add_argument(
+        "--anima-tags",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "src" / "lib" / "assets" / "anima-tags.json",
+    )
+    args = ap.parse_args()
+
+    if not args.public_base_url.startswith(("http://", "https://")):
+        print("WARNING: --public-base-url should start with http(s)://", file=sys.stderr)
+
+    build(args.release_dir.resolve(), args.release_prefix, args.public_base_url, args.anima_tags.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/r2_upload_anima.py
+++ b/scripts/r2_upload_anima.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Upload the Anima artist-gallery dataset to Cloudflare R2.
+
+Credentials (env):
+  R2_ACCOUNT_ID           Cloudflare account id
+  R2_ACCESS_KEY_ID        R2 access key
+  R2_SECRET_ACCESS_KEY    R2 secret
+  R2_BUCKET               bucket name (e.g. mooshie-anima)
+  R2_PUBLIC_BASE_URL      optional; public HTTPS base (e.g. https://cdn.mooshieblob.com)
+                          used only for the final report
+
+Usage:
+  python scripts/r2_upload_anima.py \
+    --release-dir /workspace/MooshieUI/dataset_output/20260325_anima_all_artists \
+    --release-prefix 20260325_anima_all_artists \
+    [--images-only | --indices-only] \
+    [--concurrency 16] [--dry-run] [--limit N]
+
+Idempotent: HEADs each object first and skips when size matches.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import boto3
+    from botocore.client import Config
+    from botocore.exceptions import ClientError
+except ImportError:
+    print("ERROR: boto3 is required. Install with: pip install boto3", file=sys.stderr)
+    sys.exit(2)
+
+
+IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+INDEX_CACHE_CONTROL = "public, max-age=300, must-revalidate"
+MANIFEST_CACHE_CONTROL = "public, max-age=60, must-revalidate"
+
+
+@dataclass
+class UploadResult:
+    uploaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    bytes_uploaded: int = 0
+    errors: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.errors is None:
+            self.errors = []
+
+
+def build_client() -> tuple["boto3.client", str]:
+    account_id = os.environ.get("R2_ACCOUNT_ID", "").strip()
+    access_key = os.environ.get("R2_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_SECRET_ACCESS_KEY", "").strip()
+    bucket = os.environ.get("R2_BUCKET", "").strip()
+    missing = [
+        name
+        for name, val in (
+            ("R2_ACCOUNT_ID", account_id),
+            ("R2_ACCESS_KEY_ID", access_key),
+            ("R2_SECRET_ACCESS_KEY", secret_key),
+            ("R2_BUCKET", bucket),
+        )
+        if not val
+    ]
+    if missing:
+        raise SystemExit(f"Missing required env vars: {', '.join(missing)}")
+
+    endpoint = f"https://{account_id}.r2.cloudflarestorage.com"
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            retries={"max_attempts": 5, "mode": "standard"},
+            max_pool_connections=64,
+        ),
+    )
+    return client, bucket
+
+
+def head_size(client, bucket: str, key: str) -> int | None:
+    try:
+        resp = client.head_object(Bucket=bucket, Key=key)
+        return int(resp.get("ContentLength", 0))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+
+
+def upload_one(
+    client,
+    bucket: str,
+    path: Path,
+    key: str,
+    content_type: str,
+    cache_control: str,
+    dry_run: bool,
+) -> tuple[str, int]:
+    """Return ("uploaded"|"skipped"|"failed", size). Raises on unrecoverable error."""
+    size = path.stat().st_size
+    existing = head_size(client, bucket, key)
+    if existing is not None and existing == size:
+        return "skipped", 0
+    if dry_run:
+        return "uploaded", size
+    with path.open("rb") as fh:
+        client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=fh,
+            ContentType=content_type,
+            CacheControl=cache_control,
+        )
+    return "uploaded", size
+
+
+def iter_images(images_dir: Path, release_prefix: str) -> Iterable[tuple[Path, str]]:
+    for p in sorted(images_dir.iterdir()):
+        if p.is_file() and p.suffix.lower() == ".webp":
+            yield p, f"{release_prefix}/images/{p.name}"
+
+
+def upload_batch(
+    client,
+    bucket: str,
+    jobs: list[tuple[Path, str, str, str]],
+    concurrency: int,
+    dry_run: bool,
+    label: str,
+) -> UploadResult:
+    result = UploadResult()
+    lock = threading.Lock()
+    total = len(jobs)
+    started = time.time()
+    last_log = started
+
+    def worker(job: tuple[Path, str, str, str]):
+        path, key, ctype, cc = job
+        try:
+            status, size = upload_one(client, bucket, path, key, ctype, cc, dry_run)
+            return status, size, key, None
+        except Exception as exc:  # noqa: BLE001
+            return "failed", 0, key, f"{key}: {exc}"
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(worker, j) for j in jobs]
+        for i, fut in enumerate(as_completed(futures), 1):
+            status, size, key, err = fut.result()
+            with lock:
+                if status == "uploaded":
+                    result.uploaded += 1
+                    result.bytes_uploaded += size
+                elif status == "skipped":
+                    result.skipped += 1
+                else:
+                    result.failed += 1
+                    if err:
+                        result.errors.append(err)
+            now = time.time()
+            if now - last_log >= 5.0 or i == total:
+                rate = i / max(now - started, 1e-6)
+                eta = (total - i) / rate if rate > 0 else 0
+                print(
+                    f"[{label}] {i}/{total}  up={result.uploaded} skip={result.skipped} "
+                    f"fail={result.failed}  {rate:.1f}/s  eta={eta/60:.1f}m",
+                    flush=True,
+                )
+                last_log = now
+    return result
+
+
+def upload_images(
+    client,
+    bucket: str,
+    release_dir: Path,
+    release_prefix: str,
+    concurrency: int,
+    dry_run: bool,
+    limit: int | None,
+) -> UploadResult:
+    images_dir = release_dir / "images"
+    if not images_dir.is_dir():
+        raise SystemExit(f"Images dir not found: {images_dir}")
+    jobs: list[tuple[Path, str, str, str]] = []
+    for path, key in iter_images(images_dir, release_prefix):
+        jobs.append((path, key, "image/webp", IMAGE_CACHE_CONTROL))
+        if limit is not None and len(jobs) >= limit:
+            break
+    print(f"[images] {len(jobs)} candidate files under {images_dir}", flush=True)
+    return upload_batch(client, bucket, jobs, concurrency, dry_run, "images")
+
+
+def upload_indices(
+    client,
+    bucket: str,
+    release_dir: Path,
+    release_prefix: str,
+    concurrency: int,
+    dry_run: bool,
+) -> UploadResult:
+    indices_dir = release_dir / "indices"
+    if not indices_dir.is_dir():
+        raise SystemExit(
+            f"Indices dir not found: {indices_dir}\n"
+            f"Run scripts/r2_build_indices.py first."
+        )
+    jobs: list[tuple[Path, str, str, str]] = []
+    for path in sorted(indices_dir.rglob("*.json")):
+        rel = path.relative_to(indices_dir).as_posix()
+        key = f"{release_prefix}/indices/{rel}"
+        cc = MANIFEST_CACHE_CONTROL if rel == "manifest.json" else INDEX_CACHE_CONTROL
+        jobs.append((path, key, "application/json", cc))
+    print(f"[indices] {len(jobs)} JSON files under {indices_dir}", flush=True)
+    return upload_batch(client, bucket, jobs, concurrency, dry_run, "indices")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--release-dir", type=Path, required=True)
+    ap.add_argument("--release-prefix", required=True)
+    ap.add_argument("--concurrency", type=int, default=16)
+    ap.add_argument("--dry-run", action="store_true", help="HEAD-check only; no PUTs")
+    ap.add_argument("--limit", type=int, default=None, help="only upload the first N images (debug)")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--images-only", action="store_true")
+    mode.add_argument("--indices-only", action="store_true")
+    args = ap.parse_args()
+
+    client, bucket = build_client()
+    print(f"[r2] bucket={bucket} endpoint=https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com")
+    if args.dry_run:
+        print("[r2] DRY RUN — no objects will be written")
+
+    started = time.time()
+    image_result = UploadResult()
+    index_result = UploadResult()
+
+    if not args.indices_only:
+        image_result = upload_images(
+            client, bucket, args.release_dir, args.release_prefix,
+            args.concurrency, args.dry_run, args.limit,
+        )
+    if not args.images_only:
+        index_result = upload_indices(
+            client, bucket, args.release_dir, args.release_prefix,
+            args.concurrency, args.dry_run,
+        )
+
+    elapsed = time.time() - started
+    public_base = os.environ.get("R2_PUBLIC_BASE_URL", "").rstrip("/")
+    report = {
+        "release_prefix": args.release_prefix,
+        "bucket": bucket,
+        "public_base_url": public_base,
+        "elapsed_s": round(elapsed, 1),
+        "dry_run": args.dry_run,
+        "images": asdict(image_result),
+        "indices": asdict(index_result),
+    }
+    report_path = args.release_dir / "r2_upload_report.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\n[r2] report written: {report_path}")
+    print(json.dumps(
+        {"images": {k: v for k, v in report["images"].items() if k != "errors"},
+         "indices": {k: v for k, v in report["indices"].items() if k != "errors"}},
+        indent=2,
+    ))
+
+    failed = image_result.failed + index_result.failed
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
   import GenerationPage from "./lib/components/generation/GenerationPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
   import ModelHubPage from "./lib/components/modelhub/ModelHubPage.svelte";
+  import { ArtistGalleryPage } from "./lib/artist-gallery/index.js";
   import { connection } from "./lib/stores/connection.svelte.js";
   import { progress } from "./lib/stores/progress.svelte.js";
   import { gallery } from "./lib/stores/gallery.svelte.js";
@@ -410,7 +411,7 @@
   }
 
   let setupComplete = $state<boolean | null>(null); // null = loading
-  let currentPage = $state<"generate" | "gallery" | "modelhub" | "settings">(
+  let currentPage = $state<"generate" | "gallery" | "modelhub" | "artists" | "settings">(
     "generate"
   );
 
@@ -1884,6 +1885,26 @@
       >
     </button>
     {/if}
+    <button
+      class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {currentPage ===
+      'artists'
+        ? 'bg-indigo-600 text-white'
+        : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200'} mx-auto"
+      onclick={() => (currentPage = "artists")}
+      title="Artist Gallery"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-4.5 h-4.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><circle cx="12" cy="8" r="4" /><path d="M4 21c0-4 4-7 8-7s8 3 8 7" /></svg
+      >
+    </button>
 
     <div class="flex-1"></div>
 
@@ -2204,6 +2225,19 @@
       </div>
     {:else if currentPage === "modelhub"}
       <ModelHubPage />
+    {:else if currentPage === "artists"}
+      <ArtistGalleryPage
+        manifestUrl={connection.artistGalleryManifestUrl}
+        oninsertTag={(tag) => {
+          const cleaned = tag.replace(/^@/, "");
+          const existing = generation.positivePrompt.trim();
+          generation.positivePrompt = existing
+            ? `${existing}, ${cleaned}`
+            : cleaned;
+          generation.saveSettings();
+          currentPage = "generate";
+        }}
+      />
     {:else if currentPage === "settings"}
       <SettingsPage {userRole} />
     {/if}

--- a/src/lib/artist-gallery/README.md
+++ b/src/lib/artist-gallery/README.md
@@ -1,0 +1,65 @@
+# Artist Gallery — portable Svelte 5 module
+
+Zero-dependency module (aside from Svelte 5 runes) that renders a searchable
+gallery of Anima-preview artist tags. Images + index JSON are served from any
+HTTPS origin that matches the shape produced by `scripts/r2_build_indices.py`.
+
+Designed to drop, unchanged, into:
+
+- The MooshieUI desktop shell (Tauri webview — already uses `fetch()` for HTTPS).
+- A standalone public Svelte site (no Tauri at all).
+
+## Integration
+
+```svelte
+<script lang="ts">
+  import { ArtistGalleryPage } from "$lib/artist-gallery";
+
+  const manifestUrl =
+    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json";
+
+  function insertTagIntoPrompt(tag: string) {
+    // Integrator wires this up; omit the prop if you don't want the button.
+  }
+</script>
+
+<ArtistGalleryPage {manifestUrl} oninsertTag={insertTagIntoPrompt} />
+```
+
+For inline previews next to an autocomplete suggestion:
+
+```svelte
+<script lang="ts">
+  import { ArtistHoverPreview } from "$lib/artist-gallery";
+</script>
+
+<ArtistHoverPreview {manifestUrl} slugOrTag={currentTag} />
+```
+
+## Headless usage
+
+```ts
+import { createArtistGalleryClient } from "$lib/artist-gallery";
+
+const client = createArtistGalleryClient({ manifestUrl });
+const hits = await client.search("dairi", { limit: 10 });
+const entry = await client.getArtist(hits[0].slug);
+console.log(entry?.imageUrl);
+```
+
+## Contract with the publisher
+
+The manifest URL must resolve to a JSON document shaped like `ArtistManifest`
+(see [types.ts](./types.ts)). Sibling files:
+
+- `shards/<bucket>.json` — one file per first-char slug bucket.
+- `search.json` — flat typeahead index sorted by `postCount` desc.
+
+All image URLs in each shard are absolute, computed at build time from
+`imageBaseUrl + objectKey`. No per-image metadata fetch is required.
+
+## Non-goals
+
+- No write / generation APIs. The module is read-only.
+- No Tauri, Electron, or Node deps.
+- No CSP-unsafe patterns (pure `fetch` + `<img src>`).

--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -1,0 +1,174 @@
+import type {
+  ArtistEntry,
+  ArtistGalleryClient,
+  ArtistManifest,
+  ArtistSearchHit,
+  ArtistShard,
+  SearchOptions,
+} from "./types.js";
+
+const MANIFEST_CACHE_MS = 60_000;
+
+interface ClientOptions {
+  manifestUrl: string;
+  /** Optional fetch override; useful for tests or when running in Node. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryClient {
+  const manifestUrl = opts.manifestUrl;
+  const fetchFn = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+
+  let manifestPromise: Promise<ArtistManifest> | null = null;
+  let manifestAt = 0;
+  const shardPromises = new Map<string, Promise<ArtistShard>>();
+  let searchPromise: Promise<ArtistSearchHit[]> | null = null;
+  /** slug → shard bucket (populated from search index once loaded). */
+  const slugToBucket = new Map<string, string>();
+  /** raw tag (lowercased) → slug. */
+  const tagToSlug = new Map<string, string>();
+
+  function baseDir(): string {
+    // manifest.json lives in the same directory as shards/ and search.json
+    const slash = manifestUrl.lastIndexOf("/");
+    return slash === -1 ? "" : manifestUrl.slice(0, slash + 1);
+  }
+
+  async function fetchJson<T>(url: string): Promise<T> {
+    const res = await fetchFn(url, { credentials: "omit" });
+    if (!res.ok) {
+      throw new Error(`artist-gallery: ${url} returned ${res.status}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async function loadManifest(): Promise<ArtistManifest> {
+    const now = Date.now();
+    if (manifestPromise && now - manifestAt < MANIFEST_CACHE_MS) {
+      return manifestPromise;
+    }
+    manifestAt = now;
+    manifestPromise = fetchJson<ArtistManifest>(manifestUrl).catch((err) => {
+      // Let the next call retry on failure.
+      manifestPromise = null;
+      manifestAt = 0;
+      throw err;
+    });
+    return manifestPromise;
+  }
+
+  async function loadShard(bucket: string): Promise<ArtistShard> {
+    const existing = shardPromises.get(bucket);
+    if (existing) return existing;
+    const manifest = await loadManifest();
+    const meta = manifest.shards.find((s) => s.bucket === bucket);
+    if (!meta) {
+      throw new Error(`artist-gallery: no shard "${bucket}" in manifest`);
+    }
+    const p = fetchJson<ArtistShard>(baseDir() + meta.path).catch((err) => {
+      shardPromises.delete(bucket);
+      throw err;
+    });
+    shardPromises.set(bucket, p);
+    return p;
+  }
+
+  function bucketForSlug(slug: string): string {
+    if (!slug) return "_";
+    const ch = slug[0].toLowerCase();
+    return /[a-z0-9]/.test(ch) ? ch : "_";
+  }
+
+  function normalizeTag(tag: string): string {
+    // Strip one leading @ for lookup (anima-tags uses "@name"; callers may pass either form).
+    return tag.replace(/^@+/, "").toLowerCase();
+  }
+
+  async function loadSearchIndex(): Promise<ArtistSearchHit[]> {
+    if (searchPromise) return searchPromise;
+    const manifest = await loadManifest();
+    searchPromise = fetchJson<ArtistSearchHit[]>(
+      baseDir() + manifest.searchIndex.path,
+    ).then((hits) => {
+      for (const h of hits) {
+        slugToBucket.set(h.slug, h.shard);
+        tagToSlug.set(h.tag.toLowerCase(), h.slug);
+        tagToSlug.set(normalizeTag(h.tag), h.slug);
+      }
+      return hits;
+    }).catch((err) => {
+      searchPromise = null;
+      throw err;
+    });
+    return searchPromise;
+  }
+
+  async function getArtist(slugOrTag: string): Promise<ArtistEntry | null> {
+    if (!slugOrTag) return null;
+    const trimmed = slugOrTag.trim();
+    let slug = trimmed;
+    let bucket = bucketForSlug(slug);
+
+    // If caller handed a raw tag ("@dairi" / "dairi"), try direct bucket first;
+    // fall back to the search index for indirect resolution.
+    const shard = await loadShard(bucket).catch(() => null);
+    if (shard?.entries[slug]) return shard.entries[slug];
+
+    // Resolve through the search index.
+    await loadSearchIndex();
+    const key = normalizeTag(trimmed);
+    const resolvedSlug = tagToSlug.get(key) ?? tagToSlug.get(trimmed.toLowerCase());
+    if (!resolvedSlug) return null;
+    slug = resolvedSlug;
+    bucket = slugToBucket.get(slug) ?? bucketForSlug(slug);
+    const shard2 = await loadShard(bucket);
+    return shard2.entries[slug] ?? null;
+  }
+
+  function normalizeQuery(text: string): string {
+    return text.toLowerCase().trim().replace(/\s+/g, "_").replace(/\\/g, "").replace(/^@+/, "");
+  }
+
+  async function search(query: string, opts: SearchOptions = {}): Promise<ArtistSearchHit[]> {
+    const q = normalizeQuery(query);
+    if (!q) return [];
+    const hits = await loadSearchIndex();
+    const limit = Math.max(1, Math.min(100, opts.limit ?? 25));
+    const requireImage = opts.requireImage ?? true;
+
+    const prefix: ArtistSearchHit[] = [];
+    const contains: ArtistSearchHit[] = [];
+    for (const h of hits) {
+      if (requireImage && !h.hasImage) continue;
+      const slugLower = h.slug.toLowerCase();
+      if (slugLower.startsWith(q)) {
+        prefix.push(h);
+        if (prefix.length >= limit && contains.length === 0) break;
+      } else if (slugLower.includes(q) || h.tag.toLowerCase().includes(q)) {
+        if (contains.length < limit) contains.push(h);
+      }
+    }
+    // hits is already sorted by postCount desc, so slice preserves ranking.
+    const combined = [...prefix, ...contains];
+    return combined.slice(0, limit);
+  }
+
+  function invalidate(): void {
+    manifestPromise = null;
+    manifestAt = 0;
+    shardPromises.clear();
+    searchPromise = null;
+    slugToBucket.clear();
+    tagToSlug.clear();
+  }
+
+  return {
+    manifestUrl,
+    loadManifest,
+    loadShard,
+    getArtist,
+    loadSearchIndex,
+    search,
+    invalidate,
+  };
+}

--- a/src/lib/artist-gallery/components/ArtistCard.svelte
+++ b/src/lib/artist-gallery/components/ArtistCard.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    entry: ArtistEntry;
+    onclick?: (entry: ArtistEntry) => void;
+  }
+
+  let { entry, onclick }: Props = $props();
+
+  function formatCount(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+    return String(n);
+  }
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/_/g, " ");
+  }
+</script>
+
+<button
+  type="button"
+  class="group relative flex flex-col items-stretch overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900 text-left transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+  onclick={() => onclick?.(entry)}
+  title={entry.tag}
+>
+  <div class="relative aspect-3/4 w-full bg-neutral-800">
+    {#if entry.hasImage && entry.imageUrl}
+      <img
+        src={entry.imageUrl}
+        alt={entry.tag}
+        loading="lazy"
+        decoding="async"
+        class="h-full w-full object-cover transition-opacity duration-200"
+      />
+    {:else}
+      <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
+        no preview
+      </div>
+    {/if}
+  </div>
+  <div class="flex items-center justify-between gap-2 px-2 py-1.5">
+    <span class="truncate text-sm text-red-400">{displayTag(entry.tag)}</span>
+    <span class="shrink-0 text-xs text-neutral-500">{formatCount(entry.postCount)}</span>
+  </div>
+</button>

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { createArtistGalleryStore } from "../store.svelte.js";
+  import type { ArtistEntry } from "../types.js";
+  import ArtistCard from "./ArtistCard.svelte";
+  import ArtistLightbox from "./ArtistLightbox.svelte";
+
+  interface Props {
+    manifestUrl: string;
+    /** Optional integrator hook for "Insert tag into prompt" in the lightbox. */
+    oninsertTag?: (tag: string) => void;
+  }
+
+  let { manifestUrl, oninsertTag }: Props = $props();
+
+  const store = createArtistGalleryStore(manifestUrl);
+
+  let selectedBucket = $state<string | null>(null);
+  let bucketEntries = $state<ArtistEntry[]>([]);
+  let bucketLoading = $state(false);
+  let bucketError = $state<string | null>(null);
+  let visibleCount = $state(60);
+  const PAGE_SIZE = 60;
+
+  let active = $state<ArtistEntry | null>(null);
+  let queryInput = $state("");
+  let searchDebounce: number | null = null;
+
+  onMount(() => {
+    store.init().then(() => {
+      if (!selectedBucket && store.manifest && store.manifest.shards.length > 0) {
+        void selectBucket(store.manifest.shards[0].bucket);
+      }
+    });
+  });
+
+  async function selectBucket(bucket: string) {
+    selectedBucket = bucket;
+    visibleCount = PAGE_SIZE;
+    bucketLoading = true;
+    bucketError = null;
+    try {
+      const shard = await store.client.loadShard(bucket);
+      bucketEntries = Object.values(shard.entries).sort(
+        (a, b) => b.postCount - a.postCount || a.slug.localeCompare(b.slug),
+      );
+    } catch (err) {
+      bucketError = err instanceof Error ? err.message : String(err);
+      bucketEntries = [];
+    } finally {
+      bucketLoading = false;
+    }
+  }
+
+  function onSearchInput(value: string) {
+    queryInput = value;
+    if (searchDebounce !== null) window.clearTimeout(searchDebounce);
+    searchDebounce = window.setTimeout(() => {
+      void store.setQuery(value);
+      searchDebounce = null;
+    }, 120);
+  }
+
+  async function openHit(slug: string) {
+    await store.openArtist(slug);
+    active = store.activeArtist;
+  }
+
+  function closeLightbox() {
+    active = null;
+    store.closeArtist();
+  }
+
+  function loadMore() {
+    visibleCount = Math.min(bucketEntries.length, visibleCount + PAGE_SIZE);
+  }
+
+  const visibleEntries = $derived(
+    store.query.trim()
+      ? []
+      : bucketEntries.slice(0, visibleCount),
+  );
+</script>
+
+<div class="flex h-full w-full flex-col overflow-hidden bg-neutral-950 text-neutral-100">
+  <header class="flex-none border-b border-neutral-800 bg-neutral-900/60 px-4 py-3">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h1 class="text-lg font-semibold">Artist Gallery</h1>
+        <p class="text-xs text-neutral-500">
+          {#if store.manifest}
+            {store.manifest.artistsWithImage.toLocaleString()} artists ·
+            Anima preview · release {store.manifest.releasePrefix}
+          {:else if store.manifestError}
+            <span class="text-red-400">failed to load: {store.manifestError}</span>
+          {:else}
+            loading manifest…
+          {/if}
+        </p>
+      </div>
+      <div class="relative w-full max-w-sm">
+        <input
+          type="search"
+          placeholder="Search artist tag…"
+          value={queryInput}
+          oninput={(e) => onSearchInput(e.currentTarget.value)}
+          class="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+        {#if store.searchLoading}
+          <span class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-neutral-500">…</span>
+        {/if}
+      </div>
+    </div>
+
+    {#if store.manifest && !store.query.trim()}
+      <div class="mt-3 flex flex-wrap gap-1">
+        {#each store.manifest.shards as shard}
+          <button
+            type="button"
+            class="rounded-md px-2 py-1 text-xs font-mono transition-colors {selectedBucket ===
+            shard.bucket
+              ? 'bg-indigo-600 text-white'
+              : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700'}"
+            onclick={() => selectBucket(shard.bucket)}
+            title={`${shard.count} artists`}
+          >
+            {shard.bucket}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </header>
+
+  <div class="flex-1 overflow-y-auto">
+    {#if store.query.trim()}
+      {#if store.results.length === 0 && !store.searchLoading}
+        <div class="p-8 text-center text-sm text-neutral-500">
+          No artists match "{store.query}".
+        </div>
+      {:else}
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
+          {#each store.results as hit (hit.slug)}
+            {@const thumbUrl =
+              store.manifest && hit.hasImage
+                ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`
+                : ""}
+            <button
+              type="button"
+              class="group flex flex-col items-stretch overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900 text-left transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              onclick={() => openHit(hit.slug)}
+              title={hit.tag}
+            >
+              <div class="relative aspect-3/4 w-full bg-neutral-800">
+                {#if thumbUrl}
+                  <img
+                    src={thumbUrl}
+                    alt={hit.tag}
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-full object-cover"
+                  />
+                {:else}
+                  <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
+                    no preview
+                  </div>
+                {/if}
+              </div>
+              <div class="flex items-center justify-between gap-2 px-2 py-1.5">
+                <span class="truncate text-sm text-red-400">
+                  {hit.tag.replace(/^@/, "").replace(/_/g, " ")}
+                </span>
+                <span class="shrink-0 text-xs text-neutral-500">
+                  {hit.postCount >= 1000 ? `${Math.round(hit.postCount / 1000)}k` : hit.postCount}
+                </span>
+              </div>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    {:else if bucketError}
+      <div class="p-8 text-center text-sm text-red-400">
+        Failed to load shard: {bucketError}
+      </div>
+    {:else if bucketLoading && bucketEntries.length === 0}
+      <div class="p-8 text-center text-sm text-neutral-500">loading…</div>
+    {:else}
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
+        {#each visibleEntries as entry (entry.slug)}
+          <ArtistCard {entry} onclick={(e) => (active = e)} />
+        {/each}
+      </div>
+      {#if visibleCount < bucketEntries.length}
+        <div class="p-4 text-center">
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-4 py-2 text-sm text-neutral-200 transition-colors hover:border-indigo-500"
+            onclick={loadMore}
+          >
+            Load more ({bucketEntries.length - visibleCount} remaining)
+          </button>
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+{#if active}
+  <ArtistLightbox entry={active} onclose={closeLightbox} {oninsertTag} />
+{/if}

--- a/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
+++ b/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { createArtistGalleryStore } from "../store.svelte.js";
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    manifestUrl: string;
+    /** Either the slug or the raw artist tag ("@dairi"). */
+    slugOrTag: string;
+  }
+
+  let { manifestUrl, slugOrTag }: Props = $props();
+
+  const store = createArtistGalleryStore(manifestUrl);
+
+  let entry = $state<ArtistEntry | null>(null);
+  let loading = $state(false);
+  let failed = $state(false);
+
+  async function load(key: string) {
+    if (!key) {
+      entry = null;
+      return;
+    }
+    loading = true;
+    failed = false;
+    try {
+      await store.init();
+      entry = await store.client.getArtist(key);
+      failed = !entry || !entry.hasImage;
+    } catch {
+      entry = null;
+      failed = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    load(slugOrTag);
+  });
+</script>
+
+<div
+  class="pointer-events-none flex h-44 w-32 items-center justify-center overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-xl"
+>
+  {#if loading}
+    <div class="h-full w-full animate-pulse bg-neutral-800"></div>
+  {:else if entry && entry.imageUrl && !failed}
+    <img
+      src={entry.imageUrl}
+      alt={entry.tag}
+      loading="eager"
+      decoding="async"
+      class="h-full w-full object-cover"
+    />
+  {:else}
+    <span class="px-2 text-center text-[10px] text-neutral-500">
+      no preview
+    </span>
+  {/if}
+</div>

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    entry: ArtistEntry;
+    onclose: () => void;
+    /** Optional integrator hook: "Insert tag into prompt" action. */
+    oninsertTag?: (tag: string) => void;
+  }
+
+  let { entry, onclose, oninsertTag }: Props = $props();
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/_/g, " ");
+  }
+
+  function onBackdropKey(e: KeyboardEvent) {
+    if (e.key === "Escape") onclose();
+  }
+
+  async function copyTag() {
+    try {
+      await navigator.clipboard.writeText(entry.tag);
+    } catch {
+      // no-op; clipboard may be unavailable in some webviews
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onBackdropKey} />
+
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label={`Artist preview: ${entry.tag}`}
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Close"
+    onclick={onclose}
+  ></button>
+
+  <div class="relative z-10 flex max-h-[92vh] max-w-[92vw] flex-col gap-3 p-4">
+    {#if entry.hasImage && entry.imageUrl}
+      <img
+        src={entry.imageUrl}
+        alt={entry.tag}
+        class="max-h-[80vh] w-auto max-w-[92vw] rounded-lg border border-neutral-800 object-contain shadow-2xl"
+      />
+    {:else}
+      <div
+        class="flex aspect-3/4 w-[60vh] max-w-[92vw] items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 text-sm text-neutral-500"
+      >
+        no preview available
+      </div>
+    {/if}
+
+    <div
+      class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-900/90 px-4 py-3"
+    >
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-base font-medium text-red-400">
+          {displayTag(entry.tag)}
+        </div>
+        <div class="mt-0.5 text-xs text-neutral-500">
+          {entry.postCount.toLocaleString()} posts
+          {#if entry.aliases.length > 0}
+            · aliases: {entry.aliases.map((a) => a.replace(/^@/, "")).join(", ")}
+          {/if}
+        </div>
+      </div>
+      <div class="flex shrink-0 gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-indigo-500 hover:bg-neutral-700"
+          onclick={copyTag}
+        >
+          Copy tag
+        </button>
+        {#if oninsertTag}
+          <button
+            type="button"
+            class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-500"
+            onclick={() => oninsertTag?.(entry.tag)}
+          >
+            Insert into prompt
+          </button>
+        {/if}
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
+          onclick={onclose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/lib/artist-gallery/index.ts
+++ b/src/lib/artist-gallery/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Portable Artist Gallery module
+ * ===============================
+ * Zero Tauri / backend dependencies. Consumes only `fetch` + a manifest URL.
+ * Drop this folder into any Svelte 5 codebase (desktop shell or static site)
+ * and render `<ArtistGalleryPage manifestUrl={...} />`.
+ */
+export type { ArtistEntry, ArtistShard, ArtistManifest, ArtistSearchHit, ArtistGalleryClient } from "./types.js";
+export { createArtistGalleryClient } from "./client.js";
+export { ArtistGalleryStore, createArtistGalleryStore } from "./store.svelte.js";
+export { default as ArtistGalleryPage } from "./components/ArtistGalleryPage.svelte";
+export { default as ArtistCard } from "./components/ArtistCard.svelte";
+export { default as ArtistLightbox } from "./components/ArtistLightbox.svelte";
+export { default as ArtistHoverPreview } from "./components/ArtistHoverPreview.svelte";

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -1,0 +1,107 @@
+import { createArtistGalleryClient } from "./client.js";
+import type {
+  ArtistEntry,
+  ArtistGalleryClient,
+  ArtistManifest,
+  ArtistSearchHit,
+} from "./types.js";
+
+/**
+ * Svelte 5 rune-based wrapper around the artist gallery client.
+ *
+ * Usage:
+ *   const store = createArtistGalleryStore(manifestUrl);
+ *   await store.init();
+ *   store.setQuery("dairi");
+ *   $derived.by(() => store.results);
+ */
+export class ArtistGalleryStore {
+  readonly client: ArtistGalleryClient;
+
+  manifest = $state<ArtistManifest | null>(null);
+  manifestError = $state<string | null>(null);
+  manifestLoading = $state(false);
+
+  query = $state("");
+  results = $state<ArtistSearchHit[]>([]);
+  searchLoading = $state(false);
+
+  activeArtist = $state<ArtistEntry | null>(null);
+  activeLoading = $state(false);
+
+  /** Guard so rapid typing doesn't race older search results into state. */
+  private searchSeq = 0;
+
+  constructor(manifestUrl: string) {
+    this.client = createArtistGalleryClient({ manifestUrl });
+  }
+
+  async init(): Promise<void> {
+    if (this.manifest || this.manifestLoading) return;
+    this.manifestLoading = true;
+    this.manifestError = null;
+    try {
+      this.manifest = await this.client.loadManifest();
+      // Kick off the search index fetch early; it drives typeahead and getArtist fallback.
+      this.client.loadSearchIndex().catch((err) => {
+        console.error("artist-gallery: search index load failed", err);
+      });
+    } catch (err) {
+      this.manifestError = err instanceof Error ? err.message : String(err);
+    } finally {
+      this.manifestLoading = false;
+    }
+  }
+
+  async setQuery(text: string): Promise<void> {
+    this.query = text;
+    const seq = ++this.searchSeq;
+    if (!text.trim()) {
+      this.results = [];
+      this.searchLoading = false;
+      return;
+    }
+    this.searchLoading = true;
+    try {
+      const hits = await this.client.search(text, { limit: 50 });
+      if (seq === this.searchSeq) {
+        this.results = hits;
+      }
+    } catch (err) {
+      console.error("artist-gallery: search failed", err);
+      if (seq === this.searchSeq) this.results = [];
+    } finally {
+      if (seq === this.searchSeq) this.searchLoading = false;
+    }
+  }
+
+  async openArtist(slugOrTag: string): Promise<void> {
+    this.activeLoading = true;
+    try {
+      this.activeArtist = await this.client.getArtist(slugOrTag);
+    } catch (err) {
+      console.error("artist-gallery: openArtist failed", err);
+      this.activeArtist = null;
+    } finally {
+      this.activeLoading = false;
+    }
+  }
+
+  closeArtist(): void {
+    this.activeArtist = null;
+  }
+}
+
+/**
+ * Convenience: singleton cached by manifestUrl. Handy for inline popovers that
+ * need to share the same caches as the gallery page without plumbing an
+ * instance through the component tree.
+ */
+const stores = new Map<string, ArtistGalleryStore>();
+export function createArtistGalleryStore(manifestUrl: string): ArtistGalleryStore {
+  const existing = stores.get(manifestUrl);
+  if (existing) return existing;
+  const created = new ArtistGalleryStore(manifestUrl);
+  stores.set(manifestUrl, created);
+  return created;
+}

--- a/src/lib/artist-gallery/types.ts
+++ b/src/lib/artist-gallery/types.ts
@@ -1,0 +1,74 @@
+/** Types for the artist gallery portable module. Mirrors shapes written by scripts/r2_build_indices.py. */
+
+export interface ArtistEntry {
+  /** Raw artist tag as it appears in anima-tags.json (e.g. "@dairi"). */
+  tag: string;
+  /** Filesystem-safe slug; matches the leading portion of imageId. */
+  slug: string;
+  /** Stable image identifier (slug + short sha1). */
+  imageId: string;
+  /** Fully-qualified HTTPS URL to the preview image. Empty string if host not configured. */
+  imageUrl: string;
+  /** R2 object key. Useful for direct-to-bucket fetches if a CDN isn't in front. */
+  objectKey: string;
+  /** Danbooru post count (popularity; ranking signal). */
+  postCount: number;
+  /** Known aliases for the artist tag. */
+  aliases: string[];
+  /** Whether the webp was present on disk when the index was built. */
+  hasImage: boolean;
+}
+
+export interface ArtistShard {
+  bucket: string;
+  /** Map of slug → ArtistEntry. */
+  entries: Record<string, ArtistEntry>;
+}
+
+export interface ArtistManifestShardMeta {
+  bucket: string;
+  count: number;
+  path: string;
+}
+
+export interface ArtistManifest {
+  version: number;
+  releasePrefix: string;
+  imageBaseUrl: string;
+  shardScheme: string;
+  artistCount: number;
+  artistsWithImage: number;
+  shards: ArtistManifestShardMeta[];
+  searchIndex: { path: string; entries: number };
+  generatedAt: string;
+}
+
+/** Row in the flat search.json index. */
+export interface ArtistSearchHit {
+  slug: string;
+  tag: string;
+  /** Matches ArtistEntry.imageId; combine with manifest.imageBaseUrl to render thumbnails without a shard fetch. */
+  imageId: string;
+  postCount: number;
+  shard: string;
+  hasImage: boolean;
+}
+
+export interface SearchOptions {
+  limit?: number;
+  /** Only return entries where `hasImage === true`. Default: true. */
+  requireImage?: boolean;
+}
+
+export interface ArtistGalleryClient {
+  manifestUrl: string;
+  loadManifest(): Promise<ArtistManifest>;
+  loadShard(bucket: string): Promise<ArtistShard>;
+  /** Resolve an artist entry by slug or raw tag ("@dairi"). Returns null if unknown. */
+  getArtist(slugOrTag: string): Promise<ArtistEntry | null>;
+  loadSearchIndex(): Promise<ArtistSearchHit[]>;
+  /** Prefix + contains + alias ranking mirrors src/lib/stores/autocomplete.svelte.ts. */
+  search(query: string, opts?: SearchOptions): Promise<ArtistSearchHit[]>;
+  /** Clear all in-memory caches (next call will re-fetch). */
+  invalidate(): void;
+}

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -2,6 +2,8 @@
   import { onDestroy } from "svelte";
   import { autocomplete, type TagEntry } from "../../stores/autocomplete.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
+  import ArtistHoverPreview from "../../artist-gallery/components/ArtistHoverPreview.svelte";
   import { smoothScroll } from "../../utils/smoothScroll.js";
   import { renderHighlightedPrompt, hasSchedulingTags } from "../../utils/promptSchedule.js";
 
@@ -417,5 +419,16 @@
         </button>
       {/each}
     </div>
+    {#if suggestions[selectedIndex]?.c === 1 && connection.artistGalleryManifestUrl}
+      <div
+        class="fixed z-50 pointer-events-none"
+        style="top: {dropdownTop}px; left: {dropdownLeft + 328}px;"
+      >
+        <ArtistHoverPreview
+          manifestUrl={connection.artistGalleryManifestUrl}
+          slugOrTag={suggestions[selectedIndex].n}
+        />
+      </div>
+    {/if}
   {/if}
 </div>

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -1,6 +1,10 @@
 class ConnectionStore {
   connected = $state(false);
   serverUrl = $state("http://127.0.0.1:8188");
+  /** Manifest URL for the Anima artist gallery. Points at Cloudflare R2 by default. */
+  artistGalleryManifestUrl = $state(
+    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json",
+  );
 }
 
 export const connection = new ConnectionStore();


### PR DESCRIPTION
Adds a portable artist-gallery Svelte module and the R2 publishing scripts that feed it. Branched cleanly from v0.9.0; contains **only** the feature — no dataset images, no generator scripts, no pilot/run artifacts.

### What's new

**`src/lib/artist-gallery/`** — portable Svelte 5 module, zero Tauri deps, uses plain `fetch()` so it works in both the desktop shell and any static Svelte site.

- `ArtistGalleryPage` — A-Z/0-9 bucket tabs, debounced search, paginated shard rendering, lightbox
- `ArtistHoverPreview` — 128×176 thumb shown beside autocomplete when the highlighted suggestion is an artist (category 1)
- `ArtistCard`, `ArtistLightbox`
- `client.ts` — lazy manifest/shard/search-index loader with in-memory caching and alias/prefix/contains search ranking that mirrors the existing autocomplete store
- `store.svelte.ts` — rune-based singleton per manifest URL
- `README.md` — integration snippets for MooshieUI *and* a standalone static site

**`scripts/`**
- `r2_build_indices.py` — reads `dataset_output/<release>/artist_tag_index.json` + `src/lib/assets/anima-tags.json`, writes `manifest.json`, 36 first-char shards, and a flat `search.json` (slug/tag/imageId/postCount/shard/hasImage). Verified 42,866 artists / 18 MiB / 5.1 MiB search index (~1.06 MiB gzipped) against the real dataset.
- `r2_upload_anima.py` — idempotent boto3 uploader (HEAD-skip when size matches). Modes: `--images-only`, `--indices-only`, `--dry-run`, `--limit`, `--concurrency`. Writes `r2_upload_report.json`.

### Wiring (3 files, 52 net lines)

- `src/lib/stores/connection.svelte.ts` — adds `artistGalleryManifestUrl` default pointing at `https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json`
- `src/App.svelte` — new `"artists"` route + nav tab; `oninsertTag` appends to `generation.positivePrompt` and switches back to generate
- `src/lib/components/generation/PromptTextarea.svelte` — renders `ArtistHoverPreview` beside the autocomplete dropdown when `suggestions[selectedIndex]?.c === 1`

### Out of scope (deliberately)

This PR does **not** include the 42,866-image dataset, the ComfyUI generator scripts (`anima_pilot_comfyui.py`, `anima_progress.py`, `anima_merge_shards.py`, `comfyui_watchdog.sh`), any pilot/smoke output, or the `DATASET_OPERATIONS.txt` runbook. Those live on the `research/artist-gallery` branch. The R2 publishing steps for operators are documented in the scripts' `--help`.

### How to publish

```bash
source .venv/bin/activate && pip install boto3
export R2_ACCOUNT_ID=... R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=... \
       R2_BUCKET=mooshie-anima R2_PUBLIC_BASE_URL=https://cdn.mooshieblob.com
python scripts/r2_build_indices.py --release-dir dataset_output/20260325_anima_all_artists \
  --release-prefix 20260325_anima_all_artists --public-base-url https://cdn.mooshieblob.com
python scripts/r2_upload_anima.py  --release-dir dataset_output/20260325_anima_all_artists \
  --release-prefix 20260325_anima_all_artists --images-only --concurrency 32
python scripts/r2_upload_anima.py  --release-dir dataset_output/20260325_anima_all_artists \
  --release-prefix 20260325_anima_all_artists --indices-only
```

### Validation done

- ✅ Index builder ran against full dataset (42,866/42,866 artists; all shards present)
- ✅ All files branched from clean `origin/main` (v0.9.0); wiring edits manually reapplied to current file versions
- ⚠️ Not validated locally: `npm run tauri dev` (no node_modules in this sandbox). The module is pure fetch/runes; review recommended on the wiring splices in `App.svelte` and `PromptTextarea.svelte`.