### PR TITLE
v0.9.5: Clear queue, queue reliability, password UX, CDN CORS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v0.9.5
+
+### Queue Management for Moderators & Admins
+- **Clear Queue button** — a new "Queue Management" card in Settings lets admins and moderators wipe the entire generation queue with a two-step confirmation. All held and pending prompts are cancelled, all running workers are interrupted, and every connected client receives a `mooshie:queue_cleared` event so their UI resets immediately.
+
+### Queue Reliability Fixes
+- **Faster stuck-job detection** — the reconciler that catches generations lost during SSE downtime now runs every 5 seconds (previously 15s) with a 10-second inactivity threshold (previously 30s). Missed completions are surfaced in roughly 15 seconds instead of up to 45.
+- **SSE reconnect sync** — when the SSE connection drops and reconnects, last-activity timestamps are reset so the reconciler picks up in-flight prompts immediately on the next tick rather than waiting for the next inactivity window.
+
+### UX: Password Change No Longer Shown Automatically
+- The "Change Password" form in the Account section is now collapsed by default. A single button reveals the three input fields on demand, preventing users from mistaking the always-visible form for a forced password-change prompt.
+
+### CDN CORS Fix (Browser Mode)
+- Artist gallery manifest and image index requests are now proxied through the MooshieUI server at `/internal-api/_cdn/…` instead of fetching directly from `cdn.mooshieblob.com`. This eliminates the CORS block that prevented the gallery from loading in browser mode.
+
+---
+
 ## What's New in v0.9.4
 
 ### Artist Gallery — State Persistence & Tag Display Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v0.9.5
+
+### Queue Management for Moderators & Admins
+- **Clear Queue button** — a new "Queue Management" card in Settings lets admins and moderators wipe the entire generation queue with a two-step confirmation. All held and pending prompts are cancelled, all running workers are interrupted, and every connected client receives a `mooshie:queue_cleared` event so their UI resets immediately.
+
+### Queue Reliability Fixes
+- **Faster stuck-job detection** — the reconciler that catches generations lost during SSE downtime now runs every 5 seconds (previously 15s) with a 10-second inactivity threshold (previously 30s). Missed completions are surfaced in roughly 15 seconds instead of up to 45.
+- **SSE reconnect sync** — when the SSE connection drops and reconnects, last-activity timestamps are reset so the reconciler picks up in-flight prompts immediately on the next tick rather than waiting for the next inactivity window.
+
+### UX: Password Change No Longer Shown Automatically
+- The "Change Password" form in the Account section is now collapsed by default. A single button reveals the three input fields on demand, preventing users from mistaking the always-visible form for a forced password-change prompt.
+
+### CDN CORS Fix (Browser Mode)
+- Artist gallery manifest and image index requests are now proxied through the MooshieUI server at `/internal-api/_cdn/…` instead of fetching directly from `cdn.mooshieblob.com`. This eliminates the CORS block that prevented the gallery from loading in browser mode.
+
+---
+
 ## What's New in v0.9.4
 
 ### Artist Gallery — State Persistence & Tag Display Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -292,6 +292,14 @@ impl PromptQueue {
         let mut aliases = self.aliases.write().unwrap();
         aliases.retain(|_, v| v != placeholder_id);
     }
+
+    /// Clear all queue tracking state (owners, worker_map, queue).
+    /// Does NOT clear held or aliases — those are managed separately.
+    pub fn clear_all(&self) {
+        self.queue.write().unwrap().clear();
+        self.owners.write().unwrap().clear();
+        self.worker_map.write().unwrap().clear();
+    }
 }
 
 pub struct AppState {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -131,6 +131,7 @@ const MODERATOR_COMMANDS: &[&str] = &[
     "stop_comfyui",
     "export_logs",
     "install_pip_package",
+    "clear_all_queues",
 ];
 
 /// Model Hub commands that require explicit per-user access for regular users.
@@ -270,6 +271,8 @@ pub async fn start_server(
         )
         // GPU stats — available to all authenticated users
         .route("/internal-api/_gpu_stats", get(gpu_stats_handler))
+        // CDN proxy — serves assets from cdn.mooshieblob.com to avoid CORS issues
+        .route("/internal-api/_cdn/{*path}", get(cdn_proxy_handler))
         // Generic IPC command proxy
         .route("/internal-api/{command}", post(command_handler))
         // Static file serving (frontend)
@@ -1125,6 +1128,41 @@ async fn gpu_stats_handler(
     }
 }
 
