### PR TITLE
v1.0.3: Fix visual double-queue from SSE/HTTP race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.0.3
+
+### Bug Fixes
+- **Visual double-queue on single generate fixed** — the queue counter no longer shows 2 when only 1 image is being generated. An SSE `queue_update` event could arrive before the HTTP response from `/prompt`, causing the same prompt_id to be inserted twice in the pending queue (once by `restoreFromSnapshot` and again by `enqueue`). `enqueue` is now idempotent by `promptId`: if an entry already exists (e.g. injected by the SSE snapshot), it's upgraded in place with the real params/mode instead of appending a duplicate.
+
+---
+
 ## What's New in v1.0.2
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.0.3
+
+### Bug Fixes
+- **Visual double-queue on single generate fixed** — the queue counter no longer shows 2 when only 1 image is being generated. An SSE `queue_update` event could arrive before the HTTP response from `/prompt`, causing the same prompt_id to be inserted twice in the pending queue (once by `restoreFromSnapshot` and again by `enqueue`). `enqueue` is now idempotent by `promptId`: if an entry already exists (e.g. injected by the SSE snapshot), it's upgraded in place with the real params/mode instead of appending a duplicate.
+
+---
+
 ## What's New in v1.0.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 license = "MIT"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -171,13 +171,33 @@ class ProgressStore {
     this.queueTotal = 0;
   }
 
-  /** Add a new prompt to the queue. */
+  /** Add a new prompt to the queue.
+   *
+   * Idempotent by promptId: if the prompt is already tracked (e.g. inserted by
+   * `restoreFromSnapshot` after an SSE `queue_update` event raced the HTTP
+   * response), the existing entry is upgraded with the real params/mode instead
+   * of appending a duplicate. Without this, the same prompt_id can appear twice
+   * in `pendingPrompts`, making the queue display show 2 when only 1 image is
+   * being generated.
+   */
   enqueue(
     promptId: string,
     wasUpscaled: boolean = false,
     mode: "txt2img" | "img2img" | "inpainting" = "txt2img",
     params: GenerationParams | null = null,
   ) {
+    const existingIdx = this.pendingPrompts.findIndex((p) => p.promptId === promptId);
+    if (existingIdx >= 0) {
+      const next = [...this.pendingPrompts];
+      next[existingIdx] = {
+        promptId,
+        mode,
+        wasUpscaled,
+        params: params!,
+      };
+      this.pendingPrompts = next;
+      return;
+    }
     this.pendingPrompts = [
       ...this.pendingPrompts,
       {


### PR DESCRIPTION
## v1.0.3

### Bug Fixes

- **Visual double-queue on single generate fixed** — the queue counter no longer shows 2 when only 1 image is being generated.

### Root cause

An SSE `mooshie:queue_update` event could arrive **before** the HTTP response from `/prompt` resolved. The SSE listener in `App.svelte` calls `progress.restoreFromSnapshot([prompt_id])` when it sees a prompt_id that isn't yet tracked locally, which inserts an entry with `params: null`. Moments later the `handleGenerate` HTTP response resolved and unconditionally appended a second entry via `progress.enqueue(...)` — same `promptId`, two rows in `pendingPrompts`. Only one image was actually generated, but the queue display read `pendingPrompts.length === 2`.

### Fix

`enqueue()` is now idempotent by `promptId`: if a matching entry already exists (e.g. a null-params placeholder injected by `restoreFromSnapshot`), it's upgraded in place with the real params/mode instead of appending a duplicate.