### PR TITLE
v1.1.1: Mobile browser UI, integer progress, artist gallery diagnostics, i18n coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v1.1.1
+
+### Mobile Browser UI
+- **Touch-optimized shell** — when accessed through the embedded web server from a mobile device, MooshieUI now renders a native-feeling mobile layout with bottom tab navigation (Generate / Gallery / Model Hub / Artists / Settings) instead of the desktop side panels. Activation is automatic via user-agent detection and can be overridden from Settings.
+- **Mobile generate page** — vertical layout with a 3-segment pill mode switcher (txt2img / img2img / inpaint) in the top bar, large preview area, prompt history strip below the preview, and a floating bottom dock containing the generate button and a chevron to expand/collapse the parameters bottom sheet.
+- **Side rail extras panel** — LoRAs, Checkpoints, Session images, Styles, Schedule, and Compare are now reachable from a 48-px vertical icon rail on the generate page, each opening as a full-height bottom sheet.
+- **Mobile gallery & lightbox** — touch-friendly grid with a filters bottom sheet (board / sort), pinch-to-zoom lightbox, and an action sheet (Send to Generate / Use for Upscale / Copy / Download / Delete).
+- **Mobile settings page** — language picker, "Use desktop layout" pill toggle, generation defaults sliders (Steps, CFG), account sign-out, and About section.
+
+### Polish & Fixes
+- **Integer-only progress percentages** — generation progress no longer displays repeating decimals like `33.333%`; values are rounded to whole percent.
+- **Artist gallery error diagnostics** — `JSON.parse` failures now surface the URL, content-type, and a preview of the response body instead of an opaque parse error.
+- **Mobile artist gallery** — wired the missing `manifestUrl` prop so the artist tab loads correctly in browser mode.
+- **i18n coverage** — every new mobile UI string is routed through the locale system; 22 new keys added to `en.ts` with English-fallback stubs synced to all 11 other locales. Duplicate locale keys were removed from `it.ts`, `ja.ts`, `ko.ts`, `ru.ts`, `zh.ts`, and `zh-tw.ts` (translated values restored).
+
+---
+
 ## What's New in v1.1.0
 
 ### Refine Button (SwarmUI-style)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v1.1.1
+
+### Mobile Browser UI
+- **Touch-optimized shell** — when accessed through the embedded web server from a mobile device, MooshieUI now renders a native-feeling mobile layout with bottom tab navigation (Generate / Gallery / Model Hub / Artists / Settings) instead of the desktop side panels. Activation is automatic via user-agent detection and can be overridden from Settings.
+- **Mobile generate page** — vertical layout with a 3-segment pill mode switcher (txt2img / img2img / inpaint) in the top bar, large preview area, prompt history strip below the preview, and a floating bottom dock containing the generate button and a chevron to expand/collapse the parameters bottom sheet.
+- **Side rail extras panel** — LoRAs, Checkpoints, Session images, Styles, Schedule, and Compare are now reachable from a 48-px vertical icon rail on the generate page, each opening as a full-height bottom sheet.
+- **Mobile gallery & lightbox** — touch-friendly grid with a filters bottom sheet (board / sort), pinch-to-zoom lightbox, and an action sheet (Send to Generate / Use for Upscale / Copy / Download / Delete).
+- **Mobile settings page** — language picker, "Use desktop layout" pill toggle, generation defaults sliders (Steps, CFG), account sign-out, and About section.
+
+### Polish & Fixes
+- **Integer-only progress percentages** — generation progress no longer displays repeating decimals like `33.333%`; values are rounded to whole percent.
+- **Artist gallery error diagnostics** — `JSON.parse` failures now surface the URL, content-type, and a preview of the response body instead of an opaque parse error.
+- **Mobile artist gallery** — wired the missing `manifestUrl` prop so the artist tab loads correctly in browser mode.
+- **i18n coverage** — every new mobile UI string is routed through the locale system; 22 new keys added to `en.ts` with English-fallback stubs synced to all 11 other locales. Duplicate locale keys were removed from `it.ts`, `ja.ts`, `ko.ts`, `ru.ts`, `zh.ts`, and `zh-tw.ts` (translated values restored).
+
+---
+
 ## What's New in v1.1.0
 
 ### Refine Button (SwarmUI-style)

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <title>ComfyUI Desktop</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { ipcInvoke, ipcListen, isTauri, isBrowserMode, startHeartbeat, getAuthToken, setAuthToken, setAuthUser, authHeaders, wasRememberMe } from "./lib/utils/ipc.js";
+  import { useMobileLayout } from "./lib/utils/device.js";
+  import MobileApp from "./lib/components/mobile/MobileApp.svelte";
   import SetupWizard from "./lib/components/setup/SetupWizard.svelte";
   import GenerationPage from "./lib/components/generation/GenerationPage.svelte";
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
@@ -2000,6 +2002,8 @@
   </div>
 {:else if !setupComplete}
   <SetupWizard onSetupComplete={onSetupDone} />
+{:else if useMobileLayout}
+  <MobileApp canUseModelhub={canUseModelhub} />
 {:else}
 <div class="flex h-full bg-neutral-950 text-neutral-100 {visionSimClass}">
   <!-- SVG filters for color vision simulation -->
@@ -2508,7 +2512,8 @@
 </div>
 {/if}
 
-<!-- Lightbox overlay -->
+<!-- Lightbox overlay (desktop only) -->
+{#if !useMobileLayout}
 {#if gallery.lightboxOpen && (gallery.selectedImage || gallery.lightboxUrl)}
   <div
     class="lightbox-backdrop fixed inset-0 bg-black/90 z-50 flex {visionSimClass}"
@@ -2766,6 +2771,7 @@
       {/if}
     </div>
   </div>
+{/if}
 {/if}
 
 <!-- Toast notification -->

--- a/src/app.css
+++ b/src/app.css
@@ -363,3 +363,30 @@ html.light .lightbox-backdrop {
   animation: card-slide-in 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
   animation-delay: var(--card-delay, 0ms);
 }
+
+
+/* ─── Mobile UI helpers ─── */
+.touch-target {
+  min-height: 44px;
+  min-width: 44px;
+  touch-action: manipulation;
+}
+.safe-bottom {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--safe-bottom-extra, 0px));
+}
+.safe-top {
+  padding-top: env(safe-area-inset-top, 0px);
+}
+.bottom-sheet-handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 9999px;
+  background-color: var(--color-neutral-600);
+  margin: 8px auto;
+}
+.no-scroll-chain {
+  overscroll-behavior: contain;
+}
+.tap-highlight-none {
+  -webkit-tap-highlight-color: transparent;
+}

--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -39,7 +39,15 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
     if (!res.ok) {
       throw new Error(`artist-gallery: ${url} returned ${res.status}`);
     }
