### PR TITLE
v0.9.2: Persistent artist favourites with categories and backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v0.9.2
+
+### Artist Gallery — Persistent Favourites, Categories & Backup
+- **Favourites now persist** across app restarts. Previously the heart button only affected the current session; favourited artists are now saved to disk and restored on launch.
+- **User-created categories** — group favourite artists into named categories with custom colours. A 10-colour palette plus a custom colour picker are provided.
+- **Per-card category assignment** — a coloured dot next to the heart opens a quick picker to assign/change the category for any favourite. Right-click the heart for the same shortcut.
+- **Category filter chips** — when the Favourites filter is active, a chip row lets you narrow to All, Uncategorised, or any specific category, each with its live count.
+- **Manage modal** — the new ⚙ Manage button opens a full editor for creating, renaming, recolouring, and deleting categories. Deleting a category keeps its favourites (marks them Uncategorised).
+- **Export / import** — back up your entire favourites library (artists + categories + metadata) to a `.json` file, and restore it later with Merge or Replace modes. Uses the native save/open dialog in the desktop app.
+
+---
+
 ## What's New in v0.9.1
 
 ### Artist Gallery

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v0.9.2
+
+### Artist Gallery — Persistent Favourites, Categories & Backup
+- **Favourites now persist** across app restarts. Previously the heart button only affected the current session; favourited artists are now saved to disk and restored on launch.
+- **User-created categories** — group favourite artists into named categories with custom colours. A 10-colour palette plus a custom colour picker are provided.
+- **Per-card category assignment** — a coloured dot next to the heart opens a quick picker to assign/change the category for any favourite. Right-click the heart for the same shortcut.
+- **Category filter chips** — when the Favourites filter is active, a chip row lets you narrow to All, Uncategorised, or any specific category, each with its live count.
+- **Manage modal** — the new ⚙ Manage button opens a full editor for creating, renaming, recolouring, and deleting categories. Deleting a category keeps its favourites (marks them Uncategorised).
+- **Export / import** — back up your entire favourites library (artists + categories + metadata) to a `.json` file, and restore it later with Merge or Replace modes. Uses the native save/open dialog in the desktop app.
+
+---
+
 ## What's New in v0.9.1
 
 ### Artist Gallery

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { createArtistGalleryStore } from "../store.svelte.js";
+  import { artistFavourites } from "../favourites.svelte.js";
   import type { ArtistEntry, ArtistSearchHit } from "../types.js";
   import ArtistLightbox from "./ArtistLightbox.svelte";
+  import FavouritesManager from "./FavouritesManager.svelte";
 
   interface Props {
     manifestUrl: string;
@@ -156,21 +158,50 @@
   // ---------------------------------------------------------------------------
   // Favourites + animation
   // ---------------------------------------------------------------------------
-  let favourites = $state<Set<string>>(new Set());
+  // Favourites (incl. categories) are persisted in the artistFavourites store.
+  // "All" = show every favourite, string = show only favourites in that category,
+  // "__uncat" = show only uncategorised favourites.
   let showOnlyFavourites = $state(false);
+  let favouriteCategoryFilter = $state<"all" | "__uncat" | string>("all");
+  let showFavouritesManager = $state(false);
   let showGenParams = $state(false);
   let animKey = $state(0);
 
+  // Per-card category picker popover (keyed by slug). null = closed.
+  let catPickerSlug = $state<string | null>(null);
+
   function toggleFavourite(slug: string, e: MouseEvent) {
     e.stopPropagation();
-    const next = new Set(favourites);
-    if (next.has(slug)) next.delete(slug);
-    else next.add(slug);
-    favourites = next;
+    artistFavourites.toggle(slug);
+  }
+
+  function openCategoryPicker(slug: string, e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    // Auto-favourite if not already; picker always implies "favourite this".
+    if (!artistFavourites.isFavourite(slug)) {
+      artistFavourites.add(slug);
+    }
+    catPickerSlug = catPickerSlug === slug ? null : slug;
+  }
+
+  function assignCategory(slug: string, categoryId: string | null) {
+    artistFavourites.setCategory(slug, categoryId);
+    catPickerSlug = null;
   }
 
   function setShowOnlyFavourites(val: boolean) {
     showOnlyFavourites = val;
+    currentPage = 1;
+    animKey++;
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
+  function setFavouriteCategoryFilter(value: "all" | "__uncat" | string) {
+    favouriteCategoryFilter = value;
     currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
@@ -263,9 +294,17 @@
     );
   });
 
