### PR TITLE
v1.0.2: Fix double-queue bug and null-params crash in progress store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v1.0.2
+
+### Bug Fixes
+- **Double-queue on single generate fixed** — queuing one image no longer results in two generations. The Generate button now has an in-flight guard that prevents re-submission while a request is in progress, closing a race window between the button click and the server response.
+- **Crash in progress store fixed** — `completePrompt` no longer throws `TypeError: can't access property "seed", params is null` when a prompt was restored from the server queue snapshot after a page refresh. Restored prompts have `params: null` by design; the seed is now read safely.
+- **Reconciler no longer loops on null-params prompts** — the crash above prevented the restored prompt from being removed from the pending list, causing the reconciler to retry completion every 5 seconds indefinitely. Both issues are resolved together.
+
+---
+
 ## What's New in v1.0.0
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v1.0.2
+
+### Bug Fixes
+- **Double-queue on single generate fixed** — queuing one image no longer results in two generations. The Generate button now has an in-flight guard that prevents re-submission while a request is in progress, closing a race window between the button click and the server response.
+- **Crash in progress store fixed** — `completePrompt` no longer throws `TypeError: can't access property "seed", params is null` when a prompt was restored from the server queue snapshot after a page refresh. Restored prompts have `params: null` by design; the seed is now read safely.
+- **Reconciler no longer loops on null-params prompts** — the crash above prevented the restored prompt from being removed from the pending list, causing the reconciler to retry completion every 5 seconds indefinitely. Both issues are resolved together.
+
+---
+
 ## What's New in v1.0.0
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -15,12 +15,16 @@
 
   let { canvasEditorRef }: Props = $props();
   let errorMsg = $state<string | null>(null);
+  let isSubmitting = $state(false);
 
   async function handleGenerate() {
+    if (isSubmitting) return;
+    isSubmitting = true;
     errorMsg = null;
 
     if (!generation.checkpoint) {
       errorMsg = locale.t('generation.error_no_checkpoint');
+      isSubmitting = false;
       return;
     }
 
@@ -102,6 +106,8 @@
     } catch (e) {
       console.error("Generation failed:", e);
       errorMsg = String(e);
+    } finally {
+      isSubmitting = false;
     }
   }
 

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -207,7 +207,7 @@ class ProgressStore {
 
     if (item) {
       this._lastCompletedWasUpscaled = item.wasUpscaled;
-      if (item.params.seed != null && item.params.seed >= 0) {
+      if (item.params != null && item.params.seed != null && item.params.seed >= 0) {
         this.lastCompletedSeed = item.params.seed;
       }
     }


### PR DESCRIPTION
## v1.0.2

### Bug Fixes

- **Double-queue on single generate fixed** — generating one image no longer results in two images being queued. `handleGenerate` now has an `isSubmitting` in-flight guard that prevents re-submission while the network request is in progress, closing the race window between button click and server response.

- **Crash in progress store fixed** — `completePrompt` no longer throws `TypeError: can't access property "seed", params is null` when a prompt was restored from the server queue snapshot after a page refresh. Prompts restored via `restoreFromSnapshot` have `params: null` by design; the seed is now read safely with a null check.

- **Reconciler no longer loops on null-params prompts** — the crash above prevented the restored prompt from being removed from the pending list, causing the reconciler to retry completion every 5 seconds indefinitely. Both issues are resolved together.