+/// CDN proxy handler — fetches assets from cdn.mooshieblob.com and forwards
+/// them to the browser with CORS headers so in-browser mode works correctly.
+/// Only proxies from the hardcoded CDN origin; this is NOT an open proxy.
+async fn cdn_proxy_handler(
+    AxumState(state): AxumState<SharedState>,
+    Path(path): Path<String>,
+) -> Response {
+    let target_url = format!("https://cdn.mooshieblob.com/{}", path);
+    match state.app.http_client.get(&target_url).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let content_type = resp
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .cloned();
+            let body = match resp.bytes().await {
+                Ok(b) => b,
+                Err(_) => return StatusCode::BAD_GATEWAY.into_response(),
+            };
+            let mut response = (status, body).into_response();
+            response.headers_mut().insert(
+                axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                "*".parse().unwrap(),
+            );
+            if let Some(ct) = content_type {
+                response
+                    .headers_mut()
+                    .insert(axum::http::header::CONTENT_TYPE, ct);
+            }
+            response
+        }
+        Err(_) => StatusCode::BAD_GATEWAY.into_response(),
+    }
+}
+
 /// Generic command handler — proxies IPC commands via HTTP POST.
 ///
 /// The frontend sends `POST /internal-api/{command}` with a JSON body
@@ -1437,6 +1475,62 @@ async fn dispatch_command(
         }
         "interrupt_generation" => {
             state.interrupt().await.map_err(|e| e.to_string())?;
+            Ok(serde_json::json!(null))
+        }
+        "clear_all_queues" => {
+            // 1. Drain held prompts and cancel them so their background tasks exit cleanly
+            let held_prompts: Vec<crate::state::HeldPrompt> = {
+                let mut held = state.prompt_queue.held.lock().unwrap();
+                held.drain(..).collect()
+            };
+            for hp in held_prompts {
+                let mut result = hp.result.lock().await;
+                *result = Some(Err("Queue cleared by admin".to_string()));
+                hp.submitted.notify_one();
+            }
+
+            // 2. Interrupt all currently running workers
+            let _ = state.gpu_manager.interrupt(None).await;
+
+            // 3. Delete all pending items from each ComfyUI worker queue
+            for worker in &state.gpu_manager.workers {
+                let queue_url = format!("{}/queue", worker.base_url);
+                if let Ok(resp) = state.http_client.get(&queue_url).send().await {
+                    if let Ok(val) = resp.json::<serde_json::Value>().await {
+                        let mut pending_ids: Vec<String> = Vec::new();
+                        if let Some(arr) = val.get("queue_pending").and_then(|v| v.as_array()) {
+                            for item in arr {
+                                if let Some(pid) = item
+                                    .as_array()
+                                    .and_then(|a| a.get(1))
+                                    .and_then(|v| v.as_str())
+                                {
+                                    pending_ids.push(pid.to_string());
+                                }
+                            }
+                        }
+                        if !pending_ids.is_empty() {
+                            let _ = state
+                                .http_client
+                                .post(&format!("{}/queue", worker.base_url))
+                                .json(&serde_json::json!({ "delete": pending_ids }))
+                                .send()
+                                .await;
+                        }
+                    }
+                }
+            }
+
+            // 4. Clear the internal queue tracking
+            state.prompt_queue.clear_all();
+
+            // 5. Wake the drain reactor so it sees the empty held list
+            state.prompt_queue.drain_notify.notify_one();
+
+            // 6. Broadcast empty queue state and a clear event to all clients
+            state.broadcast_queue_positions();
+            state.broadcast("mooshie:queue_cleared", serde_json::json!({}));
+
             Ok(serde_json::json!(null))
         }
         "get_client_id" => Ok(serde_json::json!(state.client_id)),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -53,6 +53,7 @@
     await Promise.race([Promise.allSettled(fetches), timeout]);
   }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
+  let sseReconnectHandler: (() => void) | null = null;
   /** Timestamp of the most recent SSE event per prompt — prevents false reconciliation. */
   let promptLastActivity = new Map<string, number>();
 
@@ -1429,6 +1430,11 @@
           progress.updateQueuePosition(data.prompt_id, data.position, data.total);
         }
       }),
