### PR TITLE
fix: pass Arc::clone(&state) to connect_websocket in server.rs (fixes desktop CI build)

### DIFF
--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -33,7 +33,7 @@ pub async fn start_comfyui(
             tokio::spawn(async move {
                 let state = app.state::<Arc<AppState>>();
                 if let Err(e) =
-                    websocket::connect_websocket(app.clone(), &state, event_tx.clone()).await
+                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone()).await
                 {
                     log::error!("Failed to connect WebSocket: {}", e);
                 }
@@ -55,7 +55,7 @@ pub async fn start_comfyui(
                     Ok(()) => {
                         log::info!("ComfyUI server is ready");
                         if let Err(e) =
-                            websocket::connect_websocket(app.clone(), &state, event_tx.clone())
+                            websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone())
                                 .await
                         {
                             log::error!("Failed to connect WebSocket: {}", e);
@@ -90,7 +90,7 @@ pub async fn start_comfyui(
             tokio::spawn(async move {
                 let state = app.state::<Arc<AppState>>();
                 if let Err(e) =
-                    websocket::connect_websocket(app.clone(), &state, event_tx.clone()).await
+                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone()).await
                 {
                     log::error!("Failed to connect WebSocket: {}", e);
                 }


### PR DESCRIPTION
## Problem

Three call sites in `commands/server.rs` were still passing `&state` (a `&tauri::State<'_, Arc<AppState>>`) after `connect_websocket`'s signature was changed to expect `Arc<AppState>` directly. This caused 3 `E0308` type mismatch errors that broke both Linux and Windows desktop Tauri builds since v0.9.9.

```
error[E0308]: mismatched types
  --> src/commands/server.rs:36:63
   |
   | ...connect_websocket(app.clone(), &state, event_tx.clone())
   |                                   ^^^^^^ expected `Arc<AppState>`, found `&State<'_, Arc<AppState>>`
```

The `commands/websocket.rs` call site was correctly updated to `Arc::clone(&state)` but `commands/server.rs` had 3 additional call sites that were missed.

## Fix

Change all 3 occurrences in `commands/server.rs` from `&state` to `Arc::clone(&state)`.