### PR TITLE
v1.0.9: Account-based preference sync, GPU compute capability command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## What's New in v1.0.9
+
+### Account-Based Preference Sync
+- **Cross-device settings sync** — user preferences are now stored server-side per account, so switching OS or device with the same MooshieUI login yields the same configuration. Synced state includes: generation parameters, prompt history, prompt presets, artist styles, artist favourites, gallery boards, autocomplete settings, accessibility options, and locale.
+- **Seamless sync on login** — on startup or login, MooshieUI fetches the server snapshot and applies it to all stores. If no server snapshot exists yet, the current local state is seeded to the server.
+- **Debounced background push** — every settings save triggers a debounced 2-second sync push to the server, collapsing rapid consecutive saves into a single request.
+- **Desktop mode unaffected** — sync is only active in browser/LAN mode; the Tauri desktop app continues to use local-only persistence as before.
+
+### New Tauri Command
+- **`get_compute_capability`** — exposes the host GPU's CUDA compute capability as a float (e.g. `8.9` for RTX 4090), used for model compatibility hints in the UI.
+
+---
+
 ## What's New in v1.0.8
 
 ### New Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## What's New in v1.0.9
+
+### Account-Based Preference Sync
+- **Cross-device settings sync** — user preferences are now stored server-side per account, so switching OS or device with the same MooshieUI login yields the same configuration. Synced state includes: generation parameters, prompt history, prompt presets, artist styles, artist favourites, gallery boards, autocomplete settings, accessibility options, and locale.
+- **Seamless sync on login** — on startup or login, MooshieUI fetches the server snapshot and applies it to all stores. If no server snapshot exists yet, the current local state is seeded to the server.
+- **Debounced background push** — every settings save triggers a debounced 2-second sync push to the server, collapsing rapid consecutive saves into a single request.
+- **Desktop mode unaffected** — sync is only active in browser/LAN mode; the Tauri desktop app continues to use local-only persistence as before.
+
+### New Tauri Command
+- **`get_compute_capability`** — exposes the host GPU's CUDA compute capability as a float (e.g. `8.9` for RTX 4090), used for model compatibility hints in the UI.
+
+---
+
 ## What's New in v1.0.8
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -3200,6 +3200,24 @@ fn detect_compute_capability() -> Option<f32> {
         .reduce(f32::max)
 }
 
+/// Lightweight standalone command — returns just the compute capability of
+/// the highest-tier GPU detected via `nvidia-smi`, without the package-listing
+/// overhead of [`check_attention_backend`]. Used by the recommended-models
+/// dropdown to gate FP8-only entries (Ada/Blackwell). Returns `None` on
+/// non-NVIDIA systems or if `nvidia-smi` is unavailable.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn get_compute_capability() -> Result<Option<f32>, AppError> {
+    Ok(detect_compute_capability())
+}
+
+/// Public wrapper over [`detect_compute_capability`] so the server-mode
+/// webserver IPC bridge can reach it without depending on the
+/// `#[tauri::command]`-only `get_compute_capability` symbol.
+pub fn detect_compute_capability_pub() -> Option<f32> {
+    detect_compute_capability()
+}
+
 /// Install (or uninstall) an attention backend package in the venv.
 /// Accepts: "default", "sage_v1", "sage_v2", "flash_v1", "flash_v2".
 #[cfg(feature = "desktop")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod setup;
 pub mod state;
 pub mod temp_images;
 pub mod templates;
+pub mod user_prefs;
 pub mod webserver;
 
 use std::sync::Arc;
