### PR TITLE
v0.9.4: Artist gallery state persistence, heart chips, Favourites tab, tag display fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v0.9.4
+
+### Artist Gallery — State Persistence & Tag Display Fixes
+- **Gallery state now persists** — switching to the generation screen and back returns you to exactly where you were: same sort mode (including Uniqueness ranking and jitter), page, search query, category filter, and scroll position. If you had a lightbox open, that is also restored.
+- **Fixed tag display with escaped parens** — artists like `@mitsu \(mitsu art\)` now render as `mitsu (mitsu art)` in gallery cards, the bottom panel, and the prompt chips, instead of the raw slug form.
+- **Category picker z-order fix** — the "Assign category" dropdown no longer slides under the card below it in the grid.
+
+### Artist Favourites — Heart Chip in Generation Settings
+- **Heart chip on detected artist tags** — when the positive prompt contains a recognised artist tag (whether typed manually, accepted via autocomplete, or inserted from the gallery) a heart chip appears in the prompt header row. Click it to toggle the artist as a favourite without leaving the generation screen. The chip shows the artist's category colour dot when one is assigned.
+
+### Favourite Artists Quick-Access Tab
+- **New "Artists" tab in the bottom panel** — all your favourited artists are available as a scrollable thumbnail grid alongside LoRAs, checkpoints, and images. Click any card to apply the tag to your positive prompt, using the same replace/append confirmation modal as the gallery.
+- **Search and filter** — a search box and category filter chips let you find the right artist instantly.
+- **Card size slider** — resize the thumbnail grid independently from the gallery, persisted across sessions.
+
+---
+
 ## What's New in v0.9.3
 
 ### Artist Gallery — Image Caching, Auto-Sort by Artist & Tag Detection

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v0.9.4
+
+### Artist Gallery — State Persistence & Tag Display Fixes
+- **Gallery state now persists** — switching to the generation screen and back returns you to exactly where you were: same sort mode (including Uniqueness ranking and jitter), page, search query, category filter, and scroll position. If you had a lightbox open, that is also restored.
+- **Fixed tag display with escaped parens** — artists like `@mitsu \(mitsu art\)` now render as `mitsu (mitsu art)` in gallery cards, the bottom panel, and the prompt chips, instead of the raw slug form.
+- **Category picker z-order fix** — the "Assign category" dropdown no longer slides under the card below it in the grid.
+
+### Artist Favourites — Heart Chip in Generation Settings
+- **Heart chip on detected artist tags** — when the positive prompt contains a recognised artist tag (whether typed manually, accepted via autocomplete, or inserted from the gallery) a heart chip appears in the prompt header row. Click it to toggle the artist as a favourite without leaving the generation screen. The chip shows the artist's category colour dot when one is assigned.
+
+### Favourite Artists Quick-Access Tab
+- **New "Artists" tab in the bottom panel** — all your favourited artists are available as a scrollable thumbnail grid alongside LoRAs, checkpoints, and images. Click any card to apply the tag to your positive prompt, using the same replace/append confirmation modal as the gallery.
+- **Search and filter** — a search box and category filter chips let you find the right artist instantly.
+- **Card size slider** — resize the thumbnail grid independently from the gallery, persisted across sessions.
+
+---
+
 ## What's New in v0.9.3
 
 ### Artist Gallery — Image Caching, Auto-Sort by Artist & Tag Detection

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,7 @@
   import DownloadBanner from "./lib/components/downloads/DownloadBanner.svelte";
   import { downloads } from "./lib/stores/downloads.svelte.js";
   import { compare } from "./lib/stores/compare.svelte.js";
+  import { artistInsert } from "./lib/stores/artistInsert.svelte.js";
   import logoUrl from "./lib/assets/logo.png";
   import { smoothScroll } from "./lib/utils/smoothScroll.js";
   import { lazyThumbnail } from "./lib/utils/lazyThumbnail.js";
@@ -648,42 +649,23 @@
   // Interrogation state (for lightbox + context menu)
   let showInterrogateModal = $state(false);
 
