### PR TITLE
v1.1.6: route model/sampler/embedding queries through GpuManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## What's New in v1.1.6
+
+### Bug Fixes
+- **Multi-GPU model/sampler/embedding queries no longer 500** — `AppState::api_get` and `api_post` previously hit the configured `server_url` (default `127.0.0.1:8188`), which in multi-GPU server-mode deployments doesn't host ComfyUI — workers run on per-GPU ports listed in `gpu_workers`. Read-only API calls now delegate to `GpuManager`, which dispatches to the first ready worker. This fixes the recurring `/internal-api/get_models` 500s and the `/object_info/*` lookups used by the dynamic node introspector.
+
 ## What's New in v1.1.5
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.1.6
+
+### Bug Fixes
+- **Multi-GPU model/sampler/embedding queries no longer 500** — `AppState::api_get` and `api_post` previously hit the configured `server_url` (default `127.0.0.1:8188`), which in multi-GPU server-mode deployments doesn't host ComfyUI — workers run on per-GPU ports listed in `gpu_workers`. Read-only API calls now delegate to `GpuManager`, which dispatches to the first ready worker. This fixes the recurring `/internal-api/get_models` 500s and the `/object_info/*` lookups used by the dynamic node introspector.
+
+---
+
 ## What's New in v1.1.5
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.5"
+version = "1.1.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -25,31 +25,17 @@ pub fn sha256_file(path: &std::path::Path) -> Result<String, AppError> {
 
 impl AppState {
     pub async fn api_get(&self, path: &str) -> Result<Value, AppError> {
-        let url = format!("{}{}", self.base_url().await, path);
-        let resp = self.http_client.get(&url).send().await?;
-        if !resp.status().is_success() {
-            return Err(AppError::ApiError {
-                status: resp.status().as_u16(),
-                message: resp.text().await.unwrap_or_default(),
-            });
-        }
-        Ok(resp.json().await?)
+        // Delegate to the GPU manager so the request is dispatched to a real
+        // worker port. The legacy single-`server_url` path was broken in
+        // multi-GPU server-mode deployments where `server_url` (default
+        // 127.0.0.1:8188) doesn't actually host ComfyUI — workers run on
+        // 8188, 8189, … per `gpu_workers` config — causing /models, /samplers
+        // and /embeddings to 500 with connection-refused.
+        self.gpu_manager.api_get(path).await
     }
 
     pub async fn api_post(&self, path: &str, body: &Value) -> Result<Value, AppError> {
-        let url = format!("{}{}", self.base_url().await, path);
-        let resp = self.http_client.post(&url).json(body).send().await?;
-        if !resp.status().is_success() {
-            return Err(AppError::ApiError {
-                status: resp.status().as_u16(),
-                message: resp.text().await.unwrap_or_default(),
-            });
-        }
-        let text = resp.text().await?;
-        if text.trim().is_empty() {
-            return Ok(Value::Null);
-        }
-        Ok(serde_json::from_str(&text)?)
+        self.gpu_manager.api_post(path, body).await
     }
 
     pub async fn get_models_list(&self, category: &str) -> Result<Vec<String>, AppError> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Fixes the recurring `/internal-api/get_models` 500 errors observed at `mooshieui.gpu.garden`.

`AppState::api_get` and `api_post` previously hit the configured `server_url` (default `127.0.0.1:8188`), which in multi-GPU server-mode deployments doesn't host ComfyUI — workers run on per-GPU ports listed in `gpu_workers`. Read-only API calls now delegate to `GpuManager`, which dispatches to the first ready worker.

This automatically fixes:
- `/models/*` (model lists per category)
- `/object_info/*` (samplers, schedulers, dynamic node introspection)
- `/embeddings`
- `/history/*`
- `/queue` (read + delete)
- `/system_stats`
- `/prompt` (queue) and `/interrupt` legacy POSTs

## Test Plan
- `cargo check --features server` ✅
- `cargo check --features desktop` ✅
- `cargo clippy --features desktop` — no new warnings on `client.rs` ✅
- `npm run build` ✅