+      ipcListen("mooshie:queue_cleared", (_event: any) => {
+        // Admin/mod cleared the queue — cancel all pending state on this client
+        progress.cancelAll();
+        compare.clearGridBatch();
+      }),
       ipcListen("comfyui:preview", async (event: any) => {
         const data = event.payload;
         if (!progress.isGenerating) return;
@@ -1622,7 +1628,7 @@
           // Skip prompts that received an SSE event within the last 30s —
           // they're clearly still alive even if the queue query missed them.
           const lastEvent = promptLastActivity.get(p.promptId) ?? 0;
-          if (now - lastEvent < 30_000) continue;
+          if (now - lastEvent < 10_000) continue;
 
           if (!allPromptIds.has(p.promptId)) {
             console.warn(`[reconcile] Prompt ${p.promptId} no longer in ComfyUI queue — completing`);
@@ -1646,7 +1652,22 @@
       } catch {
         // Queue check failed — not critical
       }
-    }, 15_000);
+    }, 5_000);
+
+    // On SSE reconnect, immediately trigger a reconcile check so missed
+    // completion events are caught within seconds rather than up to 15s later.
+    const handleSseReconnect = () => {
+      if (progress.isGenerating && connection.connected) {
+        // Reset last-activity timestamps so the reconciler doesn't skip prompts
+        for (const p of progress.pendingPrompts) {
+          if (!promptLastActivity.has(p.promptId)) {
+            promptLastActivity.set(p.promptId, 0);
+          }
+        }
+      }
+    };
+    sseReconnectHandler = handleSseReconnect;
+    window.addEventListener("mooshie:sse-reconnected", handleSseReconnect);
 
     // Start ComfyUI server — returns immediately, background task handles readiness
     // The backend will auto-connect WebSocket and emit comfyui:server_ready when done
@@ -1737,6 +1758,7 @@
 
   onDestroy(() => {
     if (reconcileIntervalId) clearInterval(reconcileIntervalId);
+    if (sseReconnectHandler) window.removeEventListener("mooshie:sse-reconnected", sseReconnectHandler);
   });
 </script>
 

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AppConfig } from "../../types/index.js";
-  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, getGalleryPath, setGalleryPath, setStorageLimit, installAttentionBackend, checkAttentionBackend } from "../../utils/api.js";
+  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, getGalleryPath, setGalleryPath, setStorageLimit, installAttentionBackend, checkAttentionBackend, clearAllQueues } from "../../utils/api.js";
   import type { ReleaseNote, ImportResult, AttentionBackendStatus } from "../../utils/api.js";
   import { smoothScroll } from "../../utils/smoothScroll.js";
   import { connection } from "../../stores/connection.svelte.js";
@@ -61,6 +61,27 @@
   let exportingLogs = $state(false);
   let logExportDone = $state(false);
   let logExportError = $state<string | null>(null);
+
+  // Clear queue state (mod/admin only)
+  let clearQueueBusy = $state(false);
+  let clearQueueDone = $state(false);
+  let clearQueueError = $state<string | null>(null);
+  let showClearQueueConfirm = $state(false);
+
+  async function handleClearQueue() {
+    clearQueueBusy = true;
+    clearQueueError = null;
+    try {
+      await clearAllQueues();
+      clearQueueDone = true;
+      showClearQueueConfirm = false;
+      setTimeout(() => (clearQueueDone = false), 3000);
+    } catch (e: any) {
+      clearQueueError = e?.message ?? String(e);
+    } finally {
+      clearQueueBusy = false;
+    }
+  }
 
   // Mode switching state
   let switchingMode = $state(false);
@@ -166,6 +187,7 @@
   });
 
   // User self-service password change
+  let showChangePasswordForm = $state(false);
   let cpCurrentPass = $state("");
   let cpNewPass1 = $state("");
   let cpNewPass2 = $state("");
