### PR TITLE
v0.9.6: Silent generation recovery, execution error toasts, auto-fix empty VAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## What's New in v0.9.6
+
+### Silent Generation Recovery After Reconnect
+- **Images are no longer silently lost on reconnect** — if the SSE connection dropped mid-generation, output images could vanish with no error and no toast. A server-side cache now preserves each output image's temp filename keyed by prompt ID. If the reconciler detects a completed generation with no locally tracked images, it automatically fetches the cached images from the server and finalises the output as normal.
+- **Error toast on total recovery failure** — if the server-side cache is also empty (e.g. the server restarted mid-generation), a clear error toast is shown: "A generation was lost due to a connection issue — please try again."
+
+### Error Feedback for Failed Generations
+- **Toast on `comfyui:execution_error`** — when ComfyUI reports a generation error (invalid VAE, missing model, validation failure), a descriptive error toast is now displayed rather than silently clearing the queue.
+
+### Auto-Fix for Empty VAE in Split-Model Configurations
+- Users with Anima / split-model checkpoints and an empty VAE setting now have the correct VAE automatically selected on next load, preventing the `vae_name: '' not in list` validation error.
+
+---
+
 ## What's New in v0.9.5
 
 ### Queue Management for Moderators & Admins

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+## What's New in v0.9.6
+
+### Silent Generation Recovery After Reconnect
+- **Images are no longer silently lost on reconnect** — if the SSE connection dropped mid-generation, output images could vanish with no error and no toast. A server-side cache now preserves each output image's temp filename keyed by prompt ID. If the reconciler detects a completed generation with no locally tracked images, it automatically fetches the cached images from the server and finalises the output as normal.
+- **Error toast on total recovery failure** — if the server-side cache is also empty (e.g. the server restarted mid-generation), a clear error toast is shown: "A generation was lost due to a connection issue — please try again."
+
+### Error Feedback for Failed Generations
+- **Toast on `comfyui:execution_error`** — when ComfyUI reports a generation error (invalid VAE, missing model, validation failure), a descriptive error toast is now displayed rather than silently clearing the queue.
+
+### Auto-Fix for Empty VAE in Split-Model Configurations
+- Users with Anima / split-model checkpoints and an empty VAE setting now have the correct VAE automatically selected on next load, preventing the `vae_name: '' not in list` validation error.
+
+---
+
 ## What's New in v0.9.5
 
 ### Queue Management for Moderators & Admins

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -326,6 +326,10 @@ pub struct AppState {
     pub prompt_queue: PromptQueue,
     /// Multi-GPU worker manager — distributes prompts across N GPU backends.
     pub gpu_manager: GpuManager,
+    /// Tracks output temp filenames by placeholder prompt_id for recovery.
+    /// Populated by the cleanup reactor when `comfyui:output_image` fires;
+    /// consumed (and cleared) by `recover_prompt_outputs`.
+    pub output_image_cache: std::sync::RwLock<HashMap<String, Vec<String>>>,
 }
 
 impl AppState {
@@ -349,6 +353,7 @@ impl AppState {
             web_server_running: std::sync::atomic::AtomicBool::new(false),
             prompt_queue: PromptQueue::new(),
             gpu_manager,
+            output_image_cache: std::sync::RwLock::new(HashMap::new()),
         }
     }
 

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -363,6 +363,8 @@ pub async fn start_server(
                                         if let Some(wid) = cleanup_state.prompt_queue.finish(&pid) {
                                             cleanup_state.gpu_manager.mark_worker_idle(wid).await;
                                         }
+                                        // Completed normally — no recovery needed; clear cache.
+                                        cleanup_state.output_image_cache.write().unwrap().remove(&pid);
                                         // Delay alias cleanup so SSE streams have time to
                                         // resolve the alias for this same event.  Without the
                                         // delay, the SSE filter_map can race with this reactor
@@ -396,6 +398,8 @@ pub async fn start_server(
                                             .mark_worker_error_then_idle(wid)
                                             .await;
                                     }
+                                    // Error — no output to recover; clear cache.
+                                    cleanup_state.output_image_cache.write().unwrap().remove(&pid);
                                     let alias_pid = pid.clone();
                                     let alias_state = cleanup_state.clone();
                                     tokio::spawn(async move {
@@ -405,6 +409,26 @@ pub async fn start_server(
                                     cleanup_state.broadcast_queue_positions();
                                     // Signal the drain reactor to submit next held prompt
                                     cleanup_state.prompt_queue.drain_notify.notify_one();
+                                }
+                            }
+                            "comfyui:output_image" => {
+                                // Cache temp_filename by placeholder_id so the reconciler
+                                // can recover images if the SSE event was dropped during
+                                // a client reconnect.
+                                if let Some(pid) = prompt_id {
+                                    if let Some(temp_fn) = evt
+                                        .payload
+                                        .get("temp_filename")
+                                        .and_then(|v| v.as_str())
+                                    {
+                                        cleanup_state
+                                            .output_image_cache
+                                            .write()
+                                            .unwrap()
+                                            .entry(pid)
+                                            .or_default()
+                                            .push(temp_fn.to_string());
+                                    }
                                 }
                             }
                             _ => {}
@@ -1472,6 +1496,25 @@ async fn dispatch_command(
                 .await
                 .map_err(|e| e.to_string())?;
             Ok(result)
+        }
+        "recover_prompt_outputs" => {
+            // Return cached output temp filenames for a prompt whose SSE events
+            // were dropped (e.g. during a client reconnect).  The cleanup reactor
+            // populates output_image_cache whenever it sees a comfyui:output_image
+            // broadcast — so even if the SSE client missed the event, the image
+            // temp file was already saved.
+            let placeholder_id = args["promptId"].as_str().ok_or("Missing promptId")?;
+            let cached = state
+                .output_image_cache
+                .write()
+                .unwrap()
+                .remove(placeholder_id)
+                .unwrap_or_default();
+            let images: Vec<serde_json::Value> = cached
+                .into_iter()
+                .map(|f| serde_json::json!({ "temp_filename": f }))
+                .collect();
+            Ok(serde_json::json!({ "images": images }))
         }
         "interrupt_generation" => {
             state.interrupt().await.map_err(|e| e.to_string())?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,7 +10,7 @@
   import { progress } from "./lib/stores/progress.svelte.js";
   import { gallery } from "./lib/stores/gallery.svelte.js";
   import { models } from "./lib/stores/models.svelte.js";
-  import { getOutputImage, uploadImageBytes, loadGalleryImage, getConfig, readImageMetadata, getQueue } from "./lib/utils/api.js";
+  import { getOutputImage, uploadImageBytes, loadGalleryImage, getConfig, readImageMetadata, getQueue, recoverPromptOutputs } from "./lib/utils/api.js";
   import { generation } from "./lib/stores/generation.svelte.js";
   import { autocomplete } from "./lib/stores/autocomplete.svelte.js";
   import { canvas } from "./lib/stores/canvas.svelte.js";
@@ -1588,6 +1588,21 @@
       ipcListen("comfyui:execution_error", (event: any) => {
         console.error("Execution error:", event.payload);
         const data = event.payload;
+        // Build a user-visible error message from the raw error string
+        const rawErr = String(data.error ?? "");
+        let toastMsg = "Generation failed";
+        if (rawErr.includes("value_not_in_list") || rawErr.includes("Value not in list") || rawErr.includes("prompt_outputs_failed_validation")) {
+          toastMsg = "Generation failed — a model or VAE may not be configured correctly. Check your model settings.";
+        } else {
+          try {
+            const m = rawErr.match(/API error \(\d+\): ([\s\S]+)/);
+            if (m) {
+              const parsed = JSON.parse(m[1]);
+              if (parsed.error?.message) toastMsg = `Generation failed: ${parsed.error.message}`;
+            }
+          } catch { /* ignore parse errors */ }
+        }
+        gallery.showToast(toastMsg, "error");
         if (data.prompt_id) {
           pendingOutputImages.delete(data.prompt_id);
           pendingOutputFetches.delete(data.prompt_id);
@@ -1641,10 +1656,35 @@
             const item = progress.completePrompt(p.promptId);
             promptLastActivity.delete(p.promptId);
             if (item) {
-              const images = pendingOutputImages.get(p.promptId) ?? [];
+              let images = pendingOutputImages.get(p.promptId) ?? [];
               pendingOutputImages.delete(p.promptId);
+
+              if (images.length === 0) {
+                // SSE event was likely dropped during a reconnect — the image was
+                // saved to a temp file on the server and cached by the cleanup
+                // reactor.  Try to recover it before giving up.
+                try {
+                  const recovered = await recoverPromptOutputs(p.promptId);
+                  for (const imgRef of recovered.images) {
+                    try {
+                      const resp = await fetch(
+                        `/internal-api/_temp_image/${encodeURIComponent(imgRef.temp_filename)}`,
+                        { headers: authHeaders() },
+                      );
+                      if (resp.ok) {
+                        const blob = await resp.blob();
+                        const url = URL.createObjectURL(blob);
+                        images.push({ blob, url, tempFilename: imgRef.temp_filename });
+                      }
+                    } catch { /* individual image fetch failed */ }
+                  }
+                } catch { /* recovery command failed */ }
+              }
+
               if (images.length > 0) {
                 finalizeOutputImages(p.promptId, item.mode, item.wasUpscaled, item.params, images);
+              } else {
+                gallery.showToast("A generation was lost due to a connection issue — please try again.", "error");
               }
             }
           }

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -922,6 +922,12 @@ class GenerationStore {
 
   /** Apply defaults if no checkpoint is selected yet (first run). */
   applyDefaultsIfNeeded(checkpoints: string[], vaes: string[]) {
+    // Always fix empty VAE for split-model users — VAELoader requires a real file.
+    // This covers existing users whose saved settings pre-date the VAE field.
+    if (this.useSplitModel && !this.vae && vaes.length > 0) {
+      this.vae = vaes.find((v) => v.includes("sdxl_vae")) ?? vaes[0];
+      this.saveSettings();
+    }
     if (this.checkpoint) return;
 
     // Look for the default SIH checkpoint

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -39,6 +39,12 @@ export async function getHistory(promptId: string): Promise<Record<string, unkno
   return ipcInvoke("get_history", { promptId });
 }
 
+export async function recoverPromptOutputs(
+  promptId: string,
+): Promise<{ images: Array<{ temp_filename: string }> }> {
+  return ipcInvoke("recover_prompt_outputs", { promptId });
+}
+
 export async function getQueue(): Promise<QueueInfo> {
   return ipcInvoke("get_queue");
 }


### PR DESCRIPTION
## Changes in v0.9.6

### Silent Generation Recovery After Reconnect
- **Images are no longer silently lost on reconnect** — if the SSE connection dropped mid-generation, output images could vanish with no error and no toast. A server-side cache now preserves each output image's temp filename keyed by prompt ID. If the reconciler detects a completed generation with no locally tracked images, it automatically fetches the cached images from the server and finalises the output as normal.
- **Error toast on total recovery failure** — if the server-side cache is also empty (e.g. the server restarted mid-generation), a clear error toast is shown: "A generation was lost due to a connection issue — please try again."

### Error Feedback for Failed Generations
- **Toast on `comfyui:execution_error`** — when ComfyUI reports a generation error (invalid VAE, missing model, validation failure), a descriptive error toast is now displayed rather than silently clearing the queue.

### Auto-Fix for Empty VAE in Split-Model Configurations
- Users with Anima / split-model checkpoints and an empty VAE setting now have the correct VAE automatically selected on next load, preventing the `vae_name: '' not in list` validation error.

---

**Files changed:**
- `src-tauri/src/state.rs` — `output_image_cache` field added to `AppState`
- `src-tauri/src/webserver.rs` — cleanup reactor caches output images by prompt ID; `recover_prompt_outputs` command added
- `src/lib/utils/api.ts` — `recoverPromptOutputs` exported
- `src/App.svelte` — reconciler uses server-side recovery; error toast on total failure
- `src/lib/stores/generation.svelte.ts` — auto-heals empty VAE on load
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` — version → 0.9.6
- `RELEASE_NOTES.md`, `CHANGELOG.md` — v0.9.6 section prepended