### PR TITLE
v1.1.0: Refine button fix, model selection consistency, terminal log panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v1.1.0
+
+### Refine Button (SwarmUI-style)
+- **One-click image refinement** — the **Refine** button on the preview panel now runs a SwarmUI-style second pass over the generated image without regenerating it from scratch. The output is uploaded to ComfyUI, fed directly into the upscale chain, and processed at low denoise — sharpening detail and adding texture while preserving the original composition completely.
+- **No redundant sampling** — `refine_only` mode skips the main img2img KSampler/VAE round-trip; only the upscale chain (VAEEncodeTiled → optional TiledDiffusion / SoftGuidance → KSampler at `upscale_denoise` → VAEDecodeTiled) runs.
+- **Reliable image sourcing** — previously the button passed a blob/preview URL directly as `LoadImage` input, causing a `value_not_in_list` validation error (surfaced as "a model or VAE may not be configured correctly"). It now fetches the bytes from the displayed preview URL and uploads them to ComfyUI's `input/` folder before queuing.
+- **Respects Refiner settings** — scale factor, denoise strength, step count, tiling, SoftGuidance multiplier, and quality-only prompts are all taken from the Refiner panel.
+- **ControlNet disabled for refine pass** — re-conditioning a refine pass against the original control input is rarely intended and is suppressed automatically.
+
+### Model Selection Consistency Fix
+- **Displayed model = loaded model** — switching from a split-model (e.g. Anima Preview 3) to a regular checkpoint in the Checkpoint Gallery now correctly clears `useSplitModel`, `diffusionModel`, `clipModel`, and `clipType`. Previously, selecting a checkpoint while a split model was active left those fields set, so the workflow loaded the old Anima diffusion/CLIP/VAE files while the UI showed the new checkpoint name.
+
+### Terminal Log Panel (Developer Mode)
+- **Live log viewer** — a scrollable terminal log panel is now available in the Settings page under Developer Mode (unlock with 10 taps on the version number). Streams the last N Rust log lines via `get_log_buffer` and a live `log:line` event subscription, with a copy-to-clipboard button. Gated behind developer mode so it doesn't surface in normal use.
+
+---
+
 ## What's New in v1.0.9
 
 ### Account-Based Preference Sync

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v1.1.0
+
+### Refine Button (SwarmUI-style)
+- **One-click image refinement** — the **Refine** button on the preview panel now runs a SwarmUI-style second pass over the generated image without regenerating it from scratch. The output is uploaded to ComfyUI, fed directly into the upscale chain, and processed at low denoise — sharpening detail and adding texture while preserving the original composition completely.
+- **No redundant sampling** — `refine_only` mode skips the main img2img KSampler/VAE round-trip; only the upscale chain (VAEEncodeTiled → optional TiledDiffusion / SoftGuidance → KSampler at `upscale_denoise` → VAEDecodeTiled) runs.
+- **Reliable image sourcing** — previously the button passed a blob/preview URL directly as `LoadImage` input, causing a `value_not_in_list` validation error (surfaced as "a model or VAE may not be configured correctly"). It now fetches the bytes from the displayed preview URL and uploads them to ComfyUI's `input/` folder before queuing — the same approach used by the gallery's upscale flow.
+- **Respects Refiner settings** — scale factor, denoise strength, step count, tiling, SoftGuidance multiplier, and quality-only prompts are all taken from the Refiner panel.
+- **ControlNet disabled for refine pass** — re-conditioning a refine pass against the original control input is rarely intended and is suppressed automatically.
+
+### Model Selection Consistency Fix
+- **Displayed model = loaded model** — switching from a split-model (e.g. Anima Preview 3) to a regular checkpoint in the Checkpoint Gallery now correctly clears `useSplitModel`, `diffusionModel`, `clipModel`, and `clipType`. Previously, selecting a checkpoint while a split model was active left those fields set, so the workflow loaded the old Anima diffusion/CLIP/VAE files while the UI showed the new checkpoint name.
+
+### Terminal Log Panel (Developer Mode)
+- **Live log viewer** — a scrollable terminal log panel is now available in the Settings page under Developer Mode (unlock with 10 taps on the version number). Streams the last N Rust log lines via `get_log_buffer` and a live `log:line` event subscription, with a copy-to-clipboard button. Gated behind developer mode so it doesn't surface in normal use.
+
+---
+
 ## What's New in v1.0.9
 
 ### Account-Based Preference Sync

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.0.9"
+version = "1.1.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.0.9"
+version = "1.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -102,6 +102,12 @@ pub struct GenerationParams {
     pub upscale_steps: u32,
     pub upscale_tile_size: u32,
     pub upscale_tiling: bool,
