### PR TITLE
v1.1.2: Validate input image for img2img and inpainting modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.1.2
+
+### Bug Fixes
+- **img2img / inpainting input validation** — the backend now rejects generation requests for `img2img` and `inpainting` modes when no input image has been provided, returning a clear `Invalid workflow` error instead of letting ComfyUI fail deep in the graph with a confusing `[Errno 21] Is a directory` error from the `LoadImage` node.
+
+---
+
 ## What's New in v1.1.1
 
 ### Mobile Browser UI

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.1.2
+
+### Bug Fixes
+- **img2img / inpainting input validation** — the backend now rejects generation requests for `img2img` and `inpainting` modes when no input image has been provided, returning a clear `Invalid workflow` error instead of letting ComfyUI fail deep in the graph with a confusing `[Errno 21] Is a directory` error from the `LoadImage` node.
+
+---
+
 ## What's New in v1.1.1
 
 ### Mobile Browser UI

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -24,6 +24,24 @@ pub async fn generate(
     // accumulation within a long session.
     crate::temp_images::cleanup(300);
 
+    // Validate input image is present for modes that require it. Without this
+    // guard, ComfyUI's LoadImage node receives an empty filename and reports
+    // `[Errno 21] Is a directory: '<input_dir>/'`, which surfaces as a generic
+    // execution error far away from the actual cause.
+    if matches!(params.mode.as_str(), "img2img" | "inpainting")
+        && params
+            .input_image
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return Err(AppError::InvalidWorkflow(format!(
+            "{} mode requires an input image — please upload one before generating.",
+            params.mode
+        )));
+    }
+
     let seed = if params.seed < 0 {
         (rand::random::<u64>() >> 1) as i64
     } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.1.2

### Bug Fixes
- **img2img / inpainting input validation** — the backend now rejects generation requests for `img2img` and `inpainting` modes when no input image has been provided, returning a clear `Invalid workflow` error instead of letting ComfyUI fail deep in the graph with a confusing `[Errno 21] Is a directory` error from the `LoadImage` node.

### Version bump
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` → `1.1.2`
- `RELEASE_NOTES.md`, `CHANGELOG.md` updated