### PR TITLE
v1.0.5: Embed frontend in binary, richer diagnostic logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v1.0.5
+
+### Bug Fixes
+- **Browser mode no longer shows "Not found"** — production installs of MooshieUI couldn't serve the UI in browser mode because the frontend `dist/` directory isn't unpacked next to the installed binary. The embedded web server now falls back to assets compiled into the binary at build time (via `rust-embed`), so opening the browser-mode URL works on every install, not just dev checkouts.
+- **Diagnostic logs now include frontend + Rust state** — the "Export Diagnostic Logs" button in Settings previously only captured ComfyUI's stderr. Exported logs now also contain a bounded ring buffer of Rust-side `log::info!`/`warn!`/`error!` output plus a capture of the frontend console (including uncaught errors and unhandled promise rejections). This is critical for diagnosing "button does nothing" bug reports on Windows app mode where users can't open dev tools.
+
+---
+
 ## What's New in v1.0.4
 
 ### Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v1.0.5
+
+### Bug Fixes
+- **Browser mode no longer shows "Not found"** — production installs of MooshieUI couldn't serve the UI in browser mode because the frontend `dist/` directory isn't unpacked next to the installed binary. The embedded web server now falls back to assets compiled into the binary at build time (via `rust-embed`), so opening the browser-mode URL works on every install, not just dev checkouts.
+- **Diagnostic logs now include frontend + Rust state** — the "Export Diagnostic Logs" button in Settings previously only captured ComfyUI's stderr. Exported logs now also contain a bounded ring buffer of Rust-side `log::info!`/`warn!`/`error!` output plus a capture of the frontend console (including uncaught errors and unhandled promise rejections). This is critical for diagnosing "button does nothing" bug reports on Windows app mode where users can't open dev tools.
+
+---
+
 ## What's New in v1.0.4
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "argon2",
  "axum",