-  // Artist tag insert state
-  type ArtistInsertPending = { tag: string; existingTags: string[]; duplicate: boolean };
-  let artistInsertPending = $state<ArtistInsertPending | null>(null);
+  // Artist tag insert: the actual replace/append logic lives in the shared
+  // `artistInsert` store so the bottom-panel favourites tab can reuse the
+  // same modal flow. `artistInsertPending` just mirrors the store for the
+  // template below; `handleArtistTagInsert` bridges to the gallery page prop.
+  const artistInsertPending = $derived(artistInsert.pending);
 
   function handleArtistTagInsert(tag: string) {
-    const withAt = "@" + tag.replace(/^@/, "");
-    const existing = generation.positivePrompt.trim();
-    const existingArtistTags = existing.split(",").map(s => s.trim()).filter(s => s.startsWith("@"));
-    // Check if this exact tag is already present
-    if (existingArtistTags.some(t => t.toLowerCase() === withAt.toLowerCase())) {
-      artistInsertPending = { tag: withAt, existingTags: existingArtistTags, duplicate: true };
-    } else if (existingArtistTags.length > 0) {
-      artistInsertPending = { tag: withAt, existingTags: existingArtistTags, duplicate: false };
-    } else {
-      applyArtistTag(withAt, "add");
+    artistInsert.request(tag);
+    // Keep the existing UX where inserting from the gallery page snaps the
+    // user back to the generate view so they can see the prompt update.
+    if (!artistInsert.pending) {
+      currentPage = "generate";
     }
   }
 
   function applyArtistTag(withAt: string, mode: "add" | "replace") {
-    const existing = generation.positivePrompt.trim();
-    let newPrompt: string;
-    if (mode === "replace") {
-      // Remove all existing @tags from the prompt, then prepend the new one
-      const stripped = existing
-        .split(",")
-        .map(s => s.trim())
-        .filter(s => !s.startsWith("@"))
-        .join(", ");
-      newPrompt = stripped ? `${withAt}, ${stripped}` : withAt;
-    } else {
-      // Add: prepend new tag before the rest
-      newPrompt = existing ? `${withAt}, ${existing}` : withAt;
-    }
-    generation.positivePrompt = newPrompt;
-    generation.saveSettings();
-    artistInsertPending = null;
+    artistInsert.apply(withAt, mode);
     currentPage = "generate";
   }
   let interrogateResult = $state<InterrogationResult | null>(null);
@@ -2611,8 +2593,8 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 z-[300] flex items-center justify-center bg-black/60"
-    onclick={(e) => { if (e.target === e.currentTarget) artistInsertPending = null; }}
-    onkeydown={(e) => { if (e.key === 'Escape') artistInsertPending = null; }}
+    onclick={(e) => { if (e.target === e.currentTarget) artistInsert.dismiss(); }}
+    onkeydown={(e) => { if (e.key === 'Escape') artistInsert.dismiss(); }}
   >
     <div class="w-96 max-w-full rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
       {#if artistInsertPending.duplicate}
@@ -2624,7 +2606,7 @@
           <button
             type="button"
             class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
-            onclick={() => artistInsertPending = null}
+            onclick={() => artistInsert.dismiss()}
           >
             OK
           </button>
@@ -2642,7 +2624,7 @@
           <button
             type="button"
             class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-neutral-500"
-            onclick={() => artistInsertPending = null}
+            onclick={() => artistInsert.dismiss()}
           >
             Cancel
           </button>

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { createArtistGalleryStore } from "../store.svelte.js";
+  import { onMount, tick } from "svelte";
+  import { createArtistGalleryStore, type ArtistSortField, type ArtistSortDir, type ArtistPageSize } from "../store.svelte.js";
   import { artistFavourites } from "../favourites.svelte.js";
-  import type { ArtistEntry, ArtistSearchHit } from "../types.js";
+  import type { ArtistSearchHit } from "../types.js";
   import ArtistLightbox from "./ArtistLightbox.svelte";
   import FavouritesManager from "./FavouritesManager.svelte";
 
@@ -16,9 +16,9 @@
 
   const store = createArtistGalleryStore(manifestUrl);
 
-  type SortField = "postCount" | "name" | "uniqueness";
-  type SortDir = "asc" | "desc";
-  type PageSize = 25 | 50 | 100;
+  type SortField = ArtistSortField;
+  type SortDir = ArtistSortDir;
+  type PageSize = ArtistPageSize;
 
   // ---------------------------------------------------------------------------
   // Uniqueness scoring
@@ -36,9 +36,8 @@
     return logNormalScore(postCount, 5.5, 1.8);
   }
 
-  /** Per-entry jitter multipliers (0.7 – 1.3). Re-generated on each rotate. */
-  let uniquenessJitter = $state<Float32Array>(new Float32Array(0));
-
+  /** Per-entry jitter multipliers (0.7 – 1.3). Stored on the singleton store
+   * so the current ranking survives navigating away and back. */
   function generateJitter(count: number): Float32Array {
     const arr = new Float32Array(count);
     for (let i = 0; i < count; i++) arr[i] = 0.7 + 0.6 * Math.random();
@@ -46,9 +45,9 @@
   }
 
   function rotateUniqueness() {
-    uniquenessJitter = generateJitter(allEntries.length);
-    sortField = "uniqueness";
-    currentPage = 1;
+    store.uniquenessJitter = generateJitter(store.allEntries.length);
+    store.sortField = "uniqueness";
+    store.currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
       scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
@@ -56,38 +55,60 @@
     });
   }
 
-  let allEntries = $state<ArtistSearchHit[]>([]);
-  let allLoading = $state(false);
-  let allError = $state<string | null>(null);
+  let allEntries = $derived(store.allEntries);
+  let allLoading = $derived(store.allEntriesLoading);
+  let allError = $derived(store.allEntriesError);
 
-  let sortField = $state<SortField>("postCount");
-  let sortDir = $state<SortDir>("desc");
   const PAGE_SIZES: PageSize[] = [25, 50, 100];
-  let pageSize = $state<PageSize>(50);
-  let currentPage = $state(1);
 
