### PR TITLE
v1.0.7: Fix desktop startup panic (tokio::spawn outside runtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.0.7
+
+### Critical Fixes
+- **Desktop app launches again (fixes #102, #124)** — v1.0.6 shipped a regression where the installed app closed instantly on Windows (and would have panicked on any desktop platform). The prompt-cleanup reactor and stuck-worker watchdog in `webserver.rs` were swapped from `tauri::async_runtime::spawn` to `tokio::spawn` to unblock the server-only Docker build, but those reactors are started from Tauri's synchronous `.setup()` hook, which runs *before* any Tokio runtime is entered on that thread — so `tokio::spawn` panicked with "there is no reactor running" and killed the process during startup. The spawns are now cfg-gated: desktop builds use `tauri::async_runtime::spawn` (Tauri's runtime handle, works outside a runtime context), while the headless server build (which always calls these from `#[tokio::main]`) keeps using `tokio::spawn`. No other behavioural changes.
+
+---
+
 ## What's New in v1.0.6
 
 ### Build Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+## What's New in v1.0.7
+
+### Critical Fixes
+- **Desktop app launches again (supersedes v1.0.6; fixes #102, #124)** — v1.0.6 shipped a regression that caused the installed app to exit immediately on startup (on Windows this looked like "the installer closes instantly"; existing installs simply wouldn't open). The prompt-cleanup reactor and stuck-worker watchdog in `webserver.rs` had been swapped from `tauri::async_runtime::spawn` to `tokio::spawn` to unblock the headless server/Docker build, but those two tasks are spawned from Tauri's synchronous `.setup()` hook — which runs on the main init thread before any Tokio runtime is entered on that thread — so `tokio::spawn` panicked with "there is no reactor running, must be called from the context of a Tokio 1.x runtime" and killed the process. The two spawns are now cfg-gated: desktop builds use `tauri::async_runtime::spawn` (safe to call outside a runtime context), while the headless server build (always invoked from `#[tokio::main]`) keeps `tokio::spawn`. v1.0.7 is functionally equivalent to v1.0.5 plus the Docker publish fix originally shipped in v1.0.6.
+
+---
+
+## What's New in v1.0.6
+
+### Build Fixes
+- **Docker image publish restored** — the `build-server` job (which produces the headless Linux server binary the Docker image wraps) was failing because three `tauri::` references leaked into the server-only build path, which doesn't link the `tauri` crate. The `#[tauri::command]` attribute on `load_gallery_image_png` is now gated behind `#[cfg(feature = "desktop")]`, and the two `tauri::async_runtime::spawn` calls in the prompt-queue cleanup reactor and stuck-worker watchdog (in `webserver.rs`) were swapped for `tokio::spawn`. **Note:** the latter change caused the desktop startup regression fixed in v1.0.7 — please upgrade straight to v1.0.7.
+
+---
+
 ## What's New in v1.0.5
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -214,7 +214,14 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
 
     let cleanup_state = state;
     let mut cleanup_rx = cleanup_state.event_tx.subscribe();
-    tokio::spawn(async move {
+    // NOTE: this function is invoked from Tauri's `.setup()` in the desktop
+    // build, which runs synchronously on the main init thread *before* any
+    // Tokio runtime is entered on that thread. Calling `tokio::spawn` there
+    // panics with "there is no reactor running..." (regression observed in
+    // v1.0.6 on Windows — installer/app exits immediately). The server build
+    // (`feature = "server"`) does not link `tauri` and always calls this
+    // from `#[tokio::main]`, so `tokio::spawn` is safe there.
+    let cleanup_fut = async move {
         loop {
             match cleanup_rx.recv().await {
                 Ok(evt) => {
@@ -281,7 +288,11 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
-    });
+    };
+    #[cfg(feature = "desktop")]
+    tauri::async_runtime::spawn(cleanup_fut);
+    #[cfg(not(feature = "desktop"))]
+    tokio::spawn(cleanup_fut);
 }
 
 /// Spawn the stuck-worker watchdog.  Every 60s, checks for workers that have
@@ -294,7 +305,10 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
 /// app init which calls both).
 pub fn spawn_stuck_worker_watchdog(state: Arc<AppState>) {
     let watchdog_state = state;
-    tokio::spawn(async move {
+    // See note in `spawn_prompt_cleanup_reactor` above — desktop init runs
+    // outside a Tokio runtime context, so we must use Tauri's runtime handle
+    // there. Server build has no tauri crate but is always inside tokio::main.
+    let watchdog_fut = async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         let max_stuck_secs = 600u64;
         loop {
@@ -333,7 +347,11 @@ pub fn spawn_stuck_worker_watchdog(state: Arc<AppState>) {
                 }
             }
         }
-    });
+    };
+    #[cfg(feature = "desktop")]
+    tauri::async_runtime::spawn(watchdog_fut);
+    #[cfg(not(feature = "desktop"))]
+    tokio::spawn(watchdog_fut);
 }
 
 pub async fn start_server(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Hotfix for v1.0.6 which panicked on desktop startup (fixes #102, #124).

## Root cause

In v1.0.6, two background task spawns in `src-tauri/src/webserver.rs` (`spawn_prompt_cleanup_reactor` and `spawn_stuck_worker_watchdog`) were changed from `tauri::async_runtime::spawn` → `tokio::spawn` to unblock the headless server/Docker build (which doesn't link the `tauri` crate).

However, both functions are invoked from Tauri's synchronous `.setup()` hook during app init, which runs on the main thread **before any Tokio runtime is entered on that thread**. So `tokio::spawn(...)` panicked with `"there is no reactor running, must be called from the context of a Tokio 1.x runtime"` and the process exited immediately — which on Windows looked exactly like "the installer closes instantly" (#124) and on existing installs like "the app won't open at all" (#102 follow-up).

## Fix

The two spawns are now cfg-gated:
- Desktop builds (`feature = "desktop"`) use `tauri::async_runtime::spawn` — goes through Tauri's stored runtime handle, safe to call outside a Tokio context.
- Headless server build (`feature = "server"`, always called from `#[tokio::main]`) keeps `tokio::spawn`.

Both build paths verified with `cargo check`. No other behavioural changes — v1.0.7 is functionally equivalent to v1.0.5 plus the Docker publish fix originally shipped in v1.0.6.

## Changes

- `src-tauri/src/webserver.rs`: cfg-gate the two outer spawns, add explanatory comments
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`: bump to 1.0.7
- `src-tauri/Cargo.lock`: auto-updated
- `CHANGELOG.md`, `RELEASE_NOTES.md`: new v1.0.7 section

Closes #102
Closes #124