@@ -409,6 +410,7 @@ pub fn run() {
             commands::api::get_gpu_stats,
             commands::api::check_attention_backend,
             commands::api::install_attention_backend,
+            commands::api::get_compute_capability,
             setup::check_setup,
             setup::detect_gpu,
             setup::run_setup,

--- a/src-tauri/src/user_prefs.rs
+++ b/src-tauri/src/user_prefs.rs
@@ -61,19 +61,23 @@ fn prefs_path(username: &str) -> Option<PathBuf> {
 
 /// Load a user's prefs from disk.  Returns `None` if the file doesn't exist
 /// or cannot be parsed (treated as "no prefs yet").
-pub fn load(username: &str) -> Option<UserPrefs> {
+pub async fn load(username: &str) -> Option<UserPrefs> {
     let path = prefs_path(username)?;
-    let bytes = std::fs::read(&path).ok()?;
+    let bytes = tokio::fs::read(&path).await.ok()?;
     serde_json::from_slice(&bytes).ok()
 }
 
 /// Save a user's prefs to disk, creating parent directories as needed.
-pub fn save(username: &str, prefs: &UserPrefs) -> Result<(), String> {
+pub async fn save(username: &str, prefs: &UserPrefs) -> Result<(), String> {
     let path = prefs_path(username).ok_or_else(|| "Cannot resolve prefs path".to_string())?;
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| e.to_string())?;
     }
     let bytes = serde_json::to_vec_pretty(prefs).map_err(|e| e.to_string())?;
-    std::fs::write(&path, &bytes).map_err(|e| e.to_string())?;
+    tokio::fs::write(&path, &bytes)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/user_prefs.rs
+++ b/src-tauri/src/user_prefs.rs
@@ -1,0 +1,79 @@
+//! Per-user preferences storage.
+//!
+//! Stores client-side preferences server-side so they persist across devices
+//! and operating systems when multiple clients connect to the same MooshieUI
+//! server instance.
+//!
+//! Data stored at `{app_data_dir}/users/{username}/prefs.json`.
+//!
+//! The special username `"_admin"` is used for localhost / single-user
+//! desktop sessions where no named account is active.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::config;
+
+/// All user-specific preferences that the frontend persists.
+///
+/// Every field is `Option` so clients can do partial PUTs (unknown fields are
+/// ignored during deserialization).  A `None` field in a PUT body leaves the
+/// server-side value for that category unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct UserPrefs {
+    /// Generation parameters (checkpoint, sampler, dimensions, LoRAs, etc.)
+    pub generation: Option<serde_json::Value>,
+    /// Prompt history (last 100 entries).
+    pub prompt_history: Option<serde_json::Value>,
+    /// Prompt presets (named snippets) and their active state.
+    pub prompt_presets: Option<serde_json::Value>,
+    /// Artist styles and their active state.
+    pub styles: Option<serde_json::Value>,
+    /// Favourited artist slugs and user-defined categories.
+    pub artist_favourites: Option<serde_json::Value>,
+    /// Gallery board assignments and custom board names.
+    pub gallery_boards: Option<serde_json::Value>,
+    /// Autocomplete source/settings.
+    pub autocomplete: Option<serde_json::Value>,
+    /// Accessibility settings (vision simulator, info tips).
+    pub accessibility: Option<serde_json::Value>,
+    /// UI locale string (e.g. `"en"`, `"ja"`).
+    pub locale: Option<serde_json::Value>,
+    /// ISO 8601 timestamp of the last update (set by the server, not the client).
+    pub updated_at: Option<String>,
+}
+
+/// Compute the path to a user's prefs file.
+///
+/// Sanitises the username to prevent path traversal: only alphanumerics,
+/// hyphens, and underscores are allowed (which also covers the reserved
+/// `"_admin"` key for localhost/admin sessions).
+fn prefs_path(username: &str) -> Option<PathBuf> {
+    let safe_name: String = username
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
+    if safe_name.is_empty() {
+        return None;
+    }
+    config::app_data_dir().map(|d| d.join("users").join(safe_name).join("prefs.json"))
+}
+
+/// Load a user's prefs from disk.  Returns `None` if the file doesn't exist
+/// or cannot be parsed (treated as "no prefs yet").
+pub fn load(username: &str) -> Option<UserPrefs> {
+    let path = prefs_path(username)?;
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Save a user's prefs to disk, creating parent directories as needed.
+pub fn save(username: &str, prefs: &UserPrefs) -> Result<(), String> {
+    let path = prefs_path(username).ok_or_else(|| "Cannot resolve prefs path".to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let bytes = serde_json::to_vec_pretty(prefs).map_err(|e| e.to_string())?;
+    std::fs::write(&path, &bytes).map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4166,7 +4166,7 @@ async fn user_prefs_get_handler(
         return unauthorized_response("Authentication required.");
     }
     let username = resolve_prefs_username(&state, &headers, &remote);
-    match user_prefs::load(&username) {
+    match user_prefs::load(&username).await {
         Some(prefs) => (StatusCode::OK, Json(prefs)).into_response(),
         None => StatusCode::NO_CONTENT.into_response(),
     }
@@ -4189,7 +4189,7 @@ async fn user_prefs_set_handler(
     let username = resolve_prefs_username(&state, &headers, &remote);
     // Stamp server-side timestamp so clients can detect stale data in the future.
     prefs.updated_at = Some(chrono::Utc::now().to_rfc3339());
-    match user_prefs::save(&username, &prefs) {
+    match user_prefs::save(&username, &prefs).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -23,6 +23,7 @@ use crate::auth::AuthState;
 use crate::commands;
 use crate::config;
 use crate::state::AppState;
+use crate::user_prefs;
 
 /// Frontend assets embedded at compile time from `../dist/`. Used as a
 /// fallback when the on-disk dist directory isn't found (e.g. installed
@@ -405,6 +406,11 @@ pub async fn start_server(
         .route(
             "/internal-api/_storage/set_limit",
             post(storage_set_limit_handler),
+        )
+        // Per-user preferences (synced across devices/OS)
+        .route(
+            "/internal-api/_user/prefs",
+            get(user_prefs_get_handler).put(user_prefs_set_handler),
         )
         // Health check (unauthenticated, for K8s probes)
         .route("/health", get(health_handler))
@@ -3338,6 +3344,15 @@ async fn dispatch_command(
             Ok(serde_json::Value::Array(encoded))
         }
 
+        // --- GPU detection ---
+        // Mirrors the desktop `get_compute_capability` Tauri command. Used by
+        // the recommended-models dropdown to gate FP8-only entries to GPUs
+        // with native FP8 tensor cores (Ada / Blackwell).
+        "get_compute_capability" => {
+            let cap = crate::commands::api::detect_compute_capability_pub();
+            Ok(serde_json::json!(cap))
+        }
+
         // For commands not yet mapped, return an error
         _ => Err(format!(
             "Command '{}' not implemented in browser mode",
@@ -4110,6 +4125,74 @@ async fn storage_set_limit_handler(
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response(),
         Err(e) => (
             StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-user preferences endpoints
+// ---------------------------------------------------------------------------
+
+/// Resolve the username key used for preferences storage.
+///
+/// Unlike gallery paths where admins share a root directory, every actor —
+/// including localhost admins — gets their own prefs file.  Localhost /
+/// single-user sessions use the reserved key `"_admin"`.
+fn resolve_prefs_username(state: &WebState, headers: &HeaderMap, remote: &SocketAddr) -> String {
+    if is_localhost(remote) || !state.lan_enabled {
+        return "_admin".to_string();
+    }
+    if let Some(token) = extract_token(headers) {
+        if let Some(username) = state.auth.validate_token(&token) {
+            return username;
+        }
+    }
+    "_admin".to_string()
+}
+
+/// GET /internal-api/_user/prefs — fetch the caller's saved preferences.
+///
+/// Returns 200 + JSON body when prefs exist, 204 when none are saved yet.
+/// Anonymous callers receive 401.
+async fn user_prefs_get_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    let role = resolve_role(&state, &headers, &remote);
+    if role == UserRole::Anonymous {
+        return unauthorized_response("Authentication required.");
+    }
+    let username = resolve_prefs_username(&state, &headers, &remote);
+    match user_prefs::load(&username) {
+        Some(prefs) => (StatusCode::OK, Json(prefs)).into_response(),
+        None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+/// PUT /internal-api/_user/prefs — save the caller's preferences.
+///
+/// The body is a full `UserPrefs` JSON object.  The server stamps
+/// `updated_at` before writing.  Anonymous callers receive 401.
+async fn user_prefs_set_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(mut prefs): Json<user_prefs::UserPrefs>,
+) -> Response {
+    let role = resolve_role(&state, &headers, &remote);
+    if role == UserRole::Anonymous {
+        return unauthorized_response("Authentication required.");
+    }
+    let username = resolve_prefs_username(&state, &headers, &remote);
+    // Stamp server-side timestamp so clients can detect stale data in the future.
+    prefs.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    match user_prefs::save(&username, &prefs) {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": e })),
         )
             .into_response(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,6 +16,7 @@
   import { canvas } from "./lib/stores/canvas.svelte.js";
   import { accessibility } from "./lib/stores/accessibility.svelte.js";
   import { locale } from "./lib/stores/locale.svelte.js";
+  import { prefsSync } from "./lib/stores/prefsSync.svelte.js";
   import type { GenerationParams, OutputImage, InterrogationResult } from "./lib/types/index.js";
   import UpdateNotification from "./lib/components/updater/UpdateNotification.svelte";
   import DownloadBanner from "./lib/components/downloads/DownloadBanner.svelte";
@@ -1378,6 +1379,8 @@
 
     // Load persisted settings
     await Promise.all([generation.loadSettings(), autocomplete.loadSettings(), locale.loadSettings()]);
+    // Sync preferences from server (browser/LAN mode only — no-op in Tauri)
+    prefsSync.loadAndApply().catch(() => {});
 
     // Set up event listeners BEFORE starting so we don't miss events
     await Promise.all([

--- a/src/lib/artist-gallery/detection.ts
+++ b/src/lib/artist-gallery/detection.ts
@@ -57,6 +57,10 @@ function tokenize(prompt: string): Array<{ token: string; hadAtPrefix: boolean }
     const hadAt = t.startsWith("@");
     if (hadAt) t = t.replace(/^@+/, "").trim();
     if (!t) continue;
+    // Skip MooshieUI directives like `@preset:foo` — those are inline preset
+    // expansions, not artist references. Only relevant when the token had an
+    // `@` prefix; a bare `preset:foo` would never reach here as a tag anyway.
+    if (hadAt && /^preset:/i.test(t)) continue;
     // Normalise: spaces → underscores, lowercase
     const normalized = t.toLowerCase().replace(/\s+/g, "_");
     if (normalized) out.push({ token: normalized, hadAtPrefix: hadAt });

--- a/src/lib/artist-gallery/favourites.svelte.ts
+++ b/src/lib/artist-gallery/favourites.svelte.ts
@@ -13,6 +13,8 @@ const STORAGE_KEY = "mooshieui.artist-gallery.favourites.v1";
 const EXPORT_KIND = "mooshieui.artist-gallery.favourites";
 const EXPORT_VERSION = 1;
 
+import { triggerSync } from "../utils/syncTrigger.js";
+
 export interface FavouriteCategory {
   id: string;
   name: string;
@@ -117,6 +119,7 @@ class ArtistFavouritesStore {
         categories: this.categories,
       };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      triggerSync();
     } catch (e) {
       console.error("artist-gallery favourites: save failed", e);
     }
@@ -334,6 +337,33 @@ class ArtistFavouritesStore {
     this.favourites = mergedFavs;
     this.saveSettings();
     return { added, updated, categoriesAdded };
+  }
+
+  /** Collect favourites state for server-side sync. */
+  collectPrefs(): unknown {
+    return {
+      version: EXPORT_VERSION,
+      favourites: Object.values(this.favourites),
+      categories: this.categories,
+    };
+  }
+
+  /** Apply favourites from the server. Replaces local storage and re-hydrates. */
+  applyServerPrefs(data: any): void {
+    try {
+      if (data) {
+        this.hydrate(data as Partial<PersistedState>);
+        // Persist server state locally as well
+        const payload: PersistedState = {
+          version: EXPORT_VERSION,
+          favourites: Object.values(this.favourites),
+          categories: this.categories,
+        };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      }
+    } catch (e) {
+      console.error("artist-gallery favourites: applyServerPrefs failed", e);
+    }
   }
 }
 

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -3,7 +3,7 @@
   import { models } from "../../stores/models.svelte.js";
   import { autocomplete } from "../../stores/autocomplete.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
-  import { downloadModel, findModelByHash, hashModelFile, readModelSpec, type ModelSpec } from "../../utils/api.js";
+  import { downloadModel, findModelByHash, hashModelFile, readModelSpec, type ModelSpec, getComputeCapability } from "../../utils/api.js";
   import { ipcListen } from "../../utils/ipc.js";
   import { onMount, onDestroy } from "svelte";
   import InfoTip from "../ui/InfoTip.svelte";
@@ -40,7 +40,17 @@
       scheduler?: string;
       upscaleSteps?: number;
       upscaleDenoise?: number;
+      facefixSteps?: number;
     };
+    /**
+     * Minimum NVIDIA compute capability required (e.g. 8.9 for Ada / Blackwell
+     * FP8 native tensor cores). Hides the entry on lower-tier GPUs where the
+     * model would either fail to load or run dramatically slower than the
+     * non-quantised alternative. `null`/absent = available everywhere.
+     */
+    minComputeCapability?: number;
+    /** Hint shown next to the size in the dropdown to explain the gate. */
+    gateHint?: string;
   }
 
   const recommendedModels: RecommendedModel[] = [
@@ -71,6 +81,42 @@
         diffusionModel: {
           filename: "anima-preview3-base.safetensors",
           url: "https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/diffusion_models/anima-preview3-base.safetensors",
+          category: "diffusion_models",
+        },
+        clipModel: {
+          filename: "qwen_3_06b_base.safetensors",
+          url: "https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/text_encoders/qwen_3_06b_base.safetensors",
+          category: "text_encoders",
+          clipType: "wan",
+        },
+        vaeModel: {
+          filename: "qwen_image_vae.safetensors",
+          url: "https://huggingface.co/circlestone-labs/Anima/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+          category: "vae",
+        },
+      },
+      autoSettings: {
+        steps: 30,
+        cfg: 4,
+        samplerName: "er_sde",
+        upscaleSteps: 10,
+        upscaleDenoise: 0.3,
+        facefixSteps: 10,
+      },
+    },
+    {
+      label: "Anima Preview 3 (FP8)",
+      size: "~7 GB",
+      // FP8 native tensor-core compute lands on Ada Lovelace (8.9) and
+      // Blackwell (10.0+ datacenter / 12.0 consumer). Earlier GPUs would
+      // fall back to BF16 emulation and lose the speed/VRAM advantage that
+      // makes this build worthwhile, so we hide the entry on those tiers.
+      minComputeCapability: 8.9,
+      gateHint: "Ada / Blackwell only",
+      splitModel: {
+        diffusionModel: {
+          filename: "anima-preview3-base-fp8.safetensors",
+          url: "https://huggingface.co/Bedovyy/Anima-FP8/resolve/main/anima-preview3-base-fp8.safetensors",
           category: "diffusion_models",
         },
         clipModel: {
@@ -199,6 +245,15 @@
   let loraSearches = $state<Record<number, string>>({});
   let downloading = $state<string | null>(null);
   let downloadError = $state("");
+
+  /**
+   * Detected NVIDIA compute capability. `null` until probed; remains `null`
+   * on non-NVIDIA systems / when nvidia-smi is unavailable. We surface gated
+   * recommended models (e.g. FP8-only builds) only when this is known to
+   * meet or exceed the entry's `minComputeCapability` — never optimistically
+   * (so AMD/Intel/CPU users don't see entries they can't run).
+   */
+  let computeCapability = $state<number | null>(null);
 
   // Per-file download progress. Keyed by filename so parallel downloads of
   // different components (diffusion model / text encoder / VAE) each have
@@ -341,6 +396,17 @@
 
     // Resolve model hashes in background
     resolveModelHashes();
+
+    // Probe NVIDIA compute capability so we can gate FP8-only recommended
+    // entries. Cheap (single nvidia-smi shell-out) and fire-and-forget — a
+    // failure just leaves the gate closed, which is the safe default.
+    try {
+      computeCapability = await getComputeCapability();
+      console.debug("[ModelSelector] detected compute capability:", computeCapability);
+    } catch (err) {
+      console.warn("[ModelSelector] getComputeCapability failed:", err);
+      computeCapability = null;
+    }
   });
 
   onDestroy(() => {
@@ -423,10 +489,17 @@
   /** Combine installed checkpoints + recommended models into a single filtered list */
   const filteredItems = $derived(() => {
     const q = checkpointSearch.toLowerCase();
-    const items: { type: "checkpoint" | "recommended"; label: string; value: string; rec?: RecommendedModel; installed: boolean; size?: string }[] = [];
+    const items: { type: "checkpoint" | "recommended"; label: string; value: string; rec?: RecommendedModel; installed: boolean; size?: string; gateHint?: string }[] = [];
 
     // Add recommended models first
     for (const rec of recommendedModels) {
+      // Hide entries gated behind a compute-capability we haven't met (or
+      // haven't been able to detect). Pre-existing installed copies still
+      // surface from `models.checkpoints` further below if the user already
+      // downloaded them by other means.
+      if (rec.minComputeCapability !== undefined) {
+        if (computeCapability === null || computeCapability < rec.minComputeCapability) continue;
+      }
       const installed = isRecommendedInstalled(rec);
       if (!q || rec.label.toLowerCase().includes(q)) {
         items.push({
@@ -436,6 +509,7 @@
           rec,
           installed,
           size: rec.size,
+          gateHint: rec.gateHint,
         });
       }
     }
@@ -669,6 +743,9 @@
               >
                 <span class="text-sm truncate">
                   {item.label}
+                  {#if item.gateHint}
+                    <span class="ml-1 rounded border border-emerald-500/40 bg-emerald-500/10 px-1 py-0.5 align-middle text-[9px] uppercase tracking-wide text-emerald-300">{item.gateHint}</span>
+                  {/if}
                   {#if !item.installed}
                     <span class="text-[10px] text-neutral-500 ml-1">({locale.t('generation.model.auto_download')})</span>
                   {/if}

--- a/src/lib/components/generation/PresetActivationModal.svelte
+++ b/src/lib/components/generation/PresetActivationModal.svelte
@@ -95,7 +95,7 @@
             <span class="block text-sm font-medium text-neutral-100">Wildcard (random)</span>
             <span class="block text-[11px] text-neutral-500">
               {#if choiceCount === 0}
-                Add comma- or newline-separated options first.
+                Add entries on separate lines first.
               {:else if choiceCount === 1}
                 Only one option — will pick that every time.
               {:else}

--- a/src/lib/components/generation/PresetEditor.svelte
+++ b/src/lib/components/generation/PresetEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { promptPresets } from "../../stores/promptPresets.svelte.js";
+  import { promptPresets, presetSlug } from "../../stores/promptPresets.svelte.js";
   import PromptTextarea from "./PromptTextarea.svelte";
 
   interface Props {
@@ -11,6 +11,8 @@
 
   const preset = $derived(promptPresets.getById(presetId));
   const choiceCount = $derived(promptPresets.countChoices(presetId));
+  const slug = $derived(preset ? presetSlug(preset.name) : "");
+  const inlineToken = $derived(slug ? `@preset:${slug}` : "");
 
   function setName(v: string) {
     if (!preset) return;
@@ -56,7 +58,7 @@
         <div>
           <h2 class="text-sm font-semibold text-neutral-100">Edit Prompt Preset</h2>
           <p class="text-[11px] text-neutral-500">
-            Store any prompt fragment as a reusable variable. Separate entries by comma or newline — used for the wildcard mode to pick one at random.
+            Store any prompt fragment as a reusable variable. Put each wildcard choice on its own line — commas within a line stay grouped (e.g. `1girl, solo` is picked as one block).
           </p>
         </div>
         <button
@@ -78,6 +80,17 @@
             placeholder="e.g. Cool hair colors"
             class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-sm text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
           />
+          {#if inlineToken}
+            <p class="mt-1 text-[10px] text-neutral-500">
+              Inline token: <button
+                type="button"
+                class="rounded border border-indigo-500/40 bg-indigo-500/10 px-1.5 py-0.5 font-mono text-[10px] text-indigo-200 hover:border-indigo-400 hover:bg-indigo-500/20"
+                title="Click to copy"
+                onclick={() => navigator.clipboard?.writeText(inlineToken)}
+              >{inlineToken}</button>
+              — drop this anywhere in your prompt to splice the content in at that exact spot.
+            </p>
+          {/if}
         </div>
 
         <div>
@@ -94,7 +107,7 @@
           <p class="mt-1 text-[10px] text-neutral-500">
             <span class="text-indigo-300">Prepend / Append:</span> whole content is injected as-is.
             <br />
-            <span class="text-indigo-300">Wildcard:</span> one comma/newline-separated entry is picked at random per generation.
+            <span class="text-indigo-300">Wildcard:</span> one line is picked at random per generation; commas within a line stay grouped.
             <br />
             <span class="text-neutral-400">Tip:</span> autocomplete suggestions match the active model's tag list.
           </p>

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -3,8 +3,9 @@
   import { autocomplete, type TagEntry } from "../../stores/autocomplete.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
   import { connection } from "../../stores/connection.svelte.js";
+  import { promptPresets } from "../../stores/promptPresets.svelte.js";
   import ArtistHoverPreview from "../../artist-gallery/components/ArtistHoverPreview.svelte";
-  import { renderHighlightedPrompt, hasSchedulingTags } from "../../utils/promptSchedule.js";
+  import { renderHighlightedPrompt, hasSchedulingTags, hasPresetTokens } from "../../utils/promptSchedule.js";
 
   interface Props {
     value: string;
@@ -359,11 +360,11 @@
     }, 200);
   }
 
-  // Reactive: detect if current value has scheduling tags
-  const showBackdrop = $derived(hasSchedulingTags(value));
+  // Reactive: detect if current value has scheduling tags or inline preset tokens
+  const showBackdrop = $derived(hasSchedulingTags(value) || hasPresetTokens(value));
 
   // Reactive: render highlighted HTML for the backdrop overlay
-  const highlightedHtml = $derived(showBackdrop ? renderHighlightedPrompt(value) : "");
+  const highlightedHtml = $derived(showBackdrop ? renderHighlightedPrompt(value, promptPresets.slugs) : "");
 
   function syncScroll() {
     if (textareaEl && backdropEl) {

--- a/src/lib/components/generation/StyleManager.svelte
+++ b/src/lib/components/generation/StyleManager.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { styles, type ArtistStyle } from "../../stores/styles.svelte.js";
-  import { promptPresets, type PromptPreset, type PresetMode } from "../../stores/promptPresets.svelte.js";
+  import { promptPresets, presetSlug, type PromptPreset, type PresetMode } from "../../stores/promptPresets.svelte.js";
   import StyleEditor from "./StyleEditor.svelte";
   import PresetEditor from "./PresetEditor.svelte";
   import PresetActivationModal from "./PresetActivationModal.svelte";
@@ -26,7 +26,6 @@
   // Shared import/export
   let importStatus = $state<string | null>(null);
   let importError = $state<string | null>(null);
-  let importMode = $state<"merge" | "replace">("merge");
   let fileInput: HTMLInputElement | null = $state(null);
 
   function createStyle() {
@@ -75,43 +74,53 @@
     return "";
   }
 
-  async function exportAll() {
+  async function exportStyle(id: string) {
     importStatus = null;
     importError = null;
-    const isStylesTab = activeTab === "styles";
-    const json = isStylesTab ? styles.exportJSON() : promptPresets.exportJSON();
-    const kind = isStylesTab ? "styles" : "presets";
-    const defaultName = `mooshieui-${kind}-${new Date().toISOString().slice(0, 10)}.json`;
+    const payload = styles.exportTxt(id);
+    if (!payload) return;
+    await saveTxt(payload.filename, payload.content);
+  }
+
+  async function exportPreset(id: string) {
+    importStatus = null;
+    importError = null;
+    const payload = promptPresets.exportTxt(id);
+    if (!payload) return;
+    await saveTxt(payload.filename, payload.content);
+  }
+
+  async function saveTxt(filename: string, content: string) {
     const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
     try {
       if (isTauri) {
         const { save } = await import("@tauri-apps/plugin-dialog");
         const { writeTextFile } = await import("@tauri-apps/plugin-fs");
         const path = await save({
-          defaultPath: defaultName,
-          filters: [{ name: "JSON", extensions: ["json"] }],
+          defaultPath: filename,
+          filters: [{ name: "Text", extensions: ["txt"] }],
         });
         if (!path) return;
-        await writeTextFile(path, json);
+        await writeTextFile(path, content);
         importStatus = `Exported to ${path}`;
       } else {
-        const blob = new Blob([json], { type: "application/json" });
+        const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
-        a.download = defaultName;
+        a.download = filename;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        importStatus = `Downloaded ${defaultName}`;
+        importStatus = `Downloaded ${filename}`;
       }
     } catch (e) {
       importError = e instanceof Error ? e.message : String(e);
     }
   }
 
-  async function importStyles() {
+  async function importTxt() {
     importStatus = null;
     importError = null;
     const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -120,12 +129,19 @@
         const { open } = await import("@tauri-apps/plugin-dialog");
         const { readTextFile } = await import("@tauri-apps/plugin-fs");
         const selected = await open({
-          multiple: false,
-          filters: [{ name: "JSON", extensions: ["json"] }],
+          multiple: true,
+          filters: [{ name: "Text", extensions: ["txt"] }],
         });
-        if (!selected || typeof selected !== "string") return;
-        const raw = await readTextFile(selected);
-        applyImport(raw);
+        if (!selected) return;
+        const paths = Array.isArray(selected) ? selected : [selected];
+        const files: Array<{ name: string; content: string }> = [];
+        for (const path of paths) {
+          if (typeof path !== "string") continue;
+          const content = await readTextFile(path);
+          const name = path.split(/[\\/]/).pop() ?? path;
+          files.push({ name, content });
+        }
+        applyFiles(files);
       } else {
         fileInput?.click();
       }
@@ -136,36 +152,46 @@
 
   async function onFilePicked(e: Event) {
     const input = e.currentTarget as HTMLInputElement;
-    const file = input.files?.[0];
+    const picked = Array.from(input.files ?? []);
     input.value = "";
-    if (!file) return;
+    if (picked.length === 0) return;
     try {
-      const raw = await file.text();
-      applyImport(raw);
+      const files: Array<{ name: string; content: string }> = [];
+      for (const f of picked) {
+        files.push({ name: f.name, content: await f.text() });
+      }
+      applyFiles(files);
     } catch (err) {
       importError = err instanceof Error ? err.message : String(err);
     }
   }
 
-  function applyImport(raw: string) {
-    try {
-      // Try both kinds — the envelope's `kind` field disambiguates.
-      let result: { added: number; skipped: number } | null = null;
-      let label = "";
+  function applyFiles(files: Array<{ name: string; content: string }>) {
+    if (files.length === 0) return;
+    const isStylesTab = activeTab === "styles";
+    let imported = 0;
+    let renamed = 0;
+    for (const f of files) {
       try {
-        result = styles.importJSON(raw, importMode);
-        label = "style";
-      } catch {
-        result = promptPresets.importJSON(raw, importMode);
-        label = "preset";
+        if (isStylesTab) {
+          const { renamed: r } = styles.importTxt(f.name, f.content);
+          if (r) renamed++;
+        } else {
+          const { renamed: r } = promptPresets.importTxt(f.name, f.content);
+          if (r) renamed++;
+        }
+        imported++;
+      } catch (e) {
+        importError = e instanceof Error ? e.message : String(e);
       }
-      importStatus = `Imported ${result.added} ${label}${result.added === 1 ? "" : "s"}${
-        result.skipped > 0 ? ` (skipped ${result.skipped} duplicate${result.skipped === 1 ? "" : "s"})` : ""
-      }.`;
-      importError = null;
-    } catch (e) {
-      importError = e instanceof Error ? e.message : String(e);
     }
+    const kind = isStylesTab ? "style" : "preset";
+    importStatus =
+      imported > 0
+        ? `Imported ${imported} ${kind}${imported === 1 ? "" : "s"}${
+            renamed > 0 ? ` (${renamed} renamed to avoid duplicates)` : ""
+          }.`
+        : null;
   }
 </script>
 
@@ -273,6 +299,13 @@
                 >⧉</button>
                 <button
                   type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-indigo-200"
+                  onclick={() => exportStyle(style.id)}
+                  title="Export as .txt"
+                  aria-label={`Export ${style.name} as .txt`}
+                >↓</button>
+                <button
+                  type="button"
                   class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:bg-red-500/10 hover:text-red-300"
                   onclick={() => confirmDelete(style)}
                   title="Delete"
@@ -331,8 +364,14 @@
                   <p class="mt-0.5 truncate font-mono text-[11px] text-neutral-500">
                     {preset.content || "(empty)"}
                   </p>
-                  <p class="text-[10px] text-neutral-600">
-                    {choiceCount} wildcard option{choiceCount === 1 ? "" : "s"}
+                  <p class="flex items-center gap-2 text-[10px] text-neutral-600">
+                    <span>{choiceCount} wildcard option{choiceCount === 1 ? "" : "s"}</span>
+                    <button
+                      type="button"
+                      class="rounded border border-neutral-800 bg-neutral-900 px-1.5 py-0.5 font-mono text-[10px] text-neutral-400 hover:border-indigo-500/40 hover:text-indigo-200"
+                      title="Inline token — click to copy"
+                      onclick={() => navigator.clipboard?.writeText(`@preset:${presetSlug(preset.name)}`)}
+                    >@preset:{presetSlug(preset.name)}</button>
                   </p>
                 </div>
                 <div class="flex shrink-0 items-center gap-1">
@@ -363,6 +402,13 @@
                   >⧉</button>
                   <button
                     type="button"
+                    class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:text-indigo-200"
+                    onclick={() => exportPreset(preset.id)}
+                    title="Export as .txt"
+                    aria-label={`Export ${preset.name} as .txt`}
+                  >↓</button>
+                  <button
+                    type="button"
                     class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-400 hover:bg-red-500/10 hover:text-red-300"
                     onclick={() => confirmDeletePreset(preset)}
                     title="Delete"
@@ -386,31 +432,25 @@
         <button
           type="button"
           class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
-          onclick={exportAll}
-          disabled={activeTab === "styles" ? styles.styles.length === 0 : promptPresets.presets.length === 0}
-        >Export all</button>
-        <button
-          type="button"
-          class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
-          onclick={importStyles}
-        >Import…</button>
-        <label class="ml-2 inline-flex items-center gap-1 text-[11px] text-neutral-400">
-          <input type="radio" bind:group={importMode} value="merge" class="accent-indigo-500" />
-          Merge
-        </label>
-        <label class="inline-flex items-center gap-1 text-[11px] text-neutral-400">
-          <input type="radio" bind:group={importMode} value="replace" class="accent-indigo-500" />
-          Replace all
-        </label>
+          onclick={importTxt}
+        >Import .txt…</button>
         <input
           bind:this={fileInput}
           type="file"
-          accept="application/json,.json"
+          accept=".txt,text/plain"
+          multiple
           class="hidden"
           onchange={onFilePicked}
         />
       </div>
-      <p class="text-[10px] text-neutral-500">Import auto-detects whether the file contains styles or presets.</p>
+      <p class="text-[10px] text-neutral-500">
+        {#if activeTab === "styles"}
+          Plain text: one artist per line as <code class="font-mono">tag</code> or <code class="font-mono">tag:weight</code>. Lines starting with <code class="font-mono">#</code> are ignored. Filename becomes the style name.
+        {:else}
+          Plain text: filename becomes the preset name; file contents are used verbatim. For wildcard mode, one line per choice (commas within a line stay grouped).
+        {/if}
+        Use the <strong>Export</strong> button on each {activeTab === "styles" ? "style" : "preset"} to download it.
+      </p>
       {#if importStatus}
         <p class="text-[11px] text-emerald-400">{importStatus}</p>
       {/if}

--- a/src/lib/stores/accessibility.svelte.ts
+++ b/src/lib/stores/accessibility.svelte.ts
@@ -1,3 +1,5 @@
+import { triggerSync } from "../utils/syncTrigger.js";
+
 const ACCESSIBILITY_SETTINGS_KEY = "mooshieui.accessibility.v1";
 
 export type VisionSimulatorMode = "none" | "protanopia" | "deuteranopia" | "tritanopia";
@@ -32,8 +34,26 @@ class AccessibilityStore {
         visionSimulatorMode: this.visionSimulatorMode,
         showInfoTips: this.showInfoTips
       }));
+      triggerSync();
     } catch (e) {
       console.error("Failed to save accessibility settings:", e);
+    }
+  }
+
+  collectPrefs(): unknown {
+    return {
+      visionSimulatorMode: this.visionSimulatorMode,
+      showInfoTips: this.showInfoTips,
+    };
+  }
+
+  applyServerPrefs(data: any): void {
+    try {
+      if (data?.visionSimulatorMode) this.visionSimulatorMode = data.visionSimulatorMode;
+      if (data?.showInfoTips !== undefined) this.showInfoTips = data.showInfoTips;
+      this.saveSettings();
+    } catch (e) {
+      console.error("Failed to apply server prefs (accessibility):", e);
     }
   }
 

--- a/src/lib/stores/autocomplete.svelte.ts
+++ b/src/lib/stores/autocomplete.svelte.ts
@@ -1,4 +1,5 @@
 import { ipcStore } from "../utils/ipc.js";
+import { triggerSync } from "../utils/syncTrigger.js";
 import builtinTags from "../assets/danbooru-tags.json";
 import animaTags from "../assets/anima-tags.json";
 
@@ -132,6 +133,7 @@ class AutocompleteStore {
         sourceFileName: this.sourceFileName,
         customTags: this._customTags,
       });
+      triggerSync();
     } catch (e) {
       console.error("Failed to save autocomplete settings:", e);
     }
@@ -245,6 +247,27 @@ class AutocompleteStore {
   async setMaxResults(n: number) {
     this.maxResults = Math.max(1, Math.min(50, n));
     await this.saveSettings();
+  }
+
+  /** Collect autocomplete settings for server-side sync. */
+  collectPrefs(): Record<string, unknown> {
+    return {
+      maxResults: this.maxResults,
+      sourceMode: this.sourceMode,
+      sourceUrl: this.sourceUrl,
+      sourceFileName: this.sourceFileName,
+      customTags: this._customTags,
+    };
+  }
+
+  /** Apply autocomplete settings from the server. Writes to ipcStore and re-hydrates. */
+  async applyServerPrefs(data: Record<string, any>): Promise<void> {
+    try {
+      await ipcStore.set(STORE_KEY, data);
+      await this.loadSettings();
+    } catch (e) {
+      console.error("autocomplete: applyServerPrefs failed", e);
+    }
   }
 }
 

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -20,6 +20,7 @@ import {
   type StorageInfo,
 } from "../utils/api.js";
 import { isTauri, isBrowserMode, getAuthToken } from "../utils/ipc.js";
+import { triggerSync } from "../utils/syncTrigger.js";
 import { locale } from "./locale.svelte.js";
 import { generation } from "./generation.svelte.js";
 import { createArtistGalleryClient } from "../artist-gallery/client.js";
@@ -136,6 +137,7 @@ class GalleryStore {
   private saveBoardAssignments() {
     try {
       localStorage.setItem(GALLERY_BOARDS_KEY, JSON.stringify(this.boardAssignments));
+      triggerSync();
     } catch (e) {
       console.error("Failed to save gallery boards:", e);
     }
@@ -156,6 +158,7 @@ class GalleryStore {
   private saveCustomBoards() {
     try {
       localStorage.setItem(GALLERY_BOARD_NAMES_KEY, JSON.stringify(this.customBoards));
+      triggerSync();
     } catch (e) {
       console.error("Failed to save custom boards:", e);
     }
@@ -1028,6 +1031,29 @@ class GalleryStore {
       this.storageInfo = await getStorageInfo();
     } catch (e) {
       console.error("Failed to fetch storage info:", e);
+    }
+  }
+  /** Collect gallery board state for server-side sync. */
+  collectPrefs(): unknown {
+    return {
+      assignments: this.boardAssignments,
+      boardNames: this.customBoards,
+    };
+  }
+
+  /** Apply gallery board state from the server. */
+  applyServerPrefs(data: any): void {
+    try {
+      if (data?.assignments && typeof data.assignments === "object") {
+        this.boardAssignments = data.assignments;
+        localStorage.setItem(GALLERY_BOARDS_KEY, JSON.stringify(data.assignments));
+      }
+      if (Array.isArray(data?.boardNames)) {
+        this.customBoards = data.boardNames.filter((n: any) => !!n && n !== "Unsorted");
+        localStorage.setItem(GALLERY_BOARD_NAMES_KEY, JSON.stringify(this.customBoards));
+      }
+    } catch (e) {
+      console.error("Failed to apply server prefs (gallery boards):", e);
     }
   }
 }

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -1,4 +1,5 @@
 import { ipcStore } from "../utils/ipc.js";
+import { triggerSync } from "../utils/syncTrigger.js";
 import { parseScheduledPrompt } from "../utils/promptSchedule.js";
 import type { LoraEntry } from "../types/index.js";
 import { autocomplete } from "./autocomplete.svelte.js";
@@ -380,6 +381,7 @@ class GenerationStore {
   private savePromptHistory() {
     try {
       localStorage.setItem(PROMPT_HISTORY_KEY, JSON.stringify(this.promptHistory.slice(0, MAX_PROMPT_HISTORY)));
+      triggerSync();
     } catch (e) {
       console.error("Failed to save prompt history:", e);
     }
@@ -766,8 +768,104 @@ class GenerationStore {
         manualSaveMode: this.manualSaveMode,
         autoSaveDirs: this.autoSaveDirs,
       });
+      triggerSync();
     } catch (e) {
       console.error("Failed to save settings:", e);
+    }
+  }
+
+  /** Collect generation settings for server-side sync. */
+  collectPrefs(): Record<string, unknown> {
+    return {
+      mode: this.mode,
+      positivePrompt: this.positivePrompt,
+      negativePrompt: this.negativePrompt,
+      checkpoint: this.checkpoint,
+      vae: this.vae,
+      loras: this.loras,
+      samplerName: this.samplerName,
+      scheduler: this.scheduler,
+      steps: this.steps,
+      cfg: this.cfg,
+      seed: this.seed,
+      width: this.width,
+      height: this.height,
+      batchSize: this.batchSize,
+      denoise: this.denoise,
+      differentialDiffusion: this.differentialDiffusion,
+      upscaleEnabled: this.upscaleEnabled,
+      upscaleMethod: this.upscaleMethod,
+      upscaleModel: this.upscaleModel,
+      upscaleScale: this.upscaleScale,
+      upscaleDenoise: this.upscaleDenoise,
+      upscaleSteps: this.upscaleSteps,
+      upscaleTileSize: this.upscaleTileSize,
+      upscaleTiling: this.upscaleTiling,
+      upscaleSoftGuidance: this.upscaleSoftGuidance,
+      upscaleSoftGuidanceMultiplier: this.upscaleSoftGuidanceMultiplier,
+      smartGuidance: this.smartGuidance,
+      useSplitModel: this.useSplitModel,
+      diffusionModel: this.diffusionModel,
+      clipModel: this.clipModel,
+      clipType: this.clipType,
+      stylePreset: this.stylePreset,
+      stylePresetsEnabled: this.stylePresetsEnabled,
+      controlnetEnabled: this.controlnetEnabled,
+      controlnetMode: this.controlnetMode,
+      controlnetPreset: this.controlnetPreset,
+      controlnetModel: this.controlnetModel,
+      controlnetPreprocessor: this.controlnetPreprocessor,
+      controlnetStrength: this.controlnetStrength,
+      controlnetStartPercent: this.controlnetStartPercent,
+      controlnetEndPercent: this.controlnetEndPercent,
+      facefixEnabled: this.facefixEnabled,
+      facefixDetector: this.facefixDetector,
+      facefixDenoise: this.facefixDenoise,
+      facefixSteps: this.facefixSteps,
+      facefixGuideSize: this.facefixGuideSize,
+      facefixMaxFaces: this.facefixMaxFaces,
+      outputBitDepth: this.outputBitDepth,
+      outputFormat: this.outputFormat,
+      metadataMode: this.metadataMode,
+      autoQualityTags: this.autoQualityTags,
+      customAnimaPositiveQuality: this.customAnimaPositiveQuality,
+      customAnimaNegativeQuality: this.customAnimaNegativeQuality,
+      customIllustriousPositiveQuality: this.customIllustriousPositiveQuality,
+      customIllustriousNegativeQuality: this.customIllustriousNegativeQuality,
+      customPonyPositiveQuality: this.customPonyPositiveQuality,
+      customPonyNegativeQuality: this.customPonyNegativeQuality,
+      customNanosaurPositiveQuality: this.customNanosaurPositiveQuality,
+      customNanosaurNegativeQuality: this.customNanosaurNegativeQuality,
+      manualSaveMode: this.manualSaveMode,
+      autoSaveDirs: this.autoSaveDirs,
+    };
+  }
+
+  /** Collect prompt history for server-side sync. */
+  collectPromptHistory(): unknown[] {
+    return this.promptHistory.slice(0, MAX_PROMPT_HISTORY);
+  }
+
+  /** Apply generation settings from the server. Writes to ipcStore and re-hydrates. */
+  async applyServerPrefs(data: Record<string, any>): Promise<void> {
+    try {
+      await ipcStore.set(STORE_KEY, data);
+      await this.loadSettings();
+    } catch (e) {
+      console.error("generation: applyServerPrefs failed", e);
+    }
+  }
+
+  /** Apply prompt history from the server. */
+  applyPromptHistory(entries: any[]): void {
+    try {
+      const valid = entries
+        .filter((e) => !!e?.id)
+        .slice(0, MAX_PROMPT_HISTORY) as PromptHistoryEntry[];
+      localStorage.setItem(PROMPT_HISTORY_KEY, JSON.stringify(valid));
+      this.promptHistory = valid;
+    } catch (e) {
+      console.error("generation: applyPromptHistory failed", e);
     }
   }
 
@@ -776,8 +874,14 @@ class GenerationStore {
       ? (STYLE_PRESETS.find((preset) => preset.id === this.stylePreset) ?? STYLE_PRESETS[0])
       : STYLE_PRESETS[0];
 
-    let positivePrompt = this.mergeTagPrompts(this.positivePrompt, style.positive);
-    let negativePrompt = this.mergeTagPrompts(this.negativePrompt, style.negative);
+    // Expand inline `@preset:<slug>` directives in the user-typed prompts
+    // first, so wildcard rolls happen before any merging/dedup logic. Each
+    // occurrence rolls independently.
+    const inlinePositive = promptPresets.resolveInline(this.positivePrompt);
+    const inlineNegative = promptPresets.resolveInline(this.negativePrompt);
+
+    let positivePrompt = this.mergeTagPrompts(inlinePositive, style.positive);
+    let negativePrompt = this.mergeTagPrompts(inlineNegative, style.negative);
 
     // Inject tags contributed by any currently-active Artist Styles. These are
     // not visible in the prompt textbox — they flow straight into the payload

--- a/src/lib/stores/locale.svelte.ts
+++ b/src/lib/stores/locale.svelte.ts
@@ -1,4 +1,5 @@
 import { ipcStore } from "../utils/ipc.js";
+import { triggerSync } from "../utils/syncTrigger.js";
 import en from "../locales/en.js";
 import es from "../locales/es.js";
 import ja from "../locales/ja.js";
@@ -85,6 +86,19 @@ class LocaleStore {
 
   async saveSettings(): Promise<void> {
     await ipcStore.set(STORE_KEY, { locale: this.current });
+    triggerSync();
+  }
+
+  applyServerPrefs(localeValue: string): void {
+    try {
+      if (localeValue && translations[localeValue as Locale]) {
+        this.current = localeValue as Locale;
+        this.hasStoredPreference = true;
+        this.saveSettings().catch(() => {});
+      }
+    } catch (e) {
+      console.error("Failed to apply server prefs (locale):", e);
+    }
   }
 }
 

--- a/src/lib/stores/prefsSync.svelte.ts
+++ b/src/lib/stores/prefsSync.svelte.ts
@@ -1,0 +1,119 @@
+/**
+ * Central hub for server-side user preference sync.
+ *
+ * All stores call `triggerSync()` whenever they persist settings.
+ * This store registers itself as the sync handler and debounces those calls
+ * into a single push to the server (2 s window).
+ *
+ * On startup/login, `loadAndApply()` pulls the server snapshot and distributes
+ * it to every participating store.  If no server snapshot exists yet the
+ * current local state is seeded to the server.
+ *
+ * Only active in browser / LAN mode — `pushServerPrefs` / `fetchServerPrefs`
+ * are no-ops in Tauri desktop mode.
+ */
+
+import { registerSyncHandler } from "../utils/syncTrigger.js";
+import { fetchServerPrefs, pushServerPrefs, type UserPrefsData } from "../utils/serverPrefs.js";
+import { generation } from "./generation.svelte.js";
+import { promptPresets } from "./promptPresets.svelte.js";
+import { styles } from "./styles.svelte.js";
+import { artistFavourites } from "../artist-gallery/favourites.svelte.js";
+import { gallery } from "./gallery.svelte.js";
+import { accessibility } from "./accessibility.svelte.js";
+import { locale } from "./locale.svelte.js";
+import { autocomplete } from "./autocomplete.svelte.js";
+
+class PrefsSyncStore {
+  private _syncTimer: ReturnType<typeof setTimeout> | null = null;
+  private _syncing = false;
+
+  constructor() {
+    registerSyncHandler(() => this.scheduleSync());
+  }
+
+  /** Gather the current state of all participating stores. */
+  collectAll(): UserPrefsData {
+    return {
+      generation: generation.collectPrefs(),
+      prompt_history: generation.collectPromptHistory(),
+      prompt_presets: promptPresets.collectPrefs(),
+      styles: styles.collectPrefs(),
+      artist_favourites: artistFavourites.collectPrefs(),
+      gallery_boards: gallery.collectPrefs(),
+      autocomplete: autocomplete.collectPrefs(),
+      accessibility: accessibility.collectPrefs(),
+      locale: locale.current,
+    };
+  }
+
+  /** Distribute a server snapshot to every participating store. */
+  applyAll(prefs: UserPrefsData): void {
+    if (prefs.generation) {
+      generation.applyServerPrefs(prefs.generation as Record<string, any>).catch(() => {});
+    }
+    if (Array.isArray(prefs.prompt_history)) {
+      generation.applyPromptHistory(prefs.prompt_history as any[]);
+    }
+    if (prefs.prompt_presets) {
+      promptPresets.applyServerPrefs(prefs.prompt_presets);
+    }
+    if (prefs.styles) {
+      styles.applyServerPrefs(prefs.styles);
+    }
+    if (prefs.artist_favourites) {
+      artistFavourites.applyServerPrefs(prefs.artist_favourites);
+    }
+    if (prefs.gallery_boards) {
+      gallery.applyServerPrefs(prefs.gallery_boards);
+    }
+    if (prefs.autocomplete) {
+      autocomplete.applyServerPrefs(prefs.autocomplete as Record<string, any>).catch(() => {});
+    }
+    if (prefs.accessibility) {
+      accessibility.applyServerPrefs(prefs.accessibility);
+    }
+    if (typeof prefs.locale === "string") {
+      locale.applyServerPrefs(prefs.locale);
+    }
+  }
+
+  /**
+   * Fetch server prefs and apply them.  If the server has no prefs yet,
+   * seed it with the current local state.
+   */
+  async loadAndApply(): Promise<void> {
+    try {
+      const prefs = await fetchServerPrefs();
+      if (prefs) {
+        this.applyAll(prefs);
+      } else {
+        // No snapshot on server yet — push current local state to seed it.
+        await pushServerPrefs(this.collectAll());
+      }
+    } catch {
+      // Non-fatal — offline or server unavailable.
+    }
+  }
+
+  /** Debounce: collapses rapid consecutive saves into one server push. */
+  scheduleSync(): void {
+    if (this._syncTimer !== null) clearTimeout(this._syncTimer);
+    this._syncTimer = setTimeout(() => {
+      this._syncTimer = null;
+      this._doSync().catch(() => {});
+    }, 2000);
+  }
+
+  private async _doSync(): Promise<void> {
+    if (this._syncing) return;
+    this._syncing = true;
+    try {
+      await pushServerPrefs(this.collectAll());
+    } finally {
+      this._syncing = false;
+    }
+  }
+}
+
+export const prefsSync = new PrefsSyncStore();

--- a/src/lib/stores/prefsSync.svelte.ts
+++ b/src/lib/stores/prefsSync.svelte.ts
@@ -48,9 +48,9 @@ class PrefsSyncStore {
   }
 
   /** Distribute a server snapshot to every participating store. */
-  applyAll(prefs: UserPrefsData): void {
+  async applyAll(prefs: UserPrefsData): Promise<void> {
     if (prefs.generation) {
-      generation.applyServerPrefs(prefs.generation as Record<string, any>).catch(() => {});
+      await generation.applyServerPrefs(prefs.generation as Record<string, any>).catch(() => {});
     }
     if (Array.isArray(prefs.prompt_history)) {
       generation.applyPromptHistory(prefs.prompt_history as any[]);
@@ -68,7 +68,7 @@ class PrefsSyncStore {
       gallery.applyServerPrefs(prefs.gallery_boards);
     }
     if (prefs.autocomplete) {
-      autocomplete.applyServerPrefs(prefs.autocomplete as Record<string, any>).catch(() => {});
+      await autocomplete.applyServerPrefs(prefs.autocomplete as Record<string, any>).catch(() => {});
     }
     if (prefs.accessibility) {
       accessibility.applyServerPrefs(prefs.accessibility);
@@ -86,7 +86,7 @@ class PrefsSyncStore {
     try {
       const prefs = await fetchServerPrefs();
       if (prefs) {
-        this.applyAll(prefs);
+        await this.applyAll(prefs);
       } else {
         // No snapshot on server yet — push current local state to seed it.
         await pushServerPrefs(this.collectAll());

--- a/src/lib/stores/promptPresets.svelte.ts
+++ b/src/lib/stores/promptPresets.svelte.ts
@@ -6,9 +6,12 @@
  * user picks a mode:
  *   - "prepend"  — injected at the start of the positive prompt
  *   - "append"   — injected at the end
- *   - "wildcard" — exactly ONE of the comma-separated tags inside `content`
- *                  is chosen at random for each generation (re-rolled every
- *                  time `resolve()` is called)
+ *   - "wildcard" — exactly ONE of the newline-separated tag groups inside
+ *                  `content` is chosen at random for each generation (re-rolled
+ *                  every time `resolve()` is called). Commas within a line
+ *                  keep tags grouped together, so `1girl, solo` on one line
+ *                  is picked as the whole block rather than "1girl" or "solo"
+ *                  in isolation.
  *
  * Like Artist Styles, presets live outside the prompt textbox — users see
  * badges, not tags — and survive reloads via localStorage.
@@ -19,12 +22,14 @@ const ACTIVE_KEY = "mooshieui.promptPresets.active.v1";
 const EXPORT_KIND = "mooshieui.prompt-presets";
 const EXPORT_VERSION = 1;
 
+import { triggerSync } from "../utils/syncTrigger.js";
+
 export type PresetMode = "prepend" | "append" | "wildcard";
 
 export interface PromptPreset {
   id: string;
   name: string;
-  /** Free-form prompt text. For wildcard mode, this is split on commas/newlines. */
+  /** Free-form prompt text. For wildcard mode, newlines split choices; commas keep tags grouped within a choice. */
   content: string;
   createdAt: number;
   updatedAt: number;
@@ -37,13 +42,6 @@ export interface ActivePreset {
 
 interface PersistedState {
   version: number;
-  presets: PromptPreset[];
-}
-
-export interface PresetsExport {
-  kind: typeof EXPORT_KIND;
-  version: number;
-  exportedAt: string;
   presets: PromptPreset[];
 }
 
@@ -63,13 +61,47 @@ function sanitizePreset(raw: any): PromptPreset | null {
   };
 }
 
-/** Split wildcard content into individual tag candidates. */
+/**
+ * Split wildcard content into individual choices. Newlines delimit choices;
+ * commas within a line are preserved so multi-tag groups (e.g. `1girl, solo`)
+ * are treated as a single wildcard block rather than as separate candidates.
+ */
 function splitWildcardChoices(content: string): string[] {
   return content
-    .split(/[,\n]/)
-    .map((s) => s.trim())
+    .split(/\r?\n/)
+    .map((s) => s.trim().replace(/^,+|,+$/g, "").trim())
     .filter((s) => s.length > 0);
 }
+
+/**
+ * Derive a URL/token-safe slug from a preset display name. Lowercased, with
+ * runs of non-alphanumeric chars collapsed to a single underscore. Used as
+ * the inline `@preset:<slug>` token form so users can drop a preset at any
+ * point in the prompt without worrying about case or punctuation.
+ */
+export function presetSlug(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "preset"
+  );
+}
+
+/**
+ * Reserved keywords that must NOT be treated as artist tags when they appear
+ * after `@`. Anything matching `@<keyword>:` is a MooshieUI directive, not
+ * an Anima artist reference. Kept tiny on purpose — easy to scan, easy to
+ * extend later (e.g. `style:`, `lora:`).
+ */
+export const RESERVED_AT_KEYWORDS: ReadonlySet<string> = new Set(["preset"]);
+
+/**
+ * Regex that matches inline preset directives: `@preset:<slug>`. The slug
+ * captures `[a-z0-9_]` only (matches `presetSlug()` output). Case-insensitive
+ * on the keyword for forgiveness; slug must already be lowercased.
+ */
+export const INLINE_PRESET_REGEX = /@preset:([a-z0-9_]+)/gi;
 
 class PromptPresetsStore {
   presets = $state<PromptPreset[]>([]);
@@ -119,6 +151,7 @@ class PromptPresetsStore {
     try {
       const payload: PersistedState = { version: EXPORT_VERSION, presets: this.presets };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      triggerSync();
     } catch (e) {
       console.error("prompt-presets: save failed", e);
     }
@@ -127,6 +160,7 @@ class PromptPresetsStore {
   private saveActive() {
     try {
       localStorage.setItem(ACTIVE_KEY, JSON.stringify(this.active));
+      triggerSync();
     } catch (e) {
       console.error("prompt-presets: save active failed", e);
     }
@@ -185,6 +219,62 @@ class PromptPresetsStore {
       prepend: prepends.join(", "),
       append: appends.join(", "),
     };
+  }
+
+  /**
+   * Map of slug → preset for inline `@preset:<slug>` lookups. Recomputed
+   * each access so it stays in sync with renames; the list is small enough
+   * that caching isn't worth the bookkeeping.
+   */
+  get bySlug(): Map<string, PromptPreset> {
+    const map = new Map<string, PromptPreset>();
+    for (const p of this.presets) {
+      const slug = presetSlug(p.name);
+      // First-write-wins on collisions — the renaming logic in importTxt and
+      // the natural uniqueness of display names means dupes are rare.
+      if (!map.has(slug)) map.set(slug, p);
+    }
+    return map;
+  }
+
+  /** Convenience getter: just the slug strings, for highlight rendering. */
+  get slugs(): Set<string> {
+    return new Set(this.bySlug.keys());
+  }
+
+  /**
+   * Resolve `@preset:<slug>` directives inline within a prompt string.
+   * - Single-line preset content is inserted verbatim (trimmed).
+   * - Multi-line preset content picks one random line per occurrence
+   *   (independent rolls — `@preset:foo, @preset:foo` rolls twice).
+   * - Empty presets resolve to an empty string; adjacent commas/whitespace
+   *   are tidied so the prompt doesn't end up with `, ,` artefacts.
+   * - Unknown slugs are left untouched (so typos are debuggable).
+   */
+  resolveInline(text: string): string {
+    if (!text || !text.includes("@preset:")) return text;
+    const lookup = this.bySlug;
+    let resolved = text.replace(INLINE_PRESET_REGEX, (full, slug: string) => {
+      const preset = lookup.get(slug.toLowerCase());
+      if (!preset) return full;
+      const choices = splitWildcardChoices(preset.content);
+      if (choices.length === 0) {
+        const verbatim = preset.content.trim();
+        return verbatim;
+      }
+      if (choices.length === 1) return choices[0];
+      return choices[Math.floor(Math.random() * choices.length)];
+    });
+    // Tidy up commas/whitespace left behind when a preset resolved to "".
+    resolved = resolved
+      .replace(/,\s*,/g, ",")
+      .replace(/\(\s*,/g, "(")
+      .replace(/,\s*\)/g, ")")
+      .replace(/^\s*,\s*/, "")
+      .replace(/\s*,\s*$/, "")
+      .replace(/[ \t]{2,}/g, " ")
+      .trim();
+    return resolved;
   }
 
   // ---------------------------------------------------------------------------
@@ -283,55 +373,94 @@ class PromptPresetsStore {
   }
 
   // ---------------------------------------------------------------------------
-  // Export / import
+  // Export / import (.txt)
   // ---------------------------------------------------------------------------
 
-  exportJSON(ids?: string[]): string {
-    const selected = ids ? this.presets.filter((p) => ids.includes(p.id)) : this.presets;
-    const payload: PresetsExport = {
-      kind: EXPORT_KIND,
-      version: EXPORT_VERSION,
-      exportedAt: new Date().toISOString(),
-      presets: selected,
+  /** Render a preset as a .txt file (filename + contents). */
+  exportTxt(id: string): { filename: string; content: string } | null {
+    const p = this.getById(id);
+    if (!p) return null;
+    return {
+      filename: `${sanitizeFilename(p.name)}.txt`,
+      content: p.content,
     };
-    return JSON.stringify(payload, null, 2);
   }
 
-  importJSON(raw: string, mode: "merge" | "replace" = "merge"): { added: number; skipped: number } {
-    const parsed = JSON.parse(raw) as Partial<PresetsExport>;
-    if (!parsed || typeof parsed !== "object") throw new Error("Invalid JSON payload");
-    if (parsed.kind !== EXPORT_KIND) throw new Error("Not a MooshieUI prompt presets export");
-    const incoming = Array.isArray(parsed.presets)
-      ? (parsed.presets.map(sanitizePreset).filter(Boolean) as PromptPreset[])
-      : [];
+  /**
+   * Import a preset from a plain .txt file. Filename (minus extension) becomes
+   * the preset name; file contents become the `content` field verbatim.
+   *
+   * If a preset with the same name already exists, a numeric suffix is added
+   * (e.g. `cats (2)`). Returns the created preset and whether it was renamed.
+   */
+  importTxt(filename: string, content: string): { preset: PromptPreset; renamed: boolean } {
+    const baseName = stripExtension(filename).trim() || "Imported preset";
+    const { name, renamed } = this.uniqueName(baseName);
+    const preset = this.create(name);
+    this.update(preset.id, { content });
+    return { preset: this.getById(preset.id) ?? preset, renamed };
+  }
 
-    if (mode === "replace") {
-      this.presets = incoming;
-      this.saveSettings();
-      const ids = new Set(this.presets.map((p) => p.id));
-      this.active = this.active.filter((a) => ids.has(a.id));
-      this.saveActive();
-      return { added: incoming.length, skipped: 0 };
+  private uniqueName(base: string): { name: string; renamed: boolean } {
+    const existing = new Set(this.presets.map((p) => p.name));
+    if (!existing.has(base)) return { name: base, renamed: false };
+    for (let i = 2; i < 1000; i++) {
+      const candidate = `${base} (${i})`;
+      if (!existing.has(candidate)) return { name: candidate, renamed: true };
     }
+    return { name: `${base} (${Date.now()})`, renamed: true };
+  }
 
-    const existing = new Set(this.presets.map((p) => p.id));
-    let added = 0;
-    let skipped = 0;
-    const fresh: PromptPreset[] = [];
-    for (const p of incoming) {
-      if (existing.has(p.id)) {
-        skipped++;
-        continue;
+  /** Collect preset state for server-side sync. */
+  collectPrefs(): unknown {
+    return {
+      presets: this.presets,
+      active: this.active,
+    };
+  }
+
+  /** Apply prompt presets fetched from the server. Replaces local storage and re-hydrates. */
+  applyServerPrefs(data: any): void {
+    try {
+      if (Array.isArray(data?.presets)) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: EXPORT_VERSION, presets: data.presets }));
       }
-      fresh.push(p);
-      added++;
+      if (Array.isArray(data?.active)) {
+        localStorage.setItem(ACTIVE_KEY, JSON.stringify(data.active));
+      }
+      // Re-hydrate from the newly-written localStorage
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<PersistedState>;
+        if (Array.isArray(parsed?.presets)) {
+          this.presets = parsed.presets.map(sanitizePreset).filter(Boolean) as PromptPreset[];
+        }
+      }
+      const rawActive = localStorage.getItem(ACTIVE_KEY);
+      if (rawActive) {
+        const parsed = JSON.parse(rawActive) as ActivePreset[];
+        if (Array.isArray(parsed)) {
+          const ids = new Set(this.presets.map((p) => p.id));
+          this.active = parsed.filter(
+            (a): a is ActivePreset =>
+              !!a && typeof a.id === "string" && ids.has(a.id) &&
+              (a.mode === "prepend" || a.mode === "append" || a.mode === "wildcard"),
+          );
+        }
+      }
+    } catch (e) {
+      console.error("prompt-presets: applyServerPrefs failed", e);
     }
-    if (fresh.length > 0) {
-      this.presets = [...fresh, ...this.presets];
-      this.saveSettings();
-    }
-    return { added, skipped };
   }
+}
+
+function stripExtension(filename: string): string {
+  return filename.replace(/\.[^./\\]+$/, "");
+}
+
+function sanitizeFilename(name: string): string {
+  // Replace reserved chars across platforms with underscores; collapse runs.
+  return name.replace(/[\\/:*?"<>|\x00-\x1f]+/g, "_").replace(/_+/g, "_").trim() || "preset";
 }
 
 export const promptPresets = new PromptPresetsStore();

--- a/src/lib/stores/styles.svelte.ts
+++ b/src/lib/stores/styles.svelte.ts
@@ -7,13 +7,16 @@
  * textbox — they are injected downstream in `generation.toParams()`.
  *
  * Storage: localStorage under `mooshieui.styles.v1`.
- * Export/import: JSON envelope with kind + version for forward-compat.
+ * Import/export: plain `.txt` files — filename (minus extension) becomes
+ * the style name. Each non-blank, non-comment line is one artist in
+ * `tag[:weight]` form (weight defaults to 1.0). `# ...` lines and blank
+ * lines are ignored. An optional `overall:NNN` line sets the overall weight.
  */
 
 const STORAGE_KEY = "mooshieui.styles.v1";
 const ACTIVE_KEY = "mooshieui.styles.active.v1";
-const EXPORT_KIND = "mooshieui.artist-styles";
-const EXPORT_VERSION = 1;
+
+import { triggerSync } from "../utils/syncTrigger.js";
 
 /** Max dimension (px) for thumbnails stored with the style. Keeps localStorage / exports small. */
 const THUMBNAIL_MAX_DIM = 384;
@@ -41,13 +44,6 @@ export interface ArtistStyle {
 
 interface PersistedState {
   version: number;
-  styles: ArtistStyle[];
-}
-
-export interface StylesExport {
-  kind: typeof EXPORT_KIND;
-  version: number;
-  exportedAt: string;
   styles: ArtistStyle[];
 }
 
@@ -175,6 +171,7 @@ class StylesStore {
     try {
       const payload: PersistedState = { version: EXPORT_VERSION, styles: this.styles };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      triggerSync();
     } catch (e) {
       console.error("styles: save failed", e);
     }
@@ -183,6 +180,7 @@ class StylesStore {
   private saveActive() {
     try {
       localStorage.setItem(ACTIVE_KEY, JSON.stringify(this.activeIds));
+      triggerSync();
     } catch (e) {
       console.error("styles: save active failed", e);
     }
@@ -366,63 +364,126 @@ class StylesStore {
   }
 
   // ---------------------------------------------------------------------------
-  // Export / import
+  // Export / import (.txt)
   // ---------------------------------------------------------------------------
 
-  exportJSON(styleIds?: string[]): string {
-    const selected = styleIds
-      ? this.styles.filter((s) => styleIds.includes(s.id))
-      : this.styles;
-    const payload: StylesExport = {
-      kind: EXPORT_KIND,
-      version: EXPORT_VERSION,
-      exportedAt: new Date().toISOString(),
-      styles: selected,
+  /**
+   * Render a style as a plain .txt file. Format:
+   *
+   *   # name (comment)
+   *   overall:1.20
+   *   dairi:1.2
+   *   greg rutkowski
+   *   @illu_no16:0.8
+   */
+  exportTxt(id: string): { filename: string; content: string } | null {
+    const style = this.getById(id);
+    if (!style) return null;
+    const lines: string[] = [];
+    lines.push(`# ${style.name}`);
+    if (style.overallWeight !== 1.0) {
+      lines.push(`overall:${style.overallWeight.toFixed(2)}`);
+    }
+    for (const a of style.artists) {
+      if (a.weight === 1.0) lines.push(a.tag);
+      else lines.push(`${a.tag}:${a.weight.toFixed(2)}`);
+    }
+    return {
+      filename: `${sanitizeFilename(style.name)}.txt`,
+      content: lines.join("\n") + "\n",
     };
-    return JSON.stringify(payload, null, 2);
   }
 
   /**
-   * Import styles from a JSON string.
-   * - "merge": new IDs are appended; existing IDs are skipped (use "replace-id" to overwrite).
-   * - "replace": wipes existing styles entirely and installs the imported set.
+   * Import a style from a plain .txt file. Filename (minus extension) becomes
+   * the style name. Format per line:
+   *
+   *   - blank or `# …` — ignored (comment)
+   *   - `overall:N`    — sets the overall weight
+   *   - `tag`          — artist with default weight 1.0
+   *   - `tag:weight`   — artist with explicit weight (e.g. `dairi:1.2`)
+   *
+   * Tag normalisation (`@` prefix handling for Anima models) happens in the
+   * editor UI, not here — the imported file's syntax is preserved.
+   *
+   * If a style with the same name already exists, a numeric suffix is added.
    */
-  importJSON(raw: string, mode: "merge" | "replace" = "merge"): { added: number; skipped: number } {
-    const parsed = JSON.parse(raw) as Partial<StylesExport>;
-    if (!parsed || typeof parsed !== "object") throw new Error("Invalid JSON payload");
-    if (parsed.kind !== EXPORT_KIND) throw new Error("Not a MooshieUI styles export");
-    const incoming = Array.isArray(parsed.styles)
-      ? (parsed.styles.map(sanitizeStyle).filter(Boolean) as ArtistStyle[])
-      : [];
-
-    if (mode === "replace") {
-      this.styles = incoming;
-      this.saveSettings();
-      // Purge active IDs that no longer exist.
-      const ids = new Set(this.styles.map((s) => s.id));
-      this.activeIds = this.activeIds.filter((id) => ids.has(id));
-      this.saveActive();
-      return { added: incoming.length, skipped: 0 };
-    }
-
-    const existing = new Set(this.styles.map((s) => s.id));
-    let added = 0;
-    let skipped = 0;
-    const fresh: ArtistStyle[] = [];
-    for (const s of incoming) {
-      if (existing.has(s.id)) {
-        skipped++;
+  importTxt(filename: string, content: string): { style: ArtistStyle; renamed: boolean } {
+    const baseName = stripExtension(filename).trim() || "Imported style";
+    const { name, renamed } = this.uniqueName(baseName);
+    let overallWeight = 1.0;
+    const artists: StyleArtist[] = [];
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
+      const overallMatch = line.match(/^overall\s*[:=]\s*([0-9]*\.?[0-9]+)\s*$/i);
+      if (overallMatch) {
+        overallWeight = clampWeight(overallMatch[1]);
         continue;
       }
-      fresh.push(s);
-      added++;
+      // Last colon splits tag:weight (so tags containing colons stay intact
+      // when their weight suffix is present, and tags without a numeric
+      // suffix retain the full text).
+      const colonIdx = line.lastIndexOf(":");
+      let tag = line;
+      let weight = 1.0;
+      if (colonIdx > 0 && colonIdx < line.length - 1) {
+        const tail = line.slice(colonIdx + 1).trim();
+        if (/^[0-9]*\.?[0-9]+$/.test(tail)) {
+          tag = line.slice(0, colonIdx).trim();
+          weight = clampWeight(tail);
+        }
+      }
+      if (!tag) continue;
+      artists.push({ tag, weight });
     }
-    if (fresh.length > 0) {
-      this.styles = [...fresh, ...this.styles];
-      this.saveSettings();
-    }
-    return { added, skipped };
+    const style = this.create(name, artists, overallWeight);
+    return { style, renamed };
   }
+
+  private uniqueName(base: string): { name: string; renamed: boolean } {
+    const existing = new Set(this.styles.map((s) => s.name));
+    if (!existing.has(base)) return { name: base, renamed: false };
+    for (let i = 2; i < 1000; i++) {
+      const candidate = `${base} (${i})`;
+      if (!existing.has(candidate)) return { name: candidate, renamed: true };
+    }
+    return { name: `${base} (${Date.now()})`, renamed: true };
+  }
+
+  /** Collect style state for server-side sync. */
+  collectPrefs(): unknown {
+    return {
+      styles: this.styles,
+      activeIds: this.activeIds,
+    };
+  }
+
+  /** Apply artist styles fetched from the server. Replaces local storage and re-hydrates. */
+  applyServerPrefs(data: any): void {
+    try {
+      if (Array.isArray(data?.styles)) {
+        const sanitized = data.styles.map(sanitizeStyle).filter(Boolean) as ArtistStyle[];
+        this.styles = sanitized;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, styles: sanitized }));
+      }
+      if (Array.isArray(data?.activeIds)) {
+        const ids = new Set(this.styles.map((s) => s.id));
+        this.activeIds = data.activeIds.filter((id: any) => typeof id === "string" && ids.has(id));
+        localStorage.setItem(ACTIVE_KEY, JSON.stringify(this.activeIds));
+      }
+    } catch (e) {
+      console.error("styles: applyServerPrefs failed", e);
+    }
+  }
+}
+
+function stripExtension(filename: string): string {
+  return filename.replace(/\.[^./\\]+$/, "");
+}
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/:*?"<>|\x00-\x1f]+/g, "_").replace(/_+/g, "_").trim() || "style";
 }
 
 export const styles = new StylesStore();

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -545,6 +545,16 @@ export async function installAttentionBackend(backend: string): Promise<void> {
   return ipcInvoke("install_attention_backend", { backend });
 }
 
+/**
+ * Highest NVIDIA GPU compute capability detected via `nvidia-smi` (e.g. 8.9
+ * for Ada Lovelace, 12.0 for consumer Blackwell). Returns `null` on
+ * non-NVIDIA systems or if `nvidia-smi` isn't available. Lightweight — does
+ * not enumerate venv packages, so safe to call on UI mount.
+ */
+export async function getComputeCapability(): Promise<number | null> {
+  return ipcInvoke("get_compute_capability");
+}
+
 export async function getConfig(): Promise<AppConfig> {
   return ipcInvoke("get_config");
 }

--- a/src/lib/utils/promptSchedule.ts
+++ b/src/lib/utils/promptSchedule.ts
@@ -185,7 +185,7 @@ const TAG_COLORS: Record<string, { bg: string; border: string; glow: string }> =
  * Render prompt text as HTML with styled highlights for scheduling blocks.
  * Used by the backdrop overlay behind the textarea.
  */
-export function renderHighlightedPrompt(raw: string): string {
+export function renderHighlightedPrompt(raw: string, knownPresetSlugs?: ReadonlySet<string>): string {
   let html = "";
   let lastIndex = 0;
 
@@ -196,7 +196,7 @@ export function renderHighlightedPrompt(raw: string): string {
     const fullMatch = match[0];
     const matchStart = match.index;
 
-    html += escapeHtml(raw.slice(lastIndex, matchStart));
+    html += renderPresetSegment(raw.slice(lastIndex, matchStart), knownPresetSlugs);
     lastIndex = matchStart + fullMatch.length;
 
     let isValid = false;
@@ -232,7 +232,41 @@ export function renderHighlightedPrompt(raw: string): string {
     html += `</span>`;
   }
 
-  html += escapeHtml(raw.slice(lastIndex));
+  html += renderPresetSegment(raw.slice(lastIndex), knownPresetSlugs);
+  return html;
+}
+
+/** Match `@preset:<slug>` directives. Slug = lowercase alnum + underscore. */
+const PRESET_TOKEN_REGEX = /@preset:([a-z0-9_]+)/gi;
+
+/**
+ * Highlight `@preset:<slug>` tokens within an arbitrary plain-text segment.
+ * Indigo pill when the slug is known, red when unknown — gives users instant
+ * feedback for typos. Returns escaped HTML so it can be concatenated into the
+ * larger highlight string.
+ */
+function renderPresetSegment(text: string, knownPresetSlugs?: ReadonlySet<string>): string {
+  if (!text) return "";
+  if (!text.includes("@preset:")) return escapeHtml(text);
+  let html = "";
+  let lastIndex = 0;
+  PRESET_TOKEN_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PRESET_TOKEN_REGEX.exec(text)) !== null) {
+    html += escapeHtml(text.slice(lastIndex, match.index));
+    lastIndex = match.index + match[0].length;
+    const slug = match[1].toLowerCase();
+    const known = knownPresetSlugs?.has(slug) ?? false;
+    const bg = known ? "rgba(99, 102, 241, 0.18)" : "rgba(239, 68, 68, 0.16)";
+    const border = known ? "rgba(129, 140, 248, 0.55)" : "rgba(248, 113, 113, 0.55)";
+    const glow = known
+      ? "0 0 8px rgba(99, 102, 241, 0.30)"
+      : "0 0 6px rgba(239, 68, 68, 0.25)";
+    html += `<span style="display:inline;color:transparent;background:${bg};border:1px solid ${border};border-radius:4px;box-shadow:${glow};padding:1px 3px;margin:0 1px;">`;
+    html += escapeHtml(match[0]);
+    html += `</span>`;
+  }
+  html += escapeHtml(text.slice(lastIndex));
   return html;
 }
 
@@ -242,4 +276,14 @@ export function renderHighlightedPrompt(raw: string): string {
 export function hasSchedulingTags(raw: string): boolean {
   COMBINED_REGEX.lastIndex = 0;
   return COMBINED_REGEX.test(raw);
+}
+
+/**
+ * Check whether the prompt contains any `@preset:<slug>` directives. Cheap
+ * substring guard first so we don't allocate a regex match on every keystroke.
+ */
+export function hasPresetTokens(raw: string): boolean {
+  if (!raw || !raw.includes("@preset:")) return false;
+  PRESET_TOKEN_REGEX.lastIndex = 0;
+  return PRESET_TOKEN_REGEX.test(raw);
 }

--- a/src/lib/utils/serverPrefs.ts
+++ b/src/lib/utils/serverPrefs.ts
@@ -1,0 +1,74 @@
+/**
+ * Server-side per-user preferences API.
+ *
+ * Only active in browser / LAN mode.  In Tauri desktop mode all functions
+ * are no-ops and return null — local persistence via ipcStore / localStorage
+ * continues unchanged.
+ */
+
+import { isBrowserMode, getAuthToken } from "./ipc.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UserPrefsData {
+  generation?: Record<string, unknown>;
+  prompt_history?: unknown[];
+  prompt_presets?: unknown;
+  styles?: unknown;
+  artist_favourites?: unknown;
+  gallery_boards?: unknown;
+  autocomplete?: unknown;
+  accessibility?: unknown;
+  locale?: string;
+  updated_at?: string;
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the current user's saved preferences from the server.
+ * Returns `null` when in Tauri mode, when unauthenticated, when no prefs
+ * are saved yet (204), or on network failure.
+ */
+export async function fetchServerPrefs(): Promise<UserPrefsData | null> {
+  if (!isBrowserMode) return null;
+  const token = getAuthToken();
+  // In LAN mode without a token we're anonymous — skip silently.
+  if (!token) return null;
+  try {
+    const resp = await fetch("/internal-api/_user/prefs", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (resp.status === 204 || resp.status === 404) return null;
+    if (!resp.ok) return null;
+    return (await resp.json()) as UserPrefsData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Push the current user's preferences to the server.
+ * Fire-and-forget — never throws; failures are logged but do not block the UI.
+ */
+export async function pushServerPrefs(prefs: UserPrefsData): Promise<void> {
+  if (!isBrowserMode) return;
+  const token = getAuthToken();
+  if (!token) return;
+  try {
+    await fetch("/internal-api/_user/prefs", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(prefs),
+    });
+  } catch (e) {
+    console.warn("[prefsSync] server push failed:", e);
+  }
+}

--- a/src/lib/utils/syncTrigger.ts
+++ b/src/lib/utils/syncTrigger.ts
@@ -1,0 +1,27 @@
+/**
+ * A lightweight callback registration module to avoid circular imports
+ * between individual stores and the central prefsSync hub.
+ *
+ * Stores call triggerSync() after every local save.
+ * prefsSync registers itself as the handler on initialisation.
+ *
+ * In Tauri desktop mode (no shared server) the handler is never registered
+ * so triggerSync() is effectively a no-op — local persistence still works
+ * exactly as before via ipcStore / localStorage.
+ */
+
+let _handler: (() => void) | null = null;
+
+/** Called by prefsSync to register its debounced server-push callback. */
+export function registerSyncHandler(handler: () => void): void {
+  _handler = handler;
+}
+
+/**
+ * Trigger a debounced push of all store state to the server.
+ * Safe to call unconditionally — is a no-op until registerSyncHandler() has
+ * been called, and always a no-op in pure Tauri / offline mode.
+ */
+export function triggerSync(): void {
+  _handler?.();
+}


### PR DESCRIPTION
## What's New in v1.0.9

### Account-Based Preference Sync
- **Cross-device settings sync** — user preferences are now stored server-side per account, so switching OS or device with the same MooshieUI login yields the same configuration. Synced state includes: generation parameters, prompt history, prompt presets, artist styles, artist favourites, gallery boards, autocomplete settings, accessibility options, and locale.
- **Seamless sync on login** — on startup or login, MooshieUI fetches the server snapshot and applies it to all stores. If no server snapshot exists yet, the current local state is seeded to the server.
- **Debounced background push** — every settings save triggers a debounced 2-second sync push to the server, collapsing rapid consecutive saves into a single request.
- **Desktop mode unaffected** — sync is only active in browser/LAN mode; the Tauri desktop app continues to use local-only persistence as before.

### New Tauri Command
- **`get_compute_capability`** — exposes the host GPU's CUDA compute capability as a float (e.g. `8.9` for RTX 4090), used for model compatibility hints in the UI.