-  let active = $state<ArtistEntry | null>(null);
-  let activeIndex = $state(-1);
-  let queryInput = $state("");
+  let active = $derived(store.lightboxEntry);
+  let activeIndex = $derived(store.lightboxIndex);
   let searchDebounce: number | null = null;
 
   onMount(() => {
     store.init().then(async () => {
-      allLoading = true;
-      allError = null;
-      try {
-        allEntries = await store.client.loadSearchIndex();
-        uniquenessJitter = generateJitter(allEntries.length);
-      } catch (err) {
-        allError = err instanceof Error ? err.message : String(err);
-      } finally {
-        allLoading = false;
+      // Load entries only once; subsequent mounts reuse cached data.
+      if (store.allEntries.length === 0 && !store.allEntriesLoading) {
+        store.allEntriesLoading = true;
+        store.allEntriesError = null;
+        try {
+          const entries = await store.client.loadSearchIndex();
+          store.allEntries = entries;
+          if (store.uniquenessJitter.length !== entries.length) {
+            store.uniquenessJitter = generateJitter(entries.length);
+          }
+        } catch (err) {
+          store.allEntriesError = err instanceof Error ? err.message : String(err);
+        } finally {
+          store.allEntriesLoading = false;
+        }
       }
+      // Sync the debounced search input into the store's live query so
+      // `store.results` is populated for the grid when returning to the page.
+      if (store.queryInput.trim()) {
+        void store.setQuery(store.queryInput);
+      }
+      // Restore scroll position on the next tick once the grid has rendered.
+      await tick();
+      requestAnimationFrame(() => {
+        scrollContainer?.scrollTo({ top: store.scrollTop, behavior: "instant" });
+      });
     });
+
+    const onScroll = () => {
+      if (scrollContainer) store.scrollTop = scrollContainer.scrollTop;
+    };
+    // Attach after mount; `scrollContainer` is bound via `bind:this` below.
+    requestAnimationFrame(() => {
+      scrollContainer?.addEventListener("scroll", onScroll, { passive: true });
+    });
+    return () => {
+      scrollContainer?.removeEventListener("scroll", onScroll);
+    };
   });
 
   function onSearchInput(value: string) {
-    queryInput = value;
+    store.queryInput = value;
     if (searchDebounce !== null) window.clearTimeout(searchDebounce);
     searchDebounce = window.setTimeout(() => {
       void store.setQuery(value);
@@ -100,11 +121,11 @@
     const imageUrl = store.manifest && hit.hasImage && hit.imageId
       ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`
       : "";
-    active = { tag: hit.tag, slug: hit.slug, imageId: hit.imageId, imageUrl, objectKey: "", postCount: hit.postCount, aliases: [], hasImage: hit.hasImage };
-    activeIndex = index;
+    store.lightboxEntry = { tag: hit.tag, slug: hit.slug, imageId: hit.imageId, imageUrl, objectKey: "", postCount: hit.postCount, aliases: [], hasImage: hit.hasImage };
+    store.lightboxIndex = index;
     // Background: fetch full shard entry to patch in aliases once loaded
     store.client.getArtist(hit.slug).then((full) => {
-      if (full && active?.slug === hit.slug) active = full;
+      if (full && store.lightboxEntry?.slug === hit.slug) store.lightboxEntry = full;
     }).catch(() => {});
   }
 
@@ -114,13 +135,14 @@
   }
 
   function closeLightbox() {
-    active = null;
-    activeIndex = -1;
+    store.lightboxEntry = null;
+    store.lightboxIndex = -1;
     store.closeArtist();
   }
 
-  // Zoom state lifted here so it persists across lightbox close/reopen
-  let lightboxZoomed = $state(false);
+  // Zoom state lifted to the singleton store so it persists across
+  // lightbox close/reopen and across page unmount/remount.
+  let lightboxZoomed = $derived(store.lightboxZoomed);
 
   // Page-jump controls
   let pageInputValue = $state("");
@@ -150,7 +172,7 @@
   }
 
   function displayTag(tag: string): string {
-    return tag.replace(/^@/, "").replace(/_/g, " ");
+    return tag.replace(/^@/, "").replace(/\\([()\[\]])/g, "$1").replace(/_/g, " ");
   }
 
   let copiedSlug = $state<string | null>(null);
@@ -161,11 +183,17 @@
   // Favourites (incl. categories) are persisted in the artistFavourites store.
   // "All" = show every favourite, string = show only favourites in that category,
   // "__uncat" = show only uncategorised favourites.
-  let showOnlyFavourites = $state(false);
-  let favouriteCategoryFilter = $state<"all" | "__uncat" | string>("all");
+  let showOnlyFavourites = $derived(store.showOnlyFavourites);
+  let favouriteCategoryFilter = $derived(store.favouriteCategoryFilter);
   let showFavouritesManager = $state(false);
   let showGenParams = $state(false);
   let animKey = $state(0);
+  let sortField = $derived(store.sortField);
+  let sortDir = $derived(store.sortDir);
+  let pageSize = $derived(store.pageSize);
+  let currentPage = $derived(store.currentPage);
+  let queryInput = $derived(store.queryInput);
+  let uniquenessJitter = $derived(store.uniquenessJitter);
 
   // Per-card category picker popover (keyed by slug). null = closed.
   let catPickerSlug = $state<string | null>(null);
@@ -191,8 +219,8 @@
   }
 
   function setShowOnlyFavourites(val: boolean) {
-    showOnlyFavourites = val;
-    currentPage = 1;
+    store.showOnlyFavourites = val;
+    store.currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
       scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
@@ -201,8 +229,8 @@
   }
 
   function setFavouriteCategoryFilter(value: "all" | "__uncat" | string) {
-    favouriteCategoryFilter = value;
-    currentPage = 1;
+    store.favouriteCategoryFilter = value;
+    store.currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
       scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
@@ -235,7 +263,7 @@
   let scrollContainer = $state<HTMLDivElement | null>(null);
 
   function goToPage(page: number) {
-    currentPage = page;
+    store.currentPage = page;
     // scrollTo then dispatch synthetic scroll so WebView2 re-evaluates
     // viewport intersection for eager images (known WebView2 overflow quirk)
     requestAnimationFrame(() => {
@@ -249,8 +277,8 @@
       rotateUniqueness();
       return;
     }
-    sortField = field;
-    currentPage = 1;
+    store.sortField = field;
+    store.currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
       scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
@@ -259,8 +287,8 @@
   }
 
   function setDir(dir: SortDir) {
-    sortDir = dir;
-    currentPage = 1;
+    store.sortDir = dir;
+    store.currentPage = 1;
     animKey++;
     requestAnimationFrame(() => {
       scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
@@ -271,8 +299,8 @@
   function setPageSize(size: PageSize) {
     // Maintain position: find which new page contains the first item currently visible
     const firstIndex = (safePage - 1) * pageSize;
-    pageSize = size;
-    currentPage = Math.max(1, Math.floor(firstIndex / size) + 1);
+    store.pageSize = size;
+    store.currentPage = Math.max(1, Math.floor(firstIndex / size) + 1);
     requestAnimationFrame(() => {
       scrollContainer?.dispatchEvent(new Event("scroll"));
     });
@@ -602,7 +630,7 @@
           <div
             role="button"
             tabindex="0"
-            class="card-slide-in group relative flex flex-col items-stretch rounded-lg border bg-neutral-900 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 {copiedSlug === hit.slug ? 'border-emerald-500' : 'border-neutral-800 hover:border-indigo-500'}"
+            class="card-slide-in group relative flex flex-col items-stretch rounded-lg border bg-neutral-900 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 {copiedSlug === hit.slug ? 'border-emerald-500' : 'border-neutral-800 hover:border-indigo-500'} {catPickerSlug === hit.slug ? 'z-50' : ''}"
             style="--card-delay: {Math.min(i * 30, 450)}ms"
             onclick={() => { void openHit(hit, i); }}
             onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); void openHit(hit, i); } }}
@@ -778,7 +806,7 @@
     onclose={closeLightbox}
     {oninsertTag}
     zoomed={lightboxZoomed}
-    ontogglezoom={() => lightboxZoomed = !lightboxZoomed}
+    ontogglezoom={() => store.lightboxZoomed = !store.lightboxZoomed}
     onprev={activeIndex > 0 ? () => navigateTo(activeIndex - 1) : undefined}
     onnext={activeIndex >= 0 && activeIndex < gridEntries.length - 1 ? () => navigateTo(activeIndex + 1) : undefined}
   />

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -15,6 +15,10 @@ import type {
  *   store.setQuery("dairi");
  *   $derived.by(() => store.results);
  */
+export type ArtistSortField = "postCount" | "name" | "uniqueness";
+export type ArtistSortDir = "asc" | "desc";
+export type ArtistPageSize = 25 | 50 | 100;
+
 export class ArtistGalleryStore {
   readonly client: ArtistGalleryClient;
 
@@ -28,6 +32,31 @@ export class ArtistGalleryStore {
 
   activeArtist = $state<ArtistEntry | null>(null);
   activeLoading = $state(false);
+
+  // --- Persistent UI state (survives page unmount) ---------------------------
+  /** Flat search index loaded on first gallery page visit. */
+  allEntries = $state<ArtistSearchHit[]>([]);
+  allEntriesLoading = $state(false);
+  allEntriesError = $state<string | null>(null);
+  /** Per-entry jitter multipliers for uniqueness sort. */
+  uniquenessJitter = $state<Float32Array>(new Float32Array(0));
+
+  sortField = $state<ArtistSortField>("postCount");
+  sortDir = $state<ArtistSortDir>("desc");
+  pageSize = $state<ArtistPageSize>(50);
+  currentPage = $state(1);
+  queryInput = $state("");
+
+  showOnlyFavourites = $state(false);
+  favouriteCategoryFilter = $state<"all" | "__uncat" | string>("all");
+
+  /** Active lightbox entry, if any. */
+  lightboxEntry = $state<ArtistEntry | null>(null);
+  lightboxIndex = $state(-1);
+  lightboxZoomed = $state(false);
+
+  /** Last known scroll position of the gallery scroll container. */
+  scrollTop = $state(0);
 
   /** Guard so rapid typing doesn't race older search results into state. */
   private searchSeq = 0;

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -2,10 +2,15 @@
   import { generation } from "../../stores/generation.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
   import { scrollCapture } from "../../utils/scrollCapture.js";
   import { models } from "../../stores/models.svelte.js";
   import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
   import { compare } from "../../stores/compare.svelte.js";
+  import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
+  import { createArtistGalleryStore } from "../../artist-gallery/store.svelte.js";
+  import { artistInsert } from "../../stores/artistInsert.svelte.js";
+  import type { ArtistSearchHit } from "../../artist-gallery/types.js";
   import LoraGallery from "./LoraGallery.svelte";
   import CheckpointGallery from "./CheckpointGallery.svelte";
   import CompareGrid from "./CompareGrid.svelte";
@@ -19,7 +24,7 @@
 
   let { onupscale, oninpaint, oncontextmenu }: Props = $props();
 
-  type TabId = "loras" | "checkpoints" | "images" | "prompts" | "compare";
+  type TabId = "loras" | "checkpoints" | "images" | "prompts" | "compare" | "artists";
 
   const TAB_KEY = "mooshieui.bottomPanel.activeTab.v1";
 
@@ -40,7 +45,7 @@
     try { localStorage.setItem(TAB_KEY, activeTab); } catch {}
   });
 
-  const allTabs: TabId[] = ["loras", "checkpoints", "images", "prompts", "compare"];
+  const allTabs: TabId[] = ["loras", "checkpoints", "images", "prompts", "artists", "compare"];
   const visibleTabs = $derived(
     showCheckpointsTab ? allTabs : allTabs.filter((t) => t !== "checkpoints")
   );
@@ -50,6 +55,7 @@
     images: "bottom_panel.tab.images",
     prompts: "bottom_panel.tab.prompts",
     compare: "bottom_panel.tab.compare",
+    artists: "bottom_panel.tab.artists",
   };
 
   // Prompt history
@@ -120,6 +126,119 @@
       localStorage.setItem(CARD_SIZE_KEY, JSON.stringify({ lora: loraCardSize, image: imageCardSize }));
     } catch {}
   });
+
+  // ---------------------------------------------------------------------------
+  // Favourite artists tab
+  // ---------------------------------------------------------------------------
+  const artistStore = $derived(
+    connection.artistGalleryManifestUrl
+      ? createArtistGalleryStore(connection.artistGalleryManifestUrl)
+      : null
+  );
+
+  // Ensure the manifest + search index are loaded the first time the tab is
+  // viewed so cards can render thumbnails without visiting the gallery page.
+  $effect(() => {
+    if (activeTab !== "artists" || !artistStore) return;
+    if (!artistStore.manifest && !artistStore.manifestLoading) {
+      void artistStore.init();
+    }
+    if (artistStore.allEntries.length === 0 && !artistStore.allEntriesLoading) {
+      artistStore.allEntriesLoading = true;
+      artistStore.client
+        .loadSearchIndex()
+        .then((entries) => {
+          artistStore.allEntries = entries;
+        })
+        .catch((err) => {
+          artistStore.allEntriesError = err instanceof Error ? err.message : String(err);
+        })
+        .finally(() => {
+          artistStore.allEntriesLoading = false;
+        });
+    }
+  });
+
+  let artistSearch = $state("");
+  let artistCategoryFilter = $state<"all" | "__uncat" | string>("all");
+  let artistCardSize = $state(110);
+
+  const ARTIST_CARD_SIZE_KEY = "mooshieui.bottomPanel.artistCardSize.v1";
+  try {
+    const raw = localStorage.getItem(ARTIST_CARD_SIZE_KEY);
+    if (raw) {
+      const n = parseInt(raw, 10);
+      if (!isNaN(n)) artistCardSize = Math.max(72, Math.min(200, n));
+    }
+  } catch {}
+  $effect(() => {
+    try { localStorage.setItem(ARTIST_CARD_SIZE_KEY, String(artistCardSize)); } catch {}
+  });
+
+  /** Resolve a favourite slug → ArtistSearchHit from the loaded index. */
+  const favouriteArtistHits = $derived.by((): ArtistSearchHit[] => {
+    const favMap = artistFavourites.favourites;
+    const entries = artistStore?.allEntries ?? [];
+    const bySlug = new Map<string, ArtistSearchHit>();
+    for (const e of entries) bySlug.set(e.slug, e);
+    const hits: ArtistSearchHit[] = [];
+    // Sort favourites by addedAt desc (most recent first).
+    const favs = Object.values(favMap).sort((a, b) => b.addedAt - a.addedAt);
+    for (const fav of favs) {
+      const hit = bySlug.get(fav.slug);
+      if (hit) {
+        hits.push(hit);
+      } else {
+        // Index not yet loaded (or tag gone from index). Provide a stub so
+        // the card still renders with a working tag + heart.
+        hits.push({
+          slug: fav.slug,
+          tag: `@${fav.slug}`,
+          imageId: "",
+          postCount: 0,
+          shard: "",
+          hasImage: false,
+        });
+      }
+    }
+    return hits;
+  });
+
+  const filteredFavouriteArtists = $derived.by(() => {
+    const q = artistSearch.toLowerCase().trim();
+    let list = favouriteArtistHits;
+    if (artistCategoryFilter !== "all") {
+      list = list.filter((hit) => {
+        const fav = artistFavourites.favourites[hit.slug];
+        if (!fav) return false;
+        if (artistCategoryFilter === "__uncat") return fav.categoryId === null;
+        return fav.categoryId === artistCategoryFilter;
+      });
+    }
+    if (q) {
+      list = list.filter(
+        (hit) =>
+          hit.slug.toLowerCase().includes(q) || hit.tag.toLowerCase().includes(q)
+      );
+    }
+    return list;
+  });
+
+  function artistThumbUrl(hit: ArtistSearchHit): string {
+    const m = artistStore?.manifest;
+    if (!m || !hit.hasImage || !hit.imageId) return "";
+    return `${m.imageBaseUrl}/${m.releasePrefix}/images/${hit.imageId}.webp`;
+  }
+
+  function applyArtistTag(hit: ArtistSearchHit) {
+    // Delegate to the shared store so the same replace/append confirmation
+    // modal that the gallery page uses is reused here.
+    artistInsert.request(hit.slug);
+  }
+
+  function displayArtistTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/\\([()[\]]])/g, "$1").replace(/_/g, " ");
+  }
 </script>
 
 <div class="flex flex-col h-full">
@@ -142,6 +261,8 @@
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
         {:else if tab === "compare"}
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        {:else if tab === "artists"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
         {/if}
         {locale.t(tabLabelKeys[tab])}
         {#if tab === "loras" && activeLoraCount > 0}
@@ -150,6 +271,8 @@
           <span class="text-[9px] px-1 py-0 rounded-full bg-indigo-600/30 text-indigo-400 tabular-nums">{sessionImageCount}</span>
         {:else if tab === "prompts" && favoriteCount > 0}
           <span class="text-[9px] px-1 py-0 rounded-full bg-amber-500/30 text-amber-400 tabular-nums">{favoriteCount}</span>
+        {:else if tab === "artists" && artistFavourites.count > 0}
+          <span class="text-[9px] px-1 py-0 rounded-full bg-red-500/30 text-red-400 tabular-nums">{artistFavourites.count}</span>
         {:else if tab === "compare" && compare.enabled}
           <span class="text-[9px] px-1 py-0 rounded-full bg-indigo-600/30 text-indigo-400 tabular-nums">{compare.cellCount}</span>
         {/if}
@@ -332,6 +455,114 @@
       {/if}
     {:else if activeTab === "compare"}
       <CompareGrid />
+    {:else if activeTab === "artists"}
+      {#if artistFavourites.count === 0}
+        <div class="flex items-center justify-center h-full text-neutral-500 text-xs px-4 text-center">
+          <p>{locale.t('bottom_panel.no_favourite_artists')}</p>
+        </div>
+      {:else}
+        <div class="flex flex-col h-full">
+          <div class="px-2 pt-1.5 pb-1 shrink-0 flex items-center gap-2">
+            <input
+              type="text"
+              name="artist-favourite-search"
+              bind:value={artistSearch}
+              placeholder={locale.t('bottom_panel.artist_search_placeholder')}
+              class="flex-1 bg-neutral-800 border border-neutral-700 rounded px-2.5 py-1 text-xs text-neutral-100 placeholder-neutral-500 focus:outline-none focus:border-indigo-500 transition-colors"
+            />
+            <div use:scrollCapture>
+              <input
+                type="range"
+                min="72"
+                max="200"
+                bind:value={artistCardSize}
+                class="w-16 h-4 accent-indigo-500 cursor-pointer"
+                title={locale.t('bottom_panel.card_size')}
+              />
+            </div>
+          </div>
+          <!-- Category filter chips -->
+          {#if artistFavourites.categories.length > 0}
+            {@const counts = artistFavourites.countsByCategory}
+            <div class="mx-2 mb-1 flex flex-wrap items-center gap-1 rounded-md border border-neutral-800 bg-neutral-900/50 p-1 shrink-0">
+              <button
+                type="button"
+                class="rounded px-2 py-0.5 text-[10px] transition-colors {artistCategoryFilter === 'all' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+                onclick={() => artistCategoryFilter = 'all'}
+              >All ({artistFavourites.count})</button>
+              <button
+                type="button"
+                class="rounded px-2 py-0.5 text-[10px] transition-colors {artistCategoryFilter === '__uncat' ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+                onclick={() => artistCategoryFilter = '__uncat'}
+              >Uncategorised ({counts[''] ?? 0})</button>
+              {#each artistFavourites.categories as cat (cat.id)}
+                <button
+                  type="button"
+                  class="flex items-center gap-1 rounded px-2 py-0.5 text-[10px] transition-colors {artistCategoryFilter === cat.id ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+                  onclick={() => artistCategoryFilter = cat.id}
+                  title={cat.name}
+                >
+                  <span class="h-2 w-2 rounded-full border border-neutral-700" style="background-color: {cat.color}" aria-hidden="true"></span>
+                  <span class="max-w-24 truncate">{cat.name}</span>
+                  <span class="text-neutral-500">({counts[cat.id] ?? 0})</span>
+                </button>
+              {/each}
+            </div>
+          {/if}
+          {#if filteredFavouriteArtists.length === 0}
+            <div class="flex items-center justify-center flex-1 text-neutral-500 text-xs">
+              <p>{locale.t('bottom_panel.no_artist_results')}</p>
+            </div>
+          {:else}
+            <div
+              class="grid gap-2 flex-1 min-h-0 overflow-y-auto px-2 py-2"
+              style="grid-template-columns: repeat(auto-fill, minmax({artistCardSize}px, 1fr)); align-content: start;"
+            >
+              {#each filteredFavouriteArtists as hit (hit.slug)}
+                {@const thumb = artistThumbUrl(hit)}
+                {@const favCat = artistFavourites.categoryOf(hit.slug)}
+                <div
+                  role="button"
+                  tabindex="0"
+                  class="group relative flex flex-col rounded-lg border border-neutral-800 bg-neutral-900 cursor-pointer transition-colors hover:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  onclick={() => applyArtistTag(hit)}
+                  onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); applyArtistTag(hit); } }}
+                  title={locale.t('bottom_panel.apply_artist_tag', { tag: hit.tag })}
+                >
+                  <div class="relative aspect-3/4 w-full overflow-hidden rounded-t-lg bg-neutral-800">
+                    {#if thumb}
+                      <img src={thumb} alt={hit.tag} loading="lazy" decoding="async" class="h-full w-full object-cover" />
+                    {:else}
+                      <div class="flex h-full w-full items-center justify-center text-[10px] text-neutral-500">no preview</div>
+                    {/if}
+                    <button
+                      type="button"
+                      class="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded-full border border-neutral-700 bg-neutral-900/90 text-sm leading-none text-red-400 transition-colors hover:bg-neutral-800"
+                      onclick={(e) => { e.stopPropagation(); artistFavourites.toggle(hit.slug); }}
+                      aria-label={locale.t('bottom_panel.unfavorite')}
+                      title={locale.t('bottom_panel.unfavorite')}
+                    >♥</button>
+                    {#if favCat}
+                      <span
+                        class="absolute left-1 top-1 h-3 w-3 rounded-full border border-black/40"
+                        style="background-color: {favCat.color}"
+                        title={favCat.name}
+                        aria-label={`Category: ${favCat.name}`}
+                      ></span>
+                    {/if}
+                  </div>
+                  <div class="px-2 py-1.5">
+                    <div class="truncate text-xs text-red-400">{displayArtistTag(hit.tag)}</div>
+                    {#if hit.postCount > 0}
+                      <div class="text-[10px] text-neutral-500">{hit.postCount.toLocaleString()} posts</div>
+                    {/if}
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/if}
     {/if}
   </div>
 </div>

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { generation } from "../../stores/generation.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
+  import { gallery } from "../../stores/gallery.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
+  import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
+  import { detectArtistsInPrompt } from "../../artist-gallery/detection.js";
   import PromptTextarea from "./PromptTextarea.svelte";
   import InfoTip from "../ui/InfoTip.svelte";
   import { parseScheduledPrompt, hasSchedulingTags } from "../../utils/promptSchedule.js";
@@ -17,6 +21,20 @@
   const positiveSegments = $derived(hasPositiveSchedule ? parseScheduledPrompt(generation.positivePrompt).segments : []);
   const negativeSegments = $derived(hasNegativeSchedule ? parseScheduledPrompt(generation.negativePrompt).segments : []);
   let schedulePanelOpen = $state(true);
+
+  // Lazy-load the artist tag index so typing an artist in the prompt without
+  // ever opening the gallery still lights up the heart chip.
+  $effect(() => {
+    if (!gallery.artistIndexReady && connection.artistGalleryManifestUrl) {
+      void gallery.loadArtistIndex(connection.artistGalleryManifestUrl);
+    }
+  });
+
+  /** Artist tags detected in the current positive prompt. */
+  const detectedArtists = $derived.by(() => {
+    if (!gallery.artistIndexReady || gallery.artistTagIndex.size === 0) return [];
+    return detectArtistsInPrompt(generation.positivePrompt, gallery.artistTagIndex);
+  });
 
   const sortedPromptHistory = $derived(
     [...generation.promptHistory].sort((a, b) => {
@@ -52,13 +70,33 @@
   {/if}
 
   <div>
-    <div class="flex items-center justify-between mb-1">
-      <div class="flex items-center gap-1.5">
+    <div class="flex items-center justify-between gap-2 mb-1">
+      <div class="flex items-center gap-1.5 shrink-0">
         <label class="text-xs text-neutral-400">{locale.t('generation.prompts.positive')}<InfoTip text={locale.t('generation.prompts.positive_tip')} /></label>
       </div>
+      <div class="flex items-center justify-end gap-1.5 flex-wrap min-w-0">
       {#if generation.isAnima || generation.isIllustrious}
         <span class="shrink-0 text-[10px] px-2 py-0.5 rounded-full bg-emerald-600/20 text-emerald-400 border border-emerald-600/30">{locale.t('generation.prompts.quality_applied')}</span>
       {/if}
+      {#each detectedArtists as hit (hit.slug)}
+        {@const isFav = artistFavourites.isFavourite(hit.slug)}
+        {@const favCat = artistFavourites.categoryOf(hit.slug)}
+        {@const displayName = hit.tag.replace(/^@/, "").replace(/\\([()\[\]])/g, "$1")}
+        <button
+          type="button"
+          onclick={() => artistFavourites.toggle(hit.slug)}
+          class="shrink-0 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] transition-colors {isFav ? 'border-red-500/50 bg-red-500/10 text-red-300 hover:bg-red-500/20' : 'border-neutral-700 bg-neutral-800/60 text-neutral-400 hover:border-red-500/60 hover:text-red-300'}"
+          title={isFav ? `Unfavourite ${hit.tag}` : `Favourite ${hit.tag}`}
+          aria-label={isFav ? `Unfavourite artist ${displayName}` : `Favourite artist ${displayName}`}
+        >
+          {#if favCat}
+            <span class="h-2 w-2 rounded-full border border-black/20" style="background-color: {favCat.color}" aria-hidden="true"></span>
+          {/if}
+          <span class="leading-none">{isFav ? '♥' : '♡'}</span>
+          <span class="font-mono max-w-28 truncate">@{displayName}</span>
+        </button>
+      {/each}
+      </div>
     </div>
     {#if generation.isAnima}
       <div class="text-[10px] text-amber-400/80 mb-1">{locale.t('generation.prompts.anima_artist_tip')}</div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -984,6 +984,11 @@ const de: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Vergleichen",
+  "bottom_panel.tab.artists": "Künstler",
+  "bottom_panel.no_favourite_artists": "Markiere einen Künstler in der Galerie als Favorit, damit er hier erscheint",
+  "bottom_panel.no_artist_results": "Keine Favoriten-Künstler passen zur Suche",
+  "bottom_panel.artist_search_placeholder": "Favoriten-Künstler suchen...",
+  "bottom_panel.apply_artist_tag": "{tag} zum positiven Prompt hinzufügen",
   "compare.enable": "Vergleichsraster starten",
   "compare.disable": "Deaktivieren",
   "compare.add_cell": "Zelle hinzufügen",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -697,6 +697,11 @@ const en: Record<string, string> = {
   "bottom_panel.no_prompt_results": "No prompts match your search",
   "bottom_panel.card_size": "Card size",
   "bottom_panel.tab.compare": "Compare",
+  "bottom_panel.tab.artists": "Artists",
+  "bottom_panel.no_favourite_artists": "Favourite an artist from the Artist Gallery or prompt and they'll appear here",
+  "bottom_panel.no_artist_results": "No favourited artists match your search",
+  "bottom_panel.artist_search_placeholder": "Search favourited artists...",
+  "bottom_panel.apply_artist_tag": "Apply {tag} to positive prompt",
 
   // ── Compare Grid ────────────────────────────────────────
   "compare.enable": "Start Compare Grid",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1011,6 +1011,11 @@ const es: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparar",
+  "bottom_panel.tab.artists": "Artistas",
+  "bottom_panel.no_favourite_artists": "Marca un artista como favorito en la galería para verlo aquí",
+  "bottom_panel.no_artist_results": "Ningún artista favorito coincide con la búsqueda",
+  "bottom_panel.artist_search_placeholder": "Buscar artistas favoritos...",
+  "bottom_panel.apply_artist_tag": "Aplicar {tag} al prompt positivo",
   "compare.enable": "Iniciar cuadrícula de comparación",
   "compare.disable": "Desactivar",
   "compare.add_cell": "Añadir celda",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1009,6 +1009,11 @@ const fr: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparer",
+  "bottom_panel.tab.artists": "Artistes",
+  "bottom_panel.no_favourite_artists": "Mets un artiste en favori depuis la galerie pour le voir ici",
+  "bottom_panel.no_artist_results": "Aucun artiste favori ne correspond à la recherche",
+  "bottom_panel.artist_search_placeholder": "Rechercher des artistes favoris...",
+  "bottom_panel.apply_artist_tag": "Appliquer {tag} au prompt positif",
   "compare.enable": "Démarrer la grille de comparaison",
   "compare.disable": "Désactiver",
   "compare.add_cell": "Ajouter une cellule",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -982,6 +982,11 @@ const it: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Confronta",
+  "bottom_panel.tab.artists": "Artisti",
+  "bottom_panel.no_favourite_artists": "Aggiungi un artista ai preferiti dalla galleria per vederlo qui",
+  "bottom_panel.no_artist_results": "Nessun artista preferito corrisponde alla ricerca",
+  "bottom_panel.artist_search_placeholder": "Cerca artisti preferiti...",
+  "bottom_panel.apply_artist_tag": "Applica {tag} al prompt positivo",
   "compare.enable": "Avvia griglia di confronto",
   "compare.disable": "Disattiva",
   "compare.add_cell": "Aggiungi cella",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1007,6 +1007,11 @@ const ja: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比較",
+  "bottom_panel.tab.artists": "アーティスト",
+  "bottom_panel.no_favourite_artists": "ギャラリーでアーティストをお気に入りに追加するとここに表示されます",
+  "bottom_panel.no_artist_results": "検索に一致するお気に入りアーティストはいません",
+  "bottom_panel.artist_search_placeholder": "お気に入りアーティストを検索...",
+  "bottom_panel.apply_artist_tag": "{tag} をポジティブプロンプトに追加",
   "compare.enable": "比較グリッドを開始",
   "compare.disable": "無効化",
   "compare.add_cell": "セルを追加",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -982,6 +982,11 @@ const ko: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "비교",
+  "bottom_panel.tab.artists": "아티스트",
+  "bottom_panel.no_favourite_artists": "갤러리에서 아티스트를 즐겨찾기에 추가하면 여기에 표시됩니다",
+  "bottom_panel.no_artist_results": "검색에 일치하는 즐겨찾기 아티스트가 없습니다",
+  "bottom_panel.artist_search_placeholder": "즐겨찾기 아티스트 검색...",
+  "bottom_panel.apply_artist_tag": "{tag} 를 긍정 프롬프트에 추가",
   "compare.enable": "비교 그리드 시작",
   "compare.disable": "비활성화",
   "compare.add_cell": "셀 추가",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -984,6 +984,11 @@ const pt: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparar",
+  "bottom_panel.tab.artists": "Artistas",
+  "bottom_panel.no_favourite_artists": "Adiciona um artista aos favoritos na galeria para vê-lo aqui",
+  "bottom_panel.no_artist_results": "Nenhum artista favorito corresponde à pesquisa",
+  "bottom_panel.artist_search_placeholder": "Pesquisar artistas favoritos...",
+  "bottom_panel.apply_artist_tag": "Aplicar {tag} ao prompt positivo",
   "compare.enable": "Iniciar grade de comparação",
   "compare.disable": "Desativar",
   "compare.add_cell": "Adicionar célula",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -982,6 +982,11 @@ const ru: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Сравнение",
+  "bottom_panel.tab.artists": "Художники",
+  "bottom_panel.no_favourite_artists": "Добавьте художника в избранное в галерее, чтобы он появился здесь",
+  "bottom_panel.no_artist_results": "Нет избранных художников, соответствующих поиску",
+  "bottom_panel.artist_search_placeholder": "Поиск избранных художников...",
+  "bottom_panel.apply_artist_tag": "Добавить {tag} в позитивный промпт",
   "compare.enable": "Начать сетку сравнения",
   "compare.disable": "Отключить",
   "compare.add_cell": "Добавить ячейку",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -982,6 +982,11 @@ const zhTw: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比較",
+  "bottom_panel.tab.artists": "藝術家",
+  "bottom_panel.no_favourite_artists": "在畫廊中將藝術家加入收藏，即可在此處查看",
+  "bottom_panel.no_artist_results": "沒有符合搜尋條件的收藏藝術家",
+  "bottom_panel.artist_search_placeholder": "搜尋收藏的藝術家...",
+  "bottom_panel.apply_artist_tag": "將 {tag} 加入正面提示詞",
   "compare.enable": "啟動比較網格",
   "compare.disable": "停用",
   "compare.add_cell": "新增儲存格",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -982,6 +982,11 @@ const zh: Record<string, string> = {
 
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比较",
+  "bottom_panel.tab.artists": "艺术家",
+  "bottom_panel.no_favourite_artists": "在画廊中收藏艺术家，即可在此处查看",
+  "bottom_panel.no_artist_results": "没有符合搜索条件的收藏艺术家",
+  "bottom_panel.artist_search_placeholder": "搜索收藏的艺术家...",
+  "bottom_panel.apply_artist_tag": "将 {tag} 添加到正面提示词",
   "compare.enable": "启动比较网格",
   "compare.disable": "禁用",
   "compare.add_cell": "添加单元格",

--- a/src/lib/stores/artistInsert.svelte.ts
+++ b/src/lib/stores/artistInsert.svelte.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared pending-state store for the "insert artist tag" confirmation modal.
+ *
+ * App.svelte renders the modal and subscribes to `artistInsert.pending`.
+ * Any component (artist gallery page, bottom-panel favourites tab, etc.) can
+ * call `artistInsert.request(tag)` to trigger the same UX.
+ */
+import { generation } from "./generation.svelte.js";
+
+export type ArtistInsertPending = {
+  tag: string;
+  existingTags: string[];
+  duplicate: boolean;
+};
+
+class ArtistInsertStore {
+  pending = $state<ArtistInsertPending | null>(null);
+
+  /**
+   * Request insertion of an artist tag into the positive prompt.
+   *
+   * - If there are no existing `@` tags, applies immediately (add).
+   * - If the exact tag is already present, opens the "already in prompt" hint.
+   * - If other `@` tags exist, opens the replace/add confirmation modal.
+   *
+   * The `tag` may be provided with or without a leading `@`.
+   */
+  request(tag: string): void {
+    const withAt = "@" + tag.replace(/^@/, "");
+    const existing = generation.positivePrompt.trim();
+    const existingArtistTags = existing
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.startsWith("@"));
+    if (existingArtistTags.some((t) => t.toLowerCase() === withAt.toLowerCase())) {
+      this.pending = { tag: withAt, existingTags: existingArtistTags, duplicate: true };
+    } else if (existingArtistTags.length > 0) {
+      this.pending = { tag: withAt, existingTags: existingArtistTags, duplicate: false };
+    } else {
+      this.apply(withAt, "add");
+    }
+  }
+
+  apply(withAt: string, mode: "add" | "replace"): void {
+    const existing = generation.positivePrompt.trim();
+    let newPrompt: string;
+    if (mode === "replace") {
+      const stripped = existing
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => !s.startsWith("@"))
+        .join(", ");
+      newPrompt = stripped ? `${withAt}, ${stripped}` : withAt;
+    } else {
+      newPrompt = existing ? `${withAt}, ${existing}` : withAt;
+    }
+    generation.positivePrompt = newPrompt;
+    generation.saveSettings();
+    this.pending = null;
+  }
+
+  dismiss(): void {
+    this.pending = null;
+  }
+}
+
+export const artistInsert = new ArtistInsertStore();


### PR DESCRIPTION
## What's New in v0.9.4

### Artist Gallery — State Persistence & Tag Display Fixes
- **Gallery state now persists** — switching to the generation screen and back returns you to exactly where you were: same sort mode (including Uniqueness ranking and jitter), page, search query, category filter, and scroll position. If you had a lightbox open, that is also restored.
- **Fixed tag display with escaped parens** — artists like `@mitsu \(mitsu art\)` now render as `mitsu (mitsu art)` in gallery cards, the bottom panel, and the prompt chips, instead of the raw slug form.
- **Category picker z-order fix** — the "Assign category" dropdown no longer slides under the card below it in the grid.

### Artist Favourites — Heart Chip in Generation Settings
- **Heart chip on detected artist tags** — when the positive prompt contains a recognised artist tag (whether typed manually, accepted via autocomplete, or inserted from the gallery) a heart chip appears in the prompt header row. Click it to toggle the artist as a favourite without leaving the generation screen. The chip shows the artist's category colour dot when one is assigned.

### Favourite Artists Quick-Access Tab
- **New "Artists" tab in the bottom panel** — all your favourited artists are available as a scrollable thumbnail grid alongside LoRAs, checkpoints, and images. Click any card to apply the tag to your positive prompt, using the same replace/append confirmation modal as the gallery.
- **Search and filter** — a search box and category filter chips let you find the right artist instantly.
- **Card size slider** — resize the thumbnail grid independently from the gallery, persisted across sessions.

### i18n
- All 5 new artist-related UI strings added to all 10 non-English locale files with native translations.