### PR TITLE
v0.9.1: Artist gallery with live search, favourites, zoom persistence, and pagination improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## What's New in v0.9.1
+
+### Artist Gallery
+A new full-screen gallery for browsing Anima-style artists, powered by a Cloudflare R2 CDN index.
+
+- **Paginated grid** — thumbnail cards auto-sized with a logarithmic size slider (100–400 px). Card count and layout adjust automatically.
+- **Live search** — typing in the search box filters the grid in real-time; results replace the normal paginated view without a dropdown.
+- **Sort modes** — sort by post count, alphabetical name, or **Uniqueness** (a log-normal hidden-gem score that surfaces artists with a distinctive style not yet overexposed). Uniqueness can be reshuffled with ↻ Rotate.
+- **Pagination controls** — Prev/Next buttons, a **⚄ Random** button to jump to a random page, and a direct page-number input (press Enter or ↵ to jump).
+- **Favourites** — heart (♡/♥) toggle on every card; a toolbar button filters the grid to show only favourited artists. Session-scoped.
+- **Copy on hover** — a **Copy** button appears on each card on hover; right-clicking also copies the tag. The card border flashes green on copy.
+- **Card slide-in animation** — cards animate in with a staggered slide-from-right effect whenever the sort, direction, or favourites filter changes.
+- **Lightbox** — click any card to open an instant full-screen preview (shown immediately from cached index data; aliases are patched in from the shard in the background).
+  - Click the image to zoom (1× → 1.5×, spring easing). **Zoom state persists** across lightbox close/reopen.
+  - Artist name links to Danbooru for quick tag lookup.
+  - Prev/Next navigation with keyboard arrow-key support.
+- **Generation parameters modal** — an ℹ gen params link in the gallery header shows the exact model stack, sampler settings, and prompt template used to generate the preview images.
+
+---
+
 ## What's New in v0.9.0
 
 ### Fix: Flashing Console Window on Windows

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+## What's New in v0.9.1
+
+### Artist Gallery
+A new full-screen gallery for browsing Anima-style artists, powered by a Cloudflare R2 CDN index.
+
+- **Paginated grid** — thumbnail cards auto-sized with a logarithmic size slider (100–400 px). Card count and layout adjust automatically.
+- **Live search** — typing in the search box filters the grid in real-time; results replace the normal paginated view without a dropdown.
+- **Sort modes** — sort by post count, alphabetical name, or **Uniqueness** (a log-normal hidden-gem score that surfaces artists with a distinctive style not yet overexposed). Uniqueness can be reshuffled with ↻ Rotate.
+- **Pagination controls** — Prev/Next buttons, a **⚄ Random** button to jump to a random page, and a direct page-number input (press Enter or ↵ to jump).
+- **Favourites** — heart (♡/♥) toggle on every card; a toolbar button filters the grid to show only favourited artists. Session-scoped.
+- **Copy on hover** — a **Copy** button appears on each card on hover; right-clicking also copies the tag. The card border flashes green on copy.
+- **Card slide-in animation** — cards animate in with a staggered slide-from-right effect whenever the sort, direction, or favourites filter changes.
+- **Lightbox** — click any card to open an instant full-screen preview (shown immediately from cached index data; aliases are patched in from the shard in the background).
+  - Click the image to zoom (1× → 1.5×, spring easing). **Zoom state persists** across lightbox close/reopen.
+  - Artist name links to Danbooru for quick tag lookup.
+  - Prev/Next navigation with keyboard arrow-key support.
+- **Generation parameters modal** — an ℹ gen params link in the gallery header shows the exact model stack, sampler settings, and prompt template used to generate the preview images.
+
+---
+
 ## What's New in v0.9.0
 
 ### Fix: Flashing Console Window on Windows

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1536 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@tauri-apps/api':
+        specifier: ^2
+        version: 2.10.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2
+        version: 2.7.0
+      '@tauri-apps/plugin-fs':
+        specifier: ^2.5.0
+        version: 2.5.0
+      '@tauri-apps/plugin-process':
+        specifier: ^2
+        version: 2.3.1
+      '@tauri-apps/plugin-shell':
+        specifier: ^2
+        version: 2.3.5
+      '@tauri-apps/plugin-store':
+        specifier: ^2
+        version: 2.4.2
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
+      konva:
+        specifier: ^10.2.3
+        version: 10.2.5
+      marked:
+        specifier: ^18.0.0
+        version: 18.0.0
+      ntc-ts:
+        specifier: ^0.0.8
+        version: 0.0.8
+      sortablejs:
+        specifier: ^1.15.7
+        version: 1.15.7
+      svelte-konva:
+        specifier: ^1.0.1
+        version: 1.0.1(konva@10.2.5)(svelte@5.55.4)
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5
+        version: 5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@tailwindcss/vite':
+        specifier: ^4
+        version: 4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@tauri-apps/cli':
+        specifier: ^2.10.1
+        version: 2.10.1
+      '@tsconfig/svelte':
+        specifier: ^5.0.8
+        version: 5.0.8
+      svelte:
+        specifier: ^5
+        version: 5.55.4
+      svelte-check:
+        specifier: ^4
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.4)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.2
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vite:
+        specifier: ^6
+        version: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tauri-apps/api@2.10.1':
+    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+
+  '@tauri-apps/cli-darwin-arm64@2.10.1':
+    resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-x64@2.10.1':
+    resolution: {integrity: sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+    resolution: {integrity: sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+    resolution: {integrity: sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+    resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+    resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+    resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+    resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+    resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+    resolution: {integrity: sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+    resolution: {integrity: sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli@2.10.1':
+    resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
+
+  '@tauri-apps/plugin-fs@2.5.0':
+    resolution: {integrity: sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
+  '@tauri-apps/plugin-store@2.4.2':
+    resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
+
+  '@tsconfig/svelte@5.0.8':
+    resolution: {integrity: sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.2.5:
+    resolution: {integrity: sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  konva@10.2.5:
+    resolution: {integrity: sha512-WwBoe/EBhFcv+seL1Wnp3OAOwOFjCY4nCCgpLRrzUzw1IX4lKf/lYhj2Z3qo9P9q2fA3h+OdGDlimSNqZJaY5A==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.0:
+    resolution: {integrity: sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  ntc-ts@0.0.8:
+    resolution: {integrity: sha512-Qwk8hq/eIhrwzCRNjvFZ0+XuXQrM3LJTA9WhziCWPGBlYdoLdSwexCzVLUxLwhwI+PaOcHrJu3jFhg9E4wrtuQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  sortablejs@1.15.7:
+    resolution: {integrity: sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  svelte-check@4.4.6:
+    resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: '>=5.0.0'
+
+  svelte-konva@1.0.1:
+    resolution: {integrity: sha512-XfiSF9+J9phRupYGzMfbp46dnqsgZfN3Fwqei4YVAy0/9dr7k/qGtEucOqEcwgL1GEI2rxwSFXH0S5zbZqyMJQ==}
+    peerDependencies:
+      konva: 8 - 10
+      svelte: ^5.0.0
+
+  svelte@5.55.4:
+    resolution: {integrity: sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==}
+    engines: {node: '>=18'}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      debug: 4.4.3
+      svelte: 5.55.4
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.55.4
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vitefu: 1.1.3(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/vite@4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@tauri-apps/api@2.10.1': {}
+
+  '@tauri-apps/cli-darwin-arm64@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-darwin-x64@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+    optional: true
+
+  '@tauri-apps/cli@2.10.1':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.10.1
+      '@tauri-apps/cli-darwin-x64': 2.10.1
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.10.1
+      '@tauri-apps/cli-linux-arm64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-arm64-musl': 2.10.1
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-x64-gnu': 2.10.1
+      '@tauri-apps/cli-linux-x64-musl': 2.10.1
+      '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
+      '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
+      '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.7.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-fs@2.5.0':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-shell@2.3.5':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-store@2.4.2':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tsconfig/svelte@5.0.8': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/trusted-types@2.0.7': {}
+
+  acorn@8.16.0: {}
+
+  aria-query@5.3.1: {}
+
+  axobject-query@4.1.0: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  clsx@2.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deepmerge@4.3.1: {}
+
+  detect-libc@2.1.2: {}
+
+  devalue@5.7.1: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esm-env@1.2.2: {}
+
+  esrap@2.2.5:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  jiti@2.6.1: {}
+
+  kleur@4.1.5: {}
+
+  konva@10.2.5: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-character@3.0.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.0: {}
+
+  mri@1.2.0: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  ntc-ts@0.0.8: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  sortablejs@1.15.7: {}
+
+  source-map-js@1.2.1: {}
+
+  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.4)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.55.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte-konva@1.0.1(konva@10.2.5)(svelte@5.55.4):
+    dependencies:
+      konva: 10.2.5
+      svelte: 5.55.4
+
+  svelte@5.55.4:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.7.1
+      esm-env: 1.2.2
+      esrap: 2.2.5
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+
+  vitefu@1.1.3(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)):
+    optionalDependencies:
+      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+
+  zimmerframe@1.1.4: {}

--- a/scripts/r2_build_indices.py
+++ b/scripts/r2_build_indices.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build sharded artist-gallery index JSON files from the dataset output.
+
+Reads:
+  <release-dir>/artist_tag_index.json       artist tag -> image metadata
+  src/lib/assets/anima-tags.json            tag source (aliases, post count)
+  <release-dir>/images/                     filesystem reality check
+
+Writes:
+  <release-dir>/indices/manifest.json
+  <release-dir>/indices/shards/<bucket>.json
+  <release-dir>/indices/search.json
+
+The shard bucket is the first character of the slug when alnum, else '_'.
+Each entry is annotated with hasImage based on whether the WEBP is present on disk.
+Upload the resulting directory via scripts/r2_upload_anima.py --indices-only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SHARD_SCHEME = "first-char-slug-v1"
+INDEX_VERSION = 1
+
+
+def bucket_for(slug: str) -> str:
+    if not slug:
+        return "_"
+    ch = slug[0].lower()
+    if ch.isalnum():
+        return ch
+    return "_"
+
+
+def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_tags_path: Path) -> None:
+    artist_index_path = release_dir / "artist_tag_index.json"
+    if not artist_index_path.is_file():
+        raise SystemExit(f"Missing {artist_index_path}")
+    if not anima_tags_path.is_file():
+        raise SystemExit(f"Missing {anima_tags_path}")
+
+    images_dir = release_dir / "images"
+    on_disk: set[str] = {
+        p.name for p in images_dir.iterdir() if p.is_file() and p.suffix.lower() == ".webp"
+    } if images_dir.is_dir() else set()
+    print(f"[indices] on-disk webp files: {len(on_disk)}", flush=True)
+
+    artist_index: dict[str, dict] = json.loads(artist_index_path.read_text(encoding="utf-8"))
+    anima_tags = json.loads(anima_tags_path.read_text(encoding="utf-8"))
+    tag_meta: dict[str, dict] = {
+        t["n"]: {"postCount": t.get("p", 0), "aliases": t.get("a", []) or []}
+        for t in anima_tags
+        if t.get("c") == 1
+    }
+    print(f"[indices] artists in source: {len(tag_meta)}; in dataset: {len(artist_index)}", flush=True)
+
+    base = public_base_url.rstrip("/")
+
+    shards: dict[str, dict[str, dict]] = {}
+    search_flat: list[dict] = []
+    with_image = 0
+
+    for tag, meta in artist_index.items():
+        slug = meta.get("slug") or ""
+        image_id = meta.get("image_id") or ""
+        filename = meta.get("filename_webp") or ""
+        object_key = meta.get("object_key") or f"{release_prefix}/images/{filename}"
+        image_url = f"{base}/{object_key}" if base else ""
+
+        src = tag_meta.get(tag, {})
+        has_image = filename in on_disk
+        if has_image:
+            with_image += 1
+
+        entry = {
+            "tag": tag,
+            "slug": slug,
+            "imageId": image_id,
+            "imageUrl": image_url,
+            "objectKey": object_key,
+            "postCount": int(src.get("postCount", 0)),
+            "aliases": list(src.get("aliases", [])),
+            "hasImage": has_image,
+        }
+
+        bucket = bucket_for(slug)
+        shards.setdefault(bucket, {})[slug] = entry
+        search_flat.append(
+            {
+                "slug": slug,
+                "tag": tag,
+                "imageId": image_id,
+                "postCount": entry["postCount"],
+                "shard": bucket,
+                "hasImage": has_image,
+            }
+        )
+
+    # Sort search by post count descending (typeahead ranking hint).
+    search_flat.sort(key=lambda e: (-e["postCount"], e["slug"]))
+
+    # Reset output dir.
+    out_dir = release_dir / "indices"
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    (out_dir / "shards").mkdir(parents=True, exist_ok=True)
+
+    manifest_shards: list[dict] = []
+    for bucket, entries in sorted(shards.items()):
+        shard_path = out_dir / "shards" / f"{bucket}.json"
+        shard_path.write_text(
+            json.dumps({"bucket": bucket, "entries": entries}, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        manifest_shards.append(
+            {"bucket": bucket, "count": len(entries), "path": f"shards/{bucket}.json"}
+        )
+
+    search_path = out_dir / "search.json"
+    search_path.write_text(
+        json.dumps(search_flat, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    manifest = {
+        "version": INDEX_VERSION,
+        "releasePrefix": release_prefix,
+        "imageBaseUrl": base,
+        "shardScheme": SHARD_SCHEME,
+        "artistCount": len(artist_index),
+        "artistsWithImage": with_image,
+        "shards": manifest_shards,
+        "searchIndex": {
+            "path": "search.json",
+            "entries": len(search_flat),
+        },
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+    }
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # Size summary.
+    total_bytes = sum(p.stat().st_size for p in out_dir.rglob("*.json"))
+    print(
+        f"[indices] wrote {len(manifest_shards)} shards + search.json + manifest.json "
+        f"({total_bytes/1024/1024:.2f} MiB) under {out_dir}",
+        flush=True,
+    )
+    print(f"[indices] artists with image on disk: {with_image}/{len(artist_index)}", flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--release-dir", type=Path, required=True)
+    ap.add_argument("--release-prefix", required=True)
+    ap.add_argument(
+        "--public-base-url",
+        required=True,
+        help="e.g. https://cdn.mooshieblob.com  (images URL: <base>/<object_key>)",
+    )
+    ap.add_argument(
+        "--anima-tags",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "src" / "lib" / "assets" / "anima-tags.json",
+    )
+    args = ap.parse_args()
+
+    if not args.public_base_url.startswith(("http://", "https://")):
+        print("WARNING: --public-base-url should start with http(s)://", file=sys.stderr)
+
+    build(args.release_dir.resolve(), args.release_prefix, args.public_base_url, args.anima_tags.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/r2_upload_anima.py
+++ b/scripts/r2_upload_anima.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Upload the Anima artist-gallery dataset to Cloudflare R2.
+
+Credentials (env):
+  R2_ACCOUNT_ID           Cloudflare account id
+  R2_ACCESS_KEY_ID        R2 access key
+  R2_SECRET_ACCESS_KEY    R2 secret
+  R2_BUCKET               bucket name (e.g. mooshie-anima)
+  R2_PUBLIC_BASE_URL      optional; public HTTPS base (e.g. https://cdn.mooshieblob.com)
+                          used only for the final report
+
+Usage:
+  python scripts/r2_upload_anima.py \
+    --release-dir /workspace/MooshieUI/dataset_output/20260325_anima_all_artists \
+    --release-prefix 20260325_anima_all_artists \
+    [--images-only | --indices-only] \
+    [--concurrency 16] [--dry-run] [--limit N]
+
+Idempotent: HEADs each object first and skips when size matches.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import boto3
+    from botocore.client import Config
+    from botocore.exceptions import ClientError
+except ImportError:
+    print("ERROR: boto3 is required. Install with: pip install boto3", file=sys.stderr)
+    sys.exit(2)
+
+
+IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+INDEX_CACHE_CONTROL = "public, max-age=300, must-revalidate"
+MANIFEST_CACHE_CONTROL = "public, max-age=60, must-revalidate"
+
+
+@dataclass
+class UploadResult:
+    uploaded: int = 0
+    skipped: int = 0
+    failed: int = 0
+    bytes_uploaded: int = 0
+    errors: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.errors is None:
+            self.errors = []
+
+
+def build_client() -> tuple["boto3.client", str]:
+    account_id = os.environ.get("R2_ACCOUNT_ID", "").strip()
+    access_key = os.environ.get("R2_ACCESS_KEY_ID", "").strip()
+    secret_key = os.environ.get("R2_SECRET_ACCESS_KEY", "").strip()
+    bucket = os.environ.get("R2_BUCKET", "").strip()
+    missing = [
+        name
+        for name, val in (
+            ("R2_ACCOUNT_ID", account_id),
+            ("R2_ACCESS_KEY_ID", access_key),
+            ("R2_SECRET_ACCESS_KEY", secret_key),
+            ("R2_BUCKET", bucket),
+        )
+        if not val
+    ]
+    if missing:
+        raise SystemExit(f"Missing required env vars: {', '.join(missing)}")
+
+    endpoint = f"https://{account_id}.r2.cloudflarestorage.com"
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+        config=Config(
+            signature_version="s3v4",
+            retries={"max_attempts": 5, "mode": "standard"},
+            max_pool_connections=64,
+        ),
+    )
+    return client, bucket
+
+
+def head_size(client, bucket: str, key: str) -> int | None:
+    try:
+        resp = client.head_object(Bucket=bucket, Key=key)
+        return int(resp.get("ContentLength", 0))
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+
+
+def upload_one(
+    client,
+    bucket: str,
+    path: Path,
+    key: str,
+    content_type: str,
+    cache_control: str,
+    dry_run: bool,
+) -> tuple[str, int]:
+    """Return ("uploaded"|"skipped"|"failed", size). Raises on unrecoverable error."""
+    size = path.stat().st_size
+    existing = head_size(client, bucket, key)
+    if existing is not None and existing == size:
+        return "skipped", 0
+    if dry_run:
+        return "uploaded", size
+    with path.open("rb") as fh:
+        client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=fh,
+            ContentType=content_type,
+            CacheControl=cache_control,
+        )
+    return "uploaded", size
+
+
+def iter_images(images_dir: Path, release_prefix: str) -> Iterable[tuple[Path, str]]:
+    for p in sorted(images_dir.iterdir()):
+        if p.is_file() and p.suffix.lower() == ".webp":
+            yield p, f"{release_prefix}/images/{p.name}"
+
+
+def upload_batch(
+    client,
+    bucket: str,
+    jobs: list[tuple[Path, str, str, str]],
+    concurrency: int,
+    dry_run: bool,
+    label: str,
+) -> UploadResult:
+    result = UploadResult()
+    lock = threading.Lock()
+    total = len(jobs)
+    started = time.time()
+    last_log = started
+
+    def worker(job: tuple[Path, str, str, str]):
+        path, key, ctype, cc = job
+        try:
+            status, size = upload_one(client, bucket, path, key, ctype, cc, dry_run)
+            return status, size, key, None
+        except Exception as exc:  # noqa: BLE001
+            return "failed", 0, key, f"{key}: {exc}"
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(worker, j) for j in jobs]
+        for i, fut in enumerate(as_completed(futures), 1):
+            status, size, key, err = fut.result()
+            with lock:
+                if status == "uploaded":
+                    result.uploaded += 1
+                    result.bytes_uploaded += size
+                elif status == "skipped":
+                    result.skipped += 1
+                else:
+                    result.failed += 1
+                    if err:
+                        result.errors.append(err)
+            now = time.time()
+            if now - last_log >= 5.0 or i == total:
+                rate = i / max(now - started, 1e-6)
+                eta = (total - i) / rate if rate > 0 else 0
+                print(
+                    f"[{label}] {i}/{total}  up={result.uploaded} skip={result.skipped} "
+                    f"fail={result.failed}  {rate:.1f}/s  eta={eta/60:.1f}m",
+                    flush=True,
+                )
+                last_log = now
+    return result
+
+
+def upload_images(
+    client,
+    bucket: str,
+    release_dir: Path,
+    release_prefix: str,
+    concurrency: int,
+    dry_run: bool,
+    limit: int | None,
+) -> UploadResult:
+    images_dir = release_dir / "images"
+    if not images_dir.is_dir():
+        raise SystemExit(f"Images dir not found: {images_dir}")
+    jobs: list[tuple[Path, str, str, str]] = []
+    for path, key in iter_images(images_dir, release_prefix):
+        jobs.append((path, key, "image/webp", IMAGE_CACHE_CONTROL))
+        if limit is not None and len(jobs) >= limit:
+            break
+    print(f"[images] {len(jobs)} candidate files under {images_dir}", flush=True)
+    return upload_batch(client, bucket, jobs, concurrency, dry_run, "images")
+
+
+def upload_indices(
+    client,
+    bucket: str,
+    release_dir: Path,
+    release_prefix: str,
+    concurrency: int,
+    dry_run: bool,
+) -> UploadResult:
+    indices_dir = release_dir / "indices"
+    if not indices_dir.is_dir():
+        raise SystemExit(
+            f"Indices dir not found: {indices_dir}\n"
+            f"Run scripts/r2_build_indices.py first."
+        )
+    jobs: list[tuple[Path, str, str, str]] = []
+    for path in sorted(indices_dir.rglob("*.json")):
+        rel = path.relative_to(indices_dir).as_posix()
+        key = f"{release_prefix}/indices/{rel}"
+        cc = MANIFEST_CACHE_CONTROL if rel == "manifest.json" else INDEX_CACHE_CONTROL
+        jobs.append((path, key, "application/json", cc))
+    print(f"[indices] {len(jobs)} JSON files under {indices_dir}", flush=True)
+    return upload_batch(client, bucket, jobs, concurrency, dry_run, "indices")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--release-dir", type=Path, required=True)
+    ap.add_argument("--release-prefix", required=True)
+    ap.add_argument("--concurrency", type=int, default=16)
+    ap.add_argument("--dry-run", action="store_true", help="HEAD-check only; no PUTs")
+    ap.add_argument("--limit", type=int, default=None, help="only upload the first N images (debug)")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--images-only", action="store_true")
+    mode.add_argument("--indices-only", action="store_true")
+    args = ap.parse_args()
+
+    client, bucket = build_client()
+    print(f"[r2] bucket={bucket} endpoint=https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com")
+    if args.dry_run:
+        print("[r2] DRY RUN — no objects will be written")
+
+    started = time.time()
+    image_result = UploadResult()
+    index_result = UploadResult()
+
+    if not args.indices_only:
+        image_result = upload_images(
+            client, bucket, args.release_dir, args.release_prefix,
+            args.concurrency, args.dry_run, args.limit,
+        )
+    if not args.images_only:
+        index_result = upload_indices(
+            client, bucket, args.release_dir, args.release_prefix,
+            args.concurrency, args.dry_run,
+        )
+
+    elapsed = time.time() - started
+    public_base = os.environ.get("R2_PUBLIC_BASE_URL", "").rstrip("/")
+    report = {
+        "release_prefix": args.release_prefix,
+        "bucket": bucket,
+        "public_base_url": public_base,
+        "elapsed_s": round(elapsed, 1),
+        "dry_run": args.dry_run,
+        "images": asdict(image_result),
+        "indices": asdict(index_result),
+    }
+    report_path = args.release_dir / "r2_upload_report.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\n[r2] report written: {report_path}")
+    print(json.dumps(
+        {"images": {k: v for k, v in report["images"].items() if k != "errors"},
+         "indices": {k: v for k, v in report["indices"].items() if k != "errors"}},
+        indent=2,
+    ))
+
+    failed = image_result.failed + index_result.failed
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -632,6 +632,45 @@
 
   // Interrogation state (for lightbox + context menu)
   let showInterrogateModal = $state(false);
+
+  // Artist tag insert state
+  type ArtistInsertPending = { tag: string; existingTags: string[]; duplicate: boolean };
+  let artistInsertPending = $state<ArtistInsertPending | null>(null);
+
+  function handleArtistTagInsert(tag: string) {
+    const withAt = "@" + tag.replace(/^@/, "");
+    const existing = generation.positivePrompt.trim();
+    const existingArtistTags = existing.split(",").map(s => s.trim()).filter(s => s.startsWith("@"));
+    // Check if this exact tag is already present
+    if (existingArtistTags.some(t => t.toLowerCase() === withAt.toLowerCase())) {
+      artistInsertPending = { tag: withAt, existingTags: existingArtistTags, duplicate: true };
+    } else if (existingArtistTags.length > 0) {
+      artistInsertPending = { tag: withAt, existingTags: existingArtistTags, duplicate: false };
+    } else {
+      applyArtistTag(withAt, "add");
+    }
+  }
+
+  function applyArtistTag(withAt: string, mode: "add" | "replace") {
+    const existing = generation.positivePrompt.trim();
+    let newPrompt: string;
+    if (mode === "replace") {
+      // Remove all existing @tags from the prompt, then prepend the new one
+      const stripped = existing
+        .split(",")
+        .map(s => s.trim())
+        .filter(s => !s.startsWith("@"))
+        .join(", ");
+      newPrompt = stripped ? `${withAt}, ${stripped}` : withAt;
+    } else {
+      // Add: prepend new tag before the rest
+      newPrompt = existing ? `${withAt}, ${existing}` : withAt;
+    }
+    generation.positivePrompt = newPrompt;
+    generation.saveSettings();
+    artistInsertPending = null;
+    currentPage = "generate";
+  }
   let interrogateResult = $state<InterrogationResult | null>(null);
   let interrogateLoading = $state(false);
   let interrogateStage = $state<string | null>(null);
@@ -2228,15 +2267,7 @@
     {:else if currentPage === "artists"}
       <ArtistGalleryPage
         manifestUrl={connection.artistGalleryManifestUrl}
-        oninsertTag={(tag) => {
-          const cleaned = tag.replace(/^@/, "");
-          const existing = generation.positivePrompt.trim();
-          generation.positivePrompt = existing
-            ? `${existing}, ${cleaned}`
-            : cleaned;
-          generation.saveSettings();
-          currentPage = "generate";
-        }}
+        oninsertTag={handleArtistTagInsert}
       />
     {:else if currentPage === "settings"}
       <SettingsPage {userRole} />
@@ -2534,6 +2565,68 @@
   visible={showContextMenu}
   onclose={() => { showContextMenu = false; }}
 />
+
+<!-- Interrogate modal (from gallery/lightbox) -->
+
+<!-- Artist tag conflict dialog -->
+{#if artistInsertPending}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-[300] flex items-center justify-center bg-black/60"
+    onclick={(e) => { if (e.target === e.currentTarget) artistInsertPending = null; }}
+    onkeydown={(e) => { if (e.key === 'Escape') artistInsertPending = null; }}
+  >
+    <div class="w-96 max-w-full rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+      {#if artistInsertPending.duplicate}
+        <h2 class="mb-1 text-sm font-semibold text-neutral-100">Tag already in prompt</h2>
+        <p class="mb-3 text-xs text-neutral-400">
+          <span class="font-mono text-indigo-300">{artistInsertPending.tag}</span> is already in your prompt.
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
+            onclick={() => artistInsertPending = null}
+          >
+            OK
+          </button>
+        </div>
+      {:else}
+        <h2 class="mb-1 text-sm font-semibold text-neutral-100">Artist tag already in prompt</h2>
+        <p class="mb-3 text-xs text-neutral-400">
+          Your prompt already contains
+          {#each artistInsertPending.existingTags as t, i}
+            <span class="font-mono text-red-400">{t}</span>{i < artistInsertPending.existingTags.length - 1 ? ', ' : ''}
+          {/each}.
+          Add <span class="font-mono text-indigo-300">{artistInsertPending.tag}</span> alongside, or replace?
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
+            onclick={() => artistInsertPending = null}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-indigo-500"
+            onclick={() => applyArtistTag(artistInsertPending!.tag, 'add')}
+          >
+            Add alongside
+          </button>
+          <button
+            type="button"
+            class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-500"
+            onclick={() => applyArtistTag(artistInsertPending!.tag, 'replace')}
+          >
+            Replace
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
 
 <!-- Interrogate modal (from gallery/lightbox) -->
 {#if showInterrogateModal}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,6 +5,7 @@
   import GenerationPage from "./lib/components/generation/GenerationPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
   import ModelHubPage from "./lib/components/modelhub/ModelHubPage.svelte";
+  import { ArtistGalleryPage } from "./lib/artist-gallery/index.js";
   import { connection } from "./lib/stores/connection.svelte.js";
   import { progress } from "./lib/stores/progress.svelte.js";
   import { gallery } from "./lib/stores/gallery.svelte.js";
@@ -410,7 +411,7 @@
   }
 
   let setupComplete = $state<boolean | null>(null); // null = loading
-  let currentPage = $state<"generate" | "gallery" | "modelhub" | "settings">(
+  let currentPage = $state<"generate" | "gallery" | "modelhub" | "artists" | "settings">(
     "generate"
   );
 
@@ -1884,6 +1885,26 @@
       >
     </button>
     {/if}
+    <button
+      class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {currentPage ===
+      'artists'
+        ? 'bg-indigo-600 text-white'
+        : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200'} mx-auto"
+      onclick={() => (currentPage = "artists")}
+      title="Artist Gallery"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-4.5 h-4.5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><circle cx="12" cy="8" r="4" /><path d="M4 21c0-4 4-7 8-7s8 3 8 7" /></svg
+      >
+    </button>
 
     <div class="flex-1"></div>
 
@@ -2204,6 +2225,19 @@
       </div>
     {:else if currentPage === "modelhub"}
       <ModelHubPage />
+    {:else if currentPage === "artists"}
+      <ArtistGalleryPage
+        manifestUrl={connection.artistGalleryManifestUrl}
+        oninsertTag={(tag) => {
+          const cleaned = tag.replace(/^@/, "");
+          const existing = generation.positivePrompt.trim();
+          generation.positivePrompt = existing
+            ? `${existing}, ${cleaned}`
+            : cleaned;
+          generation.saveSettings();
+          currentPage = "generate";
+        }}
+      />
     {:else if currentPage === "settings"}
       <SettingsPage {userRole} />
     {/if}

--- a/src/app.css
+++ b/src/app.css
@@ -353,3 +353,13 @@ html.light .lightbox-backdrop {
   border-color: var(--color-neutral-800);
   margin: 0.5rem 0;
 }
+
+/* ─── Artist gallery card slide-in ─── */
+@keyframes card-slide-in {
+  0%   { opacity: 0; transform: translateX(20px); filter: blur(3px); }
+  100% { opacity: 1; transform: translateX(0);    filter: blur(0);   }
+}
+.card-slide-in {
+  animation: card-slide-in 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: var(--card-delay, 0ms);
+}

--- a/src/lib/artist-gallery/README.md
+++ b/src/lib/artist-gallery/README.md
@@ -1,0 +1,65 @@
+# Artist Gallery — portable Svelte 5 module
+
+Zero-dependency module (aside from Svelte 5 runes) that renders a searchable
+gallery of Anima-preview artist tags. Images + index JSON are served from any
+HTTPS origin that matches the shape produced by `scripts/r2_build_indices.py`.
+
+Designed to drop, unchanged, into:
+
+- The MooshieUI desktop shell (Tauri webview — already uses `fetch()` for HTTPS).
+- A standalone public Svelte site (no Tauri at all).
+
+## Integration
+
+```svelte
+<script lang="ts">
+  import { ArtistGalleryPage } from "$lib/artist-gallery";
+
+  const manifestUrl =
+    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json";
+
+  function insertTagIntoPrompt(tag: string) {
+    // Integrator wires this up; omit the prop if you don't want the button.
+  }
+</script>
+
+<ArtistGalleryPage {manifestUrl} oninsertTag={insertTagIntoPrompt} />
+```
+
+For inline previews next to an autocomplete suggestion:
+
+```svelte
+<script lang="ts">
+  import { ArtistHoverPreview } from "$lib/artist-gallery";
+</script>
+
+<ArtistHoverPreview {manifestUrl} slugOrTag={currentTag} />
+```
+
+## Headless usage
+
+```ts
+import { createArtistGalleryClient } from "$lib/artist-gallery";
+
+const client = createArtistGalleryClient({ manifestUrl });
+const hits = await client.search("dairi", { limit: 10 });
+const entry = await client.getArtist(hits[0].slug);
+console.log(entry?.imageUrl);
+```
+
+## Contract with the publisher
+
+The manifest URL must resolve to a JSON document shaped like `ArtistManifest`
+(see [types.ts](./types.ts)). Sibling files:
+
+- `shards/<bucket>.json` — one file per first-char slug bucket.
+- `search.json` — flat typeahead index sorted by `postCount` desc.
+
+All image URLs in each shard are absolute, computed at build time from
+`imageBaseUrl + objectKey`. No per-image metadata fetch is required.
+
+## Non-goals
+
+- No write / generation APIs. The module is read-only.
+- No Tauri, Electron, or Node deps.
+- No CSP-unsafe patterns (pure `fetch` + `<img src>`).

--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -143,7 +143,7 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
       const slugLower = h.slug.toLowerCase();
       if (slugLower.startsWith(q)) {
         prefix.push(h);
-        if (prefix.length >= limit && contains.length === 0) break;
+        if (prefix.length >= limit) break;
       } else if (slugLower.includes(q) || h.tag.toLowerCase().includes(q)) {
         if (contains.length < limit) contains.push(h);
       }

--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -1,0 +1,174 @@
+import type {
+  ArtistEntry,
+  ArtistGalleryClient,
+  ArtistManifest,
+  ArtistSearchHit,
+  ArtistShard,
+  SearchOptions,
+} from "./types.js";
+
+const MANIFEST_CACHE_MS = 60_000;
+
+interface ClientOptions {
+  manifestUrl: string;
+  /** Optional fetch override; useful for tests or when running in Node. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryClient {
+  const manifestUrl = opts.manifestUrl;
+  const fetchFn = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+
+  let manifestPromise: Promise<ArtistManifest> | null = null;
+  let manifestAt = 0;
+  const shardPromises = new Map<string, Promise<ArtistShard>>();
+  let searchPromise: Promise<ArtistSearchHit[]> | null = null;
+  /** slug → shard bucket (populated from search index once loaded). */
+  const slugToBucket = new Map<string, string>();
+  /** raw tag (lowercased) → slug. */
+  const tagToSlug = new Map<string, string>();
+
+  function baseDir(): string {
+    // manifest.json lives in the same directory as shards/ and search.json
+    const slash = manifestUrl.lastIndexOf("/");
+    return slash === -1 ? "" : manifestUrl.slice(0, slash + 1);
+  }
+
+  async function fetchJson<T>(url: string): Promise<T> {
+    const res = await fetchFn(url, { credentials: "omit" });
+    if (!res.ok) {
+      throw new Error(`artist-gallery: ${url} returned ${res.status}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async function loadManifest(): Promise<ArtistManifest> {
+    const now = Date.now();
+    if (manifestPromise && now - manifestAt < MANIFEST_CACHE_MS) {
+      return manifestPromise;
+    }
+    manifestAt = now;
+    manifestPromise = fetchJson<ArtistManifest>(manifestUrl).catch((err) => {
+      // Let the next call retry on failure.
+      manifestPromise = null;
+      manifestAt = 0;
+      throw err;
+    });
+    return manifestPromise;
+  }
+
+  async function loadShard(bucket: string): Promise<ArtistShard> {
+    const existing = shardPromises.get(bucket);
+    if (existing) return existing;
+    const manifest = await loadManifest();
+    const meta = manifest.shards.find((s) => s.bucket === bucket);
+    if (!meta) {
+      throw new Error(`artist-gallery: no shard "${bucket}" in manifest`);
+    }
+    const p = fetchJson<ArtistShard>(baseDir() + meta.path).catch((err) => {
+      shardPromises.delete(bucket);
+      throw err;
+    });
+    shardPromises.set(bucket, p);
+    return p;
+  }
+
+  function bucketForSlug(slug: string): string {
+    if (!slug) return "_";
+    const ch = slug[0].toLowerCase();
+    return /[a-z0-9]/.test(ch) ? ch : "_";
+  }
+
+  function normalizeTag(tag: string): string {
+    // Strip one leading @ for lookup (anima-tags uses "@name"; callers may pass either form).
+    return tag.replace(/^@+/, "").toLowerCase();
+  }
+
+  async function loadSearchIndex(): Promise<ArtistSearchHit[]> {
+    if (searchPromise) return searchPromise;
+    const manifest = await loadManifest();
+    searchPromise = fetchJson<ArtistSearchHit[]>(
+      baseDir() + manifest.searchIndex.path,
+    ).then((hits) => {
+      for (const h of hits) {
+        slugToBucket.set(h.slug, h.shard);
+        tagToSlug.set(h.tag.toLowerCase(), h.slug);
+        tagToSlug.set(normalizeTag(h.tag), h.slug);
+      }
+      return hits;
+    }).catch((err) => {
+      searchPromise = null;
+      throw err;
+    });
+    return searchPromise;
+  }
+
+  async function getArtist(slugOrTag: string): Promise<ArtistEntry | null> {
+    if (!slugOrTag) return null;
+    const trimmed = slugOrTag.trim();
+    let slug = trimmed;
+    let bucket = bucketForSlug(slug);
+
+    // If caller handed a raw tag ("@dairi" / "dairi"), try direct bucket first;
+    // fall back to the search index for indirect resolution.
+    const shard = await loadShard(bucket).catch(() => null);
+    if (shard?.entries[slug]) return shard.entries[slug];
+
+    // Resolve through the search index.
+    await loadSearchIndex();
+    const key = normalizeTag(trimmed);
+    const resolvedSlug = tagToSlug.get(key) ?? tagToSlug.get(trimmed.toLowerCase());
+    if (!resolvedSlug) return null;
+    slug = resolvedSlug;
+    bucket = slugToBucket.get(slug) ?? bucketForSlug(slug);
+    const shard2 = await loadShard(bucket);
+    return shard2.entries[slug] ?? null;
+  }
+
+  function normalizeQuery(text: string): string {
+    return text.toLowerCase().trim().replace(/\s+/g, "_").replace(/\\/g, "").replace(/^@+/, "");
+  }
+
+  async function search(query: string, opts: SearchOptions = {}): Promise<ArtistSearchHit[]> {
+    const q = normalizeQuery(query);
+    if (!q) return [];
+    const hits = await loadSearchIndex();
+    const limit = Math.max(1, Math.min(100, opts.limit ?? 25));
+    const requireImage = opts.requireImage ?? true;
+
+    const prefix: ArtistSearchHit[] = [];
+    const contains: ArtistSearchHit[] = [];
+    for (const h of hits) {
+      if (requireImage && !h.hasImage) continue;
+      const slugLower = h.slug.toLowerCase();
+      if (slugLower.startsWith(q)) {
+        prefix.push(h);
+        if (prefix.length >= limit && contains.length === 0) break;
+      } else if (slugLower.includes(q) || h.tag.toLowerCase().includes(q)) {
+        if (contains.length < limit) contains.push(h);
+      }
+    }
+    // hits is already sorted by postCount desc, so slice preserves ranking.
+    const combined = [...prefix, ...contains];
+    return combined.slice(0, limit);
+  }
+
+  function invalidate(): void {
+    manifestPromise = null;
+    manifestAt = 0;
+    shardPromises.clear();
+    searchPromise = null;
+    slugToBucket.clear();
+    tagToSlug.clear();
+  }
+
+  return {
+    manifestUrl,
+    loadManifest,
+    loadShard,
+    getArtist,
+    loadSearchIndex,
+    search,
+    invalidate,
+  };
+}

--- a/src/lib/artist-gallery/components/ArtistCard.svelte
+++ b/src/lib/artist-gallery/components/ArtistCard.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    entry: ArtistEntry;
+    onclick?: (entry: ArtistEntry) => void;
+  }
+
+  let { entry, onclick }: Props = $props();
+
+  function formatCount(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+    return String(n);
+  }
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/_/g, " ");
+  }
+</script>
+
+<button
+  type="button"
+  class="group relative flex flex-col items-stretch overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900 text-left transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+  onclick={() => onclick?.(entry)}
+  title={entry.tag}
+>
+  <div class="relative aspect-3/4 w-full bg-neutral-800">
+    {#if entry.hasImage && entry.imageUrl}
+      <img
+        src={entry.imageUrl}
+        alt={entry.tag}
+        loading="lazy"
+        decoding="async"
+        class="h-full w-full object-cover transition-opacity duration-200"
+      />
+    {:else}
+      <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
+        no preview
+      </div>
+    {/if}
+  </div>
+  <div class="flex items-center justify-between gap-2 px-2 py-1.5">
+    <span class="truncate text-sm text-red-400">{displayTag(entry.tag)}</span>
+    <span class="shrink-0 text-xs text-neutral-500">{formatCount(entry.postCount)}</span>
+  </div>
+</button>

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { createArtistGalleryStore } from "../store.svelte.js";
-  import type { ArtistEntry } from "../types.js";
-  import ArtistCard from "./ArtistCard.svelte";
+  import type { ArtistEntry, ArtistSearchHit } from "../types.js";
   import ArtistLightbox from "./ArtistLightbox.svelte";
 
   interface Props {
@@ -15,42 +14,75 @@
 
   const store = createArtistGalleryStore(manifestUrl);
 
-  let selectedBucket = $state<string | null>(null);
-  let bucketEntries = $state<ArtistEntry[]>([]);
-  let bucketLoading = $state(false);
-  let bucketError = $state<string | null>(null);
-  let visibleCount = $state(60);
-  const PAGE_SIZE = 60;
+  type SortField = "postCount" | "name" | "uniqueness";
+  type SortDir = "asc" | "desc";
+  type PageSize = 25 | 50 | 100;
+
+  // ---------------------------------------------------------------------------
+  // Uniqueness scoring
+  // ---------------------------------------------------------------------------
+  // Log-normal distribution centred at exp(5.5) ≈ 245 posts, sigma=1.8 in log
+  // space. Artists with 50–2 000 posts score highest; mega-popular (10k+) and
+  // tiny (<10) score low — the "hidden gem" sweet spot.
+  function logNormalScore(x: number, mu: number, sigma: number): number {
+    if (x <= 0) return 0;
+    const lx = Math.log(x);
+    return Math.exp(-0.5 * ((lx - mu) / sigma) ** 2);
+  }
+
+  function baseUniqueness(postCount: number): number {
+    return logNormalScore(postCount, 5.5, 1.8);
+  }
+
+  /** Per-entry jitter multipliers (0.7 – 1.3). Re-generated on each rotate. */
+  let uniquenessJitter = $state<Float32Array>(new Float32Array(0));
+
+  function generateJitter(count: number): Float32Array {
+    const arr = new Float32Array(count);
+    for (let i = 0; i < count; i++) arr[i] = 0.7 + 0.6 * Math.random();
+    return arr;
+  }
+
+  function rotateUniqueness() {
+    uniquenessJitter = generateJitter(allEntries.length);
+    sortField = "uniqueness";
+    currentPage = 1;
+    animKey++;
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  let allEntries = $state<ArtistSearchHit[]>([]);
+  let allLoading = $state(false);
+  let allError = $state<string | null>(null);
+
+  let sortField = $state<SortField>("postCount");
+  let sortDir = $state<SortDir>("desc");
+  const PAGE_SIZES: PageSize[] = [25, 50, 100];
+  let pageSize = $state<PageSize>(50);
+  let currentPage = $state(1);
 
   let active = $state<ArtistEntry | null>(null);
+  let activeIndex = $state(-1);
   let queryInput = $state("");
   let searchDebounce: number | null = null;
 
   onMount(() => {
-    store.init().then(() => {
-      if (!selectedBucket && store.manifest && store.manifest.shards.length > 0) {
-        void selectBucket(store.manifest.shards[0].bucket);
+    store.init().then(async () => {
+      allLoading = true;
+      allError = null;
+      try {
+        allEntries = await store.client.loadSearchIndex();
+        uniquenessJitter = generateJitter(allEntries.length);
+      } catch (err) {
+        allError = err instanceof Error ? err.message : String(err);
+      } finally {
+        allLoading = false;
       }
     });
   });
-
-  async function selectBucket(bucket: string) {
-    selectedBucket = bucket;
-    visibleCount = PAGE_SIZE;
-    bucketLoading = true;
-    bucketError = null;
-    try {
-      const shard = await store.client.loadShard(bucket);
-      bucketEntries = Object.values(shard.entries).sort(
-        (a, b) => b.postCount - a.postCount || a.slug.localeCompare(b.slug),
-      );
-    } catch (err) {
-      bucketError = err instanceof Error ? err.message : String(err);
-      bucketEntries = [];
-    } finally {
-      bucketLoading = false;
-    }
-  }
 
   function onSearchInput(value: string) {
     queryInput = value;
@@ -61,25 +93,229 @@
     }, 120);
   }
 
-  async function openHit(slug: string) {
-    await store.openArtist(slug);
-    active = store.activeArtist;
+  async function openHit(hit: ArtistSearchHit, index = -1) {
+    // Instant open: build entry immediately from cached search index data
+    const imageUrl = store.manifest && hit.hasImage && hit.imageId
+      ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`
+      : "";
+    active = { tag: hit.tag, slug: hit.slug, imageId: hit.imageId, imageUrl, objectKey: "", postCount: hit.postCount, aliases: [], hasImage: hit.hasImage };
+    activeIndex = index;
+    // Background: fetch full shard entry to patch in aliases once loaded
+    store.client.getArtist(hit.slug).then((full) => {
+      if (full && active?.slug === hit.slug) active = full;
+    }).catch(() => {});
+  }
+
+  async function navigateTo(index: number) {
+    const clamped = Math.max(0, Math.min(gridEntries.length - 1, index));
+    await openHit(gridEntries[clamped], clamped);
   }
 
   function closeLightbox() {
     active = null;
+    activeIndex = -1;
     store.closeArtist();
   }
 
-  function loadMore() {
-    visibleCount = Math.min(bucketEntries.length, visibleCount + PAGE_SIZE);
+  // Zoom state lifted here so it persists across lightbox close/reopen
+  let lightboxZoomed = $state(false);
+
+  // Page-jump controls
+  let pageInputValue = $state("");
+
+  function goToRandomPage() {
+    const page = Math.floor(Math.random() * totalPages) + 1;
+    goToPage(page);
   }
 
-  const visibleEntries = $derived(
-    store.query.trim()
-      ? []
-      : bucketEntries.slice(0, visibleCount),
+  function commitPageInput() {
+    const n = parseInt(pageInputValue, 10);
+    if (!isNaN(n) && n >= 1 && n <= totalPages) {
+      goToPage(n);
+    }
+    pageInputValue = "";
+  }
+
+  function thumbUrl(hit: ArtistSearchHit): string {
+    if (!store.manifest || !hit.hasImage || !hit.imageId) return "";
+    return `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`;
+  }
+
+  function formatCount(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+    return String(n);
+  }
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/_/g, " ");
+  }
+
+  let copiedSlug = $state<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Favourites + animation
+  // ---------------------------------------------------------------------------
+  let favourites = $state<Set<string>>(new Set());
+  let showOnlyFavourites = $state(false);
+  let showGenParams = $state(false);
+  let animKey = $state(0);
+
+  function toggleFavourite(slug: string, e: MouseEvent) {
+    e.stopPropagation();
+    const next = new Set(favourites);
+    if (next.has(slug)) next.delete(slug);
+    else next.add(slug);
+    favourites = next;
+  }
+
+  function setShowOnlyFavourites(val: boolean) {
+    showOnlyFavourites = val;
+    currentPage = 1;
+    animKey++;
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function getInitialSliderValue(): number {
+    try {
+      const stored = localStorage.getItem("artist-gallery-card-size");
+      if (stored !== null) return Math.max(0, Math.min(100, parseInt(stored, 10)));
+    } catch { /* ignore */ }
+    return 60;
+  }
+
+  let sliderValue = $state(getInitialSliderValue());
+  const cardMinWidth = $derived(Math.round(100 * Math.pow(4, sliderValue / 100)));
+
+  $effect(() => {
+    try { localStorage.setItem("artist-gallery-card-size", String(sliderValue)); } catch { /* ignore */ }
+  });
+
+  async function copyTag(tag: string, slug: string) {
+    const formatted = "@" + tag.replace(/^@/, "");
+    await navigator.clipboard.writeText(formatted);
+    copiedSlug = slug;
+    window.setTimeout(() => { copiedSlug = null; }, 1500);
+  }
+
+  let scrollContainer = $state<HTMLDivElement | null>(null);
+
+  function goToPage(page: number) {
+    currentPage = page;
+    // scrollTo then dispatch synthetic scroll so WebView2 re-evaluates
+    // viewport intersection for eager images (known WebView2 overflow quirk)
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function setSort(field: SortField) {
+    if (field === "uniqueness" && sortField !== "uniqueness") {
+      rotateUniqueness();
+      return;
+    }
+    sortField = field;
+    currentPage = 1;
+    animKey++;
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function setDir(dir: SortDir) {
+    sortDir = dir;
+    currentPage = 1;
+    animKey++;
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function setPageSize(size: PageSize) {
+    // Maintain position: find which new page contains the first item currently visible
+    const firstIndex = (safePage - 1) * pageSize;
+    pageSize = size;
+    currentPage = Math.max(1, Math.floor(firstIndex / size) + 1);
+    requestAnimationFrame(() => {
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  const sortedEntries = $derived.by(() => {
+    if (sortField === "uniqueness") {
+      const jitter = uniquenessJitter;
+      return [...allEntries]
+        .map((e, i) => ({ e, score: baseUniqueness(e.postCount) * (jitter[i] ?? 1) }))
+        .sort((a, b) => b.score - a.score)
+        .map((x) => x.e);
+    }
+    const dir = sortDir === "asc" ? 1 : -1;
+    return [...allEntries].sort((a, b) =>
+      sortField === "name"
+        ? a.slug.localeCompare(b.slug) * dir
+        : (a.postCount - b.postCount) * dir,
+    );
+  });
+
+  const filteredEntries = $derived(
+    showOnlyFavourites ? sortedEntries.filter(e => favourites.has(e.slug)) : sortedEntries
   );
+  const totalPages = $derived(Math.max(1, Math.ceil(filteredEntries.length / pageSize)));
+  const safePage = $derived(Math.min(currentPage, totalPages));
+  const pageEntries = $derived(
+    filteredEntries.slice((safePage - 1) * pageSize, safePage * pageSize),
+  );
+
+  // When the user is typing in the search box, show search results directly
+  // in the grid instead of the normal paginated results.
+  const isSearching = $derived(queryInput.trim().length > 0);
+  const gridEntries = $derived<ArtistSearchHit[]>(isSearching ? store.results : pageEntries);
+
+  // ---------------------------------------------------------------------------
+  // Image preload cache
+  // ---------------------------------------------------------------------------
+  // Keep a Map of HTMLImageElement refs so the browser doesn't evict images
+  // from its cache when they're not in the DOM. The window covers the current
+  // page plus 4 pages back and 1 page ahead.
+  const _preloadCache = new Map<string, HTMLImageElement>();
+
+  const _preloadUrls = $derived.by(() => {
+    if (!store.manifest) return [] as string[];
+    const { imageBaseUrl, releasePrefix } = store.manifest;
+    const start = Math.max(1, safePage - 4);
+    const end = Math.min(totalPages, safePage + 1);
+    const urls: string[] = [];
+    for (let p = start; p <= end; p++) {
+      for (const hit of sortedEntries.slice((p - 1) * pageSize, p * pageSize)) {
+        if (hit.hasImage && hit.imageId) {
+          urls.push(`${imageBaseUrl}/${releasePrefix}/images/${hit.imageId}.webp`);
+        }
+      }
+    }
+    return urls;
+  });
+
+  $effect(() => {
+    const urlSet = new Set(_preloadUrls);
+    // Eagerly load anything not yet cached
+    for (const url of urlSet) {
+      if (!_preloadCache.has(url)) {
+        const img = new Image();
+        img.src = url;
+        _preloadCache.set(url, img);
+      }
+    }
+    // Release entries that have scrolled beyond the window
+    for (const url of _preloadCache.keys()) {
+      if (!urlSet.has(url)) _preloadCache.delete(url);
+    }
+  });
 </script>
 
 <div class="flex h-full w-full flex-col overflow-hidden bg-neutral-950 text-neutral-100">
@@ -90,7 +326,8 @@
         <p class="text-xs text-neutral-500">
           {#if store.manifest}
             {store.manifest.artistsWithImage.toLocaleString()} artists ·
-            Anima preview · release {store.manifest.releasePrefix}
+            Anima preview · release {store.manifest.releasePrefix} ·
+            <button type="button" class="underline hover:text-neutral-300" onclick={() => showGenParams = true}>ℹ gen params</button>
           {:else if store.manifestError}
             <span class="text-red-400">failed to load: {store.manifestError}</span>
           {:else}
@@ -98,6 +335,8 @@
           {/if}
         </p>
       </div>
+
+      <!-- Search -->
       <div class="relative w-full max-w-sm">
         <input
           type="search"
@@ -112,91 +351,283 @@
       </div>
     </div>
 
-    {#if store.manifest && !store.query.trim()}
-      <div class="mt-3 flex flex-wrap gap-1">
-        {#each store.manifest.shards as shard}
+    <!-- Sort + page size toolbar -->
+    {#if store.manifest}
+      <div class="mt-3 flex flex-wrap items-center gap-2">
+        <div class="flex items-center gap-0.5 rounded-lg border border-neutral-800 bg-neutral-900/50 p-1">
+          <span class="px-1.5 text-xs text-neutral-500">Sort:</span>
           <button
             type="button"
-            class="rounded-md px-2 py-1 text-xs font-mono transition-colors {selectedBucket ===
-            shard.bucket
-              ? 'bg-indigo-600 text-white'
-              : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700'}"
-            onclick={() => selectBucket(shard.bucket)}
-            title={`${shard.count} artists`}
+            class="rounded px-2 py-0.5 text-xs transition-colors {sortField === 'postCount' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => setSort('postCount')}
           >
-            {shard.bucket}
+            Post Count
           </button>
-        {/each}
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {sortField === 'name' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => setSort('name')}
+          >
+            Name
+          </button>
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {sortField === 'uniqueness' ? 'bg-amber-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => setSort('uniqueness')}
+            title="Surfaces hidden gems: artists with a distinctive style not yet overexposed"
+          >
+            Unique
+          </button>
+          <div class="mx-1 h-3 w-px shrink-0 bg-neutral-700"></div>
+          {#if sortField === 'uniqueness'}
+            <button
+              type="button"
+              class="rounded px-2 py-0.5 text-xs text-amber-400 transition-colors hover:text-amber-200"
+              onclick={rotateUniqueness}
+              title="Reshuffle the uniqueness ranking to discover a fresh set of hidden gems"
+            >
+              ↻ Rotate
+            </button>
+          {:else}
+            <button
+              type="button"
+              class="rounded px-2 py-0.5 text-xs transition-colors {sortDir === 'desc' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+              onclick={() => setDir('desc')}
+              title="Descending"
+            >
+              ↓ Desc
+            </button>
+            <button
+              type="button"
+              class="rounded px-2 py-0.5 text-xs transition-colors {sortDir === 'asc' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+              onclick={() => setDir('asc')}
+              title="Ascending"
+            >
+              ↑ Asc
+            </button>
+          {/if}
+        </div>
+
+        <div class="flex items-center gap-0.5 rounded-lg border border-neutral-800 bg-neutral-900/50 p-1">
+          <span class="px-1.5 text-xs text-neutral-500">Per page:</span>
+          {#each PAGE_SIZES as size}
+            <button
+              type="button"
+              class="rounded px-2 py-0.5 text-xs transition-colors {pageSize === size ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+              onclick={() => setPageSize(size)}
+            >
+              {size}
+            </button>
+          {/each}
+        </div>
+
+        <div class="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/50 px-2 py-1">
+          <span class="text-xs text-neutral-500">Size:</span>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={sliderValue}
+            oninput={(e) => { sliderValue = parseInt(e.currentTarget.value, 10); }}
+            class="w-20 accent-indigo-500"
+          />
+        </div>
+
+        <button
+          type="button"
+          class="rounded-lg border px-2 py-1 text-xs transition-colors {showOnlyFavourites ? 'border-red-500 bg-red-950/50 text-red-300' : 'border-neutral-800 bg-neutral-900/50 text-neutral-400 hover:text-neutral-200'}"
+          onclick={() => setShowOnlyFavourites(!showOnlyFavourites)}
+          title="Toggle favourites filter"
+        >
+          {showOnlyFavourites ? '♥' : '♡'} Favourites{favourites.size > 0 ? ` (${favourites.size})` : ''}
+        </button>
       </div>
     {/if}
   </header>
 
-  <div class="flex-1 overflow-y-auto">
-    {#if store.query.trim()}
-      {#if store.results.length === 0 && !store.searchLoading}
-        <div class="p-8 text-center text-sm text-neutral-500">
-          No artists match "{store.query}".
-        </div>
-      {:else}
-        <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
-          {#each store.results as hit (hit.slug)}
-            {@const thumbUrl =
-              store.manifest && hit.hasImage
-                ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`
-                : ""}
-            <button
-              type="button"
-              class="group flex flex-col items-stretch overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900 text-left transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              onclick={() => openHit(hit.slug)}
-              title={hit.tag}
-            >
-              <div class="relative aspect-3/4 w-full bg-neutral-800">
-                {#if thumbUrl}
-                  <img
-                    src={thumbUrl}
-                    alt={hit.tag}
-                    loading="lazy"
-                    decoding="async"
-                    class="h-full w-full object-cover"
-                  />
-                {:else}
-                  <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
-                    no preview
-                  </div>
-                {/if}
-              </div>
-              <div class="flex items-center justify-between gap-2 px-2 py-1.5">
-                <span class="truncate text-sm text-red-400">
-                  {hit.tag.replace(/^@/, "").replace(/_/g, " ")}
-                </span>
-                <span class="shrink-0 text-xs text-neutral-500">
-                  {hit.postCount >= 1000 ? `${Math.round(hit.postCount / 1000)}k` : hit.postCount}
-                </span>
-              </div>
-            </button>
-          {/each}
-        </div>
-      {/if}
-    {:else if bucketError}
+  <div class="flex-1 overflow-y-auto" bind:this={scrollContainer}>
+    {#if allError}
       <div class="p-8 text-center text-sm text-red-400">
-        Failed to load shard: {bucketError}
+        Failed to load artists: {allError}
       </div>
-    {:else if bucketLoading && bucketEntries.length === 0}
-      <div class="p-8 text-center text-sm text-neutral-500">loading…</div>
+    {:else if allLoading}
+      <div class="p-8 text-center text-sm text-neutral-500">loading artists…</div>
     {:else}
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
-        {#each visibleEntries as entry (entry.slug)}
-          <ArtistCard {entry} onclick={(e) => (active = e)} />
-        {/each}
-      </div>
-      {#if visibleCount < bucketEntries.length}
-        <div class="p-4 text-center">
+      <p class="px-4 pt-2 text-xs text-neutral-500">
+        {#if isSearching}
+          {store.searchLoading ? "Searching\u2026" : `${store.results.length.toLocaleString()} result${store.results.length === 1 ? '' : 's'} for "${queryInput}"`}
+        {:else}
+          Right-click a card or hover to copy its tag.
+        {/if}
+      </p>
+      {#if totalPages > 1 && !isSearching}
+        <div class="flex flex-wrap items-center justify-center gap-2 border-b border-neutral-800/60 px-4 py-2">
           <button
             type="button"
-            class="rounded-md border border-neutral-700 bg-neutral-800 px-4 py-2 text-sm text-neutral-200 transition-colors hover:border-indigo-500"
-            onclick={loadMore}
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1 text-sm text-neutral-300 transition-colors hover:border-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={safePage <= 1}
+            onclick={() => goToPage(safePage - 1)}
           >
-            Load more ({bucketEntries.length - visibleCount} remaining)
+            ← Prev
+          </button>
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-300 transition-colors hover:border-amber-500"
+            onclick={goToRandomPage}
+            title="Jump to a random page"
+          >
+            ⚄ Random
+          </button>
+          <span class="text-sm text-neutral-400">
+            Page {safePage} of {totalPages}
+            <span class="text-neutral-600">·</span>
+            {filteredEntries.length.toLocaleString()} artists
+          </span>
+          <div class="flex items-center gap-1">
+            <input
+              type="number"
+              min="1"
+              max={totalPages}
+              placeholder="pg #"
+              value={pageInputValue}
+              oninput={(e) => { pageInputValue = e.currentTarget.value; }}
+              onkeydown={(e) => { if (e.key === 'Enter') commitPageInput(); }}
+              class="w-14 rounded border border-neutral-700 bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-200 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-300 transition-colors hover:border-indigo-500"
+              onclick={commitPageInput}
+              title="Go to page"
+            >↵</button>
+          </div>
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1 text-sm text-neutral-300 transition-colors hover:border-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={safePage >= totalPages}
+            onclick={() => goToPage(safePage + 1)}
+          >
+            Next →
+          </button>
+        </div>
+      {/if}
+      {#key animKey}
+      <div class="grid gap-3 p-4" style="grid-template-columns: repeat(auto-fill, minmax({cardMinWidth}px, 1fr))">
+        {#each gridEntries as hit, i (hit.slug)}
+          {@const url = thumbUrl(hit)}
+          {@const rank = (safePage - 1) * pageSize + i + 1}
+          {@const isFav = favourites.has(hit.slug)}
+          <div
+            role="button"
+            tabindex="0"
+            class="card-slide-in group flex flex-col items-stretch overflow-hidden rounded-lg border bg-neutral-900 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 {copiedSlug === hit.slug ? 'border-emerald-500' : 'border-neutral-800 hover:border-indigo-500'}"
+            style="--card-delay: {Math.min(i * 30, 450)}ms"
+            onclick={() => { void openHit(hit, i); }}
+            onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); void openHit(hit, i); } }}
+            oncontextmenu={(e) => { e.preventDefault(); void copyTag(hit.tag, hit.slug); }}
+            title="{hit.tag} · Right-click to copy tag"
+          >
+            <div class="relative aspect-3/4 w-full bg-neutral-800">
+              {#if url}
+                <img
+                  src={url}
+                  alt={hit.tag}
+                  loading="eager"
+                  decoding="auto"
+                  class="h-full w-full object-cover"
+                />
+              {:else}
+                <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
+                  no preview
+                </div>
+              {/if}
+              {#if sortField === 'uniqueness'}
+                <div class="absolute left-1 top-1 rounded bg-amber-600/90 px-1 py-0.5 text-[10px] font-mono font-bold leading-none text-white">
+                  #{rank}
+                </div>
+              {/if}
+              <button
+                type="button"
+                class="absolute right-1 top-1 rounded border border-neutral-700 bg-neutral-900/90 px-1.5 py-0.5 text-[10px] text-neutral-200 opacity-0 transition-opacity group-hover:opacity-100 hover:border-indigo-500"
+                onclick={(e) => { e.stopPropagation(); void copyTag(hit.tag, hit.slug); }}
+                aria-label="Copy tag"
+              >
+                Copy
+              </button>
+              {#if copiedSlug === hit.slug}
+                <div class="absolute inset-0 flex items-center justify-center bg-neutral-900/80">
+                  <span class="rounded bg-emerald-600 px-2 py-1 text-xs font-semibold text-white">Copied!</span>
+                </div>
+              {/if}
+            </div>
+            <div class="flex items-center justify-between gap-1 px-2 py-1.5">
+              <span class="min-w-0 truncate text-sm text-red-400">{displayTag(hit.tag)}</span>
+              <div class="flex shrink-0 items-center gap-1">
+                <span class="text-xs text-neutral-500">{formatCount(hit.postCount)}</span>
+                <button
+                  type="button"
+                  class="text-sm leading-none transition-colors {isFav ? 'text-red-400' : 'text-neutral-600 hover:text-red-400'}"
+                  onclick={(e) => toggleFavourite(hit.slug, e)}
+                  aria-label={isFav ? 'Remove from favourites' : 'Add to favourites'}
+                >
+                  {isFav ? '♥' : '♡'}
+                </button>
+              </div>
+            </div>
+          </div>
+        {/each}
+      </div>
+      {/key}
+
+      <!-- Pagination -->
+      {#if totalPages > 1 && !isSearching}
+        <div class="flex flex-wrap items-center justify-center gap-2 px-4 py-4">
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-neutral-300 transition-colors hover:border-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={safePage <= 1}
+            onclick={() => goToPage(safePage - 1)}
+          >
+            ← Prev
+          </button>
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-300 transition-colors hover:border-amber-500"
+            onclick={goToRandomPage}
+            title="Jump to a random page"
+          >
+            ⚄ Random
+          </button>
+          <span class="text-sm text-neutral-400">
+            Page {safePage} of {totalPages}
+            <span class="text-neutral-600">·</span>
+            {filteredEntries.length.toLocaleString()} artists
+          </span>
+          <div class="flex items-center gap-1">
+            <input
+              type="number"
+              min="1"
+              max={totalPages}
+              placeholder="pg #"
+              value={pageInputValue}
+              oninput={(e) => { pageInputValue = e.currentTarget.value; }}
+              onkeydown={(e) => { if (e.key === 'Enter') commitPageInput(); }}
+              class="w-14 rounded border border-neutral-700 bg-neutral-800 px-1.5 py-1 text-xs text-neutral-200 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-1.5 py-1 text-xs text-neutral-300 transition-colors hover:border-indigo-500"
+              onclick={commitPageInput}
+              title="Go to page"
+            >↵</button>
+          </div>
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-neutral-300 transition-colors hover:border-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={safePage >= totalPages}
+            onclick={() => goToPage(safePage + 1)}
+          >
+            Next →
           </button>
         </div>
       {/if}
@@ -205,5 +636,64 @@
 </div>
 
 {#if active}
-  <ArtistLightbox entry={active} onclose={closeLightbox} {oninsertTag} />
+  <ArtistLightbox
+    entry={active}
+    onclose={closeLightbox}
+    {oninsertTag}
+    zoomed={lightboxZoomed}
+    ontogglezoom={() => lightboxZoomed = !lightboxZoomed}
+    onprev={activeIndex > 0 ? () => navigateTo(activeIndex - 1) : undefined}
+    onnext={activeIndex >= 0 && activeIndex < gridEntries.length - 1 ? () => navigateTo(activeIndex + 1) : undefined}
+  />
+{/if}
+
+{#if showGenParams}
+  <div
+    class="fixed inset-0 z-200 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Generation parameters"
+  >
+    <button type="button" class="absolute inset-0 h-full w-full cursor-default" aria-label="Close" onclick={() => showGenParams = false}></button>
+    <div class="relative z-10 w-full max-w-lg rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+      <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-sm font-semibold text-neutral-100">Preview Generation Parameters</h2>
+        <button type="button" class="text-neutral-500 hover:text-neutral-200 text-lg leading-none" onclick={() => showGenParams = false} aria-label="Close">✕</button>
+      </div>
+      <div class="space-y-3 text-xs text-neutral-400">
+        <section>
+          <h3 class="mb-1 font-medium text-neutral-300">Model Stack</h3>
+          <table class="w-full">
+            <tbody>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">UNet</td><td class="text-neutral-200">Anima SDXL Base</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Text Encoder</td><td class="text-neutral-200">CLIP-L + CLIP-G (SDXL dual)</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">VAE</td><td class="text-neutral-200">sdxl_vae.safetensors</td></tr>
+            </tbody>
+          </table>
+        </section>
+        <section>
+          <h3 class="mb-1 font-medium text-neutral-300">Sampler</h3>
+          <table class="w-full">
+            <tbody>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Sampler</td><td class="text-neutral-200">er_sde</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Scheduler</td><td class="text-neutral-200">sgm_uniform</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Steps</td><td class="text-neutral-200">30</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">CFG Scale</td><td class="text-neutral-200">4.0</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Seed</td><td class="text-neutral-200">42</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Resolution</td><td class="text-neutral-200">896 × 1152</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">Output</td><td class="text-neutral-200">WebP (lossy, q=85)</td></tr>
+            </tbody>
+          </table>
+        </section>
+        <section>
+          <h3 class="mb-1 font-medium text-neutral-300">Positive Prompt</h3>
+          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">score_9, score_8_up, score_7_up, masterpiece, best quality, <span class="text-red-400">@artist_tag</span></p>
+        </section>
+        <section>
+          <h3 class="mb-1 font-medium text-neutral-300">Negative Prompt</h3>
+          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">score_1, score_2, score_3, worst quality, low quality, blurry, watermark</p>
+        </section>
+      </div>
+    </div>
+  </div>
 {/if}

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { createArtistGalleryStore } from "../store.svelte.js";
+  import type { ArtistEntry } from "../types.js";
+  import ArtistCard from "./ArtistCard.svelte";
+  import ArtistLightbox from "./ArtistLightbox.svelte";
+
+  interface Props {
+    manifestUrl: string;
+    /** Optional integrator hook for "Insert tag into prompt" in the lightbox. */
+    oninsertTag?: (tag: string) => void;
+  }
+
+  let { manifestUrl, oninsertTag }: Props = $props();
+
+  const store = createArtistGalleryStore(manifestUrl);
+
+  let selectedBucket = $state<string | null>(null);
+  let bucketEntries = $state<ArtistEntry[]>([]);
+  let bucketLoading = $state(false);
+  let bucketError = $state<string | null>(null);
+  let visibleCount = $state(60);
+  const PAGE_SIZE = 60;
+
+  let active = $state<ArtistEntry | null>(null);
+  let queryInput = $state("");
+  let searchDebounce: number | null = null;
+
+  onMount(() => {
+    store.init().then(() => {
+      if (!selectedBucket && store.manifest && store.manifest.shards.length > 0) {
+        void selectBucket(store.manifest.shards[0].bucket);
+      }
+    });
+  });
+
+  async function selectBucket(bucket: string) {
+    selectedBucket = bucket;
+    visibleCount = PAGE_SIZE;
+    bucketLoading = true;
+    bucketError = null;
+    try {
+      const shard = await store.client.loadShard(bucket);
+      bucketEntries = Object.values(shard.entries).sort(
+        (a, b) => b.postCount - a.postCount || a.slug.localeCompare(b.slug),
+      );
+    } catch (err) {
+      bucketError = err instanceof Error ? err.message : String(err);
+      bucketEntries = [];
+    } finally {
+      bucketLoading = false;
+    }
+  }
+
+  function onSearchInput(value: string) {
+    queryInput = value;
+    if (searchDebounce !== null) window.clearTimeout(searchDebounce);
+    searchDebounce = window.setTimeout(() => {
+      void store.setQuery(value);
+      searchDebounce = null;
+    }, 120);
+  }
+
+  async function openHit(slug: string) {
+    await store.openArtist(slug);
+    active = store.activeArtist;
+  }
+
+  function closeLightbox() {
+    active = null;
+    store.closeArtist();
+  }
+
+  function loadMore() {
+    visibleCount = Math.min(bucketEntries.length, visibleCount + PAGE_SIZE);
+  }
+
+  const visibleEntries = $derived(
+    store.query.trim()
+      ? []
+      : bucketEntries.slice(0, visibleCount),
+  );
+</script>
+
+<div class="flex h-full w-full flex-col overflow-hidden bg-neutral-950 text-neutral-100">
+  <header class="flex-none border-b border-neutral-800 bg-neutral-900/60 px-4 py-3">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h1 class="text-lg font-semibold">Artist Gallery</h1>
+        <p class="text-xs text-neutral-500">
+          {#if store.manifest}
+            {store.manifest.artistsWithImage.toLocaleString()} artists ·
+            Anima preview · release {store.manifest.releasePrefix}
+          {:else if store.manifestError}
+            <span class="text-red-400">failed to load: {store.manifestError}</span>
+          {:else}
+            loading manifest…
+          {/if}
+        </p>
+      </div>
+      <div class="relative w-full max-w-sm">
+        <input
+          type="search"
+          placeholder="Search artist tag…"
+          value={queryInput}
+          oninput={(e) => onSearchInput(e.currentTarget.value)}
+          class="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+        {#if store.searchLoading}
+          <span class="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-neutral-500">…</span>
+        {/if}
+      </div>
+    </div>
+
+    {#if store.manifest && !store.query.trim()}
+      <div class="mt-3 flex flex-wrap gap-1">
+        {#each store.manifest.shards as shard}
+          <button
+            type="button"
+            class="rounded-md px-2 py-1 text-xs font-mono transition-colors {selectedBucket ===
+            shard.bucket
+              ? 'bg-indigo-600 text-white'
+              : 'bg-neutral-800 text-neutral-300 hover:bg-neutral-700'}"
+            onclick={() => selectBucket(shard.bucket)}
+            title={`${shard.count} artists`}
+          >
+            {shard.bucket}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </header>
+
+  <div class="flex-1 overflow-y-auto">
+    {#if store.query.trim()}
+      {#if store.results.length === 0 && !store.searchLoading}
+        <div class="p-8 text-center text-sm text-neutral-500">
+          No artists match "{store.query}".
+        </div>
+      {:else}
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
+          {#each store.results as hit (hit.slug)}
+            {@const thumbUrl =
+              store.manifest && hit.hasImage
+                ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`
+                : ""}
+            <button
+              type="button"
+              class="group flex flex-col items-stretch overflow-hidden rounded-lg border border-neutral-800 bg-neutral-900 text-left transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              onclick={() => openHit(hit.slug)}
+              title={hit.tag}
+            >
+              <div class="relative aspect-3/4 w-full bg-neutral-800">
+                {#if thumbUrl}
+                  <img
+                    src={thumbUrl}
+                    alt={hit.tag}
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-full object-cover"
+                  />
+                {:else}
+                  <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
+                    no preview
+                  </div>
+                {/if}
+              </div>
+              <div class="flex items-center justify-between gap-2 px-2 py-1.5">
+                <span class="truncate text-sm text-red-400">
+                  {hit.tag.replace(/^@/, "").replace(/_/g, " ")}
+                </span>
+                <span class="shrink-0 text-xs text-neutral-500">
+                  {hit.postCount >= 1000 ? `${Math.round(hit.postCount / 1000)}k` : hit.postCount}
+                </span>
+              </div>
+            </button>
+          {/each}
+        </div>
+      {/if}
+    {:else if bucketError}
+      <div class="p-8 text-center text-sm text-red-400">
+        Failed to load shard: {bucketError}
+      </div>
+    {:else if bucketLoading && bucketEntries.length === 0}
+      <div class="p-8 text-center text-sm text-neutral-500">loading…</div>
+    {:else}
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 p-4">
+        {#each visibleEntries as entry (entry.slug)}
+          <ArtistCard {entry} onclick={(e) => (active = e)} />
+        {/each}
+      </div>
+      {#if visibleCount < bucketEntries.length}
+        <div class="p-4 text-center">
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-4 py-2 text-sm text-neutral-200 transition-colors hover:border-indigo-500"
+            onclick={loadMore}
+          >
+            Load more ({bucketEntries.length - visibleCount} remaining)
+          </button>
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+{#if active}
+  <ArtistLightbox entry={active} onclose={closeLightbox} {oninsertTag} />
+{/if}

--- a/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
+++ b/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { createArtistGalleryStore } from "../store.svelte.js";
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    manifestUrl: string;
+    /** Either the slug or the raw artist tag ("@dairi"). */
+    slugOrTag: string;
+  }
+
+  let { manifestUrl, slugOrTag }: Props = $props();
+
+  const store = createArtistGalleryStore(manifestUrl);
+
+  let entry = $state<ArtistEntry | null>(null);
+  let loading = $state(false);
+  let failed = $state(false);
+
+  async function load(key: string) {
+    if (!key) {
+      entry = null;
+      return;
+    }
+    loading = true;
+    failed = false;
+    try {
+      await store.init();
+      entry = await store.client.getArtist(key);
+      failed = !entry || !entry.hasImage;
+    } catch {
+      entry = null;
+      failed = true;
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    load(slugOrTag);
+  });
+</script>
+
+<div
+  class="pointer-events-none flex h-44 w-32 items-center justify-center overflow-hidden rounded-md border border-neutral-700 bg-neutral-900 shadow-xl"
+>
+  {#if loading}
+    <div class="h-full w-full animate-pulse bg-neutral-800"></div>
+  {:else if entry && entry.imageUrl && !failed}
+    <img
+      src={entry.imageUrl}
+      alt={entry.tag}
+      loading="eager"
+      decoding="async"
+      class="h-full w-full object-cover"
+    />
+  {:else}
+    <span class="px-2 text-center text-[10px] text-neutral-500">
+      no preview
+    </span>
+  {/if}
+</div>

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import type { ArtistEntry } from "../types.js";
+
+  interface Props {
+    entry: ArtistEntry;
+    onclose: () => void;
+    /** Optional integrator hook: "Insert tag into prompt" action. */
+    oninsertTag?: (tag: string) => void;
+  }
+
+  let { entry, onclose, oninsertTag }: Props = $props();
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/_/g, " ");
+  }
+
+  function onBackdropKey(e: KeyboardEvent) {
+    if (e.key === "Escape") onclose();
+  }
+
+  async function copyTag() {
+    try {
+      await navigator.clipboard.writeText(entry.tag);
+    } catch {
+      // no-op; clipboard may be unavailable in some webviews
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onBackdropKey} />
+
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label={`Artist preview: ${entry.tag}`}
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Close"
+    onclick={onclose}
+  ></button>
+
+  <div class="relative z-10 flex max-h-[92vh] max-w-[92vw] flex-col gap-3 p-4">
+    {#if entry.hasImage && entry.imageUrl}
+      <img
+        src={entry.imageUrl}
+        alt={entry.tag}
+        class="max-h-[80vh] w-auto max-w-[92vw] rounded-lg border border-neutral-800 object-contain shadow-2xl"
+      />
+    {:else}
+      <div
+        class="flex aspect-3/4 w-[60vh] max-w-[92vw] items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900 text-sm text-neutral-500"
+      >
+        no preview available
+      </div>
+    {/if}
+
+    <div
+      class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-900/90 px-4 py-3"
+    >
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-base font-medium text-red-400">
+          {displayTag(entry.tag)}
+        </div>
+        <div class="mt-0.5 text-xs text-neutral-500">
+          {entry.postCount.toLocaleString()} posts
+          {#if entry.aliases.length > 0}
+            · aliases: {entry.aliases.map((a) => a.replace(/^@/, "")).join(", ")}
+          {/if}
+        </div>
+      </div>
+      <div class="flex shrink-0 gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-indigo-500 hover:bg-neutral-700"
+          onclick={copyTag}
+        >
+          Copy tag
+        </button>
+        {#if oninsertTag}
+          <button
+            type="button"
+            class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-500"
+            onclick={() => oninsertTag?.(entry.tag)}
+          >
+            Insert into prompt
+          </button>
+        {/if}
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
+          onclick={onclose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -6,9 +6,16 @@
     onclose: () => void;
     /** Optional integrator hook: "Insert tag into prompt" action. */
     oninsertTag?: (tag: string) => void;
+    onprev?: () => void;
+    onnext?: () => void;
+    /** Zoom state is owned by the parent so it survives modal close/reopen. */
+    zoomed: boolean;
+    ontogglezoom: () => void;
   }
 
-  let { entry, onclose, oninsertTag }: Props = $props();
+  let { entry, onclose, oninsertTag, onprev, onnext, zoomed, ontogglezoom }: Props = $props();
+
+  function toggleZoom() { ontogglezoom(); }
 
   function displayTag(tag: string): string {
     return tag.replace(/^@/, "").replace(/_/g, " ");
@@ -16,6 +23,8 @@
 
   function onBackdropKey(e: KeyboardEvent) {
     if (e.key === "Escape") onclose();
+    if (e.key === "ArrowLeft") { e.preventDefault(); onprev?.(); }
+    if (e.key === "ArrowRight") { e.preventDefault(); onnext?.(); }
   }
 
   async function copyTag() {
@@ -42,12 +51,35 @@
     onclick={onclose}
   ></button>
 
-  <div class="relative z-10 flex max-h-[92vh] max-w-[92vw] flex-col gap-3 p-4">
+  <div class="relative z-10 flex max-h-[92vh] overflow-y-auto flex-col items-center gap-3 p-4">
+    <!-- Prev / Next arrow overlays -->
+    {#if onprev}
+      <button
+        type="button"
+        onclick={onprev}
+        class="absolute -left-12 top-1/2 -translate-y-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-neutral-700 bg-neutral-900/90 text-neutral-200 transition-colors hover:border-indigo-500 hover:text-white focus:outline-none"
+        aria-label="Previous artist"
+      >
+        ←
+      </button>
+    {/if}
+    {#if onnext}
+      <button
+        type="button"
+        onclick={onnext}
+        class="absolute -right-12 top-1/2 -translate-y-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-neutral-700 bg-neutral-900/90 text-neutral-200 transition-colors hover:border-indigo-500 hover:text-white focus:outline-none"
+        aria-label="Next artist"
+      >
+        →
+      </button>
+    {/if}
     {#if entry.hasImage && entry.imageUrl}
       <img
         src={entry.imageUrl}
         alt={entry.tag}
-        class="max-h-[80vh] w-auto max-w-[92vw] rounded-lg border border-neutral-800 object-contain shadow-2xl"
+        class="max-h-[80vh] max-w-[92vw] w-auto rounded-lg border border-neutral-800 object-contain shadow-2xl"
+        style="zoom: {zoomed ? 1.5 : 1}; transition: zoom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); cursor: {zoomed ? 'zoom-out' : 'zoom-in'};"
+        onclick={toggleZoom}
       />
     {:else}
       <div
@@ -58,12 +90,17 @@
     {/if}
 
     <div
-      class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-900/90 px-4 py-3"
+      class="w-full max-w-[92vw] flex flex-wrap items-center justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-900/90 px-4 py-3"
     >
       <div class="min-w-0 flex-1">
-        <div class="truncate text-base font-medium text-red-400">
+        <a
+          href="https://danbooru.donmai.us/artists/show_or_new?name={encodeURIComponent(entry.tag.replace(/^@/, ''))}"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="truncate text-base font-medium text-red-400 hover:underline"
+        >
           {displayTag(entry.tag)}
-        </div>
+        </a>
         <div class="mt-0.5 text-xs text-neutral-500">
           {entry.postCount.toLocaleString()} posts
           {#if entry.aliases.length > 0}
@@ -83,7 +120,7 @@
           <button
             type="button"
             class="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-500"
-            onclick={() => oninsertTag?.(entry.tag)}
+            onclick={() => oninsertTag?.("@" + entry.tag.replace(/^@/, ""))}
           >
             Insert into prompt
           </button>

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -29,7 +29,8 @@
 
   async function copyTag() {
     try {
-      await navigator.clipboard.writeText(entry.tag);
+      const formatted = "@" + entry.tag.replace(/^@/, "");
+      await navigator.clipboard.writeText(formatted);
     } catch {
       // no-op; clipboard may be unavailable in some webviews
     }

--- a/src/lib/artist-gallery/index.ts
+++ b/src/lib/artist-gallery/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Portable Artist Gallery module
+ * ===============================
+ * Zero Tauri / backend dependencies. Consumes only `fetch` + a manifest URL.
+ * Drop this folder into any Svelte 5 codebase (desktop shell or static site)
+ * and render `<ArtistGalleryPage manifestUrl={...} />`.
+ */
+export type { ArtistEntry, ArtistShard, ArtistManifest, ArtistSearchHit, ArtistGalleryClient } from "./types.js";
+export { createArtistGalleryClient } from "./client.js";
+export { ArtistGalleryStore, createArtistGalleryStore } from "./store.svelte.js";
+export { default as ArtistGalleryPage } from "./components/ArtistGalleryPage.svelte";
+export { default as ArtistCard } from "./components/ArtistCard.svelte";
+export { default as ArtistLightbox } from "./components/ArtistLightbox.svelte";
+export { default as ArtistHoverPreview } from "./components/ArtistHoverPreview.svelte";

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -1,0 +1,107 @@
+import { createArtistGalleryClient } from "./client.js";
+import type {
+  ArtistEntry,
+  ArtistGalleryClient,
+  ArtistManifest,
+  ArtistSearchHit,
+} from "./types.js";
+
+/**
+ * Svelte 5 rune-based wrapper around the artist gallery client.
+ *
+ * Usage:
+ *   const store = createArtistGalleryStore(manifestUrl);
+ *   await store.init();
+ *   store.setQuery("dairi");
+ *   $derived.by(() => store.results);
+ */
+export class ArtistGalleryStore {
+  readonly client: ArtistGalleryClient;
+
+  manifest = $state<ArtistManifest | null>(null);
+  manifestError = $state<string | null>(null);
+  manifestLoading = $state(false);
+
+  query = $state("");
+  results = $state<ArtistSearchHit[]>([]);
+  searchLoading = $state(false);
+
+  activeArtist = $state<ArtistEntry | null>(null);
+  activeLoading = $state(false);
+
+  /** Guard so rapid typing doesn't race older search results into state. */
+  private searchSeq = 0;
+
+  constructor(manifestUrl: string) {
+    this.client = createArtistGalleryClient({ manifestUrl });
+  }
+
+  async init(): Promise<void> {
+    if (this.manifest || this.manifestLoading) return;
+    this.manifestLoading = true;
+    this.manifestError = null;
+    try {
+      this.manifest = await this.client.loadManifest();
+      // Kick off the search index fetch early; it drives typeahead and getArtist fallback.
+      this.client.loadSearchIndex().catch((err) => {
+        console.error("artist-gallery: search index load failed", err);
+      });
+    } catch (err) {
+      this.manifestError = err instanceof Error ? err.message : String(err);
+    } finally {
+      this.manifestLoading = false;
+    }
+  }
+
+  async setQuery(text: string): Promise<void> {
+    this.query = text;
+    const seq = ++this.searchSeq;
+    if (!text.trim()) {
+      this.results = [];
+      this.searchLoading = false;
+      return;
+    }
+    this.searchLoading = true;
+    try {
+      const hits = await this.client.search(text, { limit: 50 });
+      if (seq === this.searchSeq) {
+        this.results = hits;
+      }
+    } catch (err) {
+      console.error("artist-gallery: search failed", err);
+      if (seq === this.searchSeq) this.results = [];
+    } finally {
+      if (seq === this.searchSeq) this.searchLoading = false;
+    }
+  }
+
+  async openArtist(slugOrTag: string): Promise<void> {
+    this.activeLoading = true;
+    try {
+      this.activeArtist = await this.client.getArtist(slugOrTag);
+    } catch (err) {
+      console.error("artist-gallery: openArtist failed", err);
+      this.activeArtist = null;
+    } finally {
+      this.activeLoading = false;
+    }
+  }
+
+  closeArtist(): void {
+    this.activeArtist = null;
+  }
+}
+
+/**
+ * Convenience: singleton cached by manifestUrl. Handy for inline popovers that
+ * need to share the same caches as the gallery page without plumbing an
+ * instance through the component tree.
+ */
+const stores = new Map<string, ArtistGalleryStore>();
+export function createArtistGalleryStore(manifestUrl: string): ArtistGalleryStore {
+  const existing = stores.get(manifestUrl);
+  if (existing) return existing;
+  const created = new ArtistGalleryStore(manifestUrl);
+  stores.set(manifestUrl, created);
+  return created;
+}

--- a/src/lib/artist-gallery/types.ts
+++ b/src/lib/artist-gallery/types.ts
@@ -1,0 +1,74 @@
+/** Types for the artist gallery portable module. Mirrors shapes written by scripts/r2_build_indices.py. */
+
+export interface ArtistEntry {
+  /** Raw artist tag as it appears in anima-tags.json (e.g. "@dairi"). */
+  tag: string;
+  /** Filesystem-safe slug; matches the leading portion of imageId. */
+  slug: string;
+  /** Stable image identifier (slug + short sha1). */
+  imageId: string;
+  /** Fully-qualified HTTPS URL to the preview image. Empty string if host not configured. */
+  imageUrl: string;
+  /** R2 object key. Useful for direct-to-bucket fetches if a CDN isn't in front. */
+  objectKey: string;
+  /** Danbooru post count (popularity; ranking signal). */
+  postCount: number;
+  /** Known aliases for the artist tag. */
+  aliases: string[];
+  /** Whether the webp was present on disk when the index was built. */
+  hasImage: boolean;
+}
+
+export interface ArtistShard {
+  bucket: string;
+  /** Map of slug → ArtistEntry. */
+  entries: Record<string, ArtistEntry>;
+}
+
+export interface ArtistManifestShardMeta {
+  bucket: string;
+  count: number;
+  path: string;
+}
+
+export interface ArtistManifest {
+  version: number;
+  releasePrefix: string;
+  imageBaseUrl: string;
+  shardScheme: string;
+  artistCount: number;
+  artistsWithImage: number;
+  shards: ArtistManifestShardMeta[];
+  searchIndex: { path: string; entries: number };
+  generatedAt: string;
+}
+
+/** Row in the flat search.json index. */
+export interface ArtistSearchHit {
+  slug: string;
+  tag: string;
+  /** Matches ArtistEntry.imageId; combine with manifest.imageBaseUrl to render thumbnails without a shard fetch. */
+  imageId: string;
+  postCount: number;
+  shard: string;
+  hasImage: boolean;
+}
+
+export interface SearchOptions {
+  limit?: number;
+  /** Only return entries where `hasImage === true`. Default: true. */
+  requireImage?: boolean;
+}
+
+export interface ArtistGalleryClient {
+  manifestUrl: string;
+  loadManifest(): Promise<ArtistManifest>;
+  loadShard(bucket: string): Promise<ArtistShard>;
+  /** Resolve an artist entry by slug or raw tag ("@dairi"). Returns null if unknown. */
+  getArtist(slugOrTag: string): Promise<ArtistEntry | null>;
+  loadSearchIndex(): Promise<ArtistSearchHit[]>;
+  /** Prefix + contains + alias ranking mirrors src/lib/stores/autocomplete.svelte.ts. */
+  search(query: string, opts?: SearchOptions): Promise<ArtistSearchHit[]>;
+  /** Clear all in-memory caches (next call will re-fetch). */
+  invalidate(): void;
+}

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -2,6 +2,8 @@
   import { onDestroy } from "svelte";
   import { autocomplete, type TagEntry } from "../../stores/autocomplete.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
+  import ArtistHoverPreview from "../../artist-gallery/components/ArtistHoverPreview.svelte";
   import { smoothScroll } from "../../utils/smoothScroll.js";
   import { renderHighlightedPrompt, hasSchedulingTags } from "../../utils/promptSchedule.js";
 
@@ -417,5 +419,16 @@
         </button>
       {/each}
     </div>
+    {#if suggestions[selectedIndex]?.c === 1 && connection.artistGalleryManifestUrl}
+      <div
+        class="fixed z-50 pointer-events-none"
+        style="top: {dropdownTop}px; left: {dropdownLeft + 328}px;"
+      >
+        <ArtistHoverPreview
+          manifestUrl={connection.artistGalleryManifestUrl}
+          slugOrTag={suggestions[selectedIndex].n}
+        />
+      </div>
+    {/if}
   {/if}
 </div>

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -1,6 +1,10 @@
 class ConnectionStore {
   connected = $state(false);
   serverUrl = $state("http://127.0.0.1:8188");
+  /** Manifest URL for the Anima artist gallery. Points at Cloudflare R2 by default. */
+  artistGalleryManifestUrl = $state(
+    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json",
+  );
 }
 
 export const connection = new ConnectionStore();


### PR DESCRIPTION
## What's New in v0.9.1

### Artist Gallery
A new full-screen gallery for browsing Anima-style artists, powered by a Cloudflare R2 CDN index.

- **Paginated grid** — thumbnail cards auto-sized with a logarithmic size slider (100–400 px)
- **Live search** — typing filters the grid in real-time; results replace the paginated view (no dropdown)
- **Sort modes** — post count, alphabetical, or Uniqueness (log-normal hidden-gem scoring with ↻ Rotate)
- **Pagination controls** — Prev/Next, **⚄ Random** page jump, and direct page-number input
- **Favourites** — ♡/♥ toggle on every card; toolbar button filters grid to favourites only (session-scoped)
- **Copy on hover** — Copy button appears on card hover; right-click also copies; border flashes green
- **Card slide-in animation** — staggered slide-from-right on sort/direction/favourites changes
- **Lightbox** — instant open from cached index, aliases patched in from shard in background
  - Click image to zoom (1× → 1.5×, spring easing); **zoom state persists** across close/reopen
  - Artist name links to Danbooru
  - Prev/Next navigation with keyboard arrow-key support
- **Gen params modal** — ℹ gen params link shows model stack, sampler settings, and prompt template