### PR TITLE
v1.1.5: cancel works in multi-GPU, VAE auto-fix, gallery CORS, i18n setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v1.1.5
+
+### Bug Fixes
+- **Cancel actually cancels in multi-GPU mode** — clicking cancel previously only interrupted the first ComfyUI worker, so on multi-GPU deployments (e.g. `mooshieui.gpu.garden`) other workers kept running and the UI appeared to "switch between" two simultaneous generations. Cancellation is now worker-aware: the active prompt's worker is interrupted, the prompt is removed from that worker's pending queue, and `/free` is issued to flush VRAM. Held prompts that never reached ComfyUI are cancelled locally without an HTTP roundtrip.
+- **Split-model VAE auto-correction** — when an Anima/Qwen/WAN/Flux/Klein diffusion model was selected with a stale SDXL VAE in the persisted settings, generation produced a channel-mismatch error. Defaults application now detects the diffusion model family and rewrites the VAE choice (Qwen VAE for Anima/Qwen/WAN, Flux VAE for Flux/Klein, otherwise SDXL VAE) before saving.
+- **Artist gallery thumbnails in browser mode** — manifest URLs pointing at `cdn.mooshieblob.com` were blocked by CORS when MooshieUI is served from a different origin. The artist-gallery store now rewrites `imageBaseUrl` to `/internal-api/_cdn` in browser mode so all `<img>` tags load through the existing CDN proxy.
+
+### Internationalisation
+- **Setup wizard logo, title, and tagline keyed for i18n** — the last three hardcoded English strings on the first-run setup screen now use `setup.logo_alt`, `setup.title`, and `setup.subtitle`. The new `setup.logo_alt` key has been translated into all 11 supported locales.
+
+---
+
 ## What's New in v1.1.4
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v1.1.5
+
+### Bug Fixes
+- **Cancel actually cancels in multi-GPU mode** — clicking cancel previously only interrupted the first ComfyUI worker, so on multi-GPU deployments (e.g. `mooshieui.gpu.garden`) other workers kept running and the UI appeared to "switch between" two simultaneous generations. Cancellation is now worker-aware: the active prompt's worker is interrupted, the prompt is removed from that worker's pending queue, and `/free` is issued to flush VRAM. Held prompts that never reached ComfyUI are cancelled locally without an HTTP roundtrip.
+- **Split-model VAE auto-correction** — when an Anima/Qwen/WAN/Flux/Klein diffusion model was selected with a stale SDXL VAE in the persisted settings, generation produced a channel-mismatch error. Defaults application now detects the diffusion model family and rewrites the VAE choice (Qwen VAE for Anima/Qwen/WAN, Flux VAE for Flux/Klein, otherwise SDXL VAE) before saving.
+- **Artist gallery thumbnails in browser mode** — manifest URLs pointing at `cdn.mooshieblob.com` were blocked by CORS when MooshieUI is served from a different origin. The artist-gallery store now rewrites `imageBaseUrl` to `/internal-api/_cdn` in browser mode so all `<img>` tags load through the existing CDN proxy.
+
+### Internationalisation
+- **Setup wizard logo, title, and tagline keyed for i18n** — the last three hardcoded English strings on the first-run setup screen now use `setup.logo_alt`, `setup.title`, and `setup.subtitle`. The new `setup.logo_alt` key has been translated into all 11 supported locales.
+
+---
+
 ## What's New in v1.1.4
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -127,8 +127,11 @@ pub async fn get_history(
 
 #[cfg(feature = "desktop")]
 #[tauri::command]
-pub async fn interrupt_generation(state: State<'_, Arc<AppState>>) -> Result<(), AppError> {
-    state.interrupt().await
+pub async fn interrupt_generation(
+    state: State<'_, Arc<AppState>>,
+    prompt_id: Option<String>,
+) -> Result<(), AppError> {
+    state.interrupt_prompt(prompt_id.as_deref()).await
 }
 
 #[cfg(feature = "desktop")]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -407,6 +407,107 @@ impl AppState {
         config.server_url.clone()
     }
 
+    /// Cancel a generation in a worker-aware fashion.
+    ///
+    /// If `prompt_id` is `Some(id)`:
+    /// - Cancels the held prompt (if it never reached ComfyUI), OR
+    /// - Looks up which worker owns the prompt, interrupts that worker,
+    ///   and deletes the prompt from that worker's pending queue.
+    /// - Falls back to all-worker fanout if the prompt isn't tracked yet.
+    ///
+    /// If `prompt_id` is `None`, every running worker is interrupted.
+    /// In all cases, /free is issued on each affected worker to flush VRAM —
+    /// rapid interrupts on Blackwell GPUs with cudaMallocAsync can leave
+    /// VRAM in a corrupted state, producing all-black images on the next gen.
+    pub async fn interrupt_prompt(
+        &self,
+        prompt_id: Option<&str>,
+    ) -> Result<(), crate::error::AppError> {
+        // 1. If a specific prompt is being cancelled and it's still held
+        //    locally (never submitted to ComfyUI), cancel it there and stop.
+        if let Some(pid) = prompt_id {
+            let held_index = {
+                let held = self.prompt_queue.held.lock().unwrap();
+                held.iter().position(|hp| hp.placeholder_id == pid)
+            };
+            if let Some(idx) = held_index {
+                let hp = {
+                    let mut held = self.prompt_queue.held.lock().unwrap();
+                    held.remove(idx)
+                };
+                {
+                    let mut result = hp.result.lock().await;
+                    *result = Some(Err("Cancelled by user".to_string()));
+                }
+                hp.submitted.notify_one();
+                self.prompt_queue.remove(pid);
+                self.prompt_queue.drain_notify.notify_one();
+                self.broadcast_queue_positions();
+                return Ok(());
+            }
+        }
+
+        // 2. Decide which workers to hit.
+        //    - Specific prompt with a known worker → just that one.
+        //    - Otherwise → all running workers.
+        let target_worker_ids: Vec<u32> =
+            match prompt_id.and_then(|id| self.prompt_queue.worker_of(id)) {
+                Some(wid) => vec![wid],
+                None => self.gpu_manager.workers.iter().map(|w| w.id).collect(),
+            };
+
+        for wid in &target_worker_ids {
+            let _ = self.gpu_manager.interrupt(Some(*wid)).await;
+        }
+
+        // 3. Delete the specific prompt (and any aliases) from each targeted
+        //    worker's pending queue so it doesn't resume on requeue.
+        if let Some(pid) = prompt_id {
+            // Collect all known IDs for this prompt: the placeholder + any real
+            // ComfyUI ids aliased to it.
+            let mut ids_to_delete: Vec<String> = vec![pid.to_string()];
+            {
+                let aliases = self.prompt_queue.aliases.read().unwrap();
+                for (real_id, placeholder) in aliases.iter() {
+                    if placeholder == pid {
+                        ids_to_delete.push(real_id.clone());
+                    }
+                }
+            }
+
+            for wid in &target_worker_ids {
+                if let Some(worker) = self.gpu_manager.workers.get(*wid as usize) {
+                    let _ = self
+                        .http_client
+                        .post(format!("{}/queue", worker.base_url))
+                        .json(&serde_json::json!({ "delete": ids_to_delete }))
+                        .send()
+                        .await;
+                }
+            }
+
+            self.prompt_queue.remove(pid);
+            self.broadcast_queue_positions();
+        }
+
+        // 4. Flush VRAM on every targeted worker.
+        for wid in &target_worker_ids {
+            if let Some(worker) = self.gpu_manager.workers.get(*wid as usize) {
+                let _ = self
+                    .http_client
+                    .post(format!("{}/free", worker.base_url))
+                    .json(&serde_json::json!({
+                        "unload_models": true,
+                        "free_memory": true,
+                    }))
+                    .send()
+                    .await;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Broadcast an event to SSE clients.
     pub fn broadcast(&self, event: &str, payload: serde_json::Value) {
         let _ = self.event_tx.send(BroadcastEvent {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1762,7 +1762,13 @@ async fn dispatch_command(
             Ok(serde_json::json!({ "images": images }))
         }
         "interrupt_generation" => {
-            state.interrupt().await.map_err(|e| e.to_string())?;
+            // Optional: a specific placeholder prompt_id to cancel. If absent,
+            // every running worker is interrupted (legacy behaviour).
+            let prompt_id = args.get("promptId").and_then(|v| v.as_str());
+            state
+                .interrupt_prompt(prompt_id)
+                .await
+                .map_err(|e| e.to_string())?;
             Ok(serde_json::json!(null))
         }
         "clear_all_queues" => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -1,5 +1,6 @@
 import { createArtistGalleryClient } from "./client.js";
 import { cdnFetch } from "../utils/cdnFetch.js";
+import { isBrowserMode } from "../utils/ipc.js";
 import type {
   ArtistEntry,
   ArtistGalleryClient,
@@ -71,7 +72,21 @@ export class ArtistGalleryStore {
     this.manifestLoading = true;
     this.manifestError = null;
     try {
-      this.manifest = await this.client.loadManifest();
+      const manifest = await this.client.loadManifest();
+      // In browser/server mode, rewrite the manifest's `imageBaseUrl` so that
+      // image URLs used by `<img src>` and `imageCache.fetch()` go through the
+      // server's `/internal-api/_cdn/...` proxy. Otherwise the CDN's missing
+      // CORS headers block every fetch from the gallery's origin (e.g.
+      // `mooshieui.gpu.garden`). In Tauri mode the CDN is hit directly because
+      // image element loads bypass CORS and JSON fetches are routed through
+      // the `cdn_proxy_fetch` command.
+      if (isBrowserMode && manifest.imageBaseUrl?.startsWith("https://cdn.mooshieblob.com")) {
+        manifest.imageBaseUrl = manifest.imageBaseUrl.replace(
+          "https://cdn.mooshieblob.com",
+          "/internal-api/_cdn",
+        );
+      }
+      this.manifest = manifest;
       // Kick off the search index fetch early; it drives typeahead and getArtist fallback.
       this.client.loadSearchIndex().catch((err) => {
         console.error("artist-gallery: search index load failed", err);

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -115,7 +115,7 @@
   /** Left-click: cancel the current generation only, let the queue continue. */
   async function handleCancelCurrent() {
     const promptId = progress.activePromptId;
-    await interruptGeneration();
+    await interruptGeneration(promptId ?? undefined);
     if (promptId) progress.removePrompt(promptId);
   }
 
@@ -123,7 +123,8 @@
   async function handleCancelAll(e: MouseEvent) {
     e.preventDefault();
     const promptIds = progress.pendingPrompts.map((p) => p.promptId);
-    await interruptGeneration();
+    const activeId = progress.activePromptId;
+    await interruptGeneration(activeId ?? undefined);
     for (const pid of promptIds) {
       try { await deleteQueueItem(pid); } catch { /* already removed */ }
     }

--- a/src/lib/components/setup/SetupWizard.svelte
+++ b/src/lib/components/setup/SetupWizard.svelte
@@ -291,14 +291,14 @@
     <div class="text-center mb-8">
       <img
         src={logo}
-        alt="MooshieUI logo"
+        alt={locale.t('setup.logo_alt')}
         class="w-16 h-16 object-contain mx-auto mb-3 rounded-xl border border-neutral-700 bg-neutral-800/40 p-1"
       />
       <h1 class="text-4xl font-bold bg-linear-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
-        MooshieUI
+        {locale.t('setup.title')}
       </h1>
       <p class="text-neutral-400 mt-2 text-sm">
-        Beginner-friendly AI image generation
+        {locale.t('setup.subtitle')}
       </p>
     </div>
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -41,6 +41,7 @@ const de: Record<string, string> = {
   // ── Einrichtungsassistent ───────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "KI-Bilderzeugung für Einsteiger",
+  "setup.logo_alt": "MooshieUI-Logo",
   "setup.intro": "MooshieUI installiert automatisch alles Nötige (ComfyUI, Python und die passenden KI-Bibliotheken für Ihre Hardware). Keine manuelle Konfiguration erforderlich.",
   "setup.gpu_section": "Wählen Sie Ihren GPU-Typ:",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -42,6 +42,7 @@ const en: Record<string, string> = {
   // ── Setup Wizard ────────────────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "Beginner-friendly AI image generation",
+  "setup.logo_alt": "MooshieUI logo",
   "setup.intro": "MooshieUI will automatically install everything you need — ComfyUI, Python, and the right AI libraries for your hardware. No manual setup required.",
   "setup.gpu_section": "Select your GPU type:",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -41,6 +41,7 @@ const es: Record<string, string> = {
   // ── Asistente de instalación ────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "Generación de imágenes con IA para principiantes",
+  "setup.logo_alt": "Logotipo de MooshieUI",
   "setup.intro": "MooshieUI instalará automáticamente todo lo necesario — ComfyUI, Python y las bibliotecas de IA adecuadas para tu hardware. No requiere configuración manual.",
   "setup.gpu_section": "Selecciona tu tipo de GPU:",
   "setup.gpu.nvidia": "GPU NVIDIA (CUDA)",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -41,6 +41,7 @@ const fr: Record<string, string> = {
   // ── Assistant d'installation ────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "Génération d'images IA accessible à tous",
+  "setup.logo_alt": "Logo MooshieUI",
   "setup.intro": "MooshieUI installera automatiquement tout ce dont vous avez besoin — ComfyUI, Python et les bibliothèques IA adaptées à votre matériel. Aucune configuration manuelle requise.",
   "setup.gpu_section": "Sélectionnez votre type de GPU :",
   "setup.gpu.nvidia": "GPU NVIDIA (CUDA)",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -41,6 +41,7 @@ const it: Record<string, string> = {
   // ── Configurazione guidata ──────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "Generazione di immagini IA per principianti",
+  "setup.logo_alt": "Logo MooshieUI",
   "setup.intro": "MooshieUI installerà automaticamente tutto il necessario — ComfyUI, Python e le librerie IA appropriate per il tuo hardware. Nessuna configurazione manuale richiesta.",
   "setup.gpu_section": "Seleziona il tipo di GPU:",
   "setup.gpu.nvidia": "GPU NVIDIA (CUDA)",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -41,6 +41,7 @@ const ja: Record<string, string> = {
   // ── セットアップウィザード ──────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "初心者にやさしいAI画像生成",
+  "setup.logo_alt": "MooshieUI ロゴ",
   "setup.intro": "MooshieUIは必要なもの（ComfyUI、Python、お使いのハードウェアに最適なAIライブラリ）をすべて自動でインストールします。手動設定は不要です。",
   "setup.gpu_section": "GPUタイプを選択：",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -41,6 +41,7 @@ const ko: Record<string, string> = {
   // ── 설정 마법사 ─────────────────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "초보자를 위한 AI 이미지 생성",
+  "setup.logo_alt": "MooshieUI 로고",
   "setup.intro": "MooshieUI가 필요한 모든 것(ComfyUI, Python, 하드웨어에 맞는 AI 라이브러리)을 자동으로 설치합니다. 수동 설정이 필요 없습니다.",
   "setup.gpu_section": "GPU 유형을 선택하세요:",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -41,6 +41,7 @@ const pt: Record<string, string> = {
   // ── Assistente de Configuração ──────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "Geração de imagens com IA para iniciantes",
+  "setup.logo_alt": "Logotipo do MooshieUI",
   "setup.intro": "O MooshieUI instalará automaticamente tudo que você precisa — ComfyUI, Python e as bibliotecas de IA adequadas para o seu hardware. Nenhuma configuração manual necessária.",
   "setup.gpu_section": "Selecione o tipo da sua GPU:",
   "setup.gpu.nvidia": "GPU NVIDIA (CUDA)",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -41,6 +41,7 @@ const ru: Record<string, string> = {
   // ── Мастер установки ────────────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "ИИ-генерация изображений для начинающих",
+  "setup.logo_alt": "Логотип MooshieUI",
   "setup.intro": "MooshieUI автоматически установит всё необходимое — ComfyUI, Python и нужные ИИ-библиотеки для вашего оборудования. Ручная настройка не требуется.",
   "setup.gpu_section": "Выберите тип вашей видеокарты:",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -41,6 +41,7 @@ const zhTw: Record<string, string> = {
   // ── 安裝精靈 ────────────────────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "初學者專用 AI 影像生成",
+  "setup.logo_alt": "MooshieUI 標誌",
   "setup.intro": "MooshieUI 將自動安裝所有必要元件（ComfyUI、Python 以及適合您硬體的 AI 函式庫）。無需手動設定。",
   "setup.gpu_section": "選擇您的 GPU 類型：",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -41,6 +41,7 @@ const zh: Record<string, string> = {
   // ── 安装向导 ────────────────────────────────────────────
   "setup.title": "MooshieUI",
   "setup.subtitle": "面向初学者的 AI 图像生成平台",
+  "setup.logo_alt": "MooshieUI 徽标",
   "setup.intro": "MooshieUI 将自动安装所有必需组件（ComfyUI、Python 以及适合您硬件的 AI 库）。无需手动配置。",
   "setup.gpu_section": "选择您的 GPU 类型：",
   "setup.gpu.nvidia": "NVIDIA GPU (CUDA)",

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -40,6 +40,31 @@ function translateNaiWeightSyntax(prompt: string): string {
   return prompt;
 }
 
+/**
+ * Pick the right VAE filename for a split-model setup based on the diffusion
+ * model name. Anima/Qwen produces 16-channel latents and needs `qwen_image_vae`;
+ * Flux 2 / Klein needs the Flux VAE. Falls back to SDXL VAE only as a last
+ * resort. Returning a wrong VAE here is what causes
+ * `expected input[…, 16, …] to have 4 channels` at decode time.
+ */
+function pickSplitModelVae(diffusionModel: string | null, vaes: string[]): string {
+  if (vaes.length === 0) return "";
+  const dm = (diffusionModel ?? "").toLowerCase();
+  const looksAnimaOrQwen =
+    dm.includes("anima") || dm.includes("qwen") || dm.includes("wan");
+  const looksFlux = dm.includes("flux") || dm.includes("klein");
+
+  if (looksAnimaOrQwen) {
+    const qwen = vaes.find((v) => v.toLowerCase().includes("qwen"));
+    if (qwen) return qwen;
+  }
+  if (looksFlux) {
+    const flux = vaes.find((v) => v.toLowerCase().includes("flux"));
+    if (flux) return flux;
+  }
+  return vaes.find((v) => v.toLowerCase().includes("sdxl_vae")) ?? vaes[0];
+}
+
 type StylePresetId = "none" | "anime" | "cinematic" | "photoreal" | "digital_art" | "line_art";
 
 interface StylePreset {
@@ -1065,9 +1090,29 @@ class GenerationStore {
   applyDefaultsIfNeeded(checkpoints: string[], vaes: string[]) {
     // Always fix empty VAE for split-model users — VAELoader requires a real file.
     // This covers existing users whose saved settings pre-date the VAE field.
-    if (this.useSplitModel && !this.vae && vaes.length > 0) {
-      this.vae = vaes.find((v) => v.includes("sdxl_vae")) ?? vaes[0];
-      this.saveSettings();
+    // Pick a VAE that matches the diffusion model's latent channel layout, NOT
+    // the SDXL 4-channel VAE (which would crash VAEDecode with a channel
+    // mismatch on Anima/Qwen/Flux split models that produce 16-channel latents).
+    if (this.useSplitModel && vaes.length > 0) {
+      const desired = pickSplitModelVae(this.diffusionModel, vaes);
+      // Auto-correct an obvious 4-ch ↔ 16-ch latent mismatch: an Anima/Qwen/Flux
+      // split model paired with sdxl_vae cannot decode (4-channel VAE vs
+      // 16-channel latent). Force the matching VAE so generation succeeds.
+      const dm = (this.diffusionModel ?? "").toLowerCase();
+      const needs16ch =
+        dm.includes("anima") ||
+        dm.includes("qwen") ||
+        dm.includes("wan") ||
+        dm.includes("flux") ||
+        dm.includes("klein");
+      const currentVae = (this.vae ?? "").toLowerCase();
+      const currentIsSdxl = currentVae.includes("sdxl_vae");
+      if (!this.vae || (needs16ch && currentIsSdxl)) {
+        if (desired && desired !== this.vae) {
+          this.vae = desired;
+          this.saveSettings();
+        }
+      }
     }
     if (this.checkpoint) return;
 

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -50,8 +50,8 @@ export async function getQueue(): Promise<QueueInfo> {
   return ipcInvoke("get_queue");
 }
 
-export async function interruptGeneration(): Promise<void> {
-  return ipcInvoke("interrupt_generation");
+export async function interruptGeneration(promptId?: string): Promise<void> {
+  return ipcInvoke("interrupt_generation", promptId ? { promptId } : {});
 }
 
 export async function deleteQueueItem(promptId: string): Promise<void> {


### PR DESCRIPTION
## What's New in v1.1.5

### Bug Fixes
- **Cancel actually cancels in multi-GPU mode** — clicking cancel previously only interrupted the first ComfyUI worker, so on multi-GPU deployments (e.g. `mooshieui.gpu.garden`) other workers kept running and the UI appeared to "switch between" two simultaneous generations. Cancellation is now worker-aware: the active prompt's worker is interrupted, the prompt is removed from that worker's pending queue, and `/free` is issued to flush VRAM. Held prompts that never reached ComfyUI are cancelled locally without an HTTP roundtrip.
- **Split-model VAE auto-correction** — when an Anima/Qwen/WAN/Flux/Klein diffusion model was selected with a stale SDXL VAE in the persisted settings, generation produced a channel-mismatch error. Defaults application now detects the diffusion model family and rewrites the VAE choice (Qwen VAE for Anima/Qwen/WAN, Flux VAE for Flux/Klein, otherwise SDXL VAE) before saving.
- **Artist gallery thumbnails in browser mode** — manifest URLs pointing at `cdn.mooshieblob.com` were blocked by CORS when MooshieUI is served from a different origin. The artist-gallery store now rewrites `imageBaseUrl` to `/internal-api/_cdn` in browser mode so all `<img>` tags load through the existing CDN proxy.

### Internationalisation
- **Setup wizard logo, title, and tagline keyed for i18n** — the last three hardcoded English strings on the first-run setup screen now use `setup.logo_alt`, `setup.title`, and `setup.subtitle`. The new `setup.logo_alt` key has been translated into all 11 supported locales.
