### PR TITLE
v1.0.8: Artist Styles, Prompt Presets, and Schedule builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v1.0.8
+
+### New Features
+- **Artist Styles** — bundle artist tags (with per-tag weights + overall multiplier and optional thumbnails) into reusable styles. Activating a style injects its tags into the positive prompt non-destructively at generation time. Styles support duplicate, JSON export/import, and click-to-deactivate badges above the prompt.
+- **Prompt Presets** — non-artist prompt variables with three activation modes: **Prepend**, **Append**, and **Wildcard** (splits content on commas/newlines and picks one entry per generation). Active presets show as badges with ↑/↓/🎲 indicators.
+- **Styles tab in the bottom panel** — the Styles + Prompt Presets manager is now a dedicated bottom-panel tab with a live active-count badge, replacing the previous floating modal.
+- **Prompt Scheduling builder** — new **Schedule** tab in the bottom panel with a GUI for all four scheduling syntaxes (`<fromto[N]:A || B>`, `<from:N>...</from>`, `<to:N>...</to>`, `<range:A:B>...</range>`): text fields + sliders with a live preview and plain-English "applies from X% to Y%" description. Actions to append to positive/negative prompt or copy to clipboard, plus a collapsible syntax cheat-sheet.
+
+### Autocomplete Improvements
+- **Anima-aware artist autocomplete in Style editor** — artist search now uses the active model's tag list (Anima tags for Anima-architecture models, Danbooru for everything else) and adds/strips the `@` prefix to match each architecture's convention.
+- **Full autocomplete in Preset editor** — preset content uses the same `PromptTextarea` as the main prompt (tag autocomplete, scheduling highlight, NAI brackets, Ctrl+↑/↓ weights).
+
+### i18n
+- Added `bottom_panel.tab.styles` and `bottom_panel.tab.schedule` keys across all 11 supported locales.
+
+---
+
 ## What's New in v1.0.7
 
 ### Critical Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v1.0.8
+
+### New Features
+- **Artist Styles** — bundle one or more artist tags into a reusable style with per-tag weights and an overall multiplier, with optional thumbnails. Activate a style and its tags are folded into the positive prompt at generation time as a non-destructive fragment (your prompt textbox is never mutated). Styles can be duplicated, exported/imported as JSON, and show up as clickable indigo badges above the prompt — click the badge to deactivate.
+- **Prompt Presets** — a sibling system for non-artist prompt variables (e.g. quality boilerplate, negative chunks, scene vocab). Activating a preset opens a picker for **Prepend**, **Append**, or **Wildcard** mode; wildcard splits the preset content on commas/newlines and picks one entry per generation, so the same preset can drive A/B experimentation. Active presets appear as badges with ↑/↓/🎲 indicators.
+- **Styles tab in the bottom panel** — the full Styles + Prompt Presets manager now lives as a dedicated tab in the bottom panel (previously a floating modal), with a live active-count badge.
+- **Prompt Scheduling builder** — a new **Schedule** tab in the bottom panel provides a GUI for all four scheduling tag syntaxes (`<fromto[N]:A || B>`, `<from:N>...</from>`, `<to:N>...</to>`, `<range:A:B>...</range>`). Enter the text, drag a slider for the pivot/bounds, and the live preview shows the exact tag string plus a plain-English description of when it applies. One-click buttons append to the positive or negative prompt, or copy to clipboard. Includes a collapsible syntax cheat-sheet.
+
+### Autocomplete Improvements
+- **Anima-aware artist autocomplete in Style editor** — searching for artist tags inside the Style editor now queries the active model's tag list, so Anima-architecture models surface Anima artist tags and non-Anima models surface Danbooru artists. The `@` prefix is added or stripped automatically when inserting, matching each architecture's convention.
+- **Full autocomplete in the Preset editor** — preset content now uses the same `PromptTextarea` as the main prompt box, giving tag autocomplete, scheduling-tag highlighting, NAI brackets, and Ctrl+↑/↓ weight adjustments when authoring presets.
+
+### i18n
+- Added `bottom_panel.tab.styles` and `bottom_panel.tab.schedule` keys across all 11 supported locales.
+
+---
+
 ## What's New in v1.0.7
 
 ### Critical Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -14,6 +14,10 @@
   import LoraGallery from "./LoraGallery.svelte";
   import CheckpointGallery from "./CheckpointGallery.svelte";
   import CompareGrid from "./CompareGrid.svelte";
+  import StyleManager from "./StyleManager.svelte";
+  import ScheduleBuilder from "./ScheduleBuilder.svelte";
+  import { styles as stylesStore } from "../../stores/styles.svelte.js";
+  import { promptPresets } from "../../stores/promptPresets.svelte.js";
   import type { OutputImage } from "../../types/index.js";
 
   interface Props {
@@ -24,7 +28,7 @@
 
   let { onupscale, oninpaint, oncontextmenu }: Props = $props();
 
-  type TabId = "loras" | "checkpoints" | "images" | "prompts" | "compare" | "artists";
+  type TabId = "loras" | "checkpoints" | "images" | "prompts" | "compare" | "artists" | "styles" | "schedule";
 
   const TAB_KEY = "mooshieui.bottomPanel.activeTab.v1";
 
@@ -45,7 +49,7 @@
     try { localStorage.setItem(TAB_KEY, activeTab); } catch {}
   });
 
-  const allTabs: TabId[] = ["loras", "checkpoints", "images", "prompts", "artists", "compare"];
+  const allTabs: TabId[] = ["loras", "checkpoints", "images", "prompts", "artists", "styles", "schedule", "compare"];
   const visibleTabs = $derived(
     showCheckpointsTab ? allTabs : allTabs.filter((t) => t !== "checkpoints")
   );
@@ -56,6 +60,8 @@
     prompts: "bottom_panel.tab.prompts",
     compare: "bottom_panel.tab.compare",
     artists: "bottom_panel.tab.artists",
+    styles: "bottom_panel.tab.styles",
+    schedule: "bottom_panel.tab.schedule",
   };
 
   // Prompt history