@@ -620,6 +620,7 @@ dependencies = [
  "rand 0.10.0",
  "reqwest 0.12.28",
  "rusqlite",
+ "rust-embed",
  "serde",
  "serde_json",
  "sha2",
@@ -4188,6 +4189,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4673,6 +4709,15 @@ dependencies = [
  "libc",
  "sigchld",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"
@@ -76,6 +76,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 open = "5"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
+rust-embed = { version = "8", features = ["interpolate-folder-path"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "=2.0.2", optional = true }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,13 @@
 fn main() {
+    // rust-embed requires `../dist/` to exist at compile time. In CI or a
+    // fresh checkout we may build before `npm run build` has produced the
+    // frontend bundle, so create an empty placeholder if it's missing.
+    let dist = std::path::Path::new("../dist");
+    if !dist.exists() {
+        let _ = std::fs::create_dir_all(dist);
+    }
+    println!("cargo:rerun-if-changed=../dist");
+
     #[cfg(feature = "desktop")]
     tauri_build::build();
 }

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -274,25 +274,19 @@ pub async fn connect_websocket(
                                         let alias_state = Arc::clone(&ws_state);
                                         let alias_pid = resolved.clone();
                                         tokio::spawn(async move {
-                                            tokio::time::sleep(
-                                                std::time::Duration::from_secs(5),
-                                            )
-                                            .await;
+                                            tokio::time::sleep(std::time::Duration::from_secs(5))
+                                                .await;
                                             alias_state.prompt_queue.cleanup_alias(&alias_pid);
                                         });
                                         if let Some(worker_id) = wid {
-                                            ws_state
-                                                .gpu_manager
-                                                .mark_worker_idle(worker_id)
-                                                .await;
+                                            ws_state.gpu_manager.mark_worker_idle(worker_id).await;
                                         }
                                         ws_state.prompt_queue.drain_notify.notify_one();
                                         // Broadcast updated queue positions to the Tauri
                                         // frontend. broadcast_queue_positions() uses event_tx
                                         // (SSE-only); we must call app.emit() directly here.
                                         let updates: Vec<serde_json::Value> = {
-                                            let queue =
-                                                ws_state.prompt_queue.queue.read().unwrap();
+                                            let queue = ws_state.prompt_queue.queue.read().unwrap();
                                             let total = queue.len();
                                             queue
                                                 .iter()
@@ -324,14 +318,12 @@ pub async fn connect_websocket(
                                     // Prompt failed — release GPU worker so the next generation
                                     // can proceed. Without this the worker stays in Running state
                                     // and submit_prompt blocks for 300 s before timing out.
-                                    let resolved =
-                                        ws_state.prompt_queue.resolve_alias(prompt_id);
+                                    let resolved = ws_state.prompt_queue.resolve_alias(prompt_id);
                                     let wid = ws_state.prompt_queue.finish(&resolved);
                                     let alias_state = Arc::clone(&ws_state);
                                     let alias_pid = resolved.clone();
                                     tokio::spawn(async move {
-                                        tokio::time::sleep(std::time::Duration::from_secs(5))
-                                            .await;
+                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                                         alias_state.prompt_queue.cleanup_alias(&alias_pid);
                                     });
                                     if let Some(worker_id) = wid {

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2686,8 +2686,15 @@ fn collect_image_files_recursive(
 pub async fn export_logs(
     state: State<'_, Arc<AppState>>,
     destination: String,
+    frontend_logs: Option<Vec<String>>,
 ) -> Result<(), AppError> {
     use std::fmt::Write;
+
+    // Fold any newly-submitted frontend logs into the ring buffer so repeat
+    // exports include previous captures too.
+    if let Some(lines) = frontend_logs {
+        crate::log_buffer::push_frontend_lines(lines);
+    }
 
     let mut output = String::with_capacity(16 * 1024);
 
@@ -2820,8 +2827,42 @@ pub async fn export_logs(
         }
     }
 
+    // Rust-side log ring buffer (captured by log_buffer::RingLogger)
+    let rust_lines = crate::log_buffer::snapshot_rust();
+    if !rust_lines.is_empty() {
+        let _ = writeln!(output);
+        let _ = writeln!(output, "=== Rust Log (last {} lines) ===", rust_lines.len());
+        for line in &rust_lines {
+            let _ = writeln!(output, "{}", line);
+        }
+    }
+
+    // Frontend console ring buffer (captured by src/lib/utils/log-buffer.ts)
+    let frontend_lines = crate::log_buffer::snapshot_frontend();
+    if !frontend_lines.is_empty() {
+        let _ = writeln!(output);
+        let _ = writeln!(
+            output,
+            "=== Frontend Console (last {} lines) ===",
+            frontend_lines.len()
+        );
+        for line in &frontend_lines {
+            let _ = writeln!(output, "{}", line);
+        }
+    }
+
     // Write to destination
     std::fs::write(&destination, &output)?;
+    Ok(())
+}
+
+/// Append a batch of frontend console log lines to the in-memory diagnostics
+/// ring buffer. Called opportunistically by the UI so that exported logs
+/// include frontend state even when a crash prevents exporting normally.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn append_frontend_logs(lines: Vec<String>) -> Result<(), AppError> {
+    crate::log_buffer::push_frontend_lines(lines);
     Ok(())
 }
 

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -33,7 +33,8 @@ pub async fn start_comfyui(
             tokio::spawn(async move {
                 let state = app.state::<Arc<AppState>>();
                 if let Err(e) =
-                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone()).await
+                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone())
+                        .await
                 {
                     log::error!("Failed to connect WebSocket: {}", e);
                 }
@@ -54,9 +55,12 @@ pub async fn start_comfyui(
                 match process::wait_for_ready(&state, 120).await {
                     Ok(()) => {
                         log::info!("ComfyUI server is ready");
-                        if let Err(e) =
-                            websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone())
-                                .await
+                        if let Err(e) = websocket::connect_websocket(
+                            app.clone(),
+                            Arc::clone(&state),
+                            event_tx.clone(),
+                        )
+                        .await
                         {
                             log::error!("Failed to connect WebSocket: {}", e);
                         }
@@ -90,7 +94,8 @@ pub async fn start_comfyui(
             tokio::spawn(async move {
                 let state = app.state::<Arc<AppState>>();
                 if let Err(e) =
-                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone()).await
+                    websocket::connect_websocket(app.clone(), Arc::clone(&state), event_tx.clone())
+                        .await
                 {
                     log::error!("Failed to connect WebSocket: {}", e);
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gallery_index;
 #[cfg(any(feature = "desktop", feature = "server"))]
 pub mod interrogator;
 pub mod jxl;
+pub mod log_buffer;
 pub mod metadata;
 #[cfg(feature = "desktop")]
 pub mod setup;
@@ -91,11 +92,10 @@ fn fix_wayland_appimage_env() {
 pub fn run() {
     use tauri::{Manager, RunEvent};
 
-    // Enable Rust log output in desktop mode (env_logger was only initialised
-    // in server_main.rs, so all log::info!/warn!/error! were no-ops here).
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .format_timestamp_millis()
-        .init();
+    // Enable Rust log output in desktop mode. A ring-buffer logger is used
+    // (instead of plain env_logger) so the diagnostics export can include
+    // recent Rust-side logs even when the user has no dev console access.
+    log_buffer::init();
 
     // Fix WebKitGTK scroll jank and rendering glitches on NVIDIA + Wayland.
     // The DMA-BUF renderer is broken with NVIDIA proprietary drivers.
@@ -387,6 +387,7 @@ pub fn run() {
             commands::api::fetch_release_notes,
             commands::api::import_image_directory,
             commands::api::export_logs,
+            commands::api::append_frontend_logs,
             commands::api::check_node_available,
             commands::api::is_custom_node_installed,
             commands::api::install_custom_node,

--- a/src-tauri/src/log_buffer.rs
+++ b/src-tauri/src/log_buffer.rs
@@ -1,0 +1,119 @@
+//! Bounded in-memory ring buffers for diagnostic log capture.
+//!
+//! Two buffers are maintained:
+//! - `rust`: fed by a custom `log::Log` implementation that also writes to
+//!   stderr, so every `log::info!`/`warn!`/`error!` ends up in the buffer.
+//! - `frontend`: fed explicitly by the `append_frontend_logs` command, which
+//!   the UI calls when exporting diagnostics.
+//!
+//! Both buffers are capped and discard oldest entries first so they can't
+//! grow unboundedly during long sessions.
+
+use std::collections::VecDeque;
+use std::io::Write;
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+const MAX_LINES: usize = 2000;
+
+static RUST_BUFFER: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+static FRONTEND_BUFFER: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+
+fn rust_buf() -> &'static Mutex<VecDeque<String>> {
+    RUST_BUFFER.get_or_init(|| Mutex::new(VecDeque::with_capacity(MAX_LINES)))
+}
+
+fn frontend_buf() -> &'static Mutex<VecDeque<String>> {
+    FRONTEND_BUFFER.get_or_init(|| Mutex::new(VecDeque::with_capacity(MAX_LINES)))
+}
+
+fn push_bounded(buffer: &Mutex<VecDeque<String>>, line: String) {
+    if let Ok(mut b) = buffer.lock() {
+        while b.len() >= MAX_LINES {
+            b.pop_front();
+        }
+        b.push_back(line);
+    }
+}
+
+/// Append a batch of frontend log lines to the ring buffer.
+pub fn push_frontend_lines<I, S>(lines: I)
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let buf = frontend_buf();
+    for line in lines {
+        push_bounded(buf, line.into());
+    }
+}
+
+/// Return a snapshot of the Rust-side log ring buffer.
+pub fn snapshot_rust() -> Vec<String> {
+    rust_buf()
+        .lock()
+        .map(|b| b.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Return a snapshot of the frontend log ring buffer.
+pub fn snapshot_frontend() -> Vec<String> {
+    frontend_buf()
+        .lock()
+        .map(|b| b.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+struct RingLogger {
+    level: LevelFilter,
+}
+
+impl Log for RingLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f");
+        let line = format!(
+            "[{}] {:<5} {} - {}",
+            ts,
+            record.level(),
+            record.target(),
+            record.args()
+        );
+        // Best-effort stderr write — a closed stderr shouldn't crash logging.
+        let _ = writeln!(std::io::stderr(), "{}", line);
+        push_bounded(rust_buf(), line);
+    }
+
+    fn flush(&self) {
+        let _ = std::io::stderr().flush();
+    }
+}
+
+/// Initialise the ring-buffer-backed logger. Safe to call multiple times;
+/// subsequent calls after the first are no-ops.
+pub fn init() {
+    let level = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|s| {
+            // Support simple `info` / `debug` / `warn` and env_logger-style
+            // `mooshie=debug,hyper=warn` (take the first level we can parse).
+            s.split(',')
+                .map(|chunk| chunk.rsplit('=').next().unwrap_or(chunk).trim())
+                .find_map(|lvl| lvl.parse::<Level>().ok())
+        })
+        .map(|lvl| lvl.to_level_filter())
+        .unwrap_or(LevelFilter::Info);
+
+    // set_boxed_logger fails if a logger is already installed; ignore that
+    // case so tests / repeat calls don't panic.
+    if log::set_boxed_logger(Box::new(RingLogger { level })).is_ok() {
+        log::set_max_level(level);
+    }
+}

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -13,7 +13,7 @@ use comfyui_desktop_lib::{temp_images, webserver};
 
 #[tokio::main]
 async fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    comfyui_desktop_lib::log_buffer::init();
 
     log::info!("MooshieUI Server starting...");
 

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -371,7 +371,10 @@ async fn step_install_python(app: &AppHandle, base: &Path) -> Result<(), String>
     // Try once; on failure, fall back to `--reinstall` which forces uv to
     // purge and re-extract the CPython archive (handles the rarer case where
     // our heuristic above didn't match but the install dir is still broken).
-    if run_logged(app, uv.to_str().unwrap(), &args, &env).await.is_ok() {
+    if run_logged(app, uv.to_str().unwrap(), &args, &env)
+        .await
+        .is_ok()
+    {
         return Ok(());
     }
     emit_log(app, "Python install failed; retrying with --reinstall...");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -290,11 +290,7 @@ impl PromptQueue {
             .unwrap()
             .insert(comfyui_id.to_string(), username);
         // Check if completion/error arrived before this alias was bound.
-        let was_deferred = self
-            .deferred_finishes
-            .write()
-            .unwrap()
-            .remove(comfyui_id);
+        let was_deferred = self.deferred_finishes.write().unwrap().remove(comfyui_id);
         if was_deferred {
             self.worker_map.write().unwrap().remove(placeholder_id);
             self.queue

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -24,6 +24,15 @@ use crate::commands;
 use crate::config;
 use crate::state::AppState;
 
+/// Frontend assets embedded at compile time from `../dist/`. Used as a
+/// fallback when the on-disk dist directory isn't found (e.g. installed
+/// production builds where the dist folder isn't unpacked next to the exe).
+/// In dev builds rust-embed reads from disk at runtime, so `npm run dev`
+/// output is picked up without rebuilding the Rust binary.
+#[derive(rust_embed::Embed)]
+#[folder = "$CARGO_MANIFEST_DIR/../dist/"]
+struct FrontendAssets;
+
 /// Shared state for axum handlers.
 pub struct WebState {
     pub app: Arc<AppState>,
@@ -514,8 +523,7 @@ pub async fn start_server(
                                 drain_state
                                     .prompt_queue
                                     .set_worker(&hp.placeholder_id, worker_id);
-                                *hp.result.lock().await =
-                                    Some(Ok((response.prompt_id, worker_id)));
+                                *hp.result.lock().await = Some(Ok((response.prompt_id, worker_id)));
                             }
                         }
                         Err(e) => {
@@ -605,62 +613,93 @@ fn resolve_dist_dir() -> PathBuf {
         }
     }
 
-    // Fallback — will 404 on requests but won't crash
-    log::warn!(
-        "Could not find frontend dist directory, tried: {:?}",
+    // No on-disk dist found — production builds rely on the compile-time
+    // embedded FrontendAssets instead, so this is not necessarily an error.
+    log::info!(
+        "No on-disk frontend dist directory; using embedded assets. Searched: {:?}",
         candidates
     );
     candidates[0].clone()
 }
 
-/// Serve static files from the dist directory.
+/// Serve static files from the dist directory, falling back to assets
+/// embedded into the binary at compile time.
+///
+/// Lookup order:
+///   1. File on disk under `dist_dir` (prefers freshly-built `npm run dev`
+///      / `npm run build` output for dev workflows).
+///   2. Embedded asset at the same relative path.
+///   3. Embedded `index.html` (SPA fallback).
+///
+/// Production installs typically hit path 2/3 because the Tauri bundle
+/// embeds the frontend into the binary via the asset protocol and does
+/// not copy `dist/` next to the exe. Before this fallback existed, every
+/// browser-mode request in a production install returned 404 ("Not Found").
 async fn serve_static(dist_dir: PathBuf, req: axum::extract::Request) -> Response {
-    let path = req.uri().path().trim_start_matches('/');
-    let file_path = if path.is_empty() {
-        dist_dir.join("index.html")
+    let raw_path = req.uri().path().trim_start_matches('/');
+    let rel_path = if raw_path.is_empty() {
+        "index.html"
     } else {
-        dist_dir.join(path)
+        raw_path
     };
 
-    // If the path doesn't exist, serve index.html (SPA fallback)
-    let file_path = if file_path.exists() && file_path.is_file() {
-        file_path
-    } else {
-        dist_dir.join("index.html")
-    };
-
-    match tokio::fs::read(&file_path).await {
-        Ok(contents) => {
-            let mime = mime_guess::from_path(&file_path)
-                .first_or_octet_stream()
-                .to_string();
-
-            // Inject browser-mode flag into HTML so the frontend IPC layer
-            // knows to use HTTP endpoints instead of Tauri IPC.
-            let contents = if mime == "text/html" {
-                let html = String::from_utf8_lossy(&contents);
-                let injected = html.replacen(
-                    "<head>",
-                    "<head><script>window.__MOOSHIE_BROWSER_MODE__=true;</script>",
-                    1,
-                );
-                injected.into_bytes()
-            } else {
-                contents
-            };
-
-            (
-                StatusCode::OK,
-                [
-                    ("content-type", mime),
-                    ("cache-control", "no-cache".to_string()),
-                ],
-                contents,
-            )
-                .into_response()
+    // 1. On-disk first so hot-reloaded dev builds override any stale
+    //    compile-time embed.
+    let disk_path = dist_dir.join(rel_path);
+    if disk_path.is_file() {
+        if let Ok(contents) = tokio::fs::read(&disk_path).await {
+            return build_asset_response(rel_path, contents);
         }
-        Err(_) => (StatusCode::NOT_FOUND, "Not Found").into_response(),
     }
+
+    // 2. Embedded fallback.
+    if let Some(file) = FrontendAssets::get(rel_path) {
+        return build_asset_response(rel_path, file.data.into_owned());
+    }
+
+    // 3. SPA fallback — serve index.html for unknown client-side routes.
+    let index_disk = dist_dir.join("index.html");
+    if index_disk.is_file() {
+        if let Ok(contents) = tokio::fs::read(&index_disk).await {
+            return build_asset_response("index.html", contents);
+        }
+    }
+    if let Some(file) = FrontendAssets::get("index.html") {
+        return build_asset_response("index.html", file.data.into_owned());
+    }
+
+    (StatusCode::NOT_FOUND, "Not Found").into_response()
+}
+
+/// Build an HTTP response for a static asset. Injects the browser-mode flag
+/// into HTML payloads so the frontend IPC layer routes through HTTP instead
+/// of Tauri.
+fn build_asset_response(rel_path: &str, contents: Vec<u8>) -> Response {
+    let mime = mime_guess::from_path(rel_path)
+        .first_or_octet_stream()
+        .to_string();
+
+    let contents = if mime == "text/html" {
+        let html = String::from_utf8_lossy(&contents);
+        let injected = html.replacen(
+            "<head>",
+            "<head><script>window.__MOOSHIE_BROWSER_MODE__=true;</script>",
+            1,
+        );
+        injected.into_bytes()
+    } else {
+        contents
+    };
+
+    (
+        StatusCode::OK,
+        [
+            ("content-type", mime),
+            ("cache-control", "no-cache".to_string()),
+        ],
+        contents,
+    )
+        .into_response()
 }
 
 /// Health check endpoint for K8s liveness/readiness probes.
@@ -2999,6 +3038,16 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing destination")?
                 .to_string();
+            // Fold any frontend logs from the payload into the shared ring
+            // buffer before exporting so this handler matches the desktop
+            // command's behaviour.
+            if let Some(lines) = args.get("frontendLogs").and_then(|v| v.as_array()) {
+                let strings: Vec<String> = lines
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                crate::log_buffer::push_frontend_lines(strings);
+            }
             // Simplified: just write config info to the destination
             let cfg = state.config.read().await;
             let info = format!("MooshieUI Log Export\nConfig: {:?}", *cfg);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,4 +1,5 @@
 import { ipcInvoke, isBrowserMode, isTauri } from "./ipc.js";
+import { getLogSnapshot } from "./log-buffer.js";
 import { locale } from "../stores/locale.svelte.js";
 import type {
   AppConfig,
@@ -612,7 +613,10 @@ export async function readClipboardImageSafe(): Promise<number[]> {
 }
 
 export async function exportLogs(destination: string): Promise<void> {
-  return ipcInvoke("export_logs", { destination });
+  return ipcInvoke("export_logs", {
+    destination,
+    frontendLogs: getLogSnapshot(),
+  });
 }
 
 export async function getGpuStats(): Promise<GpuStats[]> {

--- a/src/lib/utils/log-buffer.ts
+++ b/src/lib/utils/log-buffer.ts
@@ -1,0 +1,69 @@
+// Bounded frontend console ring buffer for diagnostic export.
+//
+// Intercepts console.{log,info,warn,error,debug} plus uncaught errors and
+// unhandled promise rejections, storing the last N formatted lines in
+// memory. The buffer is included in exported diagnostic logs so bug reports
+// contain frontend state even when the user has no dev-tools access (Tauri
+// app mode on Windows/macOS doesn't expose them in release builds).
+
+const MAX_LINES = 1000;
+const buffer: string[] = [];
+
+function formatArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) {
+    return value.stack ?? `${value.name}: ${value.message}`;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function appendLine(level: string, args: unknown[]): void {
+  try {
+    const ts = new Date().toISOString();
+    const body = args.map(formatArg).join(" ");
+    const line = `[${ts}] ${level.toUpperCase().padEnd(5)} - ${body}`;
+    buffer.push(line);
+    while (buffer.length > MAX_LINES) buffer.shift();
+  } catch {
+    // Never let logging crash the caller
+  }
+}
+
+/** Snapshot of the frontend console ring buffer. */
+export function getLogSnapshot(): string[] {
+  return buffer.slice();
+}
+
+/**
+ * Install console and global-error interceptors. Safe to call once at app
+ * startup; subsequent calls are no-ops.
+ */
+let installed = false;
+export function installConsoleInterceptor(): void {
+  if (installed) return;
+  installed = true;
+
+  const levels = ["log", "info", "warn", "error", "debug"] as const;
+  for (const level of levels) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      appendLine(level, args);
+      original(...args);
+    };
+  }
+
+  window.addEventListener("error", (event) => {
+    appendLine("error", [
+      `${event.message} at ${event.filename ?? "?"}:${event.lineno ?? 0}:${event.colno ?? 0}`,
+      event.error,
+    ]);
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    appendLine("error", ["unhandledrejection:", event.reason]);
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import "./app.css";
+import { installConsoleInterceptor } from "./lib/utils/log-buffer.js";
 import App from "./App.svelte";
 import { mount } from "svelte";
+
+// Install before mounting so startup logs are captured.
+installConsoleInterceptor();
 
 const app = mount(App, { target: document.getElementById("app")! });
 


### PR DESCRIPTION
## What's New in v1.0.5

### Bug Fixes
- **Browser mode no longer shows "Not found"** — production installs couldn't serve the UI in browser mode because the frontend `dist/` directory isn't unpacked next to the installed binary. The embedded web server now falls back to assets compiled into the binary at build time (via `rust-embed`), so opening the browser-mode URL works on every install, not just dev checkouts. Fixes the "Not found" symptom reported in #102.
- **Diagnostic logs now include frontend + Rust state** — the "Export Diagnostic Logs" button in Settings previously only captured ComfyUI's stderr. Exported logs now also contain a bounded ring buffer of Rust-side `log::info!`/`warn!`/`error!` output plus a capture of the frontend console (including uncaught errors and unhandled promise rejections). This is critical for diagnosing "button does nothing" bug reports on Windows app mode where users can't open dev tools.

### Implementation notes
- New `FrontendAssets` struct in `webserver.rs` backed by `rust-embed` pointed at `$CARGO_MANIFEST_DIR/../dist/`. `serve_static` tries on-disk first, then embedded, then embedded `index.html` (SPA fallback), then 404.
- New `src-tauri/src/log_buffer.rs` with two bounded (2000-line) ring buffers and a custom `log::Log` implementation. Replaces the `env_logger` init in both `lib.rs` (desktop) and `server_main.rs` (headless server). Still honours `RUST_LOG`.
- New `src/lib/utils/log-buffer.ts` installs a console interceptor for `log/info/warn/error/debug` plus `window.onerror` and `unhandledrejection`. Installed from `main.ts` before `mount()`.
- `export_logs` extended with `frontend_logs: Option<Vec<String>>`. New `append_frontend_logs` Tauri command registered for future defensive telemetry.
- `build.rs` creates `../dist/` placeholder so fresh clones compile before `npm run build`.