### PR TITLE
add terminal log panel gated behind developer mode

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2867,6 +2867,26 @@ pub async fn append_frontend_logs(lines: Vec<String>) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Return a snapshot of the in-memory log buffers for display in the UI
+/// terminal log panel.
+///
+/// `source` selects which buffer to read:
+///   - `"app"`     – Rust-side ring buffer (app internals, formatted with level + target)
+///   - `"comfyui"` – ComfyUI subprocess stderr log file from the OS temp dir
+///   - anything else / omitted → same as `"app"`
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn get_logs(source: Option<String>) -> Result<Vec<String>, AppError> {
+    match source.as_deref().unwrap_or("app") {
+        "comfyui" => {
+            let log_path = std::env::temp_dir().join("comfyui-desktop-stderr.log");
+            let content = std::fs::read_to_string(&log_path).unwrap_or_default();
+            Ok(content.lines().map(String::from).collect())
+        }
+        _ => Ok(crate::log_buffer::snapshot_rust()),
+    }
+}
+
 /// Detect the MIME type of image bytes from magic bytes.
 fn detect_image_mime(bytes: &[u8]) -> &'static str {
     if bytes.starts_with(b"\x89PNG") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -389,6 +389,7 @@ pub fn run() {
             commands::api::import_image_directory,
             commands::api::export_logs,
             commands::api::append_frontend_logs,
+            commands::api::get_logs,
             commands::api::check_node_available,
             commands::api::is_custom_node_installed,
             commands::api::install_custom_node,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,6 +30,7 @@
   import type { ContextMenuItem } from "./lib/components/ui/ContextMenu.svelte";
   import InterrogateModal from "./lib/components/generation/InterrogateModal.svelte";
   import { interrogateGalleryImage, interrogateImage } from "./lib/utils/api.js";
+  import TerminalLog from "./lib/components/ui/TerminalLog.svelte";
 
   declare const __APP_VERSION__: string;
   const appVersion = __APP_VERSION__ ?? "dev";
@@ -432,6 +433,7 @@
   let currentPage = $state<"generate" | "gallery" | "modelhub" | "artists" | "settings">(
     "generate"
   );
+  let showTerminalLog = $state(false);
 
   // Auth gate state (browser mode LAN access)
   let authRequired = $state(false);
@@ -2139,6 +2141,21 @@
 
     <div class="flex-1"></div>
 
+    <!-- Terminal log toggle (only visible when enabled in Developer settings) -->
+    {#if generation.showTerminalLog}
+    <button
+      class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors mx-auto
+        {showTerminalLog ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200'}"
+      onclick={() => (showTerminalLog = !showTerminalLog)}
+      title="Toggle terminal log"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4.5 h-4.5" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+      </svg>
+    </button>
+    {/if}
+
     <button
       class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {currentPage ===
       'settings'
@@ -2484,6 +2501,9 @@
       <SettingsPage {userRole} />
     {/if}
     </div>
+    {#if generation.showTerminalLog && showTerminalLog}
+      <TerminalLog onclose={() => (showTerminalLog = false)} />
+    {/if}
   </main>
 </div>
 {/if}

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -2716,6 +2716,17 @@
                 <p class="text-[11px] text-neutral-500 mt-0.5">Shows the Checkpoints tab in the bottom panel even when fewer than 10 checkpoints are installed.</p>
               </div>
             </label>
+            <label class="flex items-center gap-3 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                class="w-4 h-4 rounded accent-amber-400"
+                bind:checked={generation.showTerminalLog}
+              />
+              <div>
+                <p class="text-xs font-medium text-neutral-200">Show terminal log panel</p>
+                <p class="text-[11px] text-neutral-500 mt-0.5">Adds a live log viewer to the sidebar showing ComfyUI output and app messages. Useful for diagnosing errors.</p>
+              </div>
+            </label>
           </div>
           {/if}
         </section>

--- a/src/lib/components/ui/TerminalLog.svelte
+++ b/src/lib/components/ui/TerminalLog.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+  import { onMount, onDestroy, tick } from "svelte";
+  import { getLogs } from "../../utils/api.js";
+  import { isTauri } from "../../utils/ipc.js";
+
+  let {
+    onclose,
+  }: {
+    onclose: () => void;
+  } = $props();
+
+  type LogSource = "comfyui" | "app";
+
+  let activeTab = $state<LogSource>("comfyui");
+  let lines = $state<string[]>([]);
+  let autoScroll = $state(true);
+  let panelHeight = $state(260);
+  let logEl = $state<HTMLElement | null>(null);
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  // Drag-to-resize state — plain vars, no reactivity needed
+  let dragging = false;
+  let dragStartY = 0;
+  let dragStartHeight = 0;
+
+  async function fetchLogs() {
+    if (!isTauri) return;
+    try {
+      lines = await getLogs(activeTab);
+    } catch {
+      // silently ignore poll failures
+    }
+  }
+
+  function startPolling() {
+    stopPolling();
+    void fetchLogs();
+    intervalId = setInterval(() => void fetchLogs(), 1500);
+  }
+
+  function stopPolling() {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+
+  $effect(() => {
+    // Re-fetch immediately when tab changes
+    void fetchLogs();
+  });
+
+  $effect(() => {
+    // Auto-scroll when new lines arrive
+    if (autoScroll && logEl) {
+      tick().then(() => {
+        if (logEl) logEl.scrollTop = logEl.scrollHeight;
+      });
+    }
+  });
+
+  function onScroll() {
+    if (!logEl) return;
+    const atBottom = logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 8;
+    autoScroll = atBottom;
+  }
+
+  function scrollToBottom() {
+    autoScroll = true;
+    tick().then(() => {
+      if (logEl) logEl.scrollTop = logEl.scrollHeight;
+    });
+  }
+
+  function copyAll() {
+    navigator.clipboard.writeText(lines.join("\n")).catch(() => {});
+  }
+
+  function clearDisplay() {
+    lines = [];
+  }
+
+  // Drag-resize handle
+  function onDragStart(e: MouseEvent | TouchEvent) {
+    dragging = true;
+    dragStartY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    dragStartHeight = panelHeight;
+
+    const onMove = (ev: MouseEvent | TouchEvent) => {
+      if (!dragging) return;
+      const y = "touches" in ev ? ev.touches[0].clientY : ev.clientY;
+      const delta = dragStartY - y;
+      panelHeight = Math.max(120, Math.min(700, dragStartHeight + delta));
+    };
+    const onUp = () => {
+      dragging = false;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      window.removeEventListener("touchmove", onMove);
+      window.removeEventListener("touchend", onUp);
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    window.addEventListener("touchmove", onMove);
+    window.addEventListener("touchend", onUp);
+  }
+
+  function levelClass(line: string): string {
+    const lower = line.toLowerCase();
+    if (lower.includes(" error") || lower.includes("[error]") || lower.includes("traceback") || lower.includes("exception")) {
+      return "text-red-400";
+    }
+    if (lower.includes(" warn") || lower.includes("[warn]") || lower.includes("warning")) {
+      return "text-amber-400";
+    }
+    if (lower.includes(" info") || lower.includes("[info]")) {
+      return "text-neutral-200";
+    }
+    return "text-neutral-400";
+  }
+
+  onMount(() => {
+    startPolling();
+  });
+
+  onDestroy(() => {
+    stopPolling();
+  });
+</script>
+
+<div
+  class="flex flex-col border-t border-neutral-700 bg-neutral-950 font-mono text-xs select-text"
+  style="height: {panelHeight}px; flex-shrink: 0;"
+>
+  <!-- Resize handle -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="h-1 bg-neutral-800 hover:bg-indigo-600 cursor-row-resize transition-colors shrink-0"
+    onmousedown={onDragStart}
+    ontouchstart={onDragStart}
+  ></div>
+
+  <!-- Header bar -->
+  <div class="flex items-center gap-1 px-2 py-1 border-b border-neutral-800 bg-neutral-900 shrink-0">
+    <!-- Tabs -->
+    <button
+      class="px-2.5 py-0.5 rounded text-[11px] transition-colors {activeTab === 'comfyui'
+        ? 'bg-neutral-700 text-neutral-100'
+        : 'text-neutral-500 hover:text-neutral-300'}"
+      onclick={() => { activeTab = 'comfyui'; }}
+    >ComfyUI</button>
+    <button
+      class="px-2.5 py-0.5 rounded text-[11px] transition-colors {activeTab === 'app'
+        ? 'bg-neutral-700 text-neutral-100'
+        : 'text-neutral-500 hover:text-neutral-300'}"
+      onclick={() => { activeTab = 'app'; }}
+    >App</button>
+
+    <div class="flex-1"></div>
+
+    <!-- Line count -->
+    <span class="text-neutral-600 text-[10px]">{lines.length} lines</span>
+
+    <!-- Auto-scroll indicator / button -->
+    <button
+      class="px-1.5 py-0.5 rounded text-[10px] transition-colors {autoScroll
+        ? 'text-indigo-400 hover:text-indigo-300'
+        : 'text-neutral-500 hover:text-neutral-300'}"
+      onclick={scrollToBottom}
+      title="Scroll to bottom"
+    >↓ auto</button>
+
+    <!-- Copy -->
+    <button
+      class="px-1.5 py-0.5 rounded text-[10px] text-neutral-500 hover:text-neutral-300 transition-colors"
+      onclick={copyAll}
+      title="Copy all to clipboard"
+    >copy</button>
+
+    <!-- Clear -->
+    <button
+      class="px-1.5 py-0.5 rounded text-[10px] text-neutral-500 hover:text-neutral-300 transition-colors"
+      onclick={clearDisplay}
+      title="Clear display"
+    >clear</button>
+
+    <!-- Close -->
+    <button
+      class="ml-1 w-5 h-5 flex items-center justify-center rounded text-neutral-500 hover:text-neutral-200 hover:bg-neutral-700 transition-colors"
+      onclick={onclose}
+      title="Close terminal log"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Log lines -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="flex-1 overflow-y-auto overflow-x-auto px-3 py-1.5 leading-5"
+    bind:this={logEl}
+    onscroll={onScroll}
+  >
+    {#if lines.length === 0}
+      <span class="text-neutral-600 italic">
+        {activeTab === 'comfyui' ? 'No ComfyUI output yet. Start ComfyUI to see logs.' : 'No app logs yet.'}
+      </span>
+    {:else}
+      {#each lines as line (line + lines.indexOf(line))}
+        <div class="whitespace-pre-wrap break-all {levelClass(line)}">{line}</div>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -188,6 +188,8 @@ class GenerationStore {
   devModeUnlocked = $state(false);
   /** Developer mode: bypasses checkpoint selector restrictions. Not persisted. */
   devMode = $state(false);
+  /** Show the terminal log panel in the sidebar. Not persisted. */
+  showTerminalLog = $state(false);
 
   /** Architecture detected from modelspec metadata, or null if not yet read. */
   modelspecArchitecture = $state<string | null>(null);

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -642,3 +642,8 @@ export async function getGpuStats(): Promise<GpuStats[]> {
   if (!resp.ok) throw new Error(await resp.text());
   return resp.json();
 }
+
+export async function getLogs(source: "app" | "comfyui"): Promise<string[]> {
+  if (!isTauri) return [];
+  return ipcInvoke("get_logs", { source });
+}


### PR DESCRIPTION
Closes #128

## Changes

```
 src-tauri/src/commands/api.rs                   | 20 ++++++++++++++++++++
 src-tauri/src/lib.rs                            |  1 +
 src/App.svelte                                  | 20 ++++++++++++++++++++
 src/lib/components/settings/SettingsPage.svelte | 11 +++++++++++
 src/lib/stores/generation.svelte.ts             |  2 ++
 src/lib/utils/api.ts                            |  5 +++++
 src/lib/components/ui/TerminalLog.svelte        | new file
```

## What was added

**Backend (`src-tauri/src/commands/api.rs` + `lib.rs`)**
- New `get_logs(source)` Tauri command — returns log lines from either the Rust app ring buffer (`"app"`) or the ComfyUI subprocess stderr file (`"comfyui"`)

**Frontend API (`src/lib/utils/api.ts`)**
- `getLogs(source)` wrapper (no-op in browser mode)

**New component (`src/lib/components/ui/TerminalLog.svelte`)**
- Resizable bottom panel (drag the top edge)
- **ComfyUI** and **App** tabs
- Auto-polls every 1.5 s; stops when hidden/destroyed
- Auto-scroll with lock + resume button
- Copy all / Clear display buttons
- Color-coded lines: red for errors, amber for warnings

**Gating**
- `showTerminalLog = $state(false)` added to `GenerationStore` (session-only, not persisted)
- Checkbox in the **Developer** section of Settings (requires 10-tap version unlock)
- Sidebar `>_` button and panel only render when the checkbox is enabled