### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps `package.json`, `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json` from `1.0.0` → `1.0.1` to produce a new tagged release with the desktop CI build fix from #117.