-    return (await res.json()) as T;
+    const text = await res.text();
+    try {
+      return JSON.parse(text) as T;
+    } catch (e) {
+      const preview = text.slice(0, 80).replace(/\s+/g, " ");
+      throw new Error(
+        `artist-gallery: ${url} returned non-JSON (${res.headers.get("content-type") ?? "no content-type"}): "${preview}…"`,
+      );
+    }
   }
 
   async function loadManifest(): Promise<ArtistManifest> {

--- a/src/lib/components/mobile/MobileActionSheet.svelte
+++ b/src/lib/components/mobile/MobileActionSheet.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import MobileBottomSheet from "./MobileBottomSheet.svelte";
+
+  export interface ActionSheetItem {
+    label: string;
+    icon?: import("svelte").Snippet;
+    onSelect: () => void;
+    destructive?: boolean;
+    disabled?: boolean;
+  }
+
+  interface Props {
+    open: boolean;
+    title?: string;
+    items: ActionSheetItem[];
+    onClose?: () => void;
+  }
+
+  let { open, title, items, onClose }: Props = $props();
+
+  function pick(item: ActionSheetItem) {
+    if (item.disabled) return;
+    onClose?.();
+    // Defer so the close animation runs first.
+    setTimeout(() => item.onSelect(), 0);
+  }
+</script>
+
+<MobileBottomSheet
+  {open}
+  snap="peek"
+  snaps={["peek"]}
+  {title}
+  auto
+  {onClose}
+>
+  <ul class="flex flex-col gap-1 py-1">
+    {#each items as item}
+      <li>
+        <button
+          type="button"
+          class="w-full touch-target flex items-center gap-3 px-3 py-3 rounded-lg text-left transition-colors
+            {item.disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-neutral-800 active:bg-neutral-700'}
+            {item.destructive ? 'text-red-400' : 'text-neutral-200'}"
+          disabled={item.disabled}
+          onclick={() => pick(item)}
+        >
+          {#if item.icon}
+            <span class="w-5 h-5 flex items-center justify-center shrink-0">
+              {@render item.icon()}
+            </span>
+          {/if}
+          <span class="text-sm font-medium">{item.label}</span>
+        </button>
+      </li>
+    {/each}
+  </ul>
+</MobileBottomSheet>

--- a/src/lib/components/mobile/MobileApp.svelte
+++ b/src/lib/components/mobile/MobileApp.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import MobileTabBar, { type MobileTab } from "./MobileTabBar.svelte";
+  import MobileGeneratePage from "./MobileGeneratePage.svelte";
+  import MobileGalleryPage from "./MobileGalleryPage.svelte";
+  import MobileSettingsPage from "./MobileSettingsPage.svelte";
+  import { ArtistGalleryPage } from "../../artist-gallery/index.js";
+  import ModelHubPage from "../modelhub/ModelHubPage.svelte";
+  import DownloadBanner from "../downloads/DownloadBanner.svelte";
+  import { connection } from "../../stores/connection.svelte.js";
+
+  interface Props {
+    canUseModelhub?: boolean;
+  }
+  let { canUseModelhub = false }: Props = $props();
+
+  let currentTab = $state<MobileTab>("generate");
+
+  function go(tab: MobileTab) {
+    currentTab = tab;
+  }
+</script>
+
+<div class="flex flex-col h-full w-full bg-neutral-950 text-neutral-100 overflow-hidden tap-highlight-none">
+  <DownloadBanner />
+  <main class="flex-1 min-h-0 overflow-hidden">
+    {#if currentTab === "generate"}
+      <MobileGeneratePage />
+    {:else if currentTab === "gallery"}
+      <MobileGalleryPage onSwitchToGenerate={() => go("generate")} />
+    {:else if currentTab === "modelhub" && canUseModelhub}
+      <div class="h-full overflow-hidden">
+        <ModelHubPage />
+      </div>
+    {:else if currentTab === "artists"}
+      <div class="h-full overflow-hidden">
+        <ArtistGalleryPage manifestUrl={connection.artistGalleryManifestUrl} />
+      </div>
+    {:else if currentTab === "settings"}
+      <MobileSettingsPage />
+    {/if}
+  </main>
+  <MobileTabBar
+    current={currentTab}
+    onChange={go}
+    showModelhub={canUseModelhub}
+  />
+</div>

--- a/src/lib/components/mobile/MobileBottomSheet.svelte
+++ b/src/lib/components/mobile/MobileBottomSheet.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+
+  type Snap = "peek" | "half" | "full" | "closed";
+
+  interface Props {
+    open: boolean;
+    snap?: Snap;
+    snaps?: Snap[];
+    onClose?: () => void;
+    onSnapChange?: (s: Snap) => void;
+    title?: string;
+    /** When true, sheet has no max-height and fills the viewport (action-sheet style). */
+    auto?: boolean;
+    children?: import("svelte").Snippet;
+  }
+
+  let {
+    open,
+    snap = $bindable("half"),
+    snaps = ["peek", "half", "full"],
+    onClose,
+    onSnapChange,
+    title,
+    auto = false,
+    children,
+  }: Props = $props();
+
+  // Heights (vh) per snap point.
+  const heights: Record<Snap, number> = {
+    closed: 0,
+    peek: 30,
+    half: 60,
+    full: 92,
+  };
+
+  let dragging = $state(false);
+  let dragStartY = 0;
+  let dragStartHeight = 0;
+  let currentHeightVh = $state(60);
+  let sheetEl = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    if (open && !dragging) {
+      currentHeightVh = heights[snap];
+    } else if (!open) {
+      currentHeightVh = 0;
+    }
+  });
+
+  function onHandlePointerDown(e: PointerEvent) {
+    if (!open) return;
+    dragging = true;
+    dragStartY = e.clientY;
+    dragStartHeight = currentHeightVh;
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+    e.preventDefault();
+  }
+
+  function onHandlePointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const dy = dragStartY - e.clientY; // up = positive
+    const vh = window.innerHeight || 800;
+    const dvh = (dy / vh) * 100;
+    currentHeightVh = Math.max(0, Math.min(95, dragStartHeight + dvh));
+  }
+
+  function onHandlePointerUp() {
+    if (!dragging) return;
+    dragging = false;
+    // Snap to closest allowed snap.
+    const allowed = snaps.filter((s) => heights[s] > 0);
+    let best: Snap = allowed[0] ?? "half";
+    let bestDiff = Infinity;
+    for (const s of allowed) {
+      const diff = Math.abs(heights[s] - currentHeightVh);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = s;
+      }
+    }
+    // If user dragged below 50% of smallest snap, treat as close intent.
+    const minH = heights[allowed[0] ?? "peek"];
+    if (currentHeightVh < minH * 0.5) {
+      onClose?.();
+      return;
+    }
+    snap = best;
+    currentHeightVh = heights[best];
+    onSnapChange?.(best);
+  }
+
+  // Esc closes
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape" && open) onClose?.();
+  }
+  onMount(() => window.addEventListener("keydown", onKey));
+  onDestroy(() => window.removeEventListener("keydown", onKey));
+
+  function onBackdropClick() {
+    onClose?.();
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-50 bg-black/60 transition-opacity tap-highlight-none"
+    onclick={onBackdropClick}
+  ></div>
+  <div
+    bind:this={sheetEl}
+    class="fixed left-0 right-0 bottom-0 z-50 flex flex-col bg-neutral-900 border-t border-neutral-800 rounded-t-2xl shadow-2xl no-scroll-chain"
+    style="height: {currentHeightVh}vh; max-height: {auto ? '90vh' : '95vh'}; transition: {dragging ? 'none' : 'height 0.18s cubic-bezier(0.32, 0.72, 0, 1)'};"
+    role="dialog"
+    aria-modal="true"
+  >
+    <!-- Drag handle -->
+    <button
+      type="button"
+      class="w-full py-1.5 flex flex-col items-center cursor-grab active:cursor-grabbing select-none touch-none"
+      onpointerdown={onHandlePointerDown}
+      onpointermove={onHandlePointerMove}
+      onpointerup={onHandlePointerUp}
+      onpointercancel={onHandlePointerUp}
+      aria-label="Drag to resize"
+    >
+      <div class="bottom-sheet-handle"></div>
+    </button>
+    {#if title}
+      <div class="px-4 pb-2 flex items-center justify-between">
+        <h2 class="text-sm font-semibold text-neutral-100">{title}</h2>
+        <button
+          type="button"
+          class="touch-target text-neutral-400 hover:text-neutral-200 -mr-2 px-2"
+          onclick={onClose}
+          aria-label="Close"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+    {/if}
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pb-[max(env(safe-area-inset-bottom),1rem)]">
+      {@render children?.()}
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/mobile/MobileExtrasPanel.svelte
+++ b/src/lib/components/mobile/MobileExtrasPanel.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  import MobileBottomSheet from "./MobileBottomSheet.svelte";
+  import LoraGallery from "../generation/LoraGallery.svelte";
+  import CheckpointGallery from "../generation/CheckpointGallery.svelte";
+  import CompareGrid from "../generation/CompareGrid.svelte";
+  import StyleManager from "../generation/StyleManager.svelte";
+  import ScheduleBuilder from "../generation/ScheduleBuilder.svelte";
+  import { models } from "../../stores/models.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
+  import { gallery } from "../../stores/gallery.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
+
+  type Tool = "loras" | "checkpoints" | "images" | "compare" | "styles" | "schedule";
+
+  let openTool = $state<Tool | null>(null);
+  let sheetSnap = $state<"half" | "full">("full");
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+
+  const showCheckpoints = $derived(
+    models.checkpoints.length > 10 || generation.devMode,
+  );
+  const activeLoraCount = $derived(
+    generation.loras.filter((l) => l.enabled && l.name).length,
+  );
+  const sessionImageCount = $derived(gallery.sessionImages.length);
+
+  interface ToolDef {
+    id: Tool;
+    label: string;
+    badge?: number;
+    visible?: boolean;
+    icon: string;
+  }
+
+  const tools: ToolDef[] = $derived(
+    ([
+      {
+        id: "loras" as Tool,
+        label: tt("bottom_panel.tab.loras", "LoRAs"),
+        badge: activeLoraCount,
+        icon:
+          '<rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>',
+      },
+      {
+        id: "checkpoints" as Tool,
+        label: tt("bottom_panel.tab.checkpoints", "Checkpoints"),
+        visible: showCheckpoints,
+        icon:
+          '<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/>',
+      },
+      {
+        id: "images" as Tool,
+        label: tt("bottom_panel.tab.images", "Session"),
+        badge: sessionImageCount,
+        icon:
+          '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/>',
+      },
+      {
+        id: "styles" as Tool,
+        label: tt("bottom_panel.tab.styles", "Styles"),
+        icon:
+          '<path d="M19 11H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2z"/><path d="M17 11V7a5 5 0 0 0-10 0v4"/>',
+      },
+      {
+        id: "schedule" as Tool,
+        label: tt("bottom_panel.tab.schedule", "Schedule"),
+        icon:
+          '<rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>',
+      },
+      {
+        id: "compare" as Tool,
+        label: tt("bottom_panel.tab.compare", "Compare"),
+        icon:
+          '<rect x="3" y="3" width="8" height="18" rx="1"/><rect x="13" y="3" width="8" height="18" rx="1"/>',
+      },
+    ] as ToolDef[]).filter((t) => t.visible !== false),
+  );
+
+  function open(tool: Tool) {
+    openTool = tool;
+    sheetSnap = "full";
+  }
+</script>
+
+<div
+  class="shrink-0 w-12 border-l border-neutral-800 bg-neutral-900/60 overflow-y-auto no-scroll-chain"
+>
+  <div class="flex flex-col items-stretch py-1.5 gap-0.5">
+    {#each tools as tool}
+      <button
+        type="button"
+        title={tool.label}
+        aria-label={tool.label}
+        onclick={() => open(tool.id)}
+        class="relative flex items-center justify-center w-full h-11 text-neutral-400 hover:text-neutral-100 hover:bg-neutral-800/70 rounded transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="w-5 h-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round">{@html tool.icon}</svg
+        >
+        {#if tool.badge && tool.badge > 0}
+          <span
+            class="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full bg-indigo-600 text-white text-[9px] font-semibold flex items-center justify-center leading-none"
+          >{tool.badge > 99 ? "99+" : tool.badge}</span>
+        {/if}
+      </button>
+    {/each}
+  </div>
+</div>
+
+<MobileBottomSheet
+  open={openTool !== null}
+  bind:snap={sheetSnap}
+  snaps={["half", "full"]}
+  onClose={() => (openTool = null)}
+  title={openTool ? (tools.find((t) => t.id === openTool)?.label ?? "") : ""}
+>
+  {#if openTool === "loras"}
+    <LoraGallery />
+  {:else if openTool === "checkpoints"}
+    <CheckpointGallery />
+  {:else if openTool === "images"}
+    {#if gallery.sessionImages.length === 0}
+      <p class="text-xs text-neutral-500 text-center py-8">
+        {tt("bottom_panel.no_session_images", "No session images yet.")}
+      </p>
+    {:else}
+      <div class="grid grid-cols-3 gap-1.5">
+        {#each gallery.sessionImages as image}
+          <button
+            type="button"
+            class="aspect-square rounded-md overflow-hidden border border-neutral-800 hover:border-indigo-500 transition-colors"
+            onclick={() => {
+              gallery.openLightbox(image);
+              openTool = null;
+            }}
+          >
+            <img
+              use:lazyThumbnail={{ image, size: 256 }}
+              alt={image.filename}
+              class="w-full h-full object-cover"
+            />
+          </button>
+        {/each}
+      </div>
+    {/if}
+  {:else if openTool === "styles"}
+    <StyleManager />
+  {:else if openTool === "schedule"}
+    <ScheduleBuilder />
+  {:else if openTool === "compare"}
+    <CompareGrid />
+  {/if}
+</MobileBottomSheet>

--- a/src/lib/components/mobile/MobileGalleryPage.svelte
+++ b/src/lib/components/mobile/MobileGalleryPage.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+  import { gallery } from "../../stores/gallery.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
+  import MobileTopBar from "./MobileTopBar.svelte";
+  import MobileActionSheet from "./MobileActionSheet.svelte";
+  import MobileLightbox from "./MobileLightbox.svelte";
+  import MobileBottomSheet from "./MobileBottomSheet.svelte";
+  import type { OutputImage } from "../../types/index.js";
+  import {
+    sendImageToImg2Img,
+    sendImageToUpscale,
+  } from "../../utils/galleryActions.js";
+  import type { ActionSheetItem } from "./MobileActionSheet.svelte";
+
+  interface Props {
+    onSwitchToGenerate?: () => void;
+  }
+  let { onSwitchToGenerate }: Props = $props();
+
+  // Filters
+  let boardFilter = $state<string>("all");
+  let sortBy = $state<"date" | "name" | "size">("date");
+  let sortDir = $state<"asc" | "desc">("desc");
+  let filtersOpen = $state(false);
+
+  // Action sheet for long-press
+  let actionImage = $state<OutputImage | null>(null);
+  let actionOpen = $state(false);
+
+  // Long-press tracking
+  let pressTimer: ReturnType<typeof setTimeout> | null = null;
+  let pressedImage: OutputImage | null = null;
+  let longPressFired = false;
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+
+  const filteredSorted = $derived.by(() => {
+    let imgs = gallery.images.slice();
+    if (boardFilter !== "all") {
+      imgs = imgs.filter((i) => gallery.getBoard(i) === boardFilter);
+    }
+    imgs.sort((a, b) => {
+      let cmp = 0;
+      if (sortBy === "date") {
+        cmp = (a.generated_at_ms ?? 0) - (b.generated_at_ms ?? 0);
+      } else if (sortBy === "name") {
+        cmp = a.filename.localeCompare(b.filename);
+      } else if (sortBy === "size") {
+        cmp = (a.file_size_bytes ?? 0) - (b.file_size_bytes ?? 0);
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return imgs;
+  });
+
+  function startPress(e: PointerEvent, image: OutputImage) {
+    pressedImage = image;
+    longPressFired = false;
+    if (pressTimer) clearTimeout(pressTimer);
+    pressTimer = setTimeout(() => {
+      longPressFired = true;
+      // Haptic if available
+      try {
+        navigator.vibrate?.(8);
+      } catch {}
+      actionImage = image;
+      actionOpen = true;
+    }, 450);
+  }
+
+  function endPress() {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      pressTimer = null;
+    }
+  }
+
+  function tapImage(image: OutputImage) {
+    if (longPressFired) return;
+    gallery.openLightbox(image);
+  }
+
+  const actionItems = $derived<ActionSheetItem[]>(
+    actionImage
+      ? [
+          {
+            label: tt("gallery.send_to_generate", "Send to Generate"),
+            onSelect: async () => {
+              if (!actionImage) return;
+              try {
+                await sendImageToImg2Img(actionImage);
+                onSwitchToGenerate?.();
+              } catch (e) {
+                console.error(e);
+              }
+            },
+          },
+          {
+            label: tt("gallery.use_for_upscale", "Use for Upscale"),
+            onSelect: async () => {
+              if (!actionImage) return;
+              try {
+                await sendImageToUpscale(actionImage);
+                onSwitchToGenerate?.();
+              } catch (e) {
+                console.error(e);
+              }
+            },
+          },
+          {
+            label: tt("gallery.copy_image", "Copy image"),
+            onSelect: () => actionImage && gallery.copyToClipboard(actionImage),
+          },
+          {
+            label: tt("gallery.save_as", "Download"),
+            onSelect: () => actionImage && gallery.saveImageAs(actionImage),
+          },
+          {
+            label: tt("gallery.delete", "Delete"),
+            destructive: true,
+            onSelect: () => actionImage && gallery.deleteImage(actionImage),
+          },
+        ]
+      : [],
+  );
+
+  const boardOptions = $derived(["all", "Unsorted", ...gallery.boards]);
+</script>
+
+<div class="h-full flex flex-col bg-neutral-950">
+  <MobileTopBar title={tt("nav.gallery", "Gallery")}>
+    {#snippet rightAction()}
+      <button
+        type="button"
+        class="touch-target px-3 text-xs text-neutral-300 hover:text-neutral-100 flex items-center gap-1"
+        onclick={() => (filtersOpen = true)}
+        aria-label="Filters"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>
+        </svg>
+        <span>{tt("gallery.filters", "Filters")}</span>
+      </button>
+    {/snippet}
+  </MobileTopBar>
+
+  <div class="flex-1 min-h-0 overflow-y-auto no-scroll-chain p-1">
+    {#if gallery.loading}
+      <div class="flex items-center justify-center py-12 text-neutral-500 text-sm">
+        {tt("gallery.loading", "Loading…")}
+      </div>
+    {:else if filteredSorted.length === 0}
+      <div class="flex items-center justify-center py-12 text-neutral-500 text-sm text-center px-6">
+        {tt("gallery.empty_generate", "No images yet — generate something!")}
+      </div>
+    {:else}
+      <div class="grid grid-cols-2 gap-1">
+        {#each filteredSorted as image (image.filename + image.subfolder)}
+          <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+          <div
+            role="button"
+            tabindex="0"
+            class="relative aspect-square overflow-hidden rounded-lg bg-neutral-900 border border-neutral-800 active:scale-[0.98] transition-transform tap-highlight-none"
+            onpointerdown={(e) => startPress(e, image)}
+            onpointerup={endPress}
+            onpointercancel={endPress}
+            onpointerleave={endPress}
+            onclick={() => tapImage(image)}
+            oncontextmenu={(e) => {
+              e.preventDefault();
+              actionImage = image;
+              actionOpen = true;
+            }}
+          >
+            <img
+              use:lazyThumbnail={{ image, size: 256 }}
+              alt={image.filename}
+              class="w-full h-full object-cover"
+              draggable="false"
+            />
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<!-- Filters sheet -->
+<MobileBottomSheet
+  open={filtersOpen}
+  snap="half"
+  snaps={["half"]}
+  title={tt("gallery.filters", "Filters")}
+  onClose={() => (filtersOpen = false)}
+>
+  <div class="space-y-4">
+    <label class="block">
+      <span class="text-xs text-neutral-400 mb-1 block">{tt("gallery.board_filter", "Board")}</span>
+      <select
+        bind:value={boardFilter}
+        class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-3 text-sm text-neutral-100"
+      >
+        {#each boardOptions as opt}
+          <option value={opt}>{opt === "all" ? tt("gallery.all_boards", "All boards") : opt}</option>
+        {/each}
+      </select>
+    </label>
+    <label class="block">
+      <span class="text-xs text-neutral-400 mb-1 block">{tt("gallery.sort_by", "Sort by")}</span>
+      <select
+        bind:value={sortBy}
+        class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-3 text-sm text-neutral-100"
+      >
+        <option value="date">{tt("gallery.sort_date", "Date")}</option>
+        <option value="name">{tt("gallery.sort_name", "Name")}</option>
+        <option value="size">{tt("gallery.sort_size", "Size")}</option>
+      </select>
+    </label>
+    <div class="flex gap-2">
+      <button
+        type="button"
+        class="touch-target flex-1 px-3 py-2.5 rounded-lg border text-sm transition-colors {sortDir === 'desc'
+          ? 'border-indigo-500 bg-indigo-500/10 text-indigo-300'
+          : 'border-neutral-700 text-neutral-300'}"
+        onclick={() => (sortDir = "desc")}
+      >
+        {tt("gallery.descending", "Descending")}
+      </button>
+      <button
+        type="button"
+        class="touch-target flex-1 px-3 py-2.5 rounded-lg border text-sm transition-colors {sortDir === 'asc'
+          ? 'border-indigo-500 bg-indigo-500/10 text-indigo-300'
+          : 'border-neutral-700 text-neutral-300'}"
+        onclick={() => (sortDir = "asc")}
+      >
+        {tt("gallery.ascending", "Ascending")}
+      </button>
+    </div>
+  </div>
+</MobileBottomSheet>
+
+<MobileActionSheet
+  open={actionOpen}
+  title={actionImage?.filename ?? ""}
+  items={actionItems}
+  onClose={() => (actionOpen = false)}
+/>
+
+<MobileLightbox images={filteredSorted} {onSwitchToGenerate} />

--- a/src/lib/components/mobile/MobileGeneratePage.svelte
+++ b/src/lib/components/mobile/MobileGeneratePage.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+  import MobileTopBar from "./MobileTopBar.svelte";
+  import MobileBottomSheet from "./MobileBottomSheet.svelte";
+  import MobilePromptHistory from "./MobilePromptHistory.svelte";
+  import MobileExtrasPanel from "./MobileExtrasPanel.svelte";
+  import PromptInputs from "../generation/PromptInputs.svelte";
+  import ModelSelector from "../generation/ModelSelector.svelte";
+  import SamplerSettings from "../generation/SamplerSettings.svelte";
+  import DimensionControls from "../generation/DimensionControls.svelte";
+  import LoraGallery from "../generation/LoraGallery.svelte";
+  import GenerateButton from "../generation/GenerateButton.svelte";
+  import ProgressBar from "../progress/ProgressBar.svelte";
+  import PreviewImage from "../progress/PreviewImage.svelte";
+  import { locale } from "../../stores/locale.svelte.js";
+  import { progress } from "../../stores/progress.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
+
+  let sheetOpen = $state(true);
+  let sheetSnap = $state<"peek" | "half" | "full">("half");
+
+  const modes: { id: "txt2img" | "img2img" | "inpainting"; label: string }[] = [
+    { id: "txt2img", label: "Text" },
+    { id: "img2img", label: "Image" },
+    { id: "inpainting", label: "Inpaint" },
+  ];
+
+  type Section = "prompts" | "model" | "sampler" | "dimensions" | "loras";
+  let openSections = $state<Record<Section, boolean>>({
+    prompts: true,
+    model: false,
+    sampler: false,
+    dimensions: false,
+    loras: false,
+  });
+
+  function toggle(s: Section) {
+    openSections[s] = !openSections[s];
+    if (openSections[s] && sheetSnap === "peek") sheetSnap = "half";
+  }
+
+  const sections: { id: Section; titleKey: string; titleFallback: string }[] = [
+    { id: "prompts", titleKey: "generation.prompts.title", titleFallback: "Prompts" },
+    { id: "model", titleKey: "generation.model.title", titleFallback: "Model" },
+    { id: "sampler", titleKey: "generation.sampler.title", titleFallback: "Sampler" },
+    { id: "dimensions", titleKey: "generation.dimensions.title", titleFallback: "Dimensions" },
+    { id: "loras", titleKey: "generation.loras.title", titleFallback: "LoRAs" },
+  ];
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+</script>
+
+<div class="h-full flex flex-col bg-neutral-950 relative overflow-hidden">
+  <MobileTopBar title="">
+    {#snippet rightAction()}
+      <div
+        class="flex items-center rounded-full bg-neutral-800/80 border border-neutral-700 p-0.5 mr-1"
+        role="tablist"
+        aria-label={tt("generation.mode.title", "Generation mode")}
+      >
+        {#each modes as m}
+          {@const active = generation.mode === m.id}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onclick={() => (generation.mode = m.id)}
+            class="px-3 h-7 text-[11px] font-semibold rounded-full transition-colors whitespace-nowrap {active
+              ? 'bg-indigo-600 text-white shadow'
+              : 'text-neutral-300 hover:text-neutral-100'}"
+          >
+            {tt(`generation.mode.${m.id}`, m.label)}
+          </button>
+        {/each}
+      </div>
+    {/snippet}
+  </MobileTopBar>
+
+  <!-- Preview area + side icons -->
+  <div class="flex-1 min-h-0 flex overflow-hidden">
+    <div class="flex-1 min-w-0 flex flex-col overflow-hidden">
+      <div class="px-3 pt-3 shrink-0">
+        <ProgressBar />
+      </div>
+      <div class="shrink-0 px-3 py-3 {sheetOpen ? 'flex-1 min-h-0 overflow-y-auto no-scroll-chain' : ''}">
+        <PreviewImage />
+      </div>
+      {#if !sheetOpen}
+        <div class="flex-1 min-h-0 border-t border-neutral-800/60">
+          <MobilePromptHistory />
+        </div>
+      {/if}
+    </div>
+    <MobileExtrasPanel />
+  </div>
+
+  <!-- Bottom dock: chevron toggle + (when collapsed) generate button -->
+  {#if !sheetOpen}
+    <div
+      class="shrink-0 border-t border-neutral-800 bg-neutral-900/95 backdrop-blur-sm"
+      style="padding-bottom: env(safe-area-inset-bottom, 0px);"
+    >
+      <button
+        type="button"
+        class="w-full flex items-center justify-center py-1.5 text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800/60 transition-colors"
+        onclick={() => (sheetOpen = true)}
+        aria-label={tt("generation.show_params", "Show parameters")}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="18 15 12 9 6 15"/>
+        </svg>
+      </button>
+      <div class="px-3 pb-2">
+        <GenerateButton />
+        {#if progress.isGenerating && progress.totalSteps > 0}
+          <p class="text-[11px] text-neutral-500 mt-1.5 text-center">
+            {progress.phaseLabel ?? ""} · {Math.round(progress.percentage)}%
+          </p>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  <MobileBottomSheet
+    open={sheetOpen}
+    bind:snap={sheetSnap}
+    snaps={["peek", "half", "full"]}
+    onClose={() => (sheetOpen = false)}
+    title={tt("generation.params", "Parameters")}
+  >
+    <div class="space-y-2">
+      {#each sections as section}
+        <div class="rounded-xl border border-neutral-800 bg-neutral-900/60 overflow-hidden">
+          <button
+            type="button"
+            class="w-full touch-target flex items-center justify-between px-3 py-2.5 text-left text-sm font-medium text-neutral-100 hover:bg-neutral-800/60 transition-colors"
+            onclick={() => toggle(section.id)}
+            aria-expanded={openSections[section.id]}
+          >
+            <span>{tt(section.titleKey, section.titleFallback)}</span>
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 transition-transform {openSections[section.id] ? 'rotate-180' : ''}"
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </button>
+          {#if openSections[section.id]}
+            <div class="px-3 pb-3 pt-1">
+              {#if section.id === "prompts"}
+                <PromptInputs />
+              {:else if section.id === "model"}
+                <ModelSelector />
+              {:else if section.id === "sampler"}
+                <SamplerSettings />
+              {:else if section.id === "dimensions"}
+                <DimensionControls />
+              {:else if section.id === "loras"}
+                <LoraGallery />
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/each}
+
+      <!-- Sticky generate button area inside sheet -->
+      <div class="sticky bottom-0 -mx-4 px-4 pt-3 pb-2 bg-gradient-to-t from-neutral-900 via-neutral-900 to-transparent">
+        <GenerateButton />
+        {#if progress.isGenerating && progress.totalSteps > 0}
+          <p class="text-[11px] text-neutral-500 mt-1.5 text-center">
+            {progress.phaseLabel ?? ""} · {Math.round(progress.percentage)}%
+          </p>
+        {/if}
+      </div>
+    </div>
+  </MobileBottomSheet>
+</div>

--- a/src/lib/components/mobile/MobileLightbox.svelte
+++ b/src/lib/components/mobile/MobileLightbox.svelte
@@ -1,0 +1,388 @@
+<script lang="ts">
+  import { gallery } from "../../stores/gallery.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import type { OutputImage } from "../../types/index.js";
+  import {
+    sendImageToImg2Img,
+    sendImageToUpscale,
+  } from "../../utils/galleryActions.js";
+  import MobileActionSheet from "./MobileActionSheet.svelte";
+  import type { ActionSheetItem } from "./MobileActionSheet.svelte";
+
+  interface Props {
+    images: OutputImage[];
+    onSwitchToGenerate?: () => void;
+  }
+  let { images, onSwitchToGenerate }: Props = $props();
+
+  let actionOpen = $state(false);
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+
+  // Touch / pinch / pan state
+  let imgEl = $state<HTMLImageElement | null>(null);
+  let scale = $state(1);
+  let translateX = $state(0);
+  let translateY = $state(0);
+  let pinchStartDist = 0;
+  let pinchStartScale = 1;
+  let panStartX = 0;
+  let panStartY = 0;
+  let panBaseX = 0;
+  let panBaseY = 0;
+  let panActive = $state(false);
+  let swipeStartX = 0;
+  let swipeStartY = 0;
+  let swipeActive = $state(false);
+  let swipeDX = $state(0);
+
+  const currentIndex = $derived.by(() => {
+    if (!gallery.selectedImage) return -1;
+    return images.findIndex(
+      (i) =>
+        i.filename === gallery.selectedImage!.filename &&
+        i.subfolder === gallery.selectedImage!.subfolder,
+    );
+  });
+
+  function navigate(dir: -1 | 1) {
+    if (currentIndex < 0) return;
+    const next = currentIndex + dir;
+    if (next < 0 || next >= images.length) return;
+    resetTransform();
+    gallery.openLightbox(images[next]);
+  }
+
+  function resetTransform() {
+    scale = 1;
+    translateX = 0;
+    translateY = 0;
+    swipeDX = 0;
+  }
+
+  function close() {
+    resetTransform();
+    gallery.closeLightbox();
+  }
+
+  function applyTransform() {
+    if (!imgEl) return;
+    imgEl.style.transform = `translate(${translateX + swipeDX}px, ${translateY}px) scale(${scale})`;
+  }
+
+  $effect(() => {
+    // re-apply on state change
+    if (imgEl) applyTransform();
+  });
+
+  // Active touches map for pinch
+  const activeTouches = new Map<number, { x: number; y: number }>();
+
+  function dist(a: { x: number; y: number }, b: { x: number; y: number }) {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    return Math.hypot(dx, dy);
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    activeTouches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (activeTouches.size === 1) {
+      if (scale > 1.01) {
+        // Pan an already-zoomed image
+        panActive = true;
+        panStartX = e.clientX;
+        panStartY = e.clientY;
+        panBaseX = translateX;
+        panBaseY = translateY;
+      } else {
+        // Track horizontal swipe for nav
+        swipeActive = true;
+        swipeStartX = e.clientX;
+        swipeStartY = e.clientY;
+      }
+    } else if (activeTouches.size === 2) {
+      panActive = false;
+      swipeActive = false;
+      swipeDX = 0;
+      const pts = [...activeTouches.values()];
+      pinchStartDist = dist(pts[0], pts[1]);
+      pinchStartScale = scale;
+    }
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!activeTouches.has(e.pointerId)) return;
+    activeTouches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (activeTouches.size >= 2) {
+      const pts = [...activeTouches.values()];
+      const d = dist(pts[0], pts[1]);
+      if (pinchStartDist > 0) {
+        scale = Math.max(1, Math.min(6, pinchStartScale * (d / pinchStartDist)));
+        applyTransform();
+      }
+    } else if (panActive) {
+      translateX = panBaseX + (e.clientX - panStartX);
+      translateY = panBaseY + (e.clientY - panStartY);
+      applyTransform();
+    } else if (swipeActive) {
+      const dx = e.clientX - swipeStartX;
+      const dy = e.clientY - swipeStartY;
+      // Only treat as horizontal swipe if dominantly horizontal
+      if (Math.abs(dx) > Math.abs(dy)) {
+        swipeDX = dx;
+        applyTransform();
+      }
+    }
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    activeTouches.delete(e.pointerId);
+    if (activeTouches.size < 2) pinchStartDist = 0;
+    if (panActive && activeTouches.size === 0) {
+      panActive = false;
+    }
+    if (swipeActive && activeTouches.size === 0) {
+      swipeActive = false;
+      const threshold = (window.innerWidth || 360) * 0.25;
+      if (swipeDX > threshold) {
+        swipeDX = 0;
+        navigate(-1);
+        return;
+      } else if (swipeDX < -threshold) {
+        swipeDX = 0;
+        navigate(1);
+        return;
+      }
+      swipeDX = 0;
+      applyTransform();
+    }
+    if (scale < 1.05) {
+      scale = 1;
+      translateX = 0;
+      translateY = 0;
+      applyTransform();
+    }
+  }
+
+  function onDoubleClick() {
+    if (scale > 1.01) {
+      resetTransform();
+    } else {
+      scale = 2.5;
+    }
+    applyTransform();
+  }
+
+  // Reset transform when image changes
+  $effect(() => {
+    if (gallery.lightboxUrl) {
+      resetTransform();
+    }
+  });
+
+  // Keyboard nav
+  function onKey(e: KeyboardEvent) {
+    if (!gallery.lightboxOpen) return;
+    if (e.key === "Escape") close();
+    else if (e.key === "ArrowLeft") navigate(-1);
+    else if (e.key === "ArrowRight") navigate(1);
+  }
+
+  $effect(() => {
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  const actionItems = $derived<ActionSheetItem[]>(
+    gallery.selectedImage
+      ? [
+          {
+            label: tt("gallery.send_to_generate", "Send to Generate"),
+            onSelect: async () => {
+              if (!gallery.selectedImage) return;
+              try {
+                await sendImageToImg2Img(gallery.selectedImage);
+                onSwitchToGenerate?.();
+              } catch (e) {
+                console.error(e);
+              }
+            },
+          },
+          {
+            label: tt("gallery.use_for_upscale", "Use for Upscale"),
+            onSelect: async () => {
+              if (!gallery.selectedImage) return;
+              try {
+                await sendImageToUpscale(gallery.selectedImage);
+                onSwitchToGenerate?.();
+              } catch (e) {
+                console.error(e);
+              }
+            },
+          },
+          {
+            label: tt("gallery.copy_image", "Copy image"),
+            onSelect: () => gallery.selectedImage && gallery.copyToClipboard(gallery.selectedImage),
+          },
+          {
+            label: tt("gallery.save_as", "Download"),
+            onSelect: () => gallery.selectedImage && gallery.saveImageAs(gallery.selectedImage),
+          },
+          {
+            label: tt("gallery.delete", "Delete"),
+            destructive: true,
+            onSelect: () => {
+              if (!gallery.selectedImage) return;
+              gallery.deleteImage(gallery.selectedImage);
+              close();
+            },
+          },
+        ]
+      : [],
+  );
+</script>
+
+{#if gallery.lightboxOpen}
+  <div class="fixed inset-0 z-[60] bg-black flex flex-col tap-highlight-none">
+    <!-- Top bar -->
+    <div class="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-2 py-2 safe-top bg-gradient-to-b from-black/70 to-transparent">
+      <button
+        type="button"
+        onclick={close}
+        class="touch-target px-3 text-white"
+        aria-label="Close"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+      </button>
+      <div class="text-xs text-white/70">
+        {#if currentIndex >= 0}
+          {currentIndex + 1} / {images.length}
+        {/if}
+      </div>
+      <button
+        type="button"
+        onclick={() => (actionOpen = true)}
+        class="touch-target px-3 text-white"
+        aria-label="Actions"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Image area -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="flex-1 min-h-0 flex items-center justify-center overflow-hidden touch-none select-none"
+      onpointerdown={onPointerDown}
+      onpointermove={onPointerMove}
+      onpointerup={onPointerUp}
+      onpointercancel={onPointerUp}
+      ondblclick={onDoubleClick}
+    >
+      {#if gallery.lightboxLoading || !gallery.lightboxUrl}
+        <div class="text-white/60 text-sm">{tt("common.loading", "Loading…")}</div>
+      {:else}
+        <img
+          bind:this={imgEl}
+          src={gallery.lightboxUrl}
+          alt={gallery.selectedImage?.filename ?? ""}
+          class="max-w-full max-h-full will-change-transform"
+          style="transform: translate({translateX + swipeDX}px, {translateY}px) scale({scale}); transition: {panActive || swipeActive ? 'none' : 'transform 0.2s ease'};"
+          draggable="false"
+        />
+      {/if}
+    </div>
+
+    <!-- Bottom action row -->
+    <div class="shrink-0 flex items-center justify-around px-2 py-2 safe-bottom bg-gradient-to-t from-black/80 to-transparent">
+      <button
+        type="button"
+        class="touch-target flex flex-col items-center gap-0.5 text-white/90 px-3 disabled:opacity-30"
+        disabled={currentIndex <= 0}
+        onclick={() => navigate(-1)}
+        aria-label="Previous"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 18 9 12 15 6"/>
+        </svg>
+        <span class="text-[10px]">{tt("common.prev", "Prev")}</span>
+      </button>
+      <button
+        type="button"
+        class="touch-target flex flex-col items-center gap-0.5 text-white/90 px-3"
+        onclick={async () => {
+          if (gallery.selectedImage) {
+            try {
+              await sendImageToImg2Img(gallery.selectedImage);
+              onSwitchToGenerate?.();
+            } catch (e) { console.error(e); }
+          }
+        }}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12a9 9 0 1 1-9-9c2.5 0 4.8 1 6.5 2.7L21 8"/><polyline points="21 3 21 8 16 8"/>
+        </svg>
+        <span class="text-[10px]">{tt("gallery.use", "Use")}</span>
+      </button>
+      <button
+        type="button"
+        class="touch-target flex flex-col items-center gap-0.5 text-white/90 px-3"
+        onclick={() => gallery.selectedImage && gallery.saveImageAs(gallery.selectedImage)}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+        <span class="text-[10px]">{tt("gallery.save_as", "Save")}</span>
+      </button>
+      <button
+        type="button"
+        class="touch-target flex flex-col items-center gap-0.5 text-red-400 px-3"
+        onclick={() => {
+          if (gallery.selectedImage) {
+            gallery.deleteImage(gallery.selectedImage);
+            close();
+          }
+        }}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+        </svg>
+        <span class="text-[10px]">{tt("gallery.delete", "Delete")}</span>
+      </button>
+      <button
+        type="button"
+        class="touch-target flex flex-col items-center gap-0.5 text-white/90 px-3 disabled:opacity-30"
+        disabled={currentIndex < 0 || currentIndex >= images.length - 1}
+        onclick={() => navigate(1)}
+        aria-label="Next"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="9 18 15 12 9 6"/>
+        </svg>
+        <span class="text-[10px]">{tt("common.next", "Next")}</span>
+      </button>
+    </div>
+  </div>
+
+  <MobileActionSheet
+    open={actionOpen}
+    title={gallery.selectedImage?.filename ?? ""}
+    items={actionItems}
+    onClose={() => (actionOpen = false)}
+  />
+{/if}

--- a/src/lib/components/mobile/MobilePromptHistory.svelte
+++ b/src/lib/components/mobile/MobilePromptHistory.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { generation } from "../../stores/generation.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+
+  const sortedPromptHistory = $derived(
+    [...generation.promptHistory].sort((a, b) => {
+      if (a.favorite !== b.favorite) return a.favorite ? -1 : 1;
+      return b.createdAt - a.createdAt;
+    }),
+  );
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+
+  function historyLabel(ts: number): string {
+    return new Date(ts).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+</script>
+
+<div class="flex flex-col h-full min-h-0">
+  <div class="px-3 pb-1.5 pt-0.5 shrink-0 flex items-center justify-between">
+    <h3 class="text-[11px] font-semibold uppercase tracking-wide text-neutral-400">
+      {tt("bottom_panel.tab.prompts", "Prompt history")}
+    </h3>
+    <span class="text-[10px] text-neutral-500">{sortedPromptHistory.length}</span>
+  </div>
+  {#if sortedPromptHistory.length === 0}
+    <div class="flex items-center justify-center flex-1 text-neutral-500 text-xs px-4">
+      <p>{tt("bottom_panel.no_prompts", "No prompts yet — generate something!")}</p>
+    </div>
+  {:else}
+    <div class="flex-1 min-h-0 overflow-y-auto px-3 pb-3 space-y-2 no-scroll-chain">
+      {#each sortedPromptHistory as entry}
+        <div
+          class="rounded-lg border overflow-hidden transition-colors {entry.favorite
+            ? 'border-amber-500/40 bg-amber-500/5'
+            : 'border-neutral-800 bg-neutral-900/60'}"
+        >
+          <button
+            type="button"
+            class="w-full text-left p-2.5"
+            onclick={() => generation.applyPromptHistoryEntry(entry.id)}
+          >
+            <p class="text-[12px] text-neutral-200 leading-relaxed line-clamp-3">
+              {entry.positivePrompt || tt("bottom_panel.empty_prompt", "(empty)")}
+            </p>
+            {#if entry.negativePrompt}
+              <p class="text-[10px] text-neutral-500 mt-1 line-clamp-1">
+                {tt("bottom_panel.neg_prefix", "Neg:")} {entry.negativePrompt}
+              </p>
+            {/if}
+          </button>
+          <div class="px-2.5 pb-2 flex items-center justify-between gap-2">
+            <div class="flex items-center gap-1.5 text-[10px] text-neutral-500">
+              <span>{historyLabel(entry.createdAt)}</span>
+              <span class="px-1 py-0.5 rounded bg-neutral-800 text-neutral-400">{entry.mode}</span>
+            </div>
+            <div class="flex items-center gap-1">
+              <button
+                type="button"
+                aria-label={entry.favorite ? "Unfavorite" : "Favorite"}
+                class="px-2 py-1 text-[11px] rounded border transition-colors {entry.favorite
+                  ? 'border-amber-500 text-amber-300 bg-amber-500/10'
+                  : 'border-neutral-700 text-neutral-400'}"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  generation.togglePromptFavorite(entry.id);
+                }}
+              >★</button>
+              <button
+                type="button"
+                aria-label="Remove"
+                class="px-2 py-1 text-[11px] rounded border border-neutral-700 text-neutral-400"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  generation.removePromptHistoryEntry(entry.id);
+                }}
+              >×</button>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/mobile/MobileSettingsPage.svelte
+++ b/src/lib/components/mobile/MobileSettingsPage.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  import { LOCALE_OPTIONS, locale, type Locale } from "../../stores/locale.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
+  import { clearAuthToken } from "../../utils/ipc.js";
+  import {
+    getForceDesktopOverride,
+    setForceDesktopOverride,
+  } from "../../utils/device.js";
+  import MobileTopBar from "./MobileTopBar.svelte";
+
+  declare const __APP_VERSION__: string;
+  const appVersion = __APP_VERSION__ ?? "dev";
+
+  let forceDesktop = $state(getForceDesktopOverride());
+
+  function tt(key: string, fb: string) {
+    const v = locale.t(key);
+    return v === key ? fb : v;
+  }
+
+  function setLocale(value: Locale) {
+    locale.current = value;
+    try {
+      localStorage.setItem(
+        "locale-settings",
+        JSON.stringify({ locale: value }),
+      );
+    } catch {}
+  }
+
+  function applyForceDesktop(v: boolean) {
+    forceDesktop = v;
+    setForceDesktopOverride(v);
+    // Reload to swap UI shells.
+    window.location.reload();
+  }
+
+  async function logout() {
+    if (!confirm(tt("settings.confirm_logout", "Sign out?"))) return;
+    clearAuthToken();
+    window.location.reload();
+  }
+</script>
+
+<div class="h-full flex flex-col bg-neutral-950">
+  <MobileTopBar title={tt("nav.settings", "Settings")} />
+
+  <div class="flex-1 min-h-0 overflow-y-auto p-3 space-y-3 no-scroll-chain">
+    <!-- Display -->
+    <section class="rounded-xl border border-neutral-800 bg-neutral-900/60 p-3 space-y-3">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+        {tt("settings.display", "Display")}
+      </h2>
+      <label class="block">
+        <span class="text-sm text-neutral-200">{tt("settings.language", "Language")}</span>
+        <select
+          name="locale"
+          value={locale.current}
+          onchange={(e) => setLocale((e.target as HTMLSelectElement).value as Locale)}
+          class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2.5 text-sm text-neutral-100"
+        >
+          {#each LOCALE_OPTIONS as opt}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+      </label>
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex-1">
+          <p class="text-sm text-neutral-200">
+            {tt("settings.use_desktop_layout", "Use desktop layout")}
+          </p>
+          <p class="text-xs text-neutral-500 mt-0.5">
+            {tt(
+              "settings.use_desktop_layout_hint",
+              "Show the full desktop UI on this device. Reloads the app.",
+            )}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-label={tt("settings.use_desktop_layout", "Use desktop layout")}
+          aria-checked={forceDesktop}
+          onclick={() => applyForceDesktop(!forceDesktop)}
+          class="relative shrink-0 w-12 h-7 rounded-full transition-colors {forceDesktop ? 'bg-indigo-600' : 'bg-neutral-700'}"
+          style="touch-action: manipulation;"
+        >
+          <span
+            class="absolute top-0.5 left-0.5 w-6 h-6 rounded-full bg-white transition-transform"
+            style="transform: translateX({forceDesktop ? '20px' : '0'});"
+          ></span>
+        </button>
+      </div>
+    </section>
+
+    <!-- Account -->
+    <section class="rounded-xl border border-neutral-800 bg-neutral-900/60 p-3 space-y-3">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+        {tt("settings.account", "Account")}
+      </h2>
+      <button
+        type="button"
+        onclick={logout}
+        class="touch-target w-full px-3 py-2.5 rounded-lg border border-red-700/50 bg-red-900/20 text-red-300 text-sm font-medium hover:bg-red-900/30"
+      >
+        {tt("settings.logout", "Sign out")}
+      </button>
+    </section>
+
+    <!-- Generation defaults -->
+    <section class="rounded-xl border border-neutral-800 bg-neutral-900/60 p-3 space-y-3">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+        {tt("settings.generation_defaults", "Generation defaults")}
+      </h2>
+      <label class="block">
+        <span class="text-sm text-neutral-200">{tt("generation.steps.title", "Steps")}: {generation.steps}</span>
+        <input
+          type="range"
+          min="1"
+          max="100"
+          step="1"
+          bind:value={generation.steps}
+          class="w-full accent-indigo-500"
+        />
+      </label>
+      <label class="block">
+        <span class="text-sm text-neutral-200">CFG: {generation.cfg.toFixed(1)}</span>
+        <input
+          type="range"
+          min="1"
+          max="20"
+          step="0.5"
+          bind:value={generation.cfg}
+          class="w-full accent-indigo-500"
+        />
+      </label>
+    </section>
+
+    <!-- About -->
+    <section class="rounded-xl border border-neutral-800 bg-neutral-900/60 p-3 space-y-2">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+        {tt("settings.about", "About")}
+      </h2>
+      <p class="text-sm text-neutral-300">
+        MooshieUI <span class="text-neutral-500">v{appVersion}</span>
+      </p>
+      <p class="text-xs text-neutral-500">
+        {tt("nav.connected", "Connected")}: <span class={connection.connected ? "text-green-400" : "text-red-400"}>{connection.connected ? tt("common.yes", "yes") : tt("common.no", "no")}</span>
+      </p>
+      {#if connection.serverUrl}
+        <p class="text-xs text-neutral-500 break-all">{connection.serverUrl}</p>
+      {/if}
+      <a
+        href="https://github.com/Mooshieblob1/MooshieUI"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-block text-xs text-indigo-400 hover:text-indigo-300 mt-1"
+      >GitHub →</a>
+    </section>
+  </div>
+</div>

--- a/src/lib/components/mobile/MobileTabBar.svelte
+++ b/src/lib/components/mobile/MobileTabBar.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { progress } from "../../stores/progress.svelte.js";
+  import { connection } from "../../stores/connection.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+
+  export type MobileTab = "generate" | "gallery" | "modelhub" | "artists" | "settings";
+
+  interface Props {
+    current: MobileTab;
+    onChange: (tab: MobileTab) => void;
+    showModelhub?: boolean;
+  }
+
+  let { current, onChange, showModelhub = true }: Props = $props();
+
+  const tabs = $derived(
+    (
+      [
+        { id: "generate", labelKey: "nav.generate" },
+        { id: "gallery", labelKey: "nav.gallery" },
+        ...(showModelhub ? [{ id: "modelhub", labelKey: "nav.modelhub" }] : []),
+        { id: "artists", labelKey: "nav.artists" },
+        { id: "settings", labelKey: "nav.settings" },
+      ] as { id: MobileTab; labelKey: string }[]
+    )
+  );
+
+  function tabLabel(id: MobileTab, labelKey: string): string {
+    const fallback: Record<MobileTab, string> = {
+      generate: "Generate",
+      gallery: "Gallery",
+      modelhub: "Models",
+      artists: "Artists",
+      settings: "Settings",
+    };
+    const t = locale.t(labelKey);
+    return t === labelKey ? fallback[id] : t;
+  }
+</script>
+
+<nav
+  class="shrink-0 flex items-stretch gap-0.5 bg-neutral-950/95 backdrop-blur border-t border-neutral-800 px-1 pt-1 pb-[max(env(safe-area-inset-bottom),0.25rem)] tap-highlight-none"
+>
+  {#each tabs as tab}
+    {@const active = current === tab.id}
+    <button
+      type="button"
+      class="touch-target flex-1 flex flex-col items-center justify-center gap-0.5 py-1.5 rounded-lg transition-colors relative
+        {active ? 'text-indigo-400' : 'text-neutral-500 active:bg-neutral-800/60'}"
+      onclick={() => onChange(tab.id)}
+      aria-current={active ? "page" : undefined}
+    >
+      <span class="w-5 h-5 flex items-center justify-center">
+        {#if tab.id === "generate"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19l7-7 3 3-7 7-3-3z"/><path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"/><path d="M2 2l7.586 7.586"/><circle cx="11" cy="11" r="2"/></svg>
+        {:else if tab.id === "gallery"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        {:else if tab.id === "modelhub"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        {:else if tab.id === "artists"}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 4-7 8-7s8 3 8 7"/></svg>
+        {:else}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        {/if}
+        {#if tab.id === "generate" && progress.isGenerating}
+          <span
+            class="absolute top-0 right-1/4 w-2 h-2 rounded-full
+              {progress.queuePosition !== null && progress.queuePosition > 0 ? 'bg-amber-500' : 'bg-indigo-400 animate-pulse'}"
+          ></span>
+        {:else if tab.id === "settings"}
+          <span
+            class="absolute top-1 right-1/4 w-1.5 h-1.5 rounded-full {connection.connected ? 'bg-green-500' : 'bg-red-500'}"
+            aria-hidden="true"
+          ></span>
+        {/if}
+      </span>
+      <span class="text-[10px] font-medium leading-none">{tabLabel(tab.id, tab.labelKey)}</span>
+    </button>
+  {/each}
+</nav>

--- a/src/lib/components/mobile/MobileTopBar.svelte
+++ b/src/lib/components/mobile/MobileTopBar.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { connection } from "../../stores/connection.svelte.js";
+
+  interface Props {
+    title: string;
+    onBack?: () => void;
+    rightAction?: import("svelte").Snippet;
+  }
+  let { title, onBack, rightAction }: Props = $props();
+</script>
+
+<header
+  class="shrink-0 flex items-center gap-2 h-12 px-2 border-b border-neutral-800 bg-neutral-950/95 backdrop-blur safe-top"
+>
+  {#if onBack}
+    <button
+      type="button"
+      onclick={onBack}
+      class="touch-target -ml-1 px-2 text-neutral-300 hover:text-neutral-100"
+      aria-label="Back"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="15 18 9 12 15 6"/>
+      </svg>
+    </button>
+  {:else}
+    <div class="w-8 flex items-center justify-center">
+      <span
+        class="w-2 h-2 rounded-full {connection.connected ? 'bg-green-500' : 'bg-red-500'}"
+        aria-hidden="true"
+      ></span>
+    </div>
+  {/if}
+  <h1 class="flex-1 text-base font-semibold text-neutral-100 truncate">{title}</h1>
+  <div class="flex items-center gap-1">
+    {@render rightAction?.()}
+  </div>
+</header>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1,4 +1,4 @@
-﻿/** German translations. */
+/** German translations. */
 const de: Record<string, string> = {
   // ── Navigation ──────────────────────────────────────────
   "nav.generate": "Generieren",
@@ -1172,6 +1172,34 @@ const de: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1223,6 +1223,30 @@ const en: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+  // ── Mobile UI ──────────────────────────────────────────
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "common.yes": "Yes",
+  "common.no": "No",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
 };
 
 export default en;

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1,4 +1,4 @@
-﻿/** Spanish translations. */
+/** Spanish translations. */
 const es: Record<string, string> = {
   // ── Navegación ──────────────────────────────────────────
   "nav.generate": "Generar",
@@ -1199,6 +1199,34 @@ const es: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1,4 +1,4 @@
-﻿/** French translations. */
+/** French translations. */
 const fr: Record<string, string> = {
   // ── Navigation ──────────────────────────────────────────
   "nav.generate": "Générer",
@@ -1197,6 +1197,34 @@ const fr: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1,4 +1,4 @@
-﻿/** Italian translations. */
+/** Italian translations. */
 const it: Record<string, string> = {
   // ── Navigazione ─────────────────────────────────────────
   "nav.generate": "Genera",
@@ -1052,9 +1052,8 @@ const it: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1172,6 +1171,32 @@ const it: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1,4 +1,4 @@
-﻿/** Japanese translations. */
+/** Japanese translations. */
 const ja: Record<string, string> = {
   // ── ナビゲーション ──────────────────────────────────────
   "nav.generate": "生成",
@@ -1077,9 +1077,8 @@ const ja: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1197,6 +1196,32 @@ const ja: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1,4 +1,4 @@
-﻿/** Korean translations. */
+/** Korean translations. */
 const ko: Record<string, string> = {
   // ── 내비게이션 ──────────────────────────────────────────
   "nav.generate": "생성",
@@ -1052,9 +1052,8 @@ const ko: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1172,6 +1171,32 @@ const ko: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1,4 +1,4 @@
-﻿/** Portuguese (Brazilian) translations. */
+/** Portuguese (Brazilian) translations. */
 const pt: Record<string, string> = {
   // ── Navegação ───────────────────────────────────────────
   "nav.generate": "Gerar",
@@ -1172,6 +1172,34 @@ const pt: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+
+  // -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1,4 +1,4 @@
-﻿/** Russian translations. */
+/** Russian translations. */
 const ru: Record<string, string> = {
   // ── Навигация ───────────────────────────────────────────
   "nav.generate": "Генерация",
@@ -1052,9 +1052,8 @@ const ru: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1172,6 +1171,32 @@ const ru: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1,4 +1,4 @@
-﻿/** Traditional Chinese (Taiwan) translations. */
+/** Traditional Chinese (Taiwan) translations. */
 const zhTw: Record<string, string> = {
   // ── 導航 ────────────────────────────────────────────────
   "nav.generate": "生成",
@@ -1052,9 +1052,8 @@ const zhTw: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1172,6 +1171,32 @@ const zhTw: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1,4 +1,4 @@
-﻿/** Simplified Chinese translations. */
+/** Simplified Chinese translations. */
 const zh: Record<string, string> = {
   // ── 导航 ────────────────────────────────────────────────
   "nav.generate": "生成",
@@ -1052,9 +1052,8 @@ const zh: Record<string, string> = {
   "generation.sampler.output_format_tip": "PNG is the standard format with wide support. JPEG XL (JXL) is lossless, ~40% smaller than PNG, and embeds metadata in a SwarmUI-compatible XMP box. Gallery images are decoded on-demand for display.",
   "generation.sampler.format_png": "PNG",
   "generation.sampler.format_jxl": "JXL",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
+"gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
   "modelhub.pick_dir.title": "Choose install directory",
   "modelhub.pick_dir.description": "Select which directory to install this model to.",
   "modelhub.pick_dir.cancel": "Cancel",
@@ -1172,6 +1171,32 @@ const zh: Record<string, string> = {
   "artist_gallery.fav_manager.import_result_cat_one": "Imported · {added} added, {updated} updated, {categories} new category.",
   "artist_gallery.fav_manager.import_result_cats": "Imported · {added} added, {updated} updated, {categories} new categories.",
   "artist_gallery.fav_manager.import_error": "Error: {error}",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.next": "Next",
+  "common.prev": "Previous",
+  "generation.params": "Parameters",
+  "generation.show_params": "Show parameters",
+  "generation.steps.title": "Steps",
+  "generation.mode.title": "Mode",
+  "gallery.filters": "Filters",
+  "gallery.send_to_generate": "Send to Generate",
+  "gallery.use": "Use",
+  "gallery.use_for_upscale": "Use for Upscale",
+  "bottom_panel.no_session_images": "No session images yet.",
+  "settings.about": "About",
+  "settings.account": "Account",
+  "settings.confirm_logout": "Sign out?",
+  "settings.display": "Display",
+  "settings.generation_defaults": "Generation defaults",
+  "settings.language": "Language",
+  "settings.logout": "Sign out",
+  "settings.use_desktop_layout": "Use desktop layout",
+  "settings.use_desktop_layout_hint": "Show the full desktop UI on this device. Reloads the app.",
+
+// -- Stubs (untranslated -- English fallback) --
+  "common.yes": "Yes",
+  "common.no": "No",
 
 };
 

--- a/src/lib/utils/device.ts
+++ b/src/lib/utils/device.ts
@@ -1,0 +1,52 @@
+/**
+ * Device detection helpers.
+ *
+ * Mobile UI is gated by:
+ *   1. running in browser mode (`isBrowserMode`), AND
+ *   2. a phone/tablet User-Agent, AND
+ *   3. user has not toggled the desktop-layout override.
+ */
+
+import { isBrowserMode } from "./ipc.js";
+
+const FORCE_DESKTOP_KEY = "mooshie:forceDesktopLayout";
+
+/** Heuristic UA test. Matches phones + tablets (incl. iPadOS faking desktop Safari). */
+export function isMobileUA(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent || "";
+  const phoneRe =
+    /Android.*Mobile|iPhone|iPod|webOS|BlackBerry|IEMobile|Opera Mini|Mobile Safari/i;
+  const tabletRe = /iPad|Android(?!.*Mobile)|Tablet|PlayBook|Silk/i;
+  if (phoneRe.test(ua) || tabletRe.test(ua)) return true;
+  // iPadOS 13+ reports desktop Safari UA; detect via touch + macOS.
+  if (
+    /Macintosh/.test(ua) &&
+    typeof navigator.maxTouchPoints === "number" &&
+    navigator.maxTouchPoints > 1
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function getForceDesktopOverride(): boolean {
+  try {
+    return localStorage.getItem(FORCE_DESKTOP_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setForceDesktopOverride(value: boolean): void {
+  try {
+    if (value) localStorage.setItem(FORCE_DESKTOP_KEY, "1");
+    else localStorage.removeItem(FORCE_DESKTOP_KEY);
+  } catch {
+    /* ignore quota / privacy mode errors */
+  }
+}
+
+/** Resolved at module load — mobile shell only renders when true. */
+export const useMobileLayout: boolean =
+  isBrowserMode && isMobileUA() && !getForceDesktopOverride();

--- a/src/lib/utils/galleryActions.ts
+++ b/src/lib/utils/galleryActions.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared gallery image actions used by both desktop App.svelte handlers and
+ * the mobile action-sheet UI. These helpers wrap the gallery / generation
+ * stores so callers don't need to duplicate the bytes-load + upload dance.
+ */
+import type { OutputImage } from "../types/index.js";
+import { gallery } from "../stores/gallery.svelte.js";
+import { generation } from "../stores/generation.svelte.js";
+import {
+  loadGalleryImage,
+  getOutputImage,
+  uploadImageBytes,
+} from "./api.js";
+
+async function loadAndUpload(image: OutputImage): Promise<string> {
+  const bytes = image.gallery_filename
+    ? await loadGalleryImage(image.gallery_filename)
+    : await getOutputImage(image.filename, image.subfolder);
+  const response = await uploadImageBytes(bytes, image.filename);
+  return response.name;
+}
+
+/** Send image to txt2img/img2img tab as the input image. Caller switches tab. */
+export async function sendImageToImg2Img(image: OutputImage): Promise<void> {
+  const name = await loadAndUpload(image);
+  generation.inputImage = name;
+  generation.mode = "img2img";
+  gallery.closeLightbox();
+}
+
+/** Re-use image as upscale input. */
+export async function sendImageToUpscale(image: OutputImage): Promise<void> {
+  const name = await loadAndUpload(image);
+  generation.inputImage = name;
+  generation.mode = "img2img";
+  generation.upscaleEnabled = true;
+  gallery.closeLightbox();
+}


### PR DESCRIPTION
## What's New in v1.1.1

### Mobile Browser UI
- **Touch-optimized shell** — when accessed through the embedded web server from a mobile device, MooshieUI now renders a native-feeling mobile layout with bottom tab navigation (Generate / Gallery / Model Hub / Artists / Settings) instead of the desktop side panels. Activation is automatic via user-agent detection and can be overridden from Settings.
- **Mobile generate page** — vertical layout with a 3-segment pill mode switcher (txt2img / img2img / inpaint) in the top bar, large preview area, prompt history strip below the preview, and a floating bottom dock containing the generate button and a chevron to expand/collapse the parameters bottom sheet.
- **Side rail extras panel** — LoRAs, Checkpoints, Session images, Styles, Schedule, and Compare are now reachable from a 48-px vertical icon rail on the generate page, each opening as a full-height bottom sheet.
- **Mobile gallery & lightbox** — touch-friendly grid with a filters bottom sheet (board / sort), pinch-to-zoom lightbox, and an action sheet (Send to Generate / Use for Upscale / Copy / Download / Delete).
- **Mobile settings page** — language picker, "Use desktop layout" pill toggle, generation defaults sliders (Steps, CFG), account sign-out, and About section.

### Polish & Fixes
- **Integer-only progress percentages** — generation progress no longer displays repeating decimals like `33.333%`; values are rounded to whole percent.
- **Artist gallery error diagnostics** — `JSON.parse` failures now surface the URL, content-type, and a preview of the response body instead of an opaque parse error.
- **Mobile artist gallery** — wired the missing `manifestUrl` prop so the artist tab loads correctly in browser mode.
- **i18n coverage** — every new mobile UI string is routed through the locale system; 22 new keys added to `en.ts` with English-fallback stubs synced to all 11 other locales. Duplicate locale keys were removed from `it.ts`, `ja.ts`, `ko.ts`, `ru.ts`, `zh.ts`, and `zh-tw.ts` (translated values restored).