### PR TITLE
v1.0.6: Fix build-server compilation for Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.0.6
+
+### Build Fixes
+- **Docker image publish restored** — the `build-server` job (which produces the headless Linux server binary that the Docker image wraps) was failing because three `tauri::` references leaked into the server-only build path, which doesn't link the `tauri` crate. The `#[tauri::command]` attribute on `load_gallery_image_png` is now gated behind `#[cfg(feature = "desktop")]`, and the two `tauri::async_runtime::spawn` calls in the prompt-queue cleanup reactor and stuck-worker watchdog (in `webserver.rs`) have been swapped for `tokio::spawn`. No user-visible changes; the desktop installers are functionally identical to v1.0.5.
+
+---
+
 ## What's New in v1.0.5
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -629,6 +629,7 @@ pub async fn load_gallery_image(filename: String) -> Result<Vec<u8>, AppError> {
 /// Load a gallery image and encode as PNG. JXL files are decoded via jxl-oxide
 /// and re-encoded as PNG. Used when copying/saving/downloading — PNG is the
 /// portable export format that supports metadata embedding.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn load_gallery_image_png(filename: String) -> Result<Vec<u8>, AppError> {
     if filename.contains('/') || filename.contains('\\') || filename.contains("..") {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -214,7 +214,7 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
 
     let cleanup_state = state;
     let mut cleanup_rx = cleanup_state.event_tx.subscribe();
-    tauri::async_runtime::spawn(async move {
+    tokio::spawn(async move {
         loop {
             match cleanup_rx.recv().await {
                 Ok(evt) => {
@@ -294,7 +294,7 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
 /// app init which calls both).
 pub fn spawn_stuck_worker_watchdog(state: Arc<AppState>) {
     let watchdog_state = state;
-    tauri::async_runtime::spawn(async move {
+    tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         let max_stuck_secs = 600u64;
         loop {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Three `tauri::` references leaked into the server-only build path (which does not link the `tauri` crate), causing the `build-server` job to fail on v1.0.4 and v1.0.5 and skipping `docker-publish`.

## Changes

- **`api.rs`**: gate `#[tauri::command]` on `load_gallery_image_png` behind `#[cfg(feature = "desktop")]`
- **`webserver.rs`**: swap `tauri::async_runtime::spawn` for `tokio::spawn` in the prompt cleanup reactor and stuck-worker watchdog

## Verification

Both builds compile cleanly locally:

```
cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server --bin mooshieui-server  # ✓
cargo check --manifest-path src-tauri/Cargo.toml                                                                 # ✓
```

## Notes

No user-visible changes; desktop installers will be functionally identical to v1.0.5. This restores the Docker image publish.