-  const filteredEntries = $derived(
-    showOnlyFavourites ? sortedEntries.filter(e => favourites.has(e.slug)) : sortedEntries
-  );
+  const filteredEntries = $derived.by(() => {
+    if (!showOnlyFavourites) return sortedEntries;
+    const favMap = artistFavourites.favourites;
+    return sortedEntries.filter((e) => {
+      const fav = favMap[e.slug];
+      if (!fav) return false;
+      if (favouriteCategoryFilter === "all") return true;
+      if (favouriteCategoryFilter === "__uncat") return fav.categoryId === null;
+      return fav.categoryId === favouriteCategoryFilter;
+    });
+  });
   const totalPages = $derived(Math.max(1, Math.ceil(filteredEntries.length / pageSize)));
   const safePage = $derived(Math.min(currentPage, totalPages));
   const pageEntries = $derived(
@@ -439,9 +478,51 @@
           onclick={() => setShowOnlyFavourites(!showOnlyFavourites)}
           title="Toggle favourites filter"
         >
-          {showOnlyFavourites ? '♥' : '♡'} Favourites{favourites.size > 0 ? ` (${favourites.size})` : ''}
+          {showOnlyFavourites ? '♥' : '♡'} Favourites{artistFavourites.count > 0 ? ` (${artistFavourites.count})` : ''}
+        </button>
+
+        <button
+          type="button"
+          class="rounded-lg border border-neutral-800 bg-neutral-900/50 px-2 py-1 text-xs text-neutral-400 transition-colors hover:text-neutral-200"
+          onclick={() => showFavouritesManager = true}
+          title="Manage categories, import/export favourites"
+        >
+          ⚙ Manage
         </button>
       </div>
+
+      {#if showOnlyFavourites}
+        {@const counts = artistFavourites.countsByCategory}
+        <div class="mt-2 flex flex-wrap items-center gap-1 rounded-lg border border-neutral-800 bg-neutral-900/50 p-1">
+          <span class="px-1.5 text-xs text-neutral-500">Category:</span>
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {favouriteCategoryFilter === 'all' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => setFavouriteCategoryFilter('all')}
+          >
+            All ({artistFavourites.count})
+          </button>
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {favouriteCategoryFilter === '__uncat' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => setFavouriteCategoryFilter('__uncat')}
+          >
+            Uncategorised ({counts[''] ?? 0})
+          </button>
+          {#each artistFavourites.categories as cat (cat.id)}
+            <button
+              type="button"
+              class="flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors {favouriteCategoryFilter === cat.id ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+              onclick={() => setFavouriteCategoryFilter(cat.id)}
+              title={cat.name}
+            >
+              <span class="h-2.5 w-2.5 rounded-full border border-neutral-700" style="background-color: {cat.color}" aria-hidden="true"></span>
+              <span class="max-w-36 truncate">{cat.name}</span>
+              <span class="text-neutral-500">({counts[cat.id] ?? 0})</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
     {/if}
   </header>
 
@@ -516,18 +597,19 @@
         {#each gridEntries as hit, i (hit.slug)}
           {@const url = thumbUrl(hit)}
           {@const rank = (safePage - 1) * pageSize + i + 1}
-          {@const isFav = favourites.has(hit.slug)}
+          {@const isFav = artistFavourites.isFavourite(hit.slug)}
+          {@const favCat = artistFavourites.categoryOf(hit.slug)}
           <div
             role="button"
             tabindex="0"
-            class="card-slide-in group flex flex-col items-stretch overflow-hidden rounded-lg border bg-neutral-900 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 {copiedSlug === hit.slug ? 'border-emerald-500' : 'border-neutral-800 hover:border-indigo-500'}"
+            class="card-slide-in group relative flex flex-col items-stretch rounded-lg border bg-neutral-900 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 {copiedSlug === hit.slug ? 'border-emerald-500' : 'border-neutral-800 hover:border-indigo-500'}"
             style="--card-delay: {Math.min(i * 30, 450)}ms"
             onclick={() => { void openHit(hit, i); }}
             onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); void openHit(hit, i); } }}
             oncontextmenu={(e) => { e.preventDefault(); void copyTag(hit.tag, hit.slug); }}
             title="{hit.tag} · Right-click to copy tag"
           >