@@ -1176,6 +1198,41 @@
 
             {#if lanAuthError}
               <p class="text-xs text-red-400 mt-1">{lanAuthError}</p>
+            {/if}
+          </div>
+        </section>
+        {/if}
+
+        <!-- Queue Management (admin / moderator in browser mode) -->
+        {#if canManageServer && isBrowserMode}
+        <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
+          <div class="p-5 space-y-3">
+            <h3 class="text-sm font-medium text-neutral-200">Queue Management</h3>
+            <p class="text-xs text-neutral-500">Clear all pending and active generations. This interrupts everyone's in-progress generation.</p>
+            {#if clearQueueError}
+              <p class="text-xs text-red-400">{clearQueueError}</p>
+            {/if}
+            {#if clearQueueDone}
+              <p class="text-xs text-green-400">Queue cleared.</p>
+            {/if}
+            {#if showClearQueueConfirm}
+              <p class="text-xs text-amber-300">This will interrupt all active and queued generations. Are you sure?</p>
+              <div class="flex gap-2">
+                <button
+                  class="flex-1 py-2 rounded-lg text-xs font-medium bg-neutral-700 hover:bg-neutral-600 text-neutral-300 transition-colors cursor-pointer"
+                  onclick={() => (showClearQueueConfirm = false)}
+                >Cancel</button>
+                <button
+                  class="flex-1 py-2 rounded-lg text-xs font-medium bg-red-600 hover:bg-red-500 text-white transition-colors cursor-pointer disabled:opacity-50"
+                  disabled={clearQueueBusy}
+                  onclick={handleClearQueue}
+                >{clearQueueBusy ? "Clearing…" : "Yes, Clear Queue"}</button>
+              </div>
+            {:else}
+              <button
+                class="w-full py-2 rounded-lg text-xs font-medium bg-red-600/20 hover:bg-red-600/40 text-red-300 border border-red-800/50 transition-colors cursor-pointer"
+                onclick={() => { clearQueueError = null; showClearQueueConfirm = true; }}
+              >Clear Queue</button>
             {/if}
           </div>
         </section>
@@ -2261,7 +2318,17 @@
         <section class="bg-neutral-900 rounded-xl border border-neutral-800 overflow-hidden break-inside-avoid mb-4">
           <div class="p-5 space-y-3">
             <h3 class="text-sm font-medium text-neutral-200">Account</h3>
-            <p class="text-xs text-neutral-500">Change your password.</p>
+            <button
+              class="w-full py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer bg-neutral-800 hover:bg-neutral-700 text-neutral-300 border border-neutral-700"
+              onclick={() => {
+                showChangePasswordForm = !showChangePasswordForm;
+                cpError = null;
+                cpSuccess = false;
+              }}
+            >
+              {showChangePasswordForm ? "Cancel" : "Change Password"}
+            </button>
+            {#if showChangePasswordForm}
             <div class="space-y-2">
               <input
                 type="password"
@@ -2293,9 +2360,10 @@
                 disabled={cpBusy}
                 onclick={changeOwnPassword}
               >
-                {cpBusy ? "Saving..." : "Change Password"}
+                {cpBusy ? "Saving..." : "Confirm Change"}
               </button>
             </div>
+            {/if}
             <hr class="border-neutral-800" />
             <button
               class="w-full py-2 rounded-lg text-xs font-medium transition-colors cursor-pointer bg-red-600/20 hover:bg-red-600/40 text-red-300 border border-red-800/50"

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -1,9 +1,15 @@
+import { isBrowserMode } from "../utils/ipc.js";
+
+const CDN_BASE = isBrowserMode
+  ? "/internal-api/_cdn"
+  : "https://cdn.mooshieblob.com";
+
 class ConnectionStore {
   connected = $state(false);
   serverUrl = $state("http://127.0.0.1:8188");
-  /** Manifest URL for the Anima artist gallery. Points at Cloudflare R2 by default. */
+  /** Manifest URL for the Anima artist gallery. Proxied in browser mode to avoid CORS. */
   artistGalleryManifestUrl = $state(
-    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json",
+    `${CDN_BASE}/20260325_anima_all_artists/indices/manifest.json`,
   );
 }
 

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -51,6 +51,10 @@ export async function deleteQueueItem(promptId: string): Promise<void> {
   return ipcInvoke("delete_queue_item", { promptId });
 }
 
+export async function clearAllQueues(): Promise<void> {
+  return ipcInvoke("clear_all_queues");
+}
+
 export async function uploadImage(imagePath: string): Promise<{
   name: string;
   subfolder: string;

--- a/src/lib/utils/ipc.ts
+++ b/src/lib/utils/ipc.ts
@@ -144,6 +144,10 @@ function ensureBrowserEventSource() {
       // ignore malformed messages
     }
   };
+  browserEventSource.onopen = () => {
+    // Notify the app that SSE reconnected so it can immediately re-sync state
+    window.dispatchEvent(new CustomEvent("mooshie:sse-reconnected"));
+  };
   browserEventSource.onerror = () => {
     // Reconnect after a short delay
     browserEventSource?.close();


### PR DESCRIPTION
## What's New in v0.9.5

### Queue Management for Moderators & Admins
- **Clear Queue button** — new "Queue Management" card in Settings lets admins and moderators wipe the entire generation queue with a two-step confirmation. All held and pending prompts are cancelled, all running workers are interrupted, and every connected client receives a `mooshie:queue_cleared` event so their UI resets immediately.

### Queue Reliability Fixes
- **Faster stuck-job detection** — the reconciler now runs every 5 seconds (previously 15s) with a 10-second inactivity threshold (previously 30s). Missed completions surface in ~15 seconds instead of up to 45.
- **SSE reconnect sync** — on SSE reconnect, last-activity timestamps are reset so the reconciler picks up in-flight prompts on the next tick rather than waiting out the full inactivity window.

### UX: Password Change No Longer Shown Automatically
- The "Change Password" form in the Account section is now collapsed by default. A toggle button reveals the three input fields on demand, preventing users from mistaking the always-visible form for a forced password-change prompt.

### CDN CORS Fix (Browser Mode)
- Artist gallery manifest and index requests are now proxied through the MooshieUI server at `/internal-api/_cdn/…` instead of fetching directly from `cdn.mooshieblob.com`. This eliminates the CORS block that prevented the gallery from loading in browser mode.