+    /// "Refine" mode — when true with mode="img2img", skip the main img2img
+    /// KSampler/VAE round-trip and feed the loaded input image directly into
+    /// the upscale chain. Mirrors SwarmUI's "Refine Image" button: a single
+    /// low-denoise second pass at higher resolution.
+    #[serde(default)]
+    pub refine_only: bool,
     /// Enable Soft Guidance (CFG rescaling) for upscale pass to prevent hallucination
     #[serde(default)]
     pub upscale_soft_guidance: bool,

--- a/src-tauri/src/templates/img2img.rs
+++ b/src-tauri/src/templates/img2img.rs
@@ -47,6 +47,27 @@ pub fn build(params: &GenerationParams, seed: i64) -> WorkflowResult {
     );
     next_id += 1;
 
+    // Refine-only mode: skip the main img2img round-trip and feed the loaded
+    // image directly into whatever runs next (typically the upscale chain).
+    // This implements SwarmUI's "Refine Image" semantics — a single low-denoise
+    // second pass at higher resolution rather than two sequential samplings.
+    if params.refine_only {
+        return WorkflowResult {
+            workflow,
+            next_id,
+            image_output: (load_img_id, 0),
+            model_source,
+            clip_source,
+            positive_source: pos_source,
+            negative_source: neg_source,
+            vae_source,
+            // Empty sampler_id — no main sampler exists. inject_*/controlnet
+            // rewiring is keyed on `workflow.get_mut(&sampler_id)` and a
+            // missing key is a safe no-op.
+            sampler_id: String::new(),
+        };
+    }
+
     // Resize input image to target dimensions (avoids VRAM issues with large images)
     let resize_id = next_id.to_string();
     workflow.insert(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/CheckpointGallery.svelte
+++ b/src/lib/components/generation/CheckpointGallery.svelte
@@ -75,7 +75,17 @@
   }
 
   function selectCheckpoint(filename: string) {
+    // Clear any previously-selected split-model state so the displayed
+    // checkpoint is actually what gets loaded. Without this, switching from
+    // a split model (e.g. Anima Preview 3) to a regular checkpoint would
+    // leave `useSplitModel = true` and the workflow would still load the
+    // old diffusion_model / clip_model / vae instead of `filename`.
+    generation.useSplitModel = false;
+    generation.diffusionModel = null;
+    generation.clipModel = null;
+    generation.clipType = null;
     generation.checkpoint = filename;
+    generation.applyModelSpecificPreset(filename);
     generation.saveSettings();
   }
 

--- a/src/lib/components/progress/PreviewImage.svelte
+++ b/src/lib/components/progress/PreviewImage.svelte
@@ -3,7 +3,8 @@
   import { gallery } from "../../stores/gallery.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
-  import { generate } from "../../utils/api.js";
+  import { generate, loadGalleryImage, uploadImageBytes } from "../../utils/api.js";
+  import type { GenerationParams } from "../../types/index.js";
 
   let currentTipIndex = $state(0);
   let progressPercent = $state(0);