-            <div class="relative aspect-3/4 w-full bg-neutral-800">
+            <div class="relative aspect-3/4 w-full overflow-hidden rounded-t-lg bg-neutral-800">
               {#if url}
                 <img
                   src={url}
@@ -562,16 +644,71 @@
             </div>
             <div class="flex items-center justify-between gap-1 px-2 py-1.5">
               <span class="min-w-0 truncate text-sm text-red-400">{displayTag(hit.tag)}</span>
-              <div class="flex shrink-0 items-center gap-1">
+              <div class="relative flex shrink-0 items-center gap-1">
                 <span class="text-xs text-neutral-500">{formatCount(hit.postCount)}</span>
+                {#if isFav}
+                  <button
+                    type="button"
+                    class="flex h-4 w-4 items-center justify-center rounded-full border border-neutral-700 transition-transform hover:scale-110"
+                    style={favCat ? `background-color: ${favCat.color}` : "background-color: transparent"}
+                    onclick={(e) => openCategoryPicker(hit.slug, e)}
+                    aria-label={favCat ? `Category: ${favCat.name}. Click to change.` : "Assign category"}
+                    title={favCat ? `Category: ${favCat.name}` : "Assign category"}
+                  ></button>
+                {/if}
                 <button
                   type="button"
                   class="text-sm leading-none transition-colors {isFav ? 'text-red-400' : 'text-neutral-600 hover:text-red-400'}"
                   onclick={(e) => toggleFavourite(hit.slug, e)}
+                  oncontextmenu={(e) => openCategoryPicker(hit.slug, e)}
                   aria-label={isFav ? 'Remove from favourites' : 'Add to favourites'}
+                  title={isFav ? 'Remove from favourites · right-click to categorise' : 'Add to favourites'}
                 >
                   {isFav ? '♥' : '♡'}
                 </button>
+                {#if catPickerSlug === hit.slug}
+                  <!-- Backdrop to dismiss -->
+                  <button
+                    type="button"
+                    class="fixed inset-0 z-40 cursor-default"
+                    aria-label="Close category picker"
+                    onclick={(e) => { e.stopPropagation(); catPickerSlug = null; }}
+                  ></button>
+                  <div
+                    class="absolute right-0 top-full z-50 mt-1 w-48 rounded-md border border-neutral-700 bg-neutral-900 p-1 shadow-xl"
+                    role="menu"
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      class="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                      onclick={(e) => { e.stopPropagation(); assignCategory(hit.slug, null); }}
+                    >
+                      <span class="h-2.5 w-2.5 rounded-full border border-neutral-700" aria-hidden="true"></span>
+                      Uncategorised
+                    </button>
+                    {#each artistFavourites.categories as cat (cat.id)}
+                      <button
+                        type="button"
+                        role="menuitem"
+                        class="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-neutral-200 hover:bg-neutral-800"
+                        onclick={(e) => { e.stopPropagation(); assignCategory(hit.slug, cat.id); }}
+                      >
+                        <span class="h-2.5 w-2.5 rounded-full border border-neutral-700" style="background-color: {cat.color}" aria-hidden="true"></span>
+                        <span class="truncate">{cat.name}</span>
+                      </button>
+                    {/each}
+                    <div class="my-1 border-t border-neutral-800"></div>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      class="flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-indigo-300 hover:bg-neutral-800"
+                      onclick={(e) => { e.stopPropagation(); catPickerSlug = null; showFavouritesManager = true; }}
+                    >
+                      ＋ New category…
+                    </button>
+                  </div>
+                {/if}
               </div>
             </div>
           </div>
@@ -645,6 +782,10 @@
     onprev={activeIndex > 0 ? () => navigateTo(activeIndex - 1) : undefined}
     onnext={activeIndex >= 0 && activeIndex < gridEntries.length - 1 ? () => navigateTo(activeIndex + 1) : undefined}
   />
+{/if}
+
+{#if showFavouritesManager}
+  <FavouritesManager onclose={() => showFavouritesManager = false} />
 {/if}
 
 {#if showGenParams}

--- a/src/lib/artist-gallery/components/FavouritesManager.svelte
+++ b/src/lib/artist-gallery/components/FavouritesManager.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import {
+    artistFavourites,
+    CATEGORY_COLOR_PALETTE,
+    type FavouriteCategory,
+  } from "../favourites.svelte.js";
+
+  interface Props {
+    onclose: () => void;
+  }
+
+  let { onclose }: Props = $props();
+
+  let newName = $state("");
+  let newColor = $state(CATEGORY_COLOR_PALETTE[0]);
+
+  // Per-row edit state (keyed by category id)
+  let editingId = $state<string | null>(null);
+  let editName = $state("");
+  let editColor = $state("");
+
+  // Import/export UI state
+  let importMode = $state<"merge" | "replace">("merge");
+  let importStatus = $state<string | null>(null);
+  let importError = $state<string | null>(null);
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  function createCategory() {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    artistFavourites.createCategory(trimmed, newColor);
+    newName = "";
+    newColor = CATEGORY_COLOR_PALETTE[0];
+  }
+
+  function startEdit(cat: FavouriteCategory) {
+    editingId = cat.id;
+    editName = cat.name;
+    editColor = cat.color;
+  }
+
+  function commitEdit() {
+    if (!editingId) return;
+    artistFavourites.updateCategory(editingId, { name: editName, color: editColor });
+    editingId = null;
+  }
+
+  function cancelEdit() {
+    editingId = null;
+  }
+
+  function deleteCategory(cat: FavouriteCategory) {
+    const count = artistFavourites.countsByCategory[cat.id] ?? 0;
+    const msg =
+      count > 0
+        ? `Delete category "${cat.name}"? ${count} favourite${count === 1 ? "" : "s"} will become uncategorised.`
+        : `Delete category "${cat.name}"?`;
+    if (!confirm(msg)) return;
+    artistFavourites.deleteCategory(cat.id);
+    if (editingId === cat.id) editingId = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export
+  // ---------------------------------------------------------------------------
+
+  async function exportFavourites() {
+    const json = artistFavourites.exportJSON();
+    const defaultName = `mooshieui-artist-favourites-${new Date().toISOString().slice(0, 10)}.json`;
+    const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+    try {
+      if (isTauri) {
+        const { save } = await import("@tauri-apps/plugin-dialog");
+        const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+        const path = await save({
+          defaultPath: defaultName,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!path) return;
+        await writeTextFile(path, json);
+        importStatus = `Exported to ${path}`;
+      } else {
+        const blob = new Blob([json], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = defaultName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        importStatus = `Downloaded ${defaultName}`;
+      }
+      importError = null;
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Import
+  // ---------------------------------------------------------------------------
+
+  async function importFavourites() {
+    importStatus = null;
+    importError = null;
+    const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+    try {
+      let raw: string | null = null;
+      if (isTauri) {
+        const { open } = await import("@tauri-apps/plugin-dialog");
+        const { readTextFile } = await import("@tauri-apps/plugin-fs");
+        const selected = await open({
+          multiple: false,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!selected || typeof selected !== "string") return;
+        raw = await readTextFile(selected);
+      } else {
+        // Browser: use hidden file input
+        fileInput?.click();
+        return;
+      }
+      applyImport(raw);
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function onFilePicked(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file) return;
+    try {
+      const raw = await file.text();
+      applyImport(raw);
+    } catch (err) {
+      importError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function applyImport(raw: string) {
+    try {
+      const result = artistFavourites.importJSON(raw, importMode);
+      importStatus =
+        `Imported · ${result.added} added, ${result.updated} updated, ` +
+        `${result.categoriesAdded} new categor${result.categoriesAdded === 1 ? "y" : "ies"}.`;
+      importError = null;
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-200 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Manage favourite categories"
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Close"
+    onclick={onclose}
+  ></button>
+  <div class="relative z-10 w-full max-w-2xl rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+    <div class="mb-4 flex items-center justify-between">
+      <h2 class="text-sm font-semibold text-neutral-100">Favourites · Categories &amp; Backup</h2>
+      <button
+        type="button"
+        class="text-neutral-500 hover:text-neutral-200 text-lg leading-none"
+        onclick={onclose}
+        aria-label="Close"
+      >✕</button>
+    </div>
+
+    <!-- Categories -->
+    <section class="mb-5">
+      <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-400">Categories</h3>
+
+      <!-- Create new -->
+      <div class="mb-3 flex items-end gap-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-2">
+        <div class="flex-1">
+          <label for="cat-new-name" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">Name</label>
+          <input
+            id="cat-new-name"
+            name="cat-new-name"
+            type="text"
+            bind:value={newName}
+            onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); createCategory(); } }}
+            placeholder="e.g. Portraits"
+            class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+          />
+        </div>
+        <div>
+          <div class="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">Colour</div>
+          <div class="flex items-center gap-1">
+            {#each CATEGORY_COLOR_PALETTE as swatch}
+              <button
+                type="button"
+                aria-label={`Pick colour ${swatch}`}
+                class="h-5 w-5 rounded-full border transition-transform hover:scale-110 {newColor === swatch ? 'border-white ring-2 ring-white/60' : 'border-neutral-700'}"
+                style="background-color: {swatch}"
+                onclick={() => newColor = swatch}
+              ></button>
+            {/each}
+            <input
+              type="color"
+              aria-label="Custom colour"
+              bind:value={newColor}
+              class="ml-1 h-5 w-6 cursor-pointer rounded border border-neutral-700 bg-transparent p-0"
+            />
+          </div>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 rounded-md border border-indigo-500 bg-indigo-600 px-3 py-1 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={!newName.trim()}
+          onclick={createCategory}
+        >
+          Add
+        </button>
+      </div>
+
+      <!-- List -->
+      {#if artistFavourites.categories.length === 0}
+        <p class="text-xs text-neutral-500">No categories yet. Create one above to organise your favourites.</p>
+      {:else}
+        <ul class="space-y-1.5">
+          {#each artistFavourites.categories as cat (cat.id)}
+            {@const count = artistFavourites.countsByCategory[cat.id] ?? 0}
+            <li class="flex items-center gap-2 rounded-md border border-neutral-800 bg-neutral-950/50 px-2 py-1.5">
+              {#if editingId === cat.id}
+                <input
+                  type="color"
+                  aria-label="Category colour"
+                  bind:value={editColor}
+                  class="h-6 w-7 cursor-pointer rounded border border-neutral-700 bg-transparent p-0"
+                />
+                <input
+                  type="text"
+                  bind:value={editName}
+                  onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitEdit(); } else if (e.key === "Escape") { e.preventDefault(); cancelEdit(); } }}
+                  class="flex-1 rounded border border-neutral-700 bg-neutral-800 px-2 py-0.5 text-sm text-neutral-100 focus:border-indigo-500 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  class="rounded border border-emerald-600 px-2 py-0.5 text-xs text-emerald-300 hover:bg-emerald-950"
+                  onclick={commitEdit}
+                >Save</button>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 px-2 py-0.5 text-xs text-neutral-400 hover:text-neutral-200"
+                  onclick={cancelEdit}
+                >Cancel</button>
+              {:else}
+                <span
+                  class="h-4 w-4 shrink-0 rounded-full border border-neutral-700"
+                  style="background-color: {cat.color}"
+                  aria-hidden="true"
+                ></span>
+                <span class="flex-1 truncate text-sm text-neutral-100">{cat.name}</span>
+                <span class="text-xs text-neutral-500">{count} fav{count === 1 ? "" : "s"}</span>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300 hover:border-indigo-500 hover:text-indigo-300"
+                  onclick={() => startEdit(cat)}
+                >Edit</button>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 px-2 py-0.5 text-xs text-neutral-300 hover:border-red-500 hover:text-red-300"
+                  onclick={() => deleteCategory(cat)}
+                >Delete</button>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <!-- Import / Export -->
+    <section class="border-t border-neutral-800 pt-4">
+      <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-400">Backup</h3>
+      <p class="mb-3 text-xs text-neutral-500">
+        Export your favourites and categories to a .json file, or import a previously saved file.
+      </p>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-neutral-200 hover:border-indigo-500"
+          onclick={exportFavourites}
+        >
+          ⬇ Export favourites…
+        </button>
+
+        <div class="flex items-center gap-1 rounded-md border border-neutral-800 bg-neutral-900/50 p-1">
+          <span class="px-1.5 text-xs text-neutral-500">Import mode:</span>
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {importMode === 'merge' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => importMode = "merge"}
+          >Merge</button>
+          <button
+            type="button"
+            class="rounded px-2 py-0.5 text-xs transition-colors {importMode === 'replace' ? 'bg-red-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+            onclick={() => importMode = "replace"}
+          >Replace</button>
+        </div>
+
+        <button
+          type="button"
+          class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-neutral-200 hover:border-indigo-500"
+          onclick={importFavourites}
+        >
+          ⬆ Import favourites…
+        </button>
+
+        <!-- Hidden file input used only in browser mode -->
+        <input
+          bind:this={fileInput}
+          type="file"
+          accept="application/json,.json"
+          class="hidden"
+          onchange={onFilePicked}
+        />
+      </div>
+
+      {#if importStatus}
+        <p class="mt-2 text-xs text-emerald-400">{importStatus}</p>
+      {/if}
+      {#if importError}
+        <p class="mt-2 text-xs text-red-400">Error: {importError}</p>
+      {/if}
+    </section>
+  </div>
+</div>

--- a/src/lib/artist-gallery/favourites.svelte.ts
+++ b/src/lib/artist-gallery/favourites.svelte.ts
@@ -1,0 +1,340 @@
+/**
+ * Artist gallery favourites store.
+ *
+ * Persists a user's favourited artist slugs along with user-created
+ * categories (name + colour) and the mapping between them.
+ *
+ * Storage: localStorage under `mooshieui.artist-gallery.favourites.v1`.
+ * Import/export: JSON blob with the same shape as the persisted payload,
+ * wrapped in a small envelope for forward-compatibility.
+ */
+
+const STORAGE_KEY = "mooshieui.artist-gallery.favourites.v1";
+const EXPORT_KIND = "mooshieui.artist-gallery.favourites";
+const EXPORT_VERSION = 1;
+
+export interface FavouriteCategory {
+  id: string;
+  name: string;
+  /** CSS colour string (hex). */
+  color: string;
+}
+
+export interface FavouriteEntry {
+  slug: string;
+  /** Category id, or null if the favourite is uncategorised. */
+  categoryId: string | null;
+  /** Epoch millis when the favourite was added. */
+  addedAt: number;
+}
+
+interface PersistedState {
+  version: number;
+  favourites: FavouriteEntry[];
+  categories: FavouriteCategory[];
+}
+
+export interface FavouritesExport {
+  kind: typeof EXPORT_KIND;
+  version: number;
+  exportedAt: string;
+  favourites: FavouriteEntry[];
+  categories: FavouriteCategory[];
+}
+
+function genId(): string {
+  // Short, collision-resistant enough for a handful of categories per user.
+  return `cat_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Default palette offered when creating a new category. */
+export const CATEGORY_COLOR_PALETTE = [
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#14b8a6", // teal
+  "#3b82f6", // blue
+  "#6366f1", // indigo
+  "#a855f7", // purple
+  "#ec4899", // pink
+  "#94a3b8", // slate
+];
+
+class ArtistFavouritesStore {
+  /** slug → FavouriteEntry. */
+  favourites = $state<Record<string, FavouriteEntry>>({});
+  categories = $state<FavouriteCategory[]>([]);
+
+  constructor() {
+    this.loadSettings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private loadSettings() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<PersistedState>;
+      this.hydrate(parsed);
+    } catch (e) {
+      console.error("artist-gallery favourites: load failed", e);
+    }
+  }
+
+  private hydrate(parsed: Partial<PersistedState>) {
+    const categories = Array.isArray(parsed.categories)
+      ? parsed.categories.filter(
+          (c): c is FavouriteCategory =>
+            !!c && typeof c.id === "string" && typeof c.name === "string" && typeof c.color === "string",
+        )
+      : [];
+    const catIds = new Set(categories.map((c) => c.id));
+
+    const favMap: Record<string, FavouriteEntry> = {};
+    if (Array.isArray(parsed.favourites)) {
+      for (const f of parsed.favourites) {
+        if (!f || typeof f.slug !== "string") continue;
+        const categoryId =
+          typeof f.categoryId === "string" && catIds.has(f.categoryId) ? f.categoryId : null;
+        const addedAt = typeof f.addedAt === "number" && f.addedAt > 0 ? f.addedAt : Date.now();
+        favMap[f.slug] = { slug: f.slug, categoryId, addedAt };
+      }
+    }
+
+    this.categories = categories;
+    this.favourites = favMap;
+  }
+
+  private saveSettings() {
+    try {
+      const payload: PersistedState = {
+        version: EXPORT_VERSION,
+        favourites: Object.values(this.favourites),
+        categories: this.categories,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (e) {
+      console.error("artist-gallery favourites: save failed", e);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  isFavourite(slug: string): boolean {
+    return slug in this.favourites;
+  }
+
+  get count(): number {
+    return Object.keys(this.favourites).length;
+  }
+
+  /** Number of favourites per category id. Uncategorised counted under "". */
+  get countsByCategory(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const f of Object.values(this.favourites)) {
+      const key = f.categoryId ?? "";
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  categoryOf(slug: string): FavouriteCategory | null {
+    const entry = this.favourites[slug];
+    if (!entry || !entry.categoryId) return null;
+    return this.categories.find((c) => c.id === entry.categoryId) ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations — favourites
+  // ---------------------------------------------------------------------------
+
+  toggle(slug: string): boolean {
+    if (slug in this.favourites) {
+      const next = { ...this.favourites };
+      delete next[slug];
+      this.favourites = next;
+      this.saveSettings();
+      return false;
+    }
+    this.favourites = {
+      ...this.favourites,
+      [slug]: { slug, categoryId: null, addedAt: Date.now() },
+    };
+    this.saveSettings();
+    return true;
+  }
+
+  add(slug: string, categoryId: string | null = null): void {
+    if (slug in this.favourites) {
+      this.setCategory(slug, categoryId);
+      return;
+    }
+    this.favourites = {
+      ...this.favourites,
+      [slug]: { slug, categoryId, addedAt: Date.now() },
+    };
+    this.saveSettings();
+  }
+
+  remove(slug: string): void {
+    if (!(slug in this.favourites)) return;
+    const next = { ...this.favourites };
+    delete next[slug];
+    this.favourites = next;
+    this.saveSettings();
+  }
+
+  setCategory(slug: string, categoryId: string | null): void {
+    const existing = this.favourites[slug];
+    if (!existing) return;
+    if (categoryId && !this.categories.some((c) => c.id === categoryId)) return;
+    this.favourites = {
+      ...this.favourites,
+      [slug]: { ...existing, categoryId },
+    };
+    this.saveSettings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations — categories
+  // ---------------------------------------------------------------------------
+
+  createCategory(name: string, color: string): FavouriteCategory | null {
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const cat: FavouriteCategory = { id: genId(), name: trimmed, color };
+    this.categories = [...this.categories, cat];
+    this.saveSettings();
+    return cat;
+  }
+
+  updateCategory(id: string, patch: Partial<Omit<FavouriteCategory, "id">>): void {
+    let changed = false;
+    this.categories = this.categories.map((c) => {
+      if (c.id !== id) return c;
+      changed = true;
+      const nextName = typeof patch.name === "string" ? patch.name.trim() || c.name : c.name;
+      const nextColor = typeof patch.color === "string" ? patch.color : c.color;
+      return { ...c, name: nextName, color: nextColor };
+    });
+    if (changed) this.saveSettings();
+  }
+
+  deleteCategory(id: string): void {
+    if (!this.categories.some((c) => c.id === id)) return;
+    this.categories = this.categories.filter((c) => c.id !== id);
+    // Unassign any favourites that referenced the removed category.
+    const nextFavs: Record<string, FavouriteEntry> = {};
+    for (const [slug, entry] of Object.entries(this.favourites)) {
+      nextFavs[slug] = entry.categoryId === id ? { ...entry, categoryId: null } : entry;
+    }
+    this.favourites = nextFavs;
+    this.saveSettings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export / import
+  // ---------------------------------------------------------------------------
+
+  exportJSON(): string {
+    const payload: FavouritesExport = {
+      kind: EXPORT_KIND,
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      favourites: Object.values(this.favourites),
+      categories: this.categories,
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+
+  /**
+   * Import favourites from a JSON string.
+   * @param mode "replace" wipes existing state; "merge" keeps existing
+   *  favourites & categories and adds new ones (categories matched by id).
+   */
+  importJSON(
+    raw: string,
+    mode: "replace" | "merge" = "merge",
+  ): { added: number; updated: number; categoriesAdded: number } {
+    const parsed = JSON.parse(raw) as Partial<FavouritesExport>;
+    if (!parsed || typeof parsed !== "object") throw new Error("Invalid JSON payload");
+    if (parsed.kind !== EXPORT_KIND) throw new Error("Not a MooshieUI artist favourites export");
+
+    const incomingCats: FavouriteCategory[] = Array.isArray(parsed.categories)
+      ? parsed.categories.filter(
+          (c): c is FavouriteCategory =>
+            !!c && typeof c.id === "string" && typeof c.name === "string" && typeof c.color === "string",
+        )
+      : [];
+    const incomingFavs: FavouriteEntry[] = Array.isArray(parsed.favourites)
+      ? parsed.favourites.filter(
+          (f): f is FavouriteEntry => !!f && typeof f.slug === "string",
+        )
+      : [];
+
+    if (mode === "replace") {
+      this.categories = incomingCats;
+      const map: Record<string, FavouriteEntry> = {};
+      const catIds = new Set(incomingCats.map((c) => c.id));
+      for (const f of incomingFavs) {
+        map[f.slug] = {
+          slug: f.slug,
+          categoryId:
+            typeof f.categoryId === "string" && catIds.has(f.categoryId) ? f.categoryId : null,
+          addedAt: typeof f.addedAt === "number" && f.addedAt > 0 ? f.addedAt : Date.now(),
+        };
+      }
+      this.favourites = map;
+      this.saveSettings();
+      return {
+        added: Object.keys(map).length,
+        updated: 0,
+        categoriesAdded: incomingCats.length,
+      };
+    }
+
+    // Merge mode
+    let categoriesAdded = 0;
+    const catsById = new Map(this.categories.map((c) => [c.id, c]));
+    for (const c of incomingCats) {
+      if (!catsById.has(c.id)) {
+        catsById.set(c.id, c);
+        categoriesAdded++;
+      }
+    }
+    const mergedCats = Array.from(catsById.values());
+    const validCatIds = new Set(mergedCats.map((c) => c.id));
+
+    let added = 0;
+    let updated = 0;
+    const mergedFavs: Record<string, FavouriteEntry> = { ...this.favourites };
+    for (const f of incomingFavs) {
+      const categoryId =
+        typeof f.categoryId === "string" && validCatIds.has(f.categoryId) ? f.categoryId : null;
+      const addedAt = typeof f.addedAt === "number" && f.addedAt > 0 ? f.addedAt : Date.now();
+      if (mergedFavs[f.slug]) {
+        // Prefer incoming category when it is more specific (non-null).
+        if (categoryId && mergedFavs[f.slug].categoryId !== categoryId) {
+          mergedFavs[f.slug] = { ...mergedFavs[f.slug], categoryId };
+          updated++;
+        }
+      } else {
+        mergedFavs[f.slug] = { slug: f.slug, categoryId, addedAt };
+        added++;
+      }
+    }
+
+    this.categories = mergedCats;
+    this.favourites = mergedFavs;
+    this.saveSettings();
+    return { added, updated, categoriesAdded };
+  }
+}
+
+export const artistFavourites = new ArtistFavouritesStore();


### PR DESCRIPTION
## v0.9.2 — Artist Gallery: Persistent Favourites, Categories & Backup

- **Favourites now persist** across app restarts (previously session-only).
- **User-created categories** with custom colours (10-colour palette + custom colour picker).
- **Per-card category assignment** via a coloured dot next to the heart, or right-click shortcut.
- **Category filter chips** when the Favourites filter is active (All / Uncategorised / each category with live counts).
- **Manage modal** (⚙ Manage) for creating, renaming, recolouring, and deleting categories. Deleting a category keeps its favourites (marks them Uncategorised).
- **Export / import** favourites to/from a `.json` file with Merge or Replace modes, using native dialogs in the desktop app.

### Files
- Added `src/lib/artist-gallery/favourites.svelte.ts` — Svelte 5 rune store backed by localStorage.
- Added `src/lib/artist-gallery/components/FavouritesManager.svelte` — categories + import/export modal.
- Updated `src/lib/artist-gallery/components/ArtistGalleryPage.svelte` — uses the new store, adds category picker + filter chips + Manage button.

### Validation
- `cargo check` ✅
- `npm run build` ✅
- pre-commit-check agent ✅
