### PR TITLE
v1.1.4: Apply input validation guards to LAN/web server generate route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v1.1.4
+
+### Bug Fixes
+- **LAN/web server input validation** — the input-image and ControlNet guards added in v1.1.2 / v1.1.3 only ran inside the Tauri `generate` command, so users connecting through the embedded web server (`mooshieui.gpu.garden` and other LAN deployments) still hit `[Errno 21] Is a directory` from ComfyUI's `LoadImage` node when generating without a required input image. The validation has been extracted into a shared `validate_generation_params` helper and is now called from both the Tauri command and the LAN web server's `generate` route.
+- **Refine without an image** — the validator now also rejects `refine_only` requests submitted without an input image, and rejects `inpainting` mode submitted without a mask.
+
+---
+
 ## What's New in v1.1.3
 
 ### Flux Model Support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v1.1.4
+
+### Bug Fixes
+- **LAN/web server input validation** — the input-image and ControlNet guards added in v1.1.2 / v1.1.3 only ran inside the Tauri `generate` command, so users connecting through the embedded web server (`mooshieui.gpu.garden` and other LAN deployments) still hit `[Errno 21] Is a directory` from ComfyUI's `LoadImage` node when generating without a required input image. The validation has been extracted into a shared `validate_generation_params` helper and is now called from both the Tauri command and the LAN web server's `generate` route.
+- **Refine without an image** — the validator now also rejects `refine_only` requests submitted without an input image, and rejects `inpainting` mode submitted without a mask.
+
+---
+
 ## What's New in v1.1.3
 
 ### Flux Model Support

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -28,29 +28,7 @@ pub async fn generate(
     // guard, ComfyUI's LoadImage node receives an empty filename and reports
     // `[Errno 21] Is a directory: '<input_dir>/'`, which surfaces as a generic
     // execution error far away from the actual cause.
-    if matches!(params.mode.as_str(), "img2img" | "inpainting")
-        && params
-            .input_image
-            .as_deref()
-            .map(str::trim)
-            .unwrap_or("")
-            .is_empty()
-    {
-        return Err(AppError::InvalidWorkflow(format!(
-            "{} mode requires an input image — please upload one before generating.",
-            params.mode
-        )));
-    }
-
-    // Same guard for ControlNet: an enabled ControlNet without a reference
-    // image hits the same `LoadImage` directory crash on the server side.
-    if let Some(cn) = params.controlnet.as_ref() {
-        if cn.enabled && cn.image.as_deref().map(str::trim).unwrap_or("").is_empty() {
-            return Err(AppError::InvalidWorkflow(
-                "ControlNet is enabled but no reference image was provided — please upload one or disable ControlNet.".into(),
-            ));
-        }
-    }
+    templates::validate_generation_params(&params).map_err(AppError::InvalidWorkflow)?;
 
     let seed = if params.seed < 0 {
         (rand::random::<u64>() >> 1) as i64

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -9,6 +9,61 @@ use serde_json::{json, Value};
 
 use crate::comfyui::types::{GenerationParams, PromptSegment};
 
+/// Validate generation parameters before workflow construction.
+///
+/// Catches missing input images for modes that require them, and ControlNet
+/// configurations with no reference image. Without these guards the request
+/// reaches ComfyUI's `LoadImage` node with an empty filename, which it
+/// resolves to the input directory and crashes with `[Errno 21] Is a directory`.
+///
+/// Both the Tauri `generate` command and the LAN web server `generate` route
+/// must call this before `build_workflow`.
+pub fn validate_generation_params(params: &GenerationParams) -> Result<(), String> {
+    let needs_input_image =
+        matches!(params.mode.as_str(), "img2img" | "inpainting") || params.refine_only;
+
+    if needs_input_image
+        && params
+            .input_image
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return Err(format!(
+            "{} mode requires an input image — please upload one before generating.",
+            if params.refine_only {
+                "refine"
+            } else {
+                params.mode.as_str()
+            }
+        ));
+    }
+
+    if matches!(params.mode.as_str(), "inpainting")
+        && params
+            .mask_image
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty()
+    {
+        return Err(
+            "Inpainting mode requires a mask image — please paint a mask before generating.".into(),
+        );
+    }
+
+    if let Some(cn) = params.controlnet.as_ref() {
+        if cn.enabled && cn.image.as_deref().map(str::trim).unwrap_or("").is_empty() {
+            return Err(
+                "ControlNet is enabled but no reference image was provided — please upload one or disable ControlNet.".into(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
 pub struct WorkflowResult {
     pub workflow: serde_json::Map<String, Value>,
     pub next_id: u32,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1938,6 +1938,13 @@ async fn dispatch_command(
             let params: crate::comfyui::types::GenerationParams =
                 serde_json::from_value(args["params"].clone())
                     .map_err(|e| format!("Invalid params: {}", e))?;
+
+            // Validate inputs (e.g. img2img/inpainting/refine without an image,
+            // ControlNet enabled without a reference image). Returning the
+            // friendly error here avoids the cryptic `[Errno 21] Is a directory`
+            // crash when ComfyUI's LoadImage node receives an empty filename.
+            crate::templates::validate_generation_params(&params)?;
+
             let seed = if params.seed < 0 {
                 (rand::random::<u64>() >> 1) as i64
             } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.1.4

### Bug Fixes
- **LAN/web server input validation** — the input-image and ControlNet guards added in v1.1.2 / v1.1.3 only ran inside the Tauri `generate` command. Users connecting through the embedded web server (`mooshieui.gpu.garden` and other LAN deployments) bypassed those guards entirely and still hit `[Errno 21] Is a directory: '<input_dir>/'` from ComfyUI's `LoadImage` node when generating without a required input image. The validation logic has been extracted into a shared `templates::validate_generation_params` helper and is now called from both code paths.
- **Refine without an image** — the validator now also rejects `refine_only` requests submitted without an input image, and rejects `inpainting` mode submitted without a mask image.

### Why this matters
v1.1.3 shipped the guard but only on the desktop IPC path. The remote/LAN deployment continued to crash. v1.1.4 is purely the deduplication + webserver wiring required to actually fix the reported issue.