@@ -96,18 +97,74 @@
   });
 
   async function upscaleImage() {
-    generation.upscaleEnabled = true;
-    if (progress.lastOutputImage) {
-      generation.inputImage = progress.lastOutputImage;
+    // The Refine button takes the most-recent output and runs it back through
+    // the upscale chain (MooshieUI's "refiner") at low denoise — analogous to
+    // SwarmUI's "Refine Image" button.
+    //
+    // The previous implementation set `generation.inputImage` directly to the
+    // preview URL (a blob: or http:// URL pointing at our local cache). The
+    // ComfyUI `LoadImage` node expects a real filename inside its `input/`
+    // folder, so the workflow failed validation with `value_not_in_list`,
+    // surfaced to the user as "a model or VAE may not be configured
+    // correctly". Fix: upload the bytes first, exactly like the gallery's
+    // upscale flow in App.svelte does.
+    const savedImage = getActiveSavedImage();
+    if (!savedImage && !progress.lastOutputImage) {
+      gallery.showToast(locale.t("preview.not_available"), "info");
+      return;
     }
-    const params = generation.toParams();
-    params.mode = "img2img";
+
     try {
+      let bytes: number[];
+      let uploadFilename: string;
+
+      // Prefer the gallery copy if it's already persisted — that file is
+      // stable. Otherwise fetch directly from the displayed preview URL,
+      // which is a blob: URL pointing at the in-memory PNG and is always
+      // available right after generation. Calling ComfyUI's /view (via
+      // getOutputImage) is unreliable here because the temp file gets
+      // cleaned up shortly after the executing-finished event fires.
+      if (savedImage?.gallery_filename) {
+        bytes = await loadGalleryImage(savedImage.gallery_filename);
+        uploadFilename = savedImage.filename || `refine_${Date.now()}.png`;
+      } else {
+        const sourceUrl = previewSrc ?? progress.lastOutputImage;
+        if (!sourceUrl) {
+          gallery.showToast(locale.t("preview.not_available"), "info");
+          return;
+        }
+        const resp = await fetch(sourceUrl);
+        if (!resp.ok) throw new Error(`fetch failed: ${resp.status}`);
+        const buf = await resp.arrayBuffer();
+        bytes = Array.from(new Uint8Array(buf));
+        uploadFilename = savedImage?.filename || `refine_${Date.now()}.png`;
+      }
+
+      const upload = await uploadImageBytes(bytes, uploadFilename);
+
+      const params = generation.toParams() as GenerationParams;
+      params.mode = "img2img";
+      params.input_image = upload.name;
+      // Force refine-only mode so we don't re-do the main img2img sampler —
+      // the upscale chain alone is the refiner pass.
+      params.refine_only = true;
+      params.upscale_enabled = true;
+      // ControlNet on a refine pass would re-condition the existing image
+      // against the original control input, which is rarely what the user
+      // wants. Disable it for this pass.
+      params.controlnet = null;
+
       const result = await generate(params);
       params.seed = result.seed;
       progress.enqueue(result.prompt_id, true, "img2img", params);
+
+      // Reflect the upload in the UI so a follow-up Generate also works.
+      generation.mode = "img2img";
+      generation.inputImage = upload.name;
+      generation.upscaleEnabled = true;
     } catch (e) {
-      console.error("Upscale failed:", e);
+      console.error("Refine failed:", e);
+      gallery.showToast(`${locale.t("preview.refine_failed")}: ${e}`, "error");
     }
   }
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -550,6 +550,7 @@ const de: Record<string, string> = {
   "preview.copy": "Kopieren",
   "preview.copy_clipboard": "In Zwischenablage kopieren",
   "preview.not_available": "Gespeichertes Bild noch nicht verfügbar",
+  "preview.refine_failed": "Verfeinerung fehlgeschlagen",
   "preview.previous_tip": "Vorheriger Tipp",
   "preview.next_tip": "Nächster Tipp",
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -586,6 +586,7 @@ const en: Record<string, string> = {
   "preview.copy": "Copy",
   "preview.copy_clipboard": "Copy to clipboard",
   "preview.not_available": "Saved image not available yet",
+  "preview.refine_failed": "Refine failed",
   "preview.previous_tip": "Previous tip",
   "preview.next_tip": "Next tip",
 

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -573,6 +573,7 @@ const es: Record<string, string> = {
   "preview.copy": "Copiar",
   "preview.copy_clipboard": "Copiar al portapapeles",
   "preview.not_available": "La imagen guardada aún no está disponible",
+  "preview.refine_failed": "Error al refinar",
   "preview.previous_tip": "Consejo anterior",
   "preview.next_tip": "Siguiente consejo",
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -572,6 +572,7 @@ const fr: Record<string, string> = {
   "preview.copy": "Copier",
   "preview.copy_clipboard": "Copier dans le presse-papiers",
   "preview.not_available": "L'image enregistrée n'est pas encore disponible",
+  "preview.refine_failed": "Échec du raffinement",
   "preview.previous_tip": "Astuce précédente",
   "preview.next_tip": "Astuce suivante",
 

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -550,6 +550,7 @@ const it: Record<string, string> = {
   "preview.copy": "Copia",
   "preview.copy_clipboard": "Copia negli appunti",
   "preview.not_available": "Immagine salvata non ancora disponibile",
+  "preview.refine_failed": "Raffinamento fallito",
   "preview.previous_tip": "Suggerimento precedente",
   "preview.next_tip": "Suggerimento successivo",
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -572,6 +572,7 @@ const ja: Record<string, string> = {
   "preview.copy": "コピー",
   "preview.copy_clipboard": "クリップボードにコピー",
   "preview.not_available": "保存された画像はまだ利用できません",
+  "preview.refine_failed": "リファインに失敗しました",
   "preview.previous_tip": "前のヒント",
   "preview.next_tip": "次のヒント",
 

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -550,6 +550,7 @@ const ko: Record<string, string> = {
   "preview.copy": "복사",
   "preview.copy_clipboard": "클립보드에 복사",
   "preview.not_available": "저장된 이미지를 아직 사용할 수 없습니다",
+  "preview.refine_failed": "리파인 실패",
   "preview.previous_tip": "이전 팁",
   "preview.next_tip": "다음 팁",
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -550,6 +550,7 @@ const pt: Record<string, string> = {
   "preview.copy": "Copiar",
   "preview.copy_clipboard": "Copiar para área de transferência",
   "preview.not_available": "Imagem salva ainda não disponível",
+  "preview.refine_failed": "Falha ao refinar",
   "preview.previous_tip": "Dica anterior",
   "preview.next_tip": "Próxima dica",
 

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -550,6 +550,7 @@ const ru: Record<string, string> = {
   "preview.copy": "Копировать",
   "preview.copy_clipboard": "Копировать в буфер обмена",
   "preview.not_available": "Сохранённое изображение пока недоступно",
+  "preview.refine_failed": "Ошибка рефайна",
   "preview.previous_tip": "Предыдущая подсказка",
   "preview.next_tip": "Следующая подсказка",
 

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -550,6 +550,7 @@ const zhTw: Record<string, string> = {
   "preview.copy": "複製",
   "preview.copy_clipboard": "複製到剪貼簿",
   "preview.not_available": "已儲存的影像尚不可用",
+  "preview.refine_failed": "精煉失敗",
   "preview.previous_tip": "上一則提示",
   "preview.next_tip": "下一則提示",
 

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -550,6 +550,7 @@ const zh: Record<string, string> = {
   "preview.copy": "复制",
   "preview.copy_clipboard": "复制到剪贴板",
   "preview.not_available": "已保存的图像尚不可用",
+  "preview.refine_failed": "精炼失败",
   "preview.previous_tip": "上一条提示",
   "preview.next_tip": "下一条提示",
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -65,6 +65,9 @@ export interface GenerationParams {
   upscale_soft_guidance: boolean;
   upscale_soft_guidance_multiplier: number;
   smart_guidance: boolean;
+  /** "Refine" mode: skip the main img2img sampler and feed the loaded image
+   *  straight into the upscale chain. Mirrors SwarmUI's Refine button. */
+  refine_only?: boolean;
   use_split_model: boolean;
   diffusion_model: string | null;
   clip_model: string | null;


### PR DESCRIPTION
## What's New in v1.1.0

### Refine Button (SwarmUI-style)
- **One-click image refinement** — the **Refine** button now runs a SwarmUI-style second pass over the generated image without regenerating it from scratch. The output is uploaded to ComfyUI, fed directly into the upscale chain, and processed at low denoise — sharpening detail and adding texture while preserving the original composition.
- **No redundant sampling** — new `refine_only` mode skips the main img2img KSampler/VAE round-trip; only the upscale chain (VAEEncodeTiled → optional TiledDiffusion / SoftGuidance → KSampler at `upscale_denoise` → VAEDecodeTiled) runs.
- **Reliable image sourcing** — previously the button passed a blob/preview URL directly as `LoadImage` input, causing a `value_not_in_list` validation error ("a model or VAE may not be configured correctly"). It now fetches bytes from the displayed preview and uploads to ComfyUI's `input/` folder before queuing.
- **Respects Refiner settings** — scale, denoise, steps, tiling, SoftGuidance, and quality-only prompts all come from the Refiner panel.
- **ControlNet suppressed** — re-conditioning a refine pass against the original control input is disabled automatically.

### Model Selection Consistency Fix
- **Displayed model = loaded model** — switching from a split-model (Anima Preview 3 etc.) to a regular checkpoint in the Checkpoint Gallery now clears `useSplitModel`, `diffusionModel`, `clipModel`, and `clipType`. Previously those fields stayed set, so the workflow loaded the old split model files while the UI showed the new checkpoint name.

### Terminal Log Panel (Developer Mode)
- **Live log viewer** in Settings → Developer Mode — streams Rust log lines via `get_log_buffer` + `log:line` events, with copy-to-clipboard. Gated behind developer mode (10 taps on version number).

### i18n
- Added `preview.refine_failed` key across all 11 supported locales. Error toast on Refine failure is now localized.