@@ -263,6 +269,10 @@
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
         {:else if tab === "artists"}
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+        {:else if tab === "styles"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15 9 22 9.5 16.5 14.5 18.5 22 12 18 5.5 22 7.5 14.5 2 9.5 9 9 12 2"/></svg>
+        {:else if tab === "schedule"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
         {/if}
         {locale.t(tabLabelKeys[tab])}
         {#if tab === "loras" && activeLoraCount > 0}
@@ -275,6 +285,8 @@
           <span class="text-[9px] px-1 py-0 rounded-full bg-red-500/30 text-red-400 tabular-nums">{artistFavourites.count}</span>
         {:else if tab === "compare" && compare.enabled}
           <span class="text-[9px] px-1 py-0 rounded-full bg-indigo-600/30 text-indigo-400 tabular-nums">{compare.cellCount}</span>
+        {:else if tab === "styles" && (stylesStore.activeStyles.length > 0 || promptPresets.activeEntries.length > 0)}
+          <span class="text-[9px] px-1 py-0 rounded-full bg-indigo-600/30 text-indigo-400 tabular-nums">{stylesStore.activeStyles.length + promptPresets.activeEntries.length}</span>
         {/if}
       </button>
     {/each}
@@ -455,6 +467,10 @@
       {/if}
     {:else if activeTab === "compare"}
       <CompareGrid />
+    {:else if activeTab === "styles"}
+      <StyleManager />
+    {:else if activeTab === "schedule"}
+      <ScheduleBuilder />
     {:else if activeTab === "artists"}
       {#if artistFavourites.count === 0}
         <div class="flex items-center justify-center h-full text-neutral-500 text-xs px-4 text-center">

--- a/src/lib/components/generation/PresetActivationModal.svelte
+++ b/src/lib/components/generation/PresetActivationModal.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { promptPresets, type PromptPreset, type PresetMode } from "../../stores/promptPresets.svelte.js";
+
+  interface Props {
+    presetId: string;
+    onclose: () => void;
+    /** Optional callback once a mode is picked and the preset becomes active. */
+    onactivated?: (mode: PresetMode) => void;
+  }
+
+  let { presetId, onclose, onactivated }: Props = $props();
+
+  const preset = $derived(promptPresets.getById(presetId));
+  const choiceCount = $derived(promptPresets.countChoices(presetId));
+  const currentMode = $derived(promptPresets.activeMode(presetId));
+
+  function pick(mode: PresetMode) {
+    if (!preset) return;
+    promptPresets.activate(preset.id, mode);
+    onactivated?.(mode);
+    onclose();
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-210 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Activate preset"
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Cancel"
+    onclick={onclose}
+  ></button>
+
+  {#if preset}
+    <div class="relative z-10 w-full max-w-md rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+      <div class="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-neutral-100">Activate "{preset.name}"</h3>
+          <p class="mt-1 text-[11px] text-neutral-500">
+            Choose how this preset contributes to the prompt. The content is injected at generation time and will NOT appear in your prompt textbox.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="text-neutral-500 hover:text-neutral-200 text-lg leading-none"
+          onclick={onclose}
+          aria-label="Cancel"
+        >✕</button>
+      </div>
+
+      <div class="mb-3 rounded border border-neutral-800 bg-neutral-950/60 p-2">
+        <p class="text-[10px] uppercase tracking-wide text-neutral-500">Content preview</p>
+        <p class="mt-1 max-h-20 overflow-y-auto whitespace-pre-wrap wrap-break-word font-mono text-[11px] text-neutral-200">
+          {preset.content || "(empty)"}
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 gap-2">
+        <button
+          type="button"
+          class="flex items-start gap-3 rounded-lg border {currentMode === 'prepend' ? 'border-indigo-500 bg-indigo-500/10' : 'border-neutral-700 bg-neutral-800/60'} p-3 text-left hover:border-indigo-500"
+          onclick={() => pick("prepend")}
+        >
+          <span class="text-lg leading-none text-indigo-300">↑</span>
+          <span class="flex-1">
+            <span class="block text-sm font-medium text-neutral-100">Prepend</span>
+            <span class="block text-[11px] text-neutral-500">Insert at the start of the positive prompt.</span>
+          </span>
+        </button>
+
+        <button
+          type="button"
+          class="flex items-start gap-3 rounded-lg border {currentMode === 'append' ? 'border-indigo-500 bg-indigo-500/10' : 'border-neutral-700 bg-neutral-800/60'} p-3 text-left hover:border-indigo-500"
+          onclick={() => pick("append")}
+        >
+          <span class="text-lg leading-none text-indigo-300">↓</span>
+          <span class="flex-1">
+            <span class="block text-sm font-medium text-neutral-100">Append</span>
+            <span class="block text-[11px] text-neutral-500">Insert at the end of the positive prompt.</span>
+          </span>
+        </button>
+
+        <button
+          type="button"
+          class="flex items-start gap-3 rounded-lg border {currentMode === 'wildcard' ? 'border-indigo-500 bg-indigo-500/10' : 'border-neutral-700 bg-neutral-800/60'} p-3 text-left hover:border-indigo-500 {choiceCount < 2 ? 'opacity-60' : ''}"
+          onclick={() => pick("wildcard")}
+          disabled={choiceCount < 1}
+        >
+          <span class="text-lg leading-none text-indigo-300">🎲</span>
+          <span class="flex-1">
+            <span class="block text-sm font-medium text-neutral-100">Wildcard (random)</span>
+            <span class="block text-[11px] text-neutral-500">
+              {#if choiceCount === 0}
+                Add comma- or newline-separated options first.
+              {:else if choiceCount === 1}
+                Only one option — will pick that every time.
+              {:else}
+                Pick one of {choiceCount} options at random per generation.
+              {/if}
+            </span>
+          </span>
+        </button>
+      </div>
+
+      <div class="mt-4 flex justify-end">
+        <button
+          type="button"
+          class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-300 hover:text-neutral-100"
+          onclick={onclose}
+        >Cancel</button>
+      </div>
+    </div>
+  {:else}
+    <div class="relative z-10 rounded-xl border border-neutral-700 bg-neutral-900 p-5 text-sm text-neutral-300">
+      Preset not found.
+      <button class="ml-3 text-indigo-400 hover:text-indigo-300" onclick={onclose}>Close</button>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/generation/PresetEditor.svelte
+++ b/src/lib/components/generation/PresetEditor.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { promptPresets } from "../../stores/promptPresets.svelte.js";
+  import PromptTextarea from "./PromptTextarea.svelte";
+
+  interface Props {
+    presetId: string;
+    onclose: () => void;
+  }
+
+  let { presetId, onclose }: Props = $props();
+
+  const preset = $derived(promptPresets.getById(presetId));
+  const choiceCount = $derived(promptPresets.countChoices(presetId));
+
+  function setName(v: string) {
+    if (!preset) return;
+    promptPresets.update(preset.id, { name: v });
+  }
+
+  // Local mirror bound to PromptTextarea; writes back to the store on change.
+  // The component is remounted per-preset (parent gates with {#if editingPresetId}),
+  // so a one-shot initializer + forward effect is sufficient.
+  let contentLocal = $state("");
+  let contentInitialized = $state(false);
+
+  $effect(() => {
+    if (!contentInitialized && preset) {
+      contentLocal = preset.content;
+      contentInitialized = true;
+    }
+  });
+
+  $effect(() => {
+    if (contentInitialized && preset && contentLocal !== preset.content) {
+      promptPresets.update(preset.id, { content: contentLocal });
+    }
+  });
+</script>
+
+<div
+  class="fixed inset-0 z-205 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Edit Prompt Preset"
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Close"
+    onclick={onclose}
+  ></button>
+
+  {#if preset}
+    <div class="relative z-10 w-full max-w-2xl max-h-[92vh] overflow-y-auto rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+      <div class="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-sm font-semibold text-neutral-100">Edit Prompt Preset</h2>
+          <p class="text-[11px] text-neutral-500">
+            Store any prompt fragment as a reusable variable. Separate entries by comma or newline — used for the wildcard mode to pick one at random.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="text-neutral-500 hover:text-neutral-200 text-lg leading-none"
+          onclick={onclose}
+          aria-label="Close"
+        >✕</button>
+      </div>
+
+      <div class="space-y-4">
+        <div>
+          <label for="pst-name" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">Name</label>
+          <input
+            id="pst-name"
+            type="text"
+            value={preset.name}
+            oninput={(e) => setName((e.currentTarget as HTMLInputElement).value)}
+            placeholder="e.g. Cool hair colors"
+            class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <div class="mb-1 flex items-center justify-between">
+            <label for="pst-content" class="text-[10px] uppercase tracking-wide text-neutral-500">Content</label>
+            <span class="text-[10px] text-neutral-500">{choiceCount} wildcard option{choiceCount === 1 ? "" : "s"}</span>
+          </div>
+          <PromptTextarea
+            bind:value={contentLocal}
+            placeholder="blue hair, red hair, green hair — OR — masterpiece, best quality, intricate details"
+            rows={8}
+            minHeight="min-h-40"
+          />
+          <p class="mt-1 text-[10px] text-neutral-500">
+            <span class="text-indigo-300">Prepend / Append:</span> whole content is injected as-is.
+            <br />
+            <span class="text-indigo-300">Wildcard:</span> one comma/newline-separated entry is picked at random per generation.
+            <br />
+            <span class="text-neutral-400">Tip:</span> autocomplete suggestions match the active model's tag list.
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-4 flex justify-end">
+        <button
+          type="button"
+          class="rounded bg-indigo-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
+          onclick={onclose}
+        >Done</button>
+      </div>
+    </div>
+  {:else}
+    <div class="relative z-10 rounded-xl border border-neutral-700 bg-neutral-900 p-5 text-sm text-neutral-300">
+      Preset not found.
+      <button class="ml-3 text-indigo-400 hover:text-indigo-300" onclick={onclose}>Close</button>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -5,6 +5,8 @@
   import { connection } from "../../stores/connection.svelte.js";
   import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
   import { detectArtistsInPrompt } from "../../artist-gallery/detection.js";
+  import { styles } from "../../stores/styles.svelte.js";
+  import { promptPresets } from "../../stores/promptPresets.svelte.js";
   import PromptTextarea from "./PromptTextarea.svelte";
   import InfoTip from "../ui/InfoTip.svelte";
   import { parseScheduledPrompt, hasSchedulingTags } from "../../utils/promptSchedule.js";
@@ -78,6 +80,38 @@
       {#if generation.isAnima || generation.isIllustrious}
         <span class="shrink-0 text-[10px] px-2 py-0.5 rounded-full bg-emerald-600/20 text-emerald-400 border border-emerald-600/30">{locale.t('generation.prompts.quality_applied')}</span>
       {/if}
+      {#each styles.activeStyles as activeStyle (activeStyle.id)}
+        <button
+          type="button"
+          onclick={() => styles.deactivate(activeStyle.id)}
+          class="shrink-0 inline-flex items-center gap-1 rounded-full border border-indigo-500/50 bg-indigo-500/10 text-indigo-200 hover:bg-red-500/15 hover:border-red-500/50 hover:text-red-200 px-2 py-0.5 text-[10px] transition-colors"
+          title={`Click to deactivate — ${activeStyle.artists.length} artists × ${activeStyle.overallWeight.toFixed(2)}`}
+          aria-label={`Deactivate style ${activeStyle.name}`}
+        >
+          {#if activeStyle.thumbnail}
+            <img src={activeStyle.thumbnail} alt="" class="h-3.5 w-3.5 rounded-sm object-cover" />
+          {:else}
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-indigo-400" aria-hidden="true"></span>
+          {/if}
+          <span class="leading-none">✦</span>
+          <span class="max-w-28 truncate">{activeStyle.name}</span>
+          <span class="font-mono text-[9px] text-indigo-300/80">×{activeStyle.overallWeight.toFixed(2)}</span>
+        </button>
+      {/each}
+      {#each promptPresets.activeEntries as entry (entry.preset.id)}
+        {@const icon = entry.mode === "prepend" ? "↑" : entry.mode === "append" ? "↓" : "🎲"}
+        <button
+          type="button"
+          onclick={() => promptPresets.deactivate(entry.preset.id)}
+          class="shrink-0 inline-flex items-center gap-1 rounded-full border border-indigo-500/50 bg-indigo-500/10 text-indigo-200 hover:bg-red-500/15 hover:border-red-500/50 hover:text-red-200 px-2 py-0.5 text-[10px] transition-colors"
+          title={`Click to deactivate — ${entry.mode}`}
+          aria-label={`Deactivate preset ${entry.preset.name}`}
+        >
+          <span class="leading-none">⚡</span>
+          <span class="max-w-28 truncate">{entry.preset.name}</span>
+          <span class="font-mono text-[9px] text-indigo-300/80">{icon}</span>
+        </button>
+      {/each}
       {#each detectedArtists as hit (hit.slug)}
         {@const isFav = artistFavourites.isFavourite(hit.slug)}
         {@const favCat = artistFavourites.categoryOf(hit.slug)}

--- a/src/lib/components/generation/ScheduleBuilder.svelte
+++ b/src/lib/components/generation/ScheduleBuilder.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { generation } from "../../stores/generation.svelte.js";
+
+  type Mode = "fromto" | "from" | "to" | "range";
+
+  let mode = $state<Mode>("fromto");
+
+  // Swap (SwarmUI fromto) inputs
+  let swapPivot = $state(0.5);
+  let swapBefore = $state("");
+  let swapAfter = $state("");
+  let swapSeparator = $state<"||" | "|" | ",">("||");
+
+  // Schedule (MooshieUI) inputs
+  let schedText = $state("");
+  let schedStart = $state(0.5);
+  let schedEnd = $state(0.8);
+
+  function clamp01(v: number): number {
+    if (isNaN(v)) return 0;
+    return Math.max(0, Math.min(1, v));
+  }
+
+  function fmt(v: number): string {
+    return clamp01(v).toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+  }
+
+  /**
+   * Pick the least-intrusive separator for SwarmUI fromto — if either side
+   * already contains `,` we prefer `|`; if either already contains `|` we
+   * prefer `||`. User can override via the dropdown.
+   */
+  const autoSeparator = $derived.by(() => {
+    const combined = `${swapBefore} ${swapAfter}`;
+    if (combined.includes("||")) return ",";
+    if (combined.includes("|")) return "||";
+    return "||";
+  });
+
+  // Keep dropdown in sync with auto-pick as the user types, but only if they
+  // haven't manually changed it recently. Simpler: always drive from auto, allow
+  // override via dropdown.
+  $effect(() => {
+    swapSeparator = autoSeparator;
+  });
+
+  const output = $derived.by(() => {
+    if (mode === "fromto") {
+      const before = swapBefore.trim();
+      const after = swapAfter.trim();
+      if (!before || !after) return "";
+      const sep = swapSeparator === "," ? ", " : ` ${swapSeparator} `;
+      return `<fromto[${fmt(swapPivot)}]:${before}${sep}${after}>`;
+    }
+    const text = schedText.trim();
+    if (!text) return "";
+    if (mode === "from") return `<from:${fmt(schedStart)}>${text}</from>`;
+    if (mode === "to") return `<to:${fmt(schedEnd)}>${text}</to>`;
+    if (mode === "range") {
+      const lo = Math.min(schedStart, schedEnd);
+      const hi = Math.max(schedStart, schedEnd);
+      return `<range:${fmt(lo)}:${fmt(hi)}>${text}</range>`;
+    }
+    return "";
+  });
+
+  const description = $derived.by(() => {
+    if (mode === "fromto") {
+      return `"before" is applied 0%→${Math.round(clamp01(swapPivot) * 100)}%, then "after" ${Math.round(clamp01(swapPivot) * 100)}%→100%.`;
+    }
+    if (mode === "from") {
+      return `Text is applied from ${Math.round(clamp01(schedStart) * 100)}% of steps onward.`;
+    }
+    if (mode === "to") {
+      return `Text is applied from 0% up to ${Math.round(clamp01(schedEnd) * 100)}% of steps.`;
+    }
+    const lo = Math.min(schedStart, schedEnd);
+    const hi = Math.max(schedStart, schedEnd);
+    return `Text is applied from ${Math.round(clamp01(lo) * 100)}% to ${Math.round(clamp01(hi) * 100)}% of steps.`;
+  });
+
+  let copied = $state(false);
+  let copyTimer: number | null = null;
+  async function copyToClipboard() {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      copied = true;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = window.setTimeout(() => (copied = false), 1200);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function appendToPrompt(target: "positive" | "negative") {
+    if (!output) return;
+    const current =
+      target === "positive" ? generation.positivePrompt : generation.negativePrompt;
+    const trimmed = current.trimEnd();
+    const sep = trimmed.length === 0 ? "" : trimmed.endsWith(",") ? " " : ", ";
+    const next = `${trimmed}${sep}${output}`;
+    if (target === "positive") generation.positivePrompt = next;
+    else generation.negativePrompt = next;
+  }
+</script>
+
+<div class="flex h-full flex-col overflow-y-auto px-3 py-2 text-neutral-200">
+  <div class="mb-3">
+    <h2 class="text-sm font-semibold text-neutral-100">Prompt Scheduling</h2>
+    <p class="text-[11px] text-neutral-500">
+      Build a timestep-scheduled tag without remembering the syntax. Pivot values are fractions of total steps (0 = start, 1 = end).
+    </p>
+  </div>
+
+  <!-- Mode tabs -->
+  <div class="mb-3 flex flex-wrap gap-1">
+    {#each [
+      { id: "fromto", label: "Swap (fromto)", hint: "SwarmUI" },
+      { id: "from", label: "From", hint: "late-stage" },
+      { id: "to", label: "To", hint: "early-stage" },
+      { id: "range", label: "Range", hint: "window" },
+    ] as m (m.id)}
+      <button
+        type="button"
+        class="rounded-md border px-2.5 py-1 text-[11px] transition-colors {mode === m.id
+          ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200'
+          : 'border-neutral-700 bg-neutral-800 text-neutral-400 hover:text-neutral-200'}"
+        onclick={() => (mode = m.id as Mode)}
+      >
+        {m.label}
+        <span class="ml-1 text-[9px] text-neutral-500">{m.hint}</span>
+      </button>
+    {/each}
+  </div>
+
+  {#if mode === "fromto"}
+    <section class="mb-3 space-y-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-3">
+      <p class="text-[11px] text-neutral-400">
+        Render "before" for the first portion of the schedule, then swap to "after".
+      </p>
+      <div>
+        <label for="sch-swap-before" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">Before</label>
+        <input
+          id="sch-swap-before"
+          type="text"
+          bind:value={swapBefore}
+          placeholder="e.g. a photo of a cat"
+          class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+      </div>
+      <div>
+        <label for="sch-swap-after" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">After</label>
+        <input
+          id="sch-swap-after"
+          type="text"
+          bind:value={swapAfter}
+          placeholder="e.g. a photo of a dog"
+          class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+      </div>
+      <div class="flex items-center gap-3">
+        <label class="flex flex-1 items-center gap-2 text-[11px] text-neutral-400">
+          <span class="w-14 shrink-0">Pivot</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            bind:value={swapPivot}
+            class="flex-1 accent-indigo-500"
+          />
+          <span class="w-10 shrink-0 text-right font-mono text-[11px] text-neutral-300">{fmt(swapPivot)}</span>
+        </label>
+        <label class="flex items-center gap-1 text-[11px] text-neutral-400">
+          Sep
+          <select
+            bind:value={swapSeparator}
+            class="rounded border border-neutral-700 bg-neutral-800 px-1.5 py-1 text-[11px] text-neutral-200 focus:border-indigo-500 focus:outline-none"
+          >
+            <option value="||">||</option>
+            <option value="|">|</option>
+            <option value=",">,</option>
+          </select>
+        </label>
+      </div>
+    </section>
+  {:else}
+    <section class="mb-3 space-y-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-3">
+      <div>
+        <label for="sch-text" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">Text</label>
+        <input
+          id="sch-text"
+          type="text"
+          bind:value={schedText}
+          placeholder="the tags to schedule"
+          class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+      </div>
+      {#if mode === "from"}
+        <label class="flex items-center gap-2 text-[11px] text-neutral-400">
+          <span class="w-14 shrink-0">Start</span>
+          <input type="range" min="0" max="1" step="0.05" bind:value={schedStart} class="flex-1 accent-indigo-500" />
+          <span class="w-10 shrink-0 text-right font-mono text-[11px] text-neutral-300">{fmt(schedStart)}</span>
+        </label>
+      {:else if mode === "to"}
+        <label class="flex items-center gap-2 text-[11px] text-neutral-400">
+          <span class="w-14 shrink-0">End</span>
+          <input type="range" min="0" max="1" step="0.05" bind:value={schedEnd} class="flex-1 accent-indigo-500" />
+          <span class="w-10 shrink-0 text-right font-mono text-[11px] text-neutral-300">{fmt(schedEnd)}</span>
+        </label>
+      {:else if mode === "range"}
+        <label class="flex items-center gap-2 text-[11px] text-neutral-400">
+          <span class="w-14 shrink-0">Start</span>
+          <input type="range" min="0" max="1" step="0.05" bind:value={schedStart} class="flex-1 accent-indigo-500" />
+          <span class="w-10 shrink-0 text-right font-mono text-[11px] text-neutral-300">{fmt(schedStart)}</span>
+        </label>
+        <label class="flex items-center gap-2 text-[11px] text-neutral-400">
+          <span class="w-14 shrink-0">End</span>
+          <input type="range" min="0" max="1" step="0.05" bind:value={schedEnd} class="flex-1 accent-indigo-500" />
+          <span class="w-10 shrink-0 text-right font-mono text-[11px] text-neutral-300">{fmt(schedEnd)}</span>
+        </label>
+      {/if}
+    </section>
+  {/if}
+
+  <!-- Preview -->
+  <section class="mb-3 rounded-lg border border-neutral-800 bg-neutral-950/70 p-3">
+    <div class="mb-1 flex items-center justify-between">
+      <h3 class="text-[10px] uppercase tracking-wide text-neutral-500">Preview</h3>
+      <span class="text-[10px] text-neutral-500">{description}</span>
+    </div>
+    {#if output}
+      <code class="block wrap-break-word rounded border border-neutral-800 bg-black/40 px-2 py-1.5 font-mono text-[12px] text-indigo-200">
+        {output}
+      </code>
+    {:else}
+      <p class="text-[11px] italic text-neutral-600">Fill in the fields above to see the generated tag.</p>
+    {/if}
+  </section>
+
+  <!-- Actions -->
+  <div class="mb-2 flex flex-wrap gap-2">
+    <button
+      type="button"
+      class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-40 disabled:hover:border-neutral-700"
+      onclick={() => appendToPrompt("positive")}
+      disabled={!output}
+    >+ Append to positive</button>
+    <button
+      type="button"
+      class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-40 disabled:hover:border-neutral-700"
+      onclick={() => appendToPrompt("negative")}
+      disabled={!output}
+    >+ Append to negative</button>
+    <button
+      type="button"
+      class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-40 disabled:hover:border-neutral-700"
+      onclick={copyToClipboard}
+      disabled={!output}
+    >
+      {copied ? "✓ Copied" : "Copy"}
+    </button>
+  </div>
+
+  <!-- Cheat-sheet -->
+  <details class="mt-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-3 text-[11px] text-neutral-400">
+    <summary class="cursor-pointer text-neutral-300">Syntax reference</summary>
+    <dl class="mt-2 space-y-1.5 font-mono text-[11px]">
+      <div>
+        <dt class="text-indigo-300">&lt;fromto[N]:A || B&gt;</dt>
+        <dd class="text-neutral-400">SwarmUI — render A for 0→N, swap to B for N→1.</dd>
+      </div>
+      <div>
+        <dt class="text-indigo-300">&lt;from:N&gt;text&lt;/from&gt;</dt>
+        <dd class="text-neutral-400">MooshieUI — apply text from step N to end.</dd>
+      </div>
+      <div>
+        <dt class="text-indigo-300">&lt;to:N&gt;text&lt;/to&gt;</dt>
+        <dd class="text-neutral-400">MooshieUI — apply text from start to step N.</dd>
+      </div>
+      <div>
+        <dt class="text-indigo-300">&lt;range:A:B&gt;text&lt;/range&gt;</dt>
+        <dd class="text-neutral-400">MooshieUI — apply text only between A and B.</dd>
+      </div>
+    </dl>
+  </details>
+</div>

--- a/src/lib/components/generation/StyleEditor.svelte
+++ b/src/lib/components/generation/StyleEditor.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+  import { styles, resizeImageToDataUrl, type ArtistStyle, type StyleArtist } from "../../stores/styles.svelte.js";
+  import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
+  import { gallery } from "../../stores/gallery.svelte.js";
+  import { autocomplete } from "../../stores/autocomplete.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
+
+  interface Props {
+    styleId: string;
+    onclose: () => void;
+  }
+
+  let { styleId, onclose }: Props = $props();
+
+  const style = $derived(styles.getById(styleId));
+
+  let newTagInput = $state("");
+  let searchQuery = $state("");
+  let thumbnailError = $state<string | null>(null);
+  let thumbnailBusy = $state(false);
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  function displayTag(tag: string): string {
+    return tag.replace(/^@/, "").replace(/\\([()\[\]])/g, "$1");
+  }
+
+  /** Favourites that are not already part of this style. */
+  const favouriteCandidates = $derived.by(() => {
+    if (!style) return [];
+    const used = new Set(style.artists.map((a) => a.tag.trim().toLowerCase()));
+    const q = searchQuery.trim().toLowerCase();
+    const slugs = Object.keys(artistFavourites.favourites);
+    const filtered = q ? slugs.filter((s) => s.toLowerCase().includes(q)) : slugs;
+    return filtered
+      .filter((slug) => !used.has(slug.toLowerCase()) && !used.has(`@${slug}`.toLowerCase()))
+      .sort()
+      .slice(0, 40);
+  });
+
+  /** Gallery artist index matches (up to 20) — excluding favourites already shown and artists already in the style. */
+  const gallerySuggestions = $derived.by(() => {
+    if (!style) return [] as { slug: string; tag: string }[];
+    const q = searchQuery.trim().toLowerCase();
+    if (!q || q.length < 2) return [];
+    const used = new Set(style.artists.map((a) => a.tag.trim().toLowerCase()));
+    const favSet = new Set(Object.keys(artistFavourites.favourites).map((s) => s.toLowerCase()));
+    const out: { slug: string; tag: string }[] = [];
+    for (const [key, hit] of gallery.artistTagIndex) {
+      if (out.length >= 20) break;
+      if (!key.includes(q)) continue;
+      const slugLower = hit.slug.toLowerCase();
+      if (used.has(slugLower) || used.has(`@${hit.slug}`.toLowerCase())) continue;
+      if (favSet.has(slugLower)) continue;
+      if (!out.some((o) => o.slug === hit.slug)) out.push({ slug: hit.slug, tag: hit.tag });
+    }
+    return out;
+  });
+
+  /**
+   * Autocomplete artist-category tags (c === 1) from the active autocomplete
+   * taglist. When an Anima model is active, the autocomplete store is already
+   * swapped to the anima list, so this naturally surfaces Anima artists.
+   */
+  const autocompleteSuggestions = $derived.by(() => {
+    if (!style) return [] as { name: string; postCount: number }[];
+    const q = searchQuery.trim();
+    if (q.length < 2) return [];
+    const used = new Set(style.artists.map((a) => a.tag.trim().toLowerCase().replace(/^@/, "")));
+    const favSet = new Set(Object.keys(artistFavourites.favourites).map((s) => s.toLowerCase()));
+    const gallerySet = new Set(gallerySuggestions.map((g) => g.slug.toLowerCase()));
+    const results = autocomplete.search(q, 30);
+    const out: { name: string; postCount: number }[] = [];
+    for (const tag of results) {
+      if (tag.c !== 1) continue; // artist category only
+      const key = tag.n.toLowerCase();
+      if (used.has(key) || favSet.has(key) || gallerySet.has(key)) continue;
+      out.push({ name: tag.n, postCount: tag.p });
+      if (out.length >= 15) break;
+    }
+    return out;
+  });
+
+  /**
+   * Normalize an artist tag for insertion. Anima-style models use an `@` prefix
+   * on artist tags; other architectures (SDXL, Pony, Illustrious, etc.) take
+   * raw danbooru-style names. Strips a leading `@` when not on Anima.
+   */
+  function normalizeArtistTag(tag: string): string {
+    if (generation.isAnima) return tag.startsWith("@") ? tag : `@${tag}`;
+    return tag.replace(/^@/, "");
+  }
+
+  function addArtist(tag: string, slug?: string) {
+    if (!style) return;
+    const normalized = normalizeArtistTag(tag.trim());
+    if (!normalized) return;
+    styles.addArtist(style.id, { tag: normalized, slug, weight: 1.0 });
+  }
+
+  function addFromFreeText() {
+    if (!style) return;
+    const raw = newTagInput.trim();
+    if (!raw) return;
+    // Allow comma-separated bulk-add.
+    for (const part of raw.split(",")) {
+      const t = part.trim();
+      if (t) addArtist(t);
+    }
+    newTagInput = "";
+  }
+
+  function updateArtistWeight(index: number, value: number) {
+    if (!style) return;
+    styles.updateArtist(style.id, index, { weight: value });
+  }
+
+  function removeArtist(index: number) {
+    if (!style) return;
+    styles.removeArtist(style.id, index);
+  }
+
+  function setName(value: string) {
+    if (!style) return;
+    styles.update(style.id, { name: value });
+  }
+
+  function setOverallWeight(value: number) {
+    if (!style) return;
+    styles.update(style.id, { overallWeight: value });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Thumbnail
+  // ---------------------------------------------------------------------------
+
+  async function setThumbnailFromLastGen() {
+    if (!style) return;
+    thumbnailError = null;
+    thumbnailBusy = true;
+    try {
+      const latest = gallery.sessionImages[0] ?? gallery.images[0];
+      if (!latest) {
+        thumbnailError = "No recent generation to use";
+        return;
+      }
+      const url = latest.fullImageUrl ?? latest.thumbnailUrl ?? latest.url;
+      if (!url) {
+        thumbnailError = "Latest image has no accessible URL";
+        return;
+      }
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`Fetch failed (${resp.status})`);
+      const blob = await resp.blob();
+      const dataUrl = await resizeImageToDataUrl(blob);
+      styles.setThumbnail(style.id, dataUrl);
+    } catch (e) {
+      thumbnailError = e instanceof Error ? e.message : String(e);
+    } finally {
+      thumbnailBusy = false;
+    }
+  }
+
+  async function onFilePicked(e: Event) {
+    if (!style) return;
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file) return;
+    thumbnailError = null;
+    thumbnailBusy = true;
+    try {
+      const dataUrl = await resizeImageToDataUrl(file);
+      styles.setThumbnail(style.id, dataUrl);
+    } catch (e) {
+      thumbnailError = e instanceof Error ? e.message : String(e);
+    } finally {
+      thumbnailBusy = false;
+    }
+  }
+
+  function clearThumbnail() {
+    if (!style) return;
+    styles.setThumbnail(style.id, null);
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-200 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Edit Style"
+>
+  <button
+    type="button"
+    class="absolute inset-0 h-full w-full cursor-default"
+    aria-label="Close"
+    onclick={onclose}
+  ></button>
+
+  {#if style}
+    <div class="relative z-10 w-full max-w-3xl max-h-[92vh] overflow-y-auto rounded-xl border border-neutral-700 bg-neutral-900 p-5 shadow-2xl">
+      <div class="mb-4 flex items-center justify-between gap-3">
+        <h2 class="text-sm font-semibold text-neutral-100">Edit Style</h2>
+        <button
+          type="button"
+          class="text-neutral-500 hover:text-neutral-200 text-lg leading-none"
+          onclick={onclose}
+          aria-label="Close"
+        >✕</button>
+      </div>
+
+      <!-- Name + overall weight + thumbnail -->
+      <section class="mb-5 grid grid-cols-1 gap-4 md:grid-cols-[auto_1fr]">
+        <!-- Thumbnail -->
+        <div class="flex flex-col gap-2">
+          <div class="relative h-32 w-32 overflow-hidden rounded-lg border border-neutral-700 bg-neutral-950 flex items-center justify-center">
+            {#if style.thumbnail}
+              <img src={style.thumbnail} alt="Style thumbnail" class="h-full w-full object-cover" />
+            {:else}
+              <span class="text-[10px] text-neutral-500">No thumbnail</span>
+            {/if}
+            {#if thumbnailBusy}
+              <div class="absolute inset-0 flex items-center justify-center bg-black/60 text-[10px] text-neutral-300">Loading…</div>
+            {/if}
+          </div>
+          <div class="flex flex-col gap-1">
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-200 hover:border-indigo-500 disabled:opacity-50"
+              onclick={setThumbnailFromLastGen}
+              disabled={thumbnailBusy}
+            >Use last gen</button>
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-200 hover:border-indigo-500 disabled:opacity-50"
+              onclick={() => fileInput?.click()}
+              disabled={thumbnailBusy}
+            >Upload…</button>
+            {#if style.thumbnail}
+              <button
+                type="button"
+                class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-red-300"
+                onclick={clearThumbnail}
+                disabled={thumbnailBusy}
+              >Clear</button>
+            {/if}
+            <input
+              bind:this={fileInput}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              class="hidden"
+              onchange={onFilePicked}
+            />
+          </div>
+          {#if thumbnailError}
+            <p class="text-[10px] text-red-400">{thumbnailError}</p>
+          {/if}
+        </div>
+
+        <div class="space-y-3">
+          <div>
+            <label for="sty-name" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">Name</label>
+            <input
+              id="sty-name"
+              type="text"
+              value={style.name}
+              oninput={(e) => setName((e.currentTarget as HTMLInputElement).value)}
+              placeholder="My signature style"
+              class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <div class="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wide text-neutral-500">
+              <label for="sty-overall">Overall weight</label>
+              <span class="font-mono text-neutral-300">{style.overallWeight.toFixed(2)}</span>
+            </div>
+            <input
+              id="sty-overall"
+              type="range"
+              min="0"
+              max="2"
+              step="0.05"
+              value={style.overallWeight}
+              oninput={(e) => setOverallWeight(parseFloat((e.currentTarget as HTMLInputElement).value))}
+              class="w-full"
+            />
+            <p class="mt-0.5 text-[10px] text-neutral-500">Multiplies every artist's individual weight when the style is active.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Artists in this style -->
+      <section class="mb-5">
+        <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-neutral-400">
+          Artists ({style.artists.length})
+        </h3>
+        {#if style.artists.length === 0}
+          <p class="rounded border border-dashed border-neutral-800 bg-neutral-950/50 p-3 text-center text-[11px] text-neutral-500">
+            No artists yet. Add some from your favourites, the gallery, or paste tags below.
+          </p>
+        {:else}
+          <div class="space-y-1.5">
+            {#each style.artists as artist, i (artist.tag + i)}
+              {@const effective = (artist.weight * style.overallWeight).toFixed(2)}
+              <div class="flex items-center gap-2 rounded border border-neutral-800 bg-neutral-950/60 px-2 py-1.5">
+                <span class="flex-1 truncate font-mono text-[11px] text-red-300">@{displayTag(artist.tag)}</span>
+                <input
+                  type="range"
+                  min="0"
+                  max="2"
+                  step="0.05"
+                  value={artist.weight}
+                  oninput={(e) => updateArtistWeight(i, parseFloat((e.currentTarget as HTMLInputElement).value))}
+                  class="w-28"
+                  aria-label={`Weight for ${displayTag(artist.tag)}`}
+                />
+                <span class="w-10 shrink-0 text-right font-mono text-[10px] text-neutral-400">{artist.weight.toFixed(2)}</span>
+                <span class="w-14 shrink-0 text-right font-mono text-[10px] text-indigo-300" title="Effective weight (per-artist × overall)">= {effective}</span>
+                <button
+                  type="button"
+                  class="rounded px-1.5 py-0.5 text-[11px] text-neutral-500 hover:bg-red-500/10 hover:text-red-300"
+                  onclick={() => removeArtist(i)}
+                  title="Remove"
+                  aria-label={`Remove ${displayTag(artist.tag)}`}
+                >✕</button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </section>
+
+      <!-- Add artists -->
+      <section class="mb-3 space-y-3">
+        <h3 class="text-xs font-medium uppercase tracking-wide text-neutral-400">Add artists</h3>
+
+        <!-- Search favourites + gallery -->
+        <div>
+          <input
+            type="text"
+            bind:value={searchQuery}
+            placeholder="Search favourites or artist gallery…"
+            class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+          />
+
+          {#if favouriteCandidates.length > 0}
+            <div class="mt-2">
+              <p class="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">From favourites</p>
+              <div class="flex flex-wrap gap-1">
+                {#each favouriteCandidates as slug (slug)}
+                  {@const cat = artistFavourites.categoryOf(slug)}
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-full border border-neutral-700 bg-neutral-800 px-2 py-0.5 text-[10px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-200"
+                    onclick={() => addArtist(slug, slug)}
+                    title={`Add ${generation.isAnima ? "@" : ""}${slug}`}
+                  >
+                    {#if cat}
+                      <span class="h-2 w-2 rounded-full" style="background-color: {cat.color}" aria-hidden="true"></span>
+                    {/if}
+                    <span class="font-mono">+ {generation.isAnima ? "@" : ""}{slug}</span>
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if gallerySuggestions.length > 0}
+            <div class="mt-2">
+              <p class="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">From gallery</p>
+              <div class="flex flex-wrap gap-1">
+                {#each gallerySuggestions as hit (hit.slug)}
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-full border border-neutral-700 bg-neutral-800 px-2 py-0.5 text-[10px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-200"
+                    onclick={() => addArtist(hit.tag, hit.slug)}
+                    title={`Add ${hit.tag}`}
+                  >
+                    <span class="font-mono">+ {generation.isAnima ? hit.tag : displayTag(hit.tag)}</span>
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if autocompleteSuggestions.length > 0}
+            <div class="mt-2">
+              <p class="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">
+                From autocomplete{generation.isAnima ? " (Anima)" : ""}
+              </p>
+              <div class="flex flex-wrap gap-1">
+                {#each autocompleteSuggestions as hit (hit.name)}
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-full border border-neutral-700 bg-neutral-800 px-2 py-0.5 text-[10px] text-red-300 hover:border-indigo-500 hover:text-indigo-200"
+                    onclick={() => addArtist(hit.name)}
+                    title={`Add ${generation.isAnima ? "@" : ""}${hit.name} — ${hit.postCount} posts`}
+                  >
+                    <span class="font-mono">+ {generation.isAnima ? "@" : ""}{hit.name.replace(/_/g, " ")}</span>
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if searchQuery.trim() && favouriteCandidates.length === 0 && gallerySuggestions.length === 0 && autocompleteSuggestions.length === 0}
+            <p class="mt-2 text-[10px] text-neutral-500">No matches. Use the free-text field below to add any tag.</p>
+          {/if}
+        </div>
+
+        <!-- Free-text add -->
+        <div>
+          <p class="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">Paste tags</p>
+          <div class="flex gap-2">
+            <input
+              type="text"
+              bind:value={newTagInput}
+              placeholder="@artist_1, @artist_2, …"
+              onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); addFromFreeText(); } }}
+              class="flex-1 rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+              onclick={addFromFreeText}
+            >Add</button>
+          </div>
+        </div>
+      </section>
+
+      <div class="flex justify-end">
+        <button
+          type="button"
+          class="rounded bg-indigo-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
+          onclick={onclose}
+        >Done</button>
+      </div>
+    </div>
+  {:else}
+    <div class="relative z-10 rounded-xl border border-neutral-700 bg-neutral-900 p-5 text-sm text-neutral-300">
+      Style not found.
+      <button class="ml-3 text-indigo-400 hover:text-indigo-300" onclick={onclose}>Close</button>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/generation/StyleManager.svelte
+++ b/src/lib/components/generation/StyleManager.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+  import { styles, type ArtistStyle } from "../../stores/styles.svelte.js";
+  import { promptPresets, type PromptPreset, type PresetMode } from "../../stores/promptPresets.svelte.js";
+  import StyleEditor from "./StyleEditor.svelte";
+  import PresetEditor from "./PresetEditor.svelte";
+  import PresetActivationModal from "./PresetActivationModal.svelte";
+
+  interface Props {
+    onclose?: () => void;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let { onclose: _onclose }: Props = $props();
+
+  let activeTab = $state<"styles" | "presets">("styles");
+
+  // Styles tab state
+  let editingId = $state<string | null>(null);
+  let newName = $state("");
+
+  // Presets tab state
+  let editingPresetId = $state<string | null>(null);
+  let activatingPresetId = $state<string | null>(null);
+  let newPresetName = $state("");
+
+  // Shared import/export
+  let importStatus = $state<string | null>(null);
+  let importError = $state<string | null>(null);
+  let importMode = $state<"merge" | "replace">("merge");
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  function createStyle() {
+    const name = newName.trim() || `Style ${styles.styles.length + 1}`;
+    const created = styles.create(name);
+    newName = "";
+    editingId = created.id;
+  }
+
+  function confirmDelete(style: ArtistStyle) {
+    if (!confirm(`Delete "${style.name}"? This cannot be undone.`)) return;
+    styles.remove(style.id);
+  }
+
+  function createPreset() {
+    const name = newPresetName.trim() || `Preset ${promptPresets.presets.length + 1}`;
+    const created = promptPresets.create(name);
+    newPresetName = "";
+    editingPresetId = created.id;
+  }
+
+  function confirmDeletePreset(preset: PromptPreset) {
+    if (!confirm(`Delete "${preset.name}"? This cannot be undone.`)) return;
+    promptPresets.remove(preset.id);
+  }
+
+  function onPresetActivateClick(preset: PromptPreset) {
+    if (promptPresets.isActive(preset.id)) {
+      promptPresets.deactivate(preset.id);
+      return;
+    }
+    activatingPresetId = preset.id;
+  }
+
+  function presetModeLabel(mode: PresetMode | null): string {
+    if (mode === "prepend") return "Prepend";
+    if (mode === "append") return "Append";
+    if (mode === "wildcard") return "Wildcard";
+    return "";
+  }
+
+  function presetModeIcon(mode: PresetMode | null): string {
+    if (mode === "prepend") return "↑";
+    if (mode === "append") return "↓";
+    if (mode === "wildcard") return "🎲";
+    return "";
+  }
+
+  async function exportAll() {
+    importStatus = null;
+    importError = null;
+    const isStylesTab = activeTab === "styles";
+    const json = isStylesTab ? styles.exportJSON() : promptPresets.exportJSON();
+    const kind = isStylesTab ? "styles" : "presets";
+    const defaultName = `mooshieui-${kind}-${new Date().toISOString().slice(0, 10)}.json`;
+    const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+    try {
+      if (isTauri) {
+        const { save } = await import("@tauri-apps/plugin-dialog");
+        const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+        const path = await save({
+          defaultPath: defaultName,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!path) return;
+        await writeTextFile(path, json);
+        importStatus = `Exported to ${path}`;
+      } else {
+        const blob = new Blob([json], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = defaultName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        importStatus = `Downloaded ${defaultName}`;
+      }
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function importStyles() {
+    importStatus = null;
+    importError = null;
+    const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+    try {
+      if (isTauri) {
+        const { open } = await import("@tauri-apps/plugin-dialog");
+        const { readTextFile } = await import("@tauri-apps/plugin-fs");
+        const selected = await open({
+          multiple: false,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!selected || typeof selected !== "string") return;
+        const raw = await readTextFile(selected);
+        applyImport(raw);
+      } else {
+        fileInput?.click();
+      }
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  async function onFilePicked(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file) return;
+    try {
+      const raw = await file.text();
+      applyImport(raw);
+    } catch (err) {
+      importError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function applyImport(raw: string) {
+    try {
+      // Try both kinds — the envelope's `kind` field disambiguates.
+      let result: { added: number; skipped: number } | null = null;
+      let label = "";
+      try {
+        result = styles.importJSON(raw, importMode);
+        label = "style";
+      } catch {
+        result = promptPresets.importJSON(raw, importMode);
+        label = "preset";
+      }
+      importStatus = `Imported ${result.added} ${label}${result.added === 1 ? "" : "s"}${
+        result.skipped > 0 ? ` (skipped ${result.skipped} duplicate${result.skipped === 1 ? "" : "s"})` : ""
+      }.`;
+      importError = null;
+    } catch (e) {
+      importError = e instanceof Error ? e.message : String(e);
+    }
+  }
+</script>
+
+<div class="flex flex-col h-full overflow-y-auto px-3 py-2">
+    <div class="mb-3 flex items-start justify-between gap-3">
+      <div>
+        <h2 class="text-sm font-semibold text-neutral-100">
+          {activeTab === "styles" ? "Artist Styles" : "Prompt Presets"}
+        </h2>
+        <p class="text-[11px] text-neutral-500">
+          {#if activeTab === "styles"}
+            Bundle artists with per-tag and overall weights. Active styles inject their tags into generations without touching your prompt textbox.
+          {:else}
+            Store reusable prompt fragments. On activation, choose whether to prepend, append, or use as a wildcard (one random entry per generation).
+          {/if}
+        </p>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="mb-4 flex gap-1 border-b border-neutral-800">
+      <button
+        type="button"
+        class="px-3 py-1.5 text-xs transition-colors border-b-2 {activeTab === 'styles' ? 'border-indigo-500 text-neutral-100' : 'border-transparent text-neutral-500 hover:text-neutral-300'}"
+        onclick={() => (activeTab = "styles")}
+      >
+        ✦ Styles <span class="text-[10px] text-neutral-500">({styles.styles.length})</span>
+      </button>
+      <button
+        type="button"
+        class="px-3 py-1.5 text-xs transition-colors border-b-2 {activeTab === 'presets' ? 'border-indigo-500 text-neutral-100' : 'border-transparent text-neutral-500 hover:text-neutral-300'}"
+        onclick={() => (activeTab = "presets")}
+      >
+        ⚡ Presets <span class="text-[10px] text-neutral-500">({promptPresets.presets.length})</span>
+      </button>
+    </div>
+
+{#if activeTab === "styles"}
+    <!-- Create -->
+    <section class="mb-5 flex items-end gap-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-2">
+      <div class="flex-1">
+        <label for="sty-mgr-new-name" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">New style</label>
+        <input
+          id="sty-mgr-new-name"
+          type="text"
+          bind:value={newName}
+          onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); createStyle(); } }}
+          placeholder="Name (optional)"
+          class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+      </div>
+      <button
+        type="button"
+        class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
+        onclick={createStyle}
+      >+ Create</button>
+    </section>
+
+    <!-- List -->
+    <section class="mb-5">
+      {#if styles.styles.length === 0}
+        <p class="rounded border border-dashed border-neutral-800 bg-neutral-950/50 p-4 text-center text-[11px] text-neutral-500">
+          You haven't created any styles yet.
+        </p>
+      {:else}
+        <ul class="space-y-2">
+          {#each styles.styles as style (style.id)}
+            {@const active = styles.isActive(style.id)}
+            <li class="flex items-center gap-3 rounded-lg border {active ? 'border-indigo-500/60 bg-indigo-500/5' : 'border-neutral-800 bg-neutral-950/60'} p-2">
+              <div class="h-14 w-14 shrink-0 overflow-hidden rounded border border-neutral-800 bg-neutral-900">
+                {#if style.thumbnail}
+                  <img src={style.thumbnail} alt="" class="h-full w-full object-cover" />
+                {:else}
+                  <div class="flex h-full w-full items-center justify-center text-[9px] text-neutral-600">no thumb</div>
+                {/if}
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2">
+                  <p class="truncate text-sm text-neutral-100">{style.name}</p>
+                  {#if active}
+                    <span class="shrink-0 rounded-full border border-indigo-500/40 bg-indigo-500/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-indigo-300">active</span>
+                  {/if}
+                </div>
+                <p class="truncate text-[11px] text-neutral-500">
+                  {style.artists.length} artist{style.artists.length === 1 ? "" : "s"} · overall ×{style.overallWeight.toFixed(2)}
+                </p>
+              </div>
+              <div class="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] {active ? 'text-indigo-300 hover:text-neutral-200' : 'text-neutral-300 hover:text-indigo-200'}"
+                  onclick={() => styles.toggleActive(style.id)}
+                  title={active ? "Deactivate" : "Activate"}
+                >{active ? "Deactivate" : "Activate"}</button>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-300 hover:text-indigo-200"
+                  onclick={() => (editingId = style.id)}
+                >Edit</button>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200"
+                  onclick={() => styles.duplicate(style.id)}
+                  title="Duplicate"
+                >⧉</button>
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:bg-red-500/10 hover:text-red-300"
+                  onclick={() => confirmDelete(style)}
+                  title="Delete"
+                  aria-label={`Delete ${style.name}`}
+                >✕</button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+{:else}
+    <!-- Presets: create -->
+    <section class="mb-5 flex items-end gap-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-2">
+      <div class="flex-1">
+        <label for="pst-mgr-new-name" class="mb-1 block text-[10px] uppercase tracking-wide text-neutral-500">New preset</label>
+        <input
+          id="pst-mgr-new-name"
+          type="text"
+          bind:value={newPresetName}
+          onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); createPreset(); } }}
+          placeholder="Name (optional)"
+          class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+      </div>
+      <button
+        type="button"
+        class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500"
+        onclick={createPreset}
+      >+ Create</button>
+    </section>
+
+    <!-- Presets: list -->
+    <section class="mb-5">
+      {#if promptPresets.presets.length === 0}
+        <p class="rounded border border-dashed border-neutral-800 bg-neutral-950/50 p-4 text-center text-[11px] text-neutral-500">
+          No presets yet. Create one to store a reusable prompt fragment or a wildcard list.
+        </p>
+      {:else}
+        <ul class="space-y-2">
+          {#each promptPresets.presets as preset (preset.id)}
+            {@const active = promptPresets.isActive(preset.id)}
+            {@const mode = promptPresets.activeMode(preset.id)}
+            {@const choiceCount = promptPresets.countChoices(preset.id)}
+            <li class="rounded-lg border {active ? 'border-indigo-500/60 bg-indigo-500/5' : 'border-neutral-800 bg-neutral-950/60'} p-2">
+              <div class="flex items-center gap-3">
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2">
+                    <p class="truncate text-sm text-neutral-100">{preset.name}</p>
+                    {#if active && mode}
+                      <span class="shrink-0 rounded-full border border-indigo-500/40 bg-indigo-500/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-indigo-300">
+                        {presetModeIcon(mode)} {presetModeLabel(mode)}
+                      </span>
+                    {/if}
+                  </div>
+                  <p class="mt-0.5 truncate font-mono text-[11px] text-neutral-500">
+                    {preset.content || "(empty)"}
+                  </p>
+                  <p class="text-[10px] text-neutral-600">
+                    {choiceCount} wildcard option{choiceCount === 1 ? "" : "s"}
+                  </p>
+                </div>
+                <div class="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] {active ? 'text-indigo-300 hover:text-neutral-200' : 'text-neutral-300 hover:text-indigo-200'}"
+                    onclick={() => onPresetActivateClick(preset)}
+                    title={active ? "Deactivate" : "Activate…"}
+                  >{active ? "Deactivate" : "Activate…"}</button>
+                  {#if active && mode}
+                    <button
+                      type="button"
+                      class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-indigo-200"
+                      onclick={() => (activatingPresetId = preset.id)}
+                      title="Change mode"
+                    >↻ mode</button>
+                  {/if}
+                  <button
+                    type="button"
+                    class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-300 hover:text-indigo-200"
+                    onclick={() => (editingPresetId = preset.id)}
+                  >Edit</button>
+                  <button
+                    type="button"
+                    class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-neutral-200"
+                    onclick={() => promptPresets.duplicate(preset.id)}
+                    title="Duplicate"
+                  >⧉</button>
+                  <button
+                    type="button"
+                    class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:bg-red-500/10 hover:text-red-300"
+                    onclick={() => confirmDeletePreset(preset)}
+                    title="Delete"
+                    aria-label={`Delete ${preset.name}`}
+                  >✕</button>
+                </div>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+{/if}
+
+    <!-- Import / export -->
+    <section class="rounded-lg border border-neutral-800 bg-neutral-950/50 p-3 space-y-2">
+      <h3 class="text-[10px] uppercase tracking-wide text-neutral-500">
+        Import / export ({activeTab === "styles" ? "styles" : "presets"})
+      </h3>
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+          onclick={exportAll}
+          disabled={activeTab === "styles" ? styles.styles.length === 0 : promptPresets.presets.length === 0}
+        >Export all</button>
+        <button
+          type="button"
+          class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+          onclick={importStyles}
+        >Import…</button>
+        <label class="ml-2 inline-flex items-center gap-1 text-[11px] text-neutral-400">
+          <input type="radio" bind:group={importMode} value="merge" class="accent-indigo-500" />
+          Merge
+        </label>
+        <label class="inline-flex items-center gap-1 text-[11px] text-neutral-400">
+          <input type="radio" bind:group={importMode} value="replace" class="accent-indigo-500" />
+          Replace all
+        </label>
+        <input
+          bind:this={fileInput}
+          type="file"
+          accept="application/json,.json"
+          class="hidden"
+          onchange={onFilePicked}
+        />
+      </div>
+      <p class="text-[10px] text-neutral-500">Import auto-detects whether the file contains styles or presets.</p>
+      {#if importStatus}
+        <p class="text-[11px] text-emerald-400">{importStatus}</p>
+      {/if}
+      {#if importError}
+        <p class="text-[11px] text-red-400">{importError}</p>
+      {/if}
+    </section>
+</div>
+
+{#if editingId}
+  <StyleEditor styleId={editingId} onclose={() => (editingId = null)} />
+{/if}
+
+{#if editingPresetId}
+  <PresetEditor presetId={editingPresetId} onclose={() => (editingPresetId = null)} />
+{/if}
+
+{#if activatingPresetId}
+  <PresetActivationModal
+    presetId={activatingPresetId}
+    onclose={() => (activatingPresetId = null)}
+  />
+{/if}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -985,6 +985,8 @@ const de: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Vergleichen",
   "bottom_panel.tab.artists": "Künstler",
+  "bottom_panel.tab.styles": "Stile",
+  "bottom_panel.tab.schedule": "Zeitplan",
   "bottom_panel.no_favourite_artists": "Markiere einen Künstler in der Galerie als Favorit, damit er hier erscheint",
   "bottom_panel.no_artist_results": "Keine Favoriten-Künstler passen zur Suche",
   "bottom_panel.artist_search_placeholder": "Favoriten-Künstler suchen...",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -703,6 +703,8 @@ const en: Record<string, string> = {
   "bottom_panel.card_size": "Card size",
   "bottom_panel.tab.compare": "Compare",
   "bottom_panel.tab.artists": "Artists",
+  "bottom_panel.tab.styles": "Styles",
+  "bottom_panel.tab.schedule": "Schedule",
   "bottom_panel.no_favourite_artists": "Favourite an artist from the Artist Gallery or prompt and they'll appear here",
   "bottom_panel.no_artist_results": "No favourited artists match your search",
   "bottom_panel.artist_search_placeholder": "Search favourited artists...",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1012,6 +1012,8 @@ const es: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparar",
   "bottom_panel.tab.artists": "Artistas",
+  "bottom_panel.tab.styles": "Estilos",
+  "bottom_panel.tab.schedule": "Programación",
   "bottom_panel.no_favourite_artists": "Marca un artista como favorito en la galería para verlo aquí",
   "bottom_panel.no_artist_results": "Ningún artista favorito coincide con la búsqueda",
   "bottom_panel.artist_search_placeholder": "Buscar artistas favoritos...",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1010,6 +1010,8 @@ const fr: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparer",
   "bottom_panel.tab.artists": "Artistes",
+  "bottom_panel.tab.styles": "Styles",
+  "bottom_panel.tab.schedule": "Planification",
   "bottom_panel.no_favourite_artists": "Mets un artiste en favori depuis la galerie pour le voir ici",
   "bottom_panel.no_artist_results": "Aucun artiste favori ne correspond à la recherche",
   "bottom_panel.artist_search_placeholder": "Rechercher des artistes favoris...",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -983,6 +983,8 @@ const it: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Confronta",
   "bottom_panel.tab.artists": "Artisti",
+  "bottom_panel.tab.styles": "Stili",
+  "bottom_panel.tab.schedule": "Pianificazione",
   "bottom_panel.no_favourite_artists": "Aggiungi un artista ai preferiti dalla galleria per vederlo qui",
   "bottom_panel.no_artist_results": "Nessun artista preferito corrisponde alla ricerca",
   "bottom_panel.artist_search_placeholder": "Cerca artisti preferiti...",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1008,6 +1008,8 @@ const ja: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比較",
   "bottom_panel.tab.artists": "アーティスト",
+  "bottom_panel.tab.styles": "スタイル",
+  "bottom_panel.tab.schedule": "スケジュール",
   "bottom_panel.no_favourite_artists": "ギャラリーでアーティストをお気に入りに追加するとここに表示されます",
   "bottom_panel.no_artist_results": "検索に一致するお気に入りアーティストはいません",
   "bottom_panel.artist_search_placeholder": "お気に入りアーティストを検索...",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -983,6 +983,8 @@ const ko: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "비교",
   "bottom_panel.tab.artists": "아티스트",
+  "bottom_panel.tab.styles": "스타일",
+  "bottom_panel.tab.schedule": "스케줄",
   "bottom_panel.no_favourite_artists": "갤러리에서 아티스트를 즐겨찾기에 추가하면 여기에 표시됩니다",
   "bottom_panel.no_artist_results": "검색에 일치하는 즐겨찾기 아티스트가 없습니다",
   "bottom_panel.artist_search_placeholder": "즐겨찾기 아티스트 검색...",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -985,6 +985,8 @@ const pt: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Comparar",
   "bottom_panel.tab.artists": "Artistas",
+  "bottom_panel.tab.styles": "Estilos",
+  "bottom_panel.tab.schedule": "Agendamento",
   "bottom_panel.no_favourite_artists": "Adiciona um artista aos favoritos na galeria para vê-lo aqui",
   "bottom_panel.no_artist_results": "Nenhum artista favorito corresponde à pesquisa",
   "bottom_panel.artist_search_placeholder": "Pesquisar artistas favoritos...",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -983,6 +983,8 @@ const ru: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "Сравнение",
   "bottom_panel.tab.artists": "Художники",
+  "bottom_panel.tab.styles": "Стили",
+  "bottom_panel.tab.schedule": "Расписание",
   "bottom_panel.no_favourite_artists": "Добавьте художника в избранное в галерее, чтобы он появился здесь",
   "bottom_panel.no_artist_results": "Нет избранных художников, соответствующих поиску",
   "bottom_panel.artist_search_placeholder": "Поиск избранных художников...",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -983,6 +983,8 @@ const zhTw: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比較",
   "bottom_panel.tab.artists": "藝術家",
+  "bottom_panel.tab.styles": "風格",
+  "bottom_panel.tab.schedule": "排程",
   "bottom_panel.no_favourite_artists": "在畫廊中將藝術家加入收藏，即可在此處查看",
   "bottom_panel.no_artist_results": "沒有符合搜尋條件的收藏藝術家",
   "bottom_panel.artist_search_placeholder": "搜尋收藏的藝術家...",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -983,6 +983,8 @@ const zh: Record<string, string> = {
   // ── Compare Grid ────────────────────────────────────────
   "bottom_panel.tab.compare": "比较",
   "bottom_panel.tab.artists": "艺术家",
+  "bottom_panel.tab.styles": "风格",
+  "bottom_panel.tab.schedule": "调度",
   "bottom_panel.no_favourite_artists": "在画廊中收藏艺术家，即可在此处查看",
   "bottom_panel.no_artist_results": "没有符合搜索条件的收藏艺术家",
   "bottom_panel.artist_search_placeholder": "搜索收藏的艺术家...",

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -2,6 +2,8 @@ import { ipcStore } from "../utils/ipc.js";
 import { parseScheduledPrompt } from "../utils/promptSchedule.js";
 import type { LoraEntry } from "../types/index.js";
 import { autocomplete } from "./autocomplete.svelte.js";
+import { styles } from "./styles.svelte.js";
+import { promptPresets } from "./promptPresets.svelte.js";
 
 const STORE_KEY = "generation-settings";
 const PROMPT_HISTORY_KEY = "mooshieui.promptHistory.v1";
@@ -776,6 +778,25 @@ class GenerationStore {
 
     let positivePrompt = this.mergeTagPrompts(this.positivePrompt, style.positive);
     let negativePrompt = this.mergeTagPrompts(this.negativePrompt, style.negative);
+
+    // Inject tags contributed by any currently-active Artist Styles. These are
+    // not visible in the prompt textbox — they flow straight into the payload
+    // so the user sees badges in the UI instead.
+    const styleFragment = styles.buildPromptFragment();
+    if (styleFragment) {
+      positivePrompt = this.mergeTagPrompts(positivePrompt, styleFragment);
+    }
+
+    // Inject active Prompt Presets (prepend / append / wildcard). Wildcards
+    // pick a random choice per generation — mergeTagPrompts dedupes against
+    // whatever the user has already typed.
+    const preset = promptPresets.resolve();
+    if (preset.prepend) {
+      positivePrompt = this.mergeTagPrompts(preset.prepend, positivePrompt);
+    }
+    if (preset.append) {
+      positivePrompt = this.mergeTagPrompts(positivePrompt, preset.append);
+    }
 
     // Auto-apply quality tags for supported model families
     if (this.autoQualityTags) {

--- a/src/lib/stores/promptPresets.svelte.ts
+++ b/src/lib/stores/promptPresets.svelte.ts
@@ -1,0 +1,337 @@
+/**
+ * Prompt Presets store.
+ *
+ * A "Preset" is a named chunk of prompt text (any tags, not just artists)
+ * that the user can activate to inject into generations. On activation the
+ * user picks a mode:
+ *   - "prepend"  — injected at the start of the positive prompt
+ *   - "append"   — injected at the end
+ *   - "wildcard" — exactly ONE of the comma-separated tags inside `content`
+ *                  is chosen at random for each generation (re-rolled every
+ *                  time `resolve()` is called)
+ *
+ * Like Artist Styles, presets live outside the prompt textbox — users see
+ * badges, not tags — and survive reloads via localStorage.
+ */
+
+const STORAGE_KEY = "mooshieui.promptPresets.v1";
+const ACTIVE_KEY = "mooshieui.promptPresets.active.v1";
+const EXPORT_KIND = "mooshieui.prompt-presets";
+const EXPORT_VERSION = 1;
+
+export type PresetMode = "prepend" | "append" | "wildcard";
+
+export interface PromptPreset {
+  id: string;
+  name: string;
+  /** Free-form prompt text. For wildcard mode, this is split on commas/newlines. */
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ActivePreset {
+  id: string;
+  mode: PresetMode;
+}
+
+interface PersistedState {
+  version: number;
+  presets: PromptPreset[];
+}
+
+export interface PresetsExport {
+  kind: typeof EXPORT_KIND;
+  version: number;
+  exportedAt: string;
+  presets: PromptPreset[];
+}
+
+function genId(): string {
+  return `pst_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sanitizePreset(raw: any): PromptPreset | null {
+  if (!raw || typeof raw.id !== "string" || typeof raw.name !== "string") return null;
+  const now = Date.now();
+  return {
+    id: raw.id,
+    name: raw.name.trim() || "Untitled preset",
+    content: typeof raw.content === "string" ? raw.content : "",
+    createdAt: typeof raw.createdAt === "number" && raw.createdAt > 0 ? raw.createdAt : now,
+    updatedAt: typeof raw.updatedAt === "number" && raw.updatedAt > 0 ? raw.updatedAt : now,
+  };
+}
+
+/** Split wildcard content into individual tag candidates. */
+function splitWildcardChoices(content: string): string[] {
+  return content
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+class PromptPresetsStore {
+  presets = $state<PromptPreset[]>([]);
+  active = $state<ActivePreset[]>([]);
+
+  constructor() {
+    this.loadSettings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private loadSettings() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<PersistedState>;
+        if (parsed && Array.isArray(parsed.presets)) {
+          this.presets = parsed.presets.map(sanitizePreset).filter(Boolean) as PromptPreset[];
+        }
+      }
+    } catch (e) {
+      console.error("prompt-presets: load failed", e);
+    }
+    try {
+      const raw = localStorage.getItem(ACTIVE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as ActivePreset[];
+        if (Array.isArray(parsed)) {
+          const ids = new Set(this.presets.map((p) => p.id));
+          this.active = parsed.filter(
+            (a): a is ActivePreset =>
+              !!a &&
+              typeof a.id === "string" &&
+              ids.has(a.id) &&
+              (a.mode === "prepend" || a.mode === "append" || a.mode === "wildcard"),
+          );
+        }
+      }
+    } catch (e) {
+      console.error("prompt-presets: load active failed", e);
+    }
+  }
+
+  private saveSettings() {
+    try {
+      const payload: PersistedState = { version: EXPORT_VERSION, presets: this.presets };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (e) {
+      console.error("prompt-presets: save failed", e);
+    }
+  }
+
+  private saveActive() {
+    try {
+      localStorage.setItem(ACTIVE_KEY, JSON.stringify(this.active));
+    } catch (e) {
+      console.error("prompt-presets: save active failed", e);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  getById(id: string): PromptPreset | null {
+    return this.presets.find((p) => p.id === id) ?? null;
+  }
+
+  activeMode(id: string): PresetMode | null {
+    return this.active.find((a) => a.id === id)?.mode ?? null;
+  }
+
+  isActive(id: string): boolean {
+    return this.active.some((a) => a.id === id);
+  }
+
+  get activeEntries(): Array<{ preset: PromptPreset; mode: PresetMode }> {
+    const byId = new Map(this.presets.map((p) => [p.id, p]));
+    const out: Array<{ preset: PromptPreset; mode: PresetMode }> = [];
+    for (const a of this.active) {
+      const preset = byId.get(a.id);
+      if (preset) out.push({ preset, mode: a.mode });
+    }
+    return out;
+  }
+
+  /**
+   * Resolve active presets into concrete text fragments. Wildcard mode picks
+   * one random choice from the preset content. Called once per generation.
+   */
+  resolve(): { prepend: string; append: string } {
+    const prepends: string[] = [];
+    const appends: string[] = [];
+    for (const { preset, mode } of this.activeEntries) {
+      if (mode === "wildcard") {
+        const choices = splitWildcardChoices(preset.content);
+        if (choices.length === 0) continue;
+        const picked = choices[Math.floor(Math.random() * choices.length)];
+        // Wildcard picks are appended by convention (same semantic weight
+        // regardless of position within the prompt).
+        appends.push(picked);
+      } else if (mode === "prepend") {
+        const text = preset.content.trim();
+        if (text) prepends.push(text);
+      } else {
+        const text = preset.content.trim();
+        if (text) appends.push(text);
+      }
+    }
+    return {
+      prepend: prepends.join(", "),
+      append: appends.join(", "),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Activation
+  // ---------------------------------------------------------------------------
+
+  activate(id: string, mode: PresetMode) {
+    if (!this.getById(id)) return;
+    const filtered = this.active.filter((a) => a.id !== id);
+    this.active = [...filtered, { id, mode }];
+    this.saveActive();
+  }
+
+  deactivate(id: string) {
+    if (!this.isActive(id)) return;
+    this.active = this.active.filter((a) => a.id !== id);
+    this.saveActive();
+  }
+
+  setMode(id: string, mode: PresetMode) {
+    if (!this.isActive(id)) return;
+    this.active = this.active.map((a) => (a.id === id ? { ...a, mode } : a));
+    this.saveActive();
+  }
+
+  clearActive() {
+    if (this.active.length === 0) return;
+    this.active = [];
+    this.saveActive();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  create(name: string, content = ""): PromptPreset {
+    const now = Date.now();
+    const preset: PromptPreset = {
+      id: genId(),
+      name: name.trim() || "Untitled preset",
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.presets = [preset, ...this.presets];
+    this.saveSettings();
+    return preset;
+  }
+
+  update(id: string, patch: Partial<Omit<PromptPreset, "id" | "createdAt">>): void {
+    let changed = false;
+    this.presets = this.presets.map((p) => {
+      if (p.id !== id) return p;
+      changed = true;
+      return {
+        ...p,
+        name: typeof patch.name === "string" ? patch.name.trim() || p.name : p.name,
+        content: typeof patch.content === "string" ? patch.content : p.content,
+        updatedAt: Date.now(),
+      };
+    });
+    if (changed) this.saveSettings();
+  }
+
+  duplicate(id: string): PromptPreset | null {
+    const src = this.getById(id);
+    if (!src) return null;
+    const now = Date.now();
+    const copy: PromptPreset = {
+      ...src,
+      id: genId(),
+      name: `${src.name} (copy)`,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.presets = [copy, ...this.presets];
+    this.saveSettings();
+    return copy;
+  }
+
+  remove(id: string): void {
+    if (!this.getById(id)) return;
+    this.presets = this.presets.filter((p) => p.id !== id);
+    this.saveSettings();
+    if (this.isActive(id)) {
+      this.active = this.active.filter((a) => a.id !== id);
+      this.saveActive();
+    }
+  }
+
+  /** Count of comma/newline-separated choices — surfaced in the editor UI. */
+  countChoices(id: string): number {
+    const p = this.getById(id);
+    if (!p) return 0;
+    return splitWildcardChoices(p.content).length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export / import
+  // ---------------------------------------------------------------------------
+
+  exportJSON(ids?: string[]): string {
+    const selected = ids ? this.presets.filter((p) => ids.includes(p.id)) : this.presets;
+    const payload: PresetsExport = {
+      kind: EXPORT_KIND,
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      presets: selected,
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+
+  importJSON(raw: string, mode: "merge" | "replace" = "merge"): { added: number; skipped: number } {
+    const parsed = JSON.parse(raw) as Partial<PresetsExport>;
+    if (!parsed || typeof parsed !== "object") throw new Error("Invalid JSON payload");
+    if (parsed.kind !== EXPORT_KIND) throw new Error("Not a MooshieUI prompt presets export");
+    const incoming = Array.isArray(parsed.presets)
+      ? (parsed.presets.map(sanitizePreset).filter(Boolean) as PromptPreset[])
+      : [];
+
+    if (mode === "replace") {
+      this.presets = incoming;
+      this.saveSettings();
+      const ids = new Set(this.presets.map((p) => p.id));
+      this.active = this.active.filter((a) => ids.has(a.id));
+      this.saveActive();
+      return { added: incoming.length, skipped: 0 };
+    }
+
+    const existing = new Set(this.presets.map((p) => p.id));
+    let added = 0;
+    let skipped = 0;
+    const fresh: PromptPreset[] = [];
+    for (const p of incoming) {
+      if (existing.has(p.id)) {
+        skipped++;
+        continue;
+      }
+      fresh.push(p);
+      added++;
+    }
+    if (fresh.length > 0) {
+      this.presets = [...fresh, ...this.presets];
+      this.saveSettings();
+    }
+    return { added, skipped };
+  }
+}
+
+export const promptPresets = new PromptPresetsStore();

--- a/src/lib/stores/styles.svelte.ts
+++ b/src/lib/stores/styles.svelte.ts
@@ -1,0 +1,428 @@
+/**
+ * Artist Styles store.
+ *
+ * A "Style" is a user-curated bundle of artist tags, each with its own
+ * weight, multiplied by an overall style weight. Styles can be activated to
+ * contribute tags to the generated prompt WITHOUT appearing in the prompt
+ * textbox — they are injected downstream in `generation.toParams()`.
+ *
+ * Storage: localStorage under `mooshieui.styles.v1`.
+ * Export/import: JSON envelope with kind + version for forward-compat.
+ */
+
+const STORAGE_KEY = "mooshieui.styles.v1";
+const ACTIVE_KEY = "mooshieui.styles.active.v1";
+const EXPORT_KIND = "mooshieui.artist-styles";
+const EXPORT_VERSION = 1;
+
+/** Max dimension (px) for thumbnails stored with the style. Keeps localStorage / exports small. */
+const THUMBNAIL_MAX_DIM = 384;
+
+export interface StyleArtist {
+  /** Artist tag as it will appear in the prompt (e.g. "@dairi" or "dairi"). Escaping handled at injection time. */
+  tag: string;
+  /** Optional slug to cross-link with the artist gallery (for UI enrichment). */
+  slug?: string;
+  /** Per-artist weight. Multiplied by the parent style's overallWeight at injection. */
+  weight: number;
+}
+
+export interface ArtistStyle {
+  id: string;
+  name: string;
+  artists: StyleArtist[];
+  /** Multiplier applied on top of each artist's individual weight. */
+  overallWeight: number;
+  /** Base64 data URL. Omitted when the style has no thumbnail. */
+  thumbnail: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface PersistedState {
+  version: number;
+  styles: ArtistStyle[];
+}
+
+export interface StylesExport {
+  kind: typeof EXPORT_KIND;
+  version: number;
+  exportedAt: string;
+  styles: ArtistStyle[];
+}
+
+function genId(): string {
+  return `sty_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function clampWeight(w: unknown, fallback = 1.0): number {
+  const n = typeof w === "number" ? w : Number(w);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(3, n));
+}
+
+function sanitizeArtist(raw: any): StyleArtist | null {
+  if (!raw || typeof raw.tag !== "string") return null;
+  const tag = raw.tag.trim();
+  if (!tag) return null;
+  return {
+    tag,
+    slug: typeof raw.slug === "string" ? raw.slug : undefined,
+    weight: clampWeight(raw.weight, 1.0),
+  };
+}
+
+function sanitizeStyle(raw: any): ArtistStyle | null {
+  if (!raw || typeof raw.id !== "string" || typeof raw.name !== "string") return null;
+  const artists = Array.isArray(raw.artists)
+    ? (raw.artists.map(sanitizeArtist).filter(Boolean) as StyleArtist[])
+    : [];
+  const now = Date.now();
+  return {
+    id: raw.id,
+    name: raw.name.trim() || "Untitled style",
+    artists,
+    overallWeight: clampWeight(raw.overallWeight, 1.0),
+    thumbnail: typeof raw.thumbnail === "string" && raw.thumbnail.startsWith("data:") ? raw.thumbnail : null,
+    createdAt: typeof raw.createdAt === "number" && raw.createdAt > 0 ? raw.createdAt : now,
+    updatedAt: typeof raw.updatedAt === "number" && raw.updatedAt > 0 ? raw.updatedAt : now,
+  };
+}
+
+/**
+ * Escape a tag for the ComfyUI/A1111 weight syntax. Raw parentheses that
+ * are part of the artist's name itself must be backslash-escaped so they
+ * aren't parsed as attention brackets.
+ */
+function escapeTagForPrompt(tag: string): string {
+  return tag.replace(/([()\[\]])/g, "\\$1");
+}
+
+/** Round to 2 decimal places for a stable, compact prompt representation. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Resize an image (blob/dataUrl) down to THUMBNAIL_MAX_DIM and return a JPEG
+ * data URL. Keeps exports/localStorage reasonably sized.
+ */
+export async function resizeImageToDataUrl(source: Blob | string): Promise<string> {
+  const blobUrl = typeof source === "string" ? source : URL.createObjectURL(source);
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image();
+      el.crossOrigin = "anonymous";
+      el.onload = () => resolve(el);
+      el.onerror = () => reject(new Error("Failed to load image for thumbnail"));
+      el.src = blobUrl;
+    });
+    const scale = Math.min(1, THUMBNAIL_MAX_DIM / Math.max(img.naturalWidth, img.naturalHeight));
+    const w = Math.max(1, Math.round(img.naturalWidth * scale));
+    const h = Math.max(1, Math.round(img.naturalHeight * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+    ctx.drawImage(img, 0, 0, w, h);
+    return canvas.toDataURL("image/jpeg", 0.82);
+  } finally {
+    if (typeof source !== "string") URL.revokeObjectURL(blobUrl);
+  }
+}
+
+class StylesStore {
+  styles = $state<ArtistStyle[]>([]);
+  /** IDs of currently-active styles. Their tags are injected into every generation. */
+  activeIds = $state<string[]>([]);
+
+  constructor() {
+    this.loadSettings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  private loadSettings() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<PersistedState>;
+        if (parsed && Array.isArray(parsed.styles)) {
+          this.styles = parsed.styles.map(sanitizeStyle).filter(Boolean) as ArtistStyle[];
+        }
+      }
+    } catch (e) {
+      console.error("styles: load failed", e);
+    }
+    try {
+      const raw = localStorage.getItem(ACTIVE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as string[];
+        if (Array.isArray(parsed)) {
+          const ids = new Set(this.styles.map((s) => s.id));
+          this.activeIds = parsed.filter((id) => typeof id === "string" && ids.has(id));
+        }
+      }
+    } catch (e) {
+      console.error("styles: load active failed", e);
+    }
+  }
+
+  private saveSettings() {
+    try {
+      const payload: PersistedState = { version: EXPORT_VERSION, styles: this.styles };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (e) {
+      console.error("styles: save failed", e);
+    }
+  }
+
+  private saveActive() {
+    try {
+      localStorage.setItem(ACTIVE_KEY, JSON.stringify(this.activeIds));
+    } catch (e) {
+      console.error("styles: save active failed", e);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Queries
+  // ---------------------------------------------------------------------------
+
+  getById(id: string): ArtistStyle | null {
+    return this.styles.find((s) => s.id === id) ?? null;
+  }
+
+  isActive(id: string): boolean {
+    return this.activeIds.includes(id);
+  }
+
+  get activeStyles(): ArtistStyle[] {
+    const byId = new Map(this.styles.map((s) => [s.id, s]));
+    return this.activeIds.map((id) => byId.get(id)).filter(Boolean) as ArtistStyle[];
+  }
+
+  /**
+   * Build the prompt fragment (comma-separated weighted tags) contributed by
+   * all currently-active styles. Returns empty string when nothing active.
+   */
+  buildPromptFragment(): string {
+    const parts: string[] = [];
+    const seen = new Set<string>();
+    for (const style of this.activeStyles) {
+      for (const a of style.artists) {
+        const tag = a.tag.trim();
+        if (!tag) continue;
+        const key = tag.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const w = round2(clampWeight(a.weight) * clampWeight(style.overallWeight));
+        if (w <= 0) continue;
+        const safeTag = escapeTagForPrompt(tag);
+        // Always emit (tag:weight) so downstream code has stable weights, even at 1.0.
+        parts.push(`(${safeTag}:${w})`);
+      }
+    }
+    return parts.join(", ");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Activation
+  // ---------------------------------------------------------------------------
+
+  activate(id: string) {
+    if (!this.getById(id)) return;
+    if (this.activeIds.includes(id)) return;
+    this.activeIds = [...this.activeIds, id];
+    this.saveActive();
+  }
+
+  deactivate(id: string) {
+    if (!this.activeIds.includes(id)) return;
+    this.activeIds = this.activeIds.filter((x) => x !== id);
+    this.saveActive();
+  }
+
+  toggleActive(id: string): boolean {
+    if (this.activeIds.includes(id)) {
+      this.deactivate(id);
+      return false;
+    }
+    this.activate(id);
+    return true;
+  }
+
+  clearActive() {
+    if (this.activeIds.length === 0) return;
+    this.activeIds = [];
+    this.saveActive();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  create(name: string, artists: StyleArtist[] = [], overallWeight = 1.0): ArtistStyle {
+    const now = Date.now();
+    const style: ArtistStyle = {
+      id: genId(),
+      name: name.trim() || "Untitled style",
+      artists: artists.map((a) => ({ ...a, weight: clampWeight(a.weight, 1.0) })),
+      overallWeight: clampWeight(overallWeight, 1.0),
+      thumbnail: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.styles = [style, ...this.styles];
+    this.saveSettings();
+    return style;
+  }
+
+  update(id: string, patch: Partial<Omit<ArtistStyle, "id" | "createdAt">>): void {
+    let changed = false;
+    this.styles = this.styles.map((s) => {
+      if (s.id !== id) return s;
+      changed = true;
+      return {
+        ...s,
+        name: typeof patch.name === "string" ? patch.name.trim() || s.name : s.name,
+        artists: Array.isArray(patch.artists)
+          ? patch.artists
+              .map((a) => sanitizeArtist(a))
+              .filter(Boolean) as StyleArtist[]
+          : s.artists,
+        overallWeight:
+          typeof patch.overallWeight === "number"
+            ? clampWeight(patch.overallWeight, s.overallWeight)
+            : s.overallWeight,
+        thumbnail:
+          patch.thumbnail === null
+            ? null
+            : typeof patch.thumbnail === "string" && patch.thumbnail.startsWith("data:")
+              ? patch.thumbnail
+              : s.thumbnail,
+        updatedAt: Date.now(),
+      };
+    });
+    if (changed) this.saveSettings();
+  }
+
+  duplicate(id: string): ArtistStyle | null {
+    const src = this.getById(id);
+    if (!src) return null;
+    const now = Date.now();
+    const copy: ArtistStyle = {
+      ...src,
+      id: genId(),
+      name: `${src.name} (copy)`,
+      artists: src.artists.map((a) => ({ ...a })),
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.styles = [copy, ...this.styles];
+    this.saveSettings();
+    return copy;
+  }
+
+  remove(id: string): void {
+    if (!this.getById(id)) return;
+    this.styles = this.styles.filter((s) => s.id !== id);
+    this.saveSettings();
+    if (this.activeIds.includes(id)) {
+      this.activeIds = this.activeIds.filter((x) => x !== id);
+      this.saveActive();
+    }
+  }
+
+  // Convenience mutations used by the editor UI.
+  addArtist(id: string, artist: StyleArtist): void {
+    const style = this.getById(id);
+    if (!style) return;
+    const tagLower = artist.tag.trim().toLowerCase();
+    if (!tagLower) return;
+    if (style.artists.some((a) => a.tag.trim().toLowerCase() === tagLower)) return;
+    this.update(id, { artists: [...style.artists, { ...artist, weight: clampWeight(artist.weight, 1.0) }] });
+  }
+
+  updateArtist(styleId: string, index: number, patch: Partial<StyleArtist>): void {
+    const style = this.getById(styleId);
+    if (!style) return;
+    if (index < 0 || index >= style.artists.length) return;
+    const next = style.artists.map((a, i) => (i === index ? { ...a, ...patch } : a));
+    this.update(styleId, { artists: next });
+  }
+
+  removeArtist(styleId: string, index: number): void {
+    const style = this.getById(styleId);
+    if (!style) return;
+    this.update(styleId, { artists: style.artists.filter((_, i) => i !== index) });
+  }
+
+  setThumbnail(id: string, dataUrl: string | null): void {
+    this.update(id, { thumbnail: dataUrl });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export / import
+  // ---------------------------------------------------------------------------
+
+  exportJSON(styleIds?: string[]): string {
+    const selected = styleIds
+      ? this.styles.filter((s) => styleIds.includes(s.id))
+      : this.styles;
+    const payload: StylesExport = {
+      kind: EXPORT_KIND,
+      version: EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      styles: selected,
+    };
+    return JSON.stringify(payload, null, 2);
+  }
+
+  /**
+   * Import styles from a JSON string.
+   * - "merge": new IDs are appended; existing IDs are skipped (use "replace-id" to overwrite).
+   * - "replace": wipes existing styles entirely and installs the imported set.
+   */
+  importJSON(raw: string, mode: "merge" | "replace" = "merge"): { added: number; skipped: number } {
+    const parsed = JSON.parse(raw) as Partial<StylesExport>;
+    if (!parsed || typeof parsed !== "object") throw new Error("Invalid JSON payload");
+    if (parsed.kind !== EXPORT_KIND) throw new Error("Not a MooshieUI styles export");
+    const incoming = Array.isArray(parsed.styles)
+      ? (parsed.styles.map(sanitizeStyle).filter(Boolean) as ArtistStyle[])
+      : [];
+
+    if (mode === "replace") {
+      this.styles = incoming;
+      this.saveSettings();
+      // Purge active IDs that no longer exist.
+      const ids = new Set(this.styles.map((s) => s.id));
+      this.activeIds = this.activeIds.filter((id) => ids.has(id));
+      this.saveActive();
+      return { added: incoming.length, skipped: 0 };
+    }
+
+    const existing = new Set(this.styles.map((s) => s.id));
+    let added = 0;
+    let skipped = 0;
+    const fresh: ArtistStyle[] = [];
+    for (const s of incoming) {
+      if (existing.has(s.id)) {
+        skipped++;
+        continue;
+      }
+      fresh.push(s);
+      added++;
+    }
+    if (fresh.length > 0) {
+      this.styles = [...fresh, ...this.styles];
+      this.saveSettings();
+    }
+    return { added, skipped };
+  }
+}
+
+export const styles = new StylesStore();


### PR DESCRIPTION
v1.0.8: Artist Styles, Prompt Presets, and Schedule builder

### New Features
- **Artist Styles** — bundle artist tags (with per-tag weights + overall multiplier and optional thumbnails) into reusable styles. Activating a style injects its tags into the positive prompt non-destructively at generation time (the prompt textbox is never mutated). Duplicate, JSON export/import, and click-to-deactivate badges above the prompt.
- **Prompt Presets** — non-artist prompt variables with three activation modes: **Prepend**, **Append**, and **Wildcard** (splits content on commas/newlines and picks one entry per generation). Active presets show as badges with ↑/↓/🎲 indicators.
- **Styles tab in the bottom panel** — Styles + Prompt Presets manager is now a dedicated bottom-panel tab with a live active-count badge, replacing the earlier floating modal.
- **Prompt Scheduling builder** — new **Schedule** tab in the bottom panel with a GUI for all four scheduling syntaxes (`<fromto[N]:A || B>`, `<from:N>...</from>`, `<to:N>...</to>`, `<range:A:B>...</range>`): text fields + sliders with a live preview and plain-English description of when each segment applies. One-click buttons append to the positive/negative prompt or copy to clipboard. Collapsible syntax cheat-sheet included.

### Autocomplete Improvements
- **Anima-aware artist autocomplete in Style editor** — artist search uses the active model's tag list (Anima tags for Anima-architecture models, Danbooru otherwise) and adds/strips the `@` prefix automatically to match each architecture's convention.
- **Full autocomplete in Preset editor** — preset content uses the same `PromptTextarea` as the main prompt (tag autocomplete, scheduling highlight, NAI brackets, Ctrl+↑/↓ weights).

### i18n
- Added `bottom_panel.tab.styles` and `bottom_panel.tab.schedule` keys across all 11 supported locales.
