### PR TITLE
v1.1.3: Flux guidance slider, Flux 2 Klein detection, ControlNet input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## What's New in v1.1.3
+
+### Flux Model Support
+- **Flux Guidance slider** — when a Flux Dev or Flux 2 Klein checkpoint is selected, the Smart Guidance toggle is replaced with a dedicated Flux Guidance slider (range 0–10, default 3.5). The value is plumbed through to the `FluxGuidance` node in the workflow, replacing the previously hardcoded `3.5`. The setting is persisted alongside other generation defaults and round-trips through PNG metadata as `mooshie_flux_guidance`.
+- **Negative prompt is greyed out for Flux models** — Flux is guidance-distilled and ignores the negative conditioning, so the textarea is now visually disabled (40% opacity, no pointer interaction) with an inline "ignored by Flux models" hint when a Flux checkpoint is active.
+- **Flux 2 Klein 9B (NVFP4) detection** — the model selector now correctly detects `flux-2-klein-9b-nvfp4.safetensors` in `diffusion_models/`, its `qwen_3_8b_fp4mixed.safetensors` text encoder in either `clip/` or `text_encoders/`, and the `flux-vae.safetensors` VAE. Hashes are auto-cached on first activation so subsequent loads resolve instantly.
+
+### Bug Fixes
+- **ControlNet input validation** — the backend now rejects generation requests when ControlNet is enabled but no reference image has been uploaded, returning a clear `Invalid workflow` error instead of crashing the server with `[Errno 21] Is a directory` from the `LoadImage` node. Mirrors the existing img2img / inpainting guard.
+- **Text encoder discovery** — model lookup now searches both `clip/` and `text_encoders/` ComfyUI directories and falls back through both during hash resolution, fixing missing-encoder errors when ComfyUI installs split a model's CLIP across the two folders.
+
+---
+
 ## What's New in v1.1.2
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## What's New in v1.1.3
+
+### Flux Model Support
+- **Flux Guidance slider** — when a Flux Dev or Flux 2 Klein checkpoint is selected, the Smart Guidance toggle is replaced with a dedicated Flux Guidance slider (range 0–10, default 3.5). The value is plumbed through to the `FluxGuidance` node in the workflow, replacing the previously hardcoded `3.5`. The setting is persisted alongside other generation defaults and round-trips through PNG metadata as `mooshie_flux_guidance`.
+- **Negative prompt is greyed out for Flux models** — Flux is guidance-distilled and ignores the negative conditioning, so the textarea is now visually disabled (40% opacity, no pointer interaction) with an inline "ignored by Flux models" hint when a Flux checkpoint is active.
+- **Flux 2 Klein 9B (NVFP4) detection** — the model selector now correctly detects `flux-2-klein-9b-nvfp4.safetensors` in `diffusion_models/`, its `qwen_3_8b_fp4mixed.safetensors` text encoder in either `clip/` or `text_encoders/`, and the `flux-vae.safetensors` VAE. Hashes are auto-cached on first activation so subsequent loads resolve instantly.
+
+### Bug Fixes
+- **ControlNet input validation** — the backend now rejects generation requests when ControlNet is enabled but no reference image has been uploaded, returning a clear `Invalid workflow` error instead of crashing the server with `[Errno 21] Is a directory` from the `LoadImage` node. Mirrors the existing img2img / inpainting guard.
+- **Text encoder discovery** — model lookup now searches both `clip/` and `text_encoders/` ComfyUI directories and falls back through both during hash resolution, fixing missing-encoder errors when ComfyUI installs split a model's CLIP across the two folders.
+
+---
+
 ## What's New in v1.1.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -144,6 +144,9 @@ pub struct GenerationParams {
     /// Enable Smart Guidance (positive-biased) — patches model for all generation passes
     #[serde(default)]
     pub smart_guidance: bool,
+    /// FluxGuidance value for Flux Dev / Flux 2 Klein family. Default 3.5.
+    #[serde(default = "default_flux_guidance")]
+    pub flux_guidance: f32,
     /// Face fix (FaceDetailer) — detect faces with YOLOv8 and re-denoise them
     #[serde(default)]
     pub facefix_enabled: bool,
@@ -200,6 +203,10 @@ fn default_end_percent() -> f64 {
 
 fn default_facefix_denoise() -> f64 {
     0.4
+}
+
+fn default_flux_guidance() -> f32 {
+    3.5
 }
 
 fn default_soft_guidance_multiplier() -> f64 {

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1423,39 +1423,55 @@ pub async fn find_model_by_hash(
     if config.comfyui_path.is_empty() {
         return Ok(None);
     }
-    let models_dir = std::path::Path::new(&config.comfyui_path)
-        .join("models")
-        .join(&category);
 
-    if !models_dir.exists() {
-        return Ok(None);
-    }
+    // Text encoders historically live under either `text_encoders/` (modern
+    // split-file layout) or `clip/` (legacy ComfyUI / Forge layout). Search
+    // both when looking up text encoder hashes so a model placed in `clip/`
+    // still resolves.
+    let categories: Vec<&str> = match category.as_str() {
+        "text_encoders" => vec!["text_encoders", "clip"],
+        "clip" => vec!["clip", "text_encoders"],
+        other => vec![other],
+    };
 
     let needle = hash.to_uppercase();
     let is_autov2 = needle.len() == 10;
 
-    let entries = std::fs::read_dir(&models_dir)?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
+    for cat in categories {
+        let models_dir = std::path::Path::new(&config.comfyui_path)
+            .join("models")
+            .join(cat);
+
+        if !models_dir.exists() {
             continue;
         }
-        let name = path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-        if !(name.ends_with(".safetensors") || name.ends_with(".ckpt")) {
-            continue;
-        }
-        if let Ok(h) = full_sha256(&path) {
-            let matches = if is_autov2 {
-                autov2_hash(&h) == needle
-            } else {
-                h == needle
-            };
-            if matches {
-                return Ok(Some(name));
+
+        let entries = match std::fs::read_dir(&models_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            if !(name.ends_with(".safetensors") || name.ends_with(".ckpt")) {
+                continue;
+            }
+            if let Ok(h) = full_sha256(&path) {
+                let matches = if is_autov2 {
+                    autov2_hash(&h) == needle
+                } else {
+                    h == needle
+                };
+                if matches {
+                    return Ok(Some(name));
+                }
             }
         }
     }
@@ -1479,6 +1495,30 @@ pub async fn hash_model_file(
         .join("models")
         .join(&category)
         .join(&filename);
+
+    // Fall back to the alternate directory for text encoders (clip ↔ text_encoders).
+    let path = if !path.exists() {
+        let alt = match category.as_str() {
+            "text_encoders" => Some("clip"),
+            "clip" => Some("text_encoders"),
+            _ => None,
+        };
+        if let Some(alt) = alt {
+            let alt_path = std::path::Path::new(&config.comfyui_path)
+                .join("models")
+                .join(alt)
+                .join(&filename);
+            if alt_path.exists() {
+                alt_path
+            } else {
+                path
+            }
+        } else {
+            path
+        }
+    } else {
+        path
+    };
 
     if !path.exists() {
         return Err(AppError::Other(format!("File not found: {}", filename)));

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1409,6 +1409,16 @@ pub async fn install_pip_package(
     Ok(())
 }
 
+/// Reject category/filename inputs containing path-traversal components.
+/// Returns true if the input is safe to join into a model path.
+fn is_safe_path_component(s: &str) -> bool {
+    !s.is_empty()
+        && !s.contains("..")
+        && !s.contains('/')
+        && !s.contains('\\')
+        && !s.starts_with('.')
+}
+
 /// Search for a model file by SHA256 hash (full or AutoV2) within a model category directory.
 /// Returns the filename if found, or null if no match.
 /// Note: this hashes each file in the directory, so it may take a while for large collections.
@@ -1419,6 +1429,11 @@ pub async fn find_model_by_hash(
     category: String,
     hash: String,
 ) -> Result<Option<String>, AppError> {
+    // Reject path-traversal attempts on the user-supplied category.
+    if !is_safe_path_component(&category) {
+        return Ok(None);
+    }
+
     let config = state.config.read().await;
     if config.comfyui_path.is_empty() {
         return Ok(None);
@@ -1487,6 +1502,11 @@ pub async fn hash_model_file(
     category: String,
     filename: String,
 ) -> Result<ModelHashResult, AppError> {
+    // Reject path-traversal attempts on user-supplied inputs.
+    if !is_safe_path_component(&category) || !is_safe_path_component(&filename) {
+        return Err(AppError::Other("Invalid category or filename".into()));
+    }
+
     let config = state.config.read().await;
     if config.comfyui_path.is_empty() {
         return Err(AppError::Other("ComfyUI path not configured".into()));

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -42,6 +42,16 @@ pub async fn generate(
         )));
     }
 
+    // Same guard for ControlNet: an enabled ControlNet without a reference
+    // image hits the same `LoadImage` directory crash on the server side.
+    if let Some(cn) = params.controlnet.as_ref() {
+        if cn.enabled && cn.image.as_deref().map(str::trim).unwrap_or("").is_empty() {
+            return Err(AppError::InvalidWorkflow(
+                "ControlNet is enabled but no reference image was provided — please upload one or disable ControlNet.".into(),
+            ));
+        }
+    }
+
     let seed = if params.seed < 0 {
         (rand::random::<u64>() >> 1) as i64
     } else {

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -669,7 +669,7 @@ fn inject_flux_guidance(result: &mut WorkflowResult, params: &GenerationParams) 
             "class_type": "FluxGuidance",
             "inputs": {
                 "conditioning": [result.positive_source.0.clone(), result.positive_source.1],
-                "guidance": 3.5
+                "guidance": params.flux_guidance
             }
         }),
     );

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -870,6 +870,10 @@
       metadata.mooshie_smart_guidance = "true";
     }
 
+    if (typeof params.flux_guidance === "number") {
+      metadata.mooshie_flux_guidance = String(params.flux_guidance);
+    }
+
     if (params.differential_diffusion) {
       metadata.mooshie_differential_diffusion = "true";
     }
@@ -956,6 +960,10 @@
       // MooshieUI-exclusive params round-trip
       if (metadata.mooshie_smart_guidance !== undefined) {
         generation.smartGuidance = metadata.mooshie_smart_guidance === "true";
+      }
+      if (metadata.mooshie_flux_guidance !== undefined) {
+        const fg = parseFloat(metadata.mooshie_flux_guidance);
+        if (Number.isFinite(fg)) generation.fluxGuidance = fg;
       }
       if (metadata.mooshie_differential_diffusion !== undefined) {
         generation.differentialDiffusion = metadata.mooshie_differential_diffusion === "true";

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -11,6 +11,7 @@
 
   interface ModelFile {
     filename: string;
+    /** Download URL. Empty string means detection-only — no download attempted. */
     url: string;
     category: string;
     /** AutoV2 hash (first 10 chars of full SHA256, uppercase) — CivitAI-compatible */
@@ -51,6 +52,12 @@
     minComputeCapability?: number;
     /** Hint shown next to the size in the dropdown to explain the gate. */
     gateHint?: string;
+    /**
+     * When true, the entry is shown only if all components are detected
+     * locally (by hash or filename). Used for models we can't redistribute
+     * but want to recognise / auto-pair when the user has them on disk.
+     */
+    detectionOnly?: boolean;
   }
 
   const recommendedModels: RecommendedModel[] = [
@@ -168,6 +175,46 @@
         upscaleSteps: 10,
         upscaleDenoise: 0.3,
         facefixSteps: 10,
+      },
+    },
+    {
+      // Flux 2 Klein 9B (NVFP4) — detection-only entry. We can't redistribute
+      // BFL's weights, but if the user has dropped the three components into
+      // their ComfyUI models tree we recognise them and auto-wire the split
+      // model + Qwen 3 text encoder + Flux VAE. Resolution by hash via
+      // `findModelByHash` handles renamed files, and the unified text-encoder
+      // listing in `models.svelte.ts` picks up encoders living under the
+      // legacy `clip/` directory (where the user's `qwen_3_8b_fp4mixed`
+      // happens to live).
+      label: "Flux 2 Klein 9B (NVFP4)",
+      size: "Local",
+      detectionOnly: true,
+      splitModel: {
+        diffusionModel: {
+          filename: "flux-2-klein-9b-nvfp4.safetensors",
+          url: "",
+          category: "diffusion_models",
+        },
+        clipModel: {
+          filename: "qwen_3_8b_fp4mixed.safetensors",
+          url: "",
+          // Listed under text_encoders so the picker resolves correctly;
+          // backend hash lookup also falls through to `clip/`.
+          category: "text_encoders",
+          // Flux 2 Klein ships with Qwen 3 as its text encoder.
+          clipType: "qwen_image",
+        },
+        vaeModel: {
+          filename: "flux-vae.safetensors",
+          url: "",
+          category: "vae",
+        },
+      },
+      autoSettings: {
+        steps: 20,
+        cfg: 1.0,
+        samplerName: "euler",
+        scheduler: "simple",
       },
     },
   ];
@@ -501,6 +548,10 @@
         if (computeCapability === null || computeCapability < rec.minComputeCapability) continue;
       }
       const installed = isRecommendedInstalled(rec);
+      // Detection-only entries (no download URLs) are hidden until every
+      // component is present on disk — otherwise the user would see an entry
+      // they can't action.
+      if (rec.detectionOnly && !installed) continue;
       if (!q || rec.label.toLowerCase().includes(q)) {
         items.push({
           type: "recommended",
@@ -565,6 +616,18 @@
     }
 
     if (missingFiles.length > 0) {
+      // Detection-only entries have no download URLs — surface a clear error
+      // rather than letting the empty URL hit the backend.
+      const undownloadable = missingFiles.filter((m) => !m.file.url);
+      if (undownloadable.length > 0) {
+        downloadError = `Missing local file(s): ${undownloadable.map((m) => m.file.filename).join(", ")}`;
+        downloading = rec.label;
+        setTimeout(() => {
+          downloading = null;
+          downloadError = "";
+        }, 4000);
+        return;
+      }
       downloading = rec.label;
       downloadError = "";
       // Seed a progress row for every file up-front so all three bars are
@@ -624,6 +687,19 @@
       generation.clipType = sm.clipModel.clipType;
       generation.vae = resolvedFilename(sm.vaeModel);
       generation.checkpoint = rec.label;
+
+      // For detection-only entries we never went through the download path,
+      // so cache hashes the first time the user activates the entry. This
+      // makes future detections survive renames / directory moves without
+      // requiring the user to relink.
+      if (rec.detectionOnly) {
+        // Fire-and-forget — hashing GBs of weights can take a while.
+        void Promise.all([
+          cacheHashAfterDownload({ ...sm.diffusionModel, filename: generation.diffusionModel! }),
+          cacheHashAfterDownload({ ...sm.clipModel, filename: generation.clipModel! }),
+          cacheHashAfterDownload({ ...sm.vaeModel, filename: generation.vae }),
+        ]).catch((e) => console.warn("[ModelSelector] hash caching failed:", e));
+      }
     } else if (rec.checkpoint) {
       generation.useSplitModel = false;
       generation.diffusionModel = null;

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -144,8 +144,13 @@
     />
   </div>
 
-  <div>
-    <label class="block text-xs text-neutral-400 mb-1">{locale.t('generation.prompts.negative')}<InfoTip text={locale.t('generation.prompts.negative_tip')} /></label>
+  <div class="transition-opacity {generation.isFlux ? 'opacity-40 pointer-events-none' : ''}">
+    <label class="block text-xs text-neutral-400 mb-1">
+      {locale.t('generation.prompts.negative')}<InfoTip text={locale.t('generation.prompts.negative_tip')} />
+      {#if generation.isFlux}
+        <span class="ml-1 text-[10px] text-amber-400">({locale.t('generation.prompts.negative_flux_disabled')})</span>
+      {/if}
+    </label>
     <PromptTextarea
       bind:value={generation.negativePrompt}
       placeholder={locale.t('generation.prompts.negative_placeholder')}

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -316,17 +316,34 @@
     </p>
   {/if}
 
-  <!-- Smart Guidance toggle -->
-  <div class="flex items-center gap-2">
-    <input
-      type="checkbox"
-      id="smart-guidance"
-      bind:checked={generation.smartGuidance}
-      class="w-4 h-4 accent-indigo-500 rounded"
-    />
-    <label for="smart-guidance" class="text-xs text-neutral-400">
-      {locale.t('generation.sampler.smart_guidance_label')}<InfoTip text={locale.t('generation.sampler.smart_guidance_tip')} />
-    </label>
-  </div>
+  <!-- Smart Guidance toggle (hidden for Flux models which use FluxGuidance instead) -->
+  {#if generation.isFlux}
+    <div use:scrollCapture>
+      <label class="flex items-center justify-between text-xs text-neutral-400 mb-1">
+        <span>{locale.t('generation.sampler.flux_guidance_label')}<InfoTip text={locale.t('generation.sampler.flux_guidance_tip')} /></span>
+        <EditableValue value={generation.fluxGuidance} min={0} max={10} step={0.1} decimals={1} onchange={(v) => generation.fluxGuidance = v} />
+      </label>
+      <input
+        type="range"
+        bind:value={generation.fluxGuidance}
+        min="0"
+        max="10"
+        step="0.1"
+        class="w-full accent-indigo-500"
+      />
+    </div>
+  {:else}
+    <div class="flex items-center gap-2">
+      <input
+        type="checkbox"
+        id="smart-guidance"
+        bind:checked={generation.smartGuidance}
+        class="w-4 h-4 accent-indigo-500 rounded"
+      />
+      <label for="smart-guidance" class="text-xs text-neutral-400">
+        {locale.t('generation.sampler.smart_guidance_label')}<InfoTip text={locale.t('generation.sampler.smart_guidance_tip')} />
+      </label>
+    </div>
+  {/if}
 
 </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1201,6 +1201,12 @@ const de: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+
 };
 
 export default de;

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -301,6 +301,7 @@ const en: Record<string, string> = {
   "generation.prompts.positive_tip": "Describe what you want to see in the image. Use commas to separate concepts. More specific prompts give better results — include style, subject, lighting, and quality tags.",
   "generation.prompts.negative": "Negative Prompt",
   "generation.prompts.negative_tip": "Describe what you don't want to see. Common negatives: blurry, low quality, text, watermark. The model will try to avoid these concepts.",
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.prompts.positive_placeholder": "A beautiful sunset over the ocean...",
   "generation.prompts.negative_placeholder": "low quality, blurry...",
   "generation.prompts.style_preset": "Style Preset",
@@ -517,6 +518,8 @@ const en: Record<string, string> = {
   "generation.upscale.soft_guidance_multiplier_tip": "How much to rescale CFG. Lower = gentler guidance, less hallucination. 0.4 is recommended for refining, 0.7 for general use. 0 disables the effect.",
   "generation.sampler.smart_guidance_label": "Smart Guidance",
   "generation.sampler.smart_guidance_tip": "Positive-biased adaptive guidance — makes the model follow your prompt more closely instead of just avoiding the negative. Applies to all generation steps. No tuning needed.",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
 
   // Refiner History
   "generation.upscale_history.title": "Refiner History",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1228,6 +1228,12 @@ const es: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+
 };
 
 export default es;

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1226,6 +1226,12 @@ const fr: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+
 };
 
 export default fr;

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1198,6 +1198,15 @@ const it: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default it;

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1223,6 +1223,15 @@ const ja: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default ja;

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1198,6 +1198,15 @@ const ko: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default ko;

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1201,6 +1201,12 @@ const pt: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+
 };
 
 export default pt;

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1198,6 +1198,15 @@ const ru: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default ru;

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1198,6 +1198,15 @@ const zhTw: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default zhTw;

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1198,6 +1198,15 @@ const zh: Record<string, string> = {
   "common.yes": "Yes",
   "common.no": "No",
 
+
+  // -- Stubs (untranslated -- English fallback) --
+  "generation.prompts.negative_flux_disabled": "ignored by Flux models",
+  "generation.sampler.flux_guidance_label": "Flux Guidance",
+  "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
+  "bottom_panel.tab.checkpoints": "Checkpoints",
+  "bottom_panel.tab.images": "Images",
+  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
+
 };
 
 export default zh;

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -145,6 +145,12 @@ class GenerationStore {
   upscaleSoftGuidance = $state(true);
   upscaleSoftGuidanceMultiplier = $state(0.4);
   smartGuidance = $state(false);
+  /**
+   * FluxGuidance value (used by Flux Dev / Flux 2 Klein family). Replaces
+   * CFG for those models since they're guidance-distilled and ignore CFG.
+   * Range: 0-10, sweet spot 2-4. Default matches ComfyUI's FluxGuidance node.
+   */
+  fluxGuidance = $state(3.5);
   useSplitModel = $state(false);
   diffusionModel = $state<string | null>(null);
   clipModel = $state<string | null>(null);
@@ -656,6 +662,7 @@ class GenerationStore {
         if (saved.upscaleSoftGuidance !== undefined) this.upscaleSoftGuidance = saved.upscaleSoftGuidance;
         if (saved.upscaleSoftGuidanceMultiplier !== undefined) this.upscaleSoftGuidanceMultiplier = saved.upscaleSoftGuidanceMultiplier;
         if (saved.smartGuidance !== undefined) this.smartGuidance = saved.smartGuidance;
+        if (saved.fluxGuidance !== undefined) this.fluxGuidance = saved.fluxGuidance;
         if (saved.useSplitModel !== undefined) this.useSplitModel = saved.useSplitModel;
         if (saved.diffusionModel !== undefined) this.diffusionModel = saved.diffusionModel;
         if (saved.clipModel !== undefined) this.clipModel = saved.clipModel;
@@ -735,6 +742,7 @@ class GenerationStore {
         upscaleSoftGuidance: this.upscaleSoftGuidance,
         upscaleSoftGuidanceMultiplier: this.upscaleSoftGuidanceMultiplier,
         smartGuidance: this.smartGuidance,
+        fluxGuidance: this.fluxGuidance,
         useSplitModel: this.useSplitModel,
         diffusionModel: this.diffusionModel,
         clipModel: this.clipModel,
@@ -806,6 +814,7 @@ class GenerationStore {
       upscaleSoftGuidance: this.upscaleSoftGuidance,
       upscaleSoftGuidanceMultiplier: this.upscaleSoftGuidanceMultiplier,
       smartGuidance: this.smartGuidance,
+      fluxGuidance: this.fluxGuidance,
       useSplitModel: this.useSplitModel,
       diffusionModel: this.diffusionModel,
       clipModel: this.clipModel,
@@ -1003,6 +1012,7 @@ class GenerationStore {
       upscale_soft_guidance: this.upscaleSoftGuidance,
       upscale_soft_guidance_multiplier: this.upscaleSoftGuidanceMultiplier,
       smart_guidance: this.smartGuidance,
+      flux_guidance: this.fluxGuidance,
       upscale_positive_prompt: upscalePositivePrompt,
       upscale_negative_prompt: upscaleNegativePrompt,
       use_split_model: this.useSplitModel,

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -18,7 +18,11 @@ class ModelsStore {
     this.loading = true;
     try {
       console.log("ModelsStore: fetching models...");
-      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, textEncoders, controlnetModels, ultralyticsModels] =
+      // Text encoders may live in either `text_encoders/` (modern split-file
+      // layout) or `clip/` (legacy ComfyUI / Forge layout). Fetch both and
+      // merge so the picker doesn't miss encoders in the legacy directory
+      // (e.g. `qwen_3_8b_fp4mixed.safetensors` placed under `clip/`).
+      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
         await Promise.all([
           getModels("checkpoints"),
           getModels("vae"),
@@ -28,6 +32,7 @@ class ModelsStore {
           getModels("upscale_models"),
           getModels("diffusion_models").catch(() => [] as string[]),
           getModels("text_encoders").catch(() => [] as string[]),
+          getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
           getModels("ultralytics").catch(() => [] as string[]),
         ]);
@@ -43,7 +48,9 @@ class ModelsStore {
       this.embeddings = embeddings;
       this.upscaleModels = upscaleModels;
       this.diffusionModels = diffusionModels;
-      this.textEncoders = textEncoders;
+      // De-duplicate by basename — ComfyUI sometimes returns the same file under
+      // both `clip` and `text_encoders` when both directories are mapped.
+      this.textEncoders = Array.from(new Set([...textEncoders, ...clipEncoders]));
       this.controlnetModels = controlnetModels;
       this.ultralyticsModels = ultralyticsModels;
     } catch (e) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -65,6 +65,8 @@ export interface GenerationParams {
   upscale_soft_guidance: boolean;
   upscale_soft_guidance_multiplier: number;
   smart_guidance: boolean;
+  /** FluxGuidance value (Flux Dev / Flux 2 Klein only). Default 3.5. */
+  flux_guidance?: number;
   /** "Refine" mode: skip the main img2img sampler and feed the loaded image
    *  straight into the upscale chain. Mirrors SwarmUI's Refine button. */
   refine_only?: boolean;


### PR DESCRIPTION
## v1.1.3

### Flux Model Support
- **Flux Guidance slider** — when a Flux Dev or Flux 2 Klein checkpoint is selected, the Smart Guidance toggle is replaced with a dedicated Flux Guidance slider (range 0–10, default 3.5). Plumbed through to the `FluxGuidance` node, replacing the previously hardcoded `3.5`. Persisted alongside other generation defaults and round-trips through PNG metadata as `mooshie_flux_guidance`.
- **Negative prompt is greyed out for Flux models** — Flux is guidance-distilled and ignores the negative conditioning, so the textarea is now visually disabled (40% opacity, no pointer interaction) with an inline "ignored by Flux models" hint when a Flux checkpoint is active.
- **Flux 2 Klein 9B (NVFP4) detection** — model selector detects `flux-2-klein-9b-nvfp4.safetensors` in `diffusion_models/`, its `qwen_3_8b_fp4mixed.safetensors` text encoder in either `clip/` or `text_encoders/`, and the `flux-vae.safetensors` VAE. Hashes are auto-cached on first activation.

### Bug Fixes
- **ControlNet input validation** — backend rejects generation requests when ControlNet is enabled but no reference image has been uploaded, returning a clear `Invalid workflow` error instead of crashing the server with `[Errno 21] Is a directory` from the `LoadImage` node. Mirrors the existing img2img / inpainting guard.
- **Text encoder discovery** — model lookup now searches both `clip/` and `text_encoders/` ComfyUI directories and falls back through both during hash resolution.

### Housekeeping
- Locale stubs added to all 10 non-English locales for the 3 new strings.
