### PR TITLE
v1.1.7: improve generation reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## What's New in v1.1.7
+
+### Generation Reliability
+- **Recover from ComfyUI WebSocket drops** — the Tauri, browser/SSE, and per-worker WebSocket bridges now reconnect with backoff instead of exiting permanently. If a prompt finishes while the socket is down, MooshieUI checks ComfyUI history and emits a synthetic completion event so the UI can finalize the image instead of hanging.
+
+### Cancel & Queue Fixes
+- **Cancel releases multi-GPU workers cleanly** — cancelling a generation now removes the prompt from internal queue tracking, deletes placeholder and real ComfyUI prompt IDs from every worker queue, interrupts/frees the affected worker, and marks it idle so the next generation does not briefly sit behind a stale cancelled prompt.
+- **Cancel-before-active race fixed** — clicking cancel before ComfyUI reports an active prompt now targets the first pending prompt, covering the fast cancel-and-requeue path.
+
+### Internationalisation
+- **Generation error toasts use locale keys** — generation failure, model/VAE configuration, detailed error, and cancellation messages now route through the locale system across all supported languages.
+- **Locale duplicate-key cleanup** — duplicate bottom-panel/gallery locale stubs were removed while preserving translated bottom-panel tab labels.
+
+---
+
 ## What's New in v1.1.6
 
 ### Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## What's New in v1.1.7
+
+### Generation Reliability
+- **Recover from ComfyUI WebSocket drops** — the Tauri, browser/SSE, and per-worker WebSocket bridges now reconnect with backoff instead of exiting permanently. If a prompt finishes while the socket is down, MooshieUI checks ComfyUI history and emits a synthetic completion event so the UI can finalize the image instead of hanging.
+
+### Cancel & Queue Fixes
+- **Cancel releases multi-GPU workers cleanly** — cancelling a generation now removes the prompt from internal queue tracking, deletes placeholder and real ComfyUI prompt IDs from every worker queue, interrupts/frees the affected worker, and marks it idle so the next generation does not briefly sit behind a stale cancelled prompt.
+- **Cancel-before-active race fixed** — clicking cancel before ComfyUI reports an active prompt now targets the first pending prompt, covering the fast cancel-and-requeue path.
+
+### Internationalisation
+- **Generation error toasts use locale keys** — generation failure, model/VAE configuration, detailed error, and cancellation messages now route through the locale system across all supported languages.
+- **Locale duplicate-key cleanup** — duplicate bottom-panel/gallery locale stubs were removed while preserving translated bottom-panel tab labels.
+
+---
+
 ## What's New in v1.1.6
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-desktop",
-  "version": "0.9.7",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "0.9.7",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.6"
+version = "1.1.7"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -189,8 +189,28 @@ impl AppState {
     }
 
     pub async fn delete_queue_items(&self, ids: Vec<String>) -> Result<(), AppError> {
-        self.api_post("/queue", &serde_json::json!({ "delete": ids }))
-            .await?;
+        let mut ids_to_delete: Vec<String> = Vec::new();
+        for id in ids {
+            for related_id in self.prompt_queue.cancel_and_remove(&id) {
+                if !ids_to_delete.iter().any(|existing| existing == &related_id) {
+                    ids_to_delete.push(related_id);
+                }
+            }
+        }
+
+        if !ids_to_delete.is_empty() {
+            for worker in &self.gpu_manager.workers {
+                let _ = self
+                    .http_client
+                    .post(format!("{}/queue", worker.base_url))
+                    .json(&serde_json::json!({ "delete": ids_to_delete }))
+                    .send()
+                    .await;
+            }
+        }
+
+        self.broadcast_queue_positions();
+        self.prompt_queue.drain_notify.notify_one();
         Ok(())
     }
 

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -228,46 +228,141 @@ pub async fn connect_websocket(
                     payload: sse_payload,
                 });
             };
-        let result = connect_async(&ws_url).await;
-        let (ws_stream, _) = match result {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("WebSocket connection failed: {}", e);
-                emit(
-                    "comfyui:connection",
-                    serde_json::json!({"connected": false}),
-                );
-                return;
-            }
-        };
-
-        emit("comfyui:connection", serde_json::json!({"connected": true}));
-
-        let (_, mut read) = ws_stream.split();
+        // Persist across reconnects so we can detect prompts that completed
+        // while the WebSocket was down and emit a synthetic completion event.
         let mut current_prompt_id: Option<String> = None;
+        let mut backoff_ms: u64 = 0;
 
-        while let Some(msg) = read.next().await {
-            match msg {
-                Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
-                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
-                        let event_type = parsed["type"].as_str().unwrap_or("unknown");
-                        let data = &parsed["data"];
+        'reconnect: loop {
+            if backoff_ms > 0 {
+                log::info!("WebSocket reconnecting in {} ms", backoff_ms);
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
 
-                        if let Some(prompt_id) = data["prompt_id"].as_str() {
-                            match event_type {
-                                "execution_start" => {
-                                    current_prompt_id = Some(prompt_id.to_string());
-                                }
-                                "executing" => {
-                                    if data["node"].is_null() {
-                                        if current_prompt_id.as_deref() == Some(prompt_id) {
-                                            current_prompt_id = None;
+                // If a prompt was mid-execution when we disconnected, query
+                // /history/{prompt_id} — if it landed there, it completed
+                // during the gap and we lost the terminal `executing { node: null }`
+                // event. Emit a synthetic one so the frontend can finalize.
+                if let Some(pid) = current_prompt_id.clone() {
+                    match ws_state.get_history_for(&pid).await {
+                        Ok(history) => {
+                            let completed =
+                                history.get(&pid).map(|v| !v.is_null()).unwrap_or(false);
+                            if completed {
+                                log::warn!(
+                                    "Prompt {} completed during WS disconnect — emitting synthetic completion",
+                                    pid
+                                );
+                                emit(
+                                    "comfyui:executing",
+                                    serde_json::json!({"node": null, "prompt_id": pid}),
+                                );
+                                current_prompt_id = None;
+                            }
+                        }
+                        Err(e) => log::warn!("History query for {} failed: {}", pid, e),
+                    }
+                }
+            }
+
+            let result = connect_async(&ws_url).await;
+            let (ws_stream, _) = match result {
+                Ok(s) => {
+                    backoff_ms = 0;
+                    s
+                }
+                Err(e) => {
+                    log::error!("WebSocket connection failed: {}", e);
+                    emit(
+                        "comfyui:connection",
+                        serde_json::json!({"connected": false}),
+                    );
+                    backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
+                    continue 'reconnect;
+                }
+            };
+
+            emit("comfyui:connection", serde_json::json!({"connected": true}));
+
+            let (_, mut read) = ws_stream.split();
+
+            while let Some(msg) = read.next().await {
+                match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                            let event_type = parsed["type"].as_str().unwrap_or("unknown");
+                            let data = &parsed["data"];
+
+                            if let Some(prompt_id) = data["prompt_id"].as_str() {
+                                match event_type {
+                                    "execution_start" => {
+                                        current_prompt_id = Some(prompt_id.to_string());
+                                    }
+                                    "executing" => {
+                                        if data["node"].is_null() {
+                                            if current_prompt_id.as_deref() == Some(prompt_id) {
+                                                current_prompt_id = None;
+                                            }
+                                            // Prompt completed — release GPU worker and clean up
+                                            // the internal queue. In browser mode this is done by
+                                            // the cleanup reactor in webserver.rs; in Tauri desktop
+                                            // mode we must do it here so the worker becomes available
+                                            // for the next generation.
+                                            let resolved =
+                                                ws_state.prompt_queue.resolve_alias(prompt_id);
+                                            let wid = ws_state.prompt_queue.finish(&resolved);
+                                            let alias_state = Arc::clone(&ws_state);
+                                            let alias_pid = resolved.clone();
+                                            tokio::spawn(async move {
+                                                tokio::time::sleep(std::time::Duration::from_secs(
+                                                    5,
+                                                ))
+                                                .await;
+                                                alias_state.prompt_queue.cleanup_alias(&alias_pid);
+                                            });
+                                            if let Some(worker_id) = wid {
+                                                ws_state
+                                                    .gpu_manager
+                                                    .mark_worker_idle(worker_id)
+                                                    .await;
+                                            }
+                                            ws_state.prompt_queue.drain_notify.notify_one();
+                                            // Broadcast updated queue positions to the Tauri
+                                            // frontend. broadcast_queue_positions() uses event_tx
+                                            // (SSE-only); we must call app.emit() directly here.
+                                            let updates: Vec<serde_json::Value> = {
+                                                let queue =
+                                                    ws_state.prompt_queue.queue.read().unwrap();
+                                                let total = queue.len();
+                                                queue
+                                                    .iter()
+                                                    .enumerate()
+                                                    .map(|(pos, (pid, _))| {
+                                                        serde_json::json!({
+                                                            "prompt_id": pid,
+                                                            "position": pos,
+                                                            "total": total,
+                                                        })
+                                                    })
+                                                    .collect()
+                                            };
+                                            if updates.is_empty() {
+                                                emit(
+                                                    "mooshie:queue_update",
+                                                    serde_json::json!({ "total": 0_u32 }),
+                                                );
+                                            } else {
+                                                for payload in updates {
+                                                    emit("mooshie:queue_update", payload);
+                                                }
+                                            }
+                                        } else {
+                                            current_prompt_id = Some(prompt_id.to_string());
                                         }
-                                        // Prompt completed — release GPU worker and clean up
-                                        // the internal queue. In browser mode this is done by
-                                        // the cleanup reactor in webserver.rs; in Tauri desktop
-                                        // mode we must do it here so the worker becomes available
-                                        // for the next generation.
+                                    }
+                                    "execution_error" => {
+                                        // Prompt failed — release GPU worker so the next generation
+                                        // can proceed. Without this the worker stays in Running state
+                                        // and submit_prompt blocks for 300 s before timing out.
                                         let resolved =
                                             ws_state.prompt_queue.resolve_alias(prompt_id);
                                         let wid = ws_state.prompt_queue.finish(&resolved);
@@ -279,268 +374,223 @@ pub async fn connect_websocket(
                                             alias_state.prompt_queue.cleanup_alias(&alias_pid);
                                         });
                                         if let Some(worker_id) = wid {
-                                            ws_state.gpu_manager.mark_worker_idle(worker_id).await;
+                                            ws_state
+                                                .gpu_manager
+                                                .mark_worker_error_then_idle(worker_id)
+                                                .await;
                                         }
                                         ws_state.prompt_queue.drain_notify.notify_one();
-                                        // Broadcast updated queue positions to the Tauri
-                                        // frontend. broadcast_queue_positions() uses event_tx
-                                        // (SSE-only); we must call app.emit() directly here.
-                                        let updates: Vec<serde_json::Value> = {
-                                            let queue = ws_state.prompt_queue.queue.read().unwrap();
-                                            let total = queue.len();
-                                            queue
-                                                .iter()
-                                                .enumerate()
-                                                .map(|(pos, (pid, _))| {
-                                                    serde_json::json!({
-                                                        "prompt_id": pid,
-                                                        "position": pos,
-                                                        "total": total,
-                                                    })
-                                                })
-                                                .collect()
-                                        };
-                                        if updates.is_empty() {
-                                            emit(
-                                                "mooshie:queue_update",
-                                                serde_json::json!({ "total": 0_u32 }),
-                                            );
-                                        } else {
-                                            for payload in updates {
-                                                emit("mooshie:queue_update", payload);
-                                            }
-                                        }
-                                    } else {
-                                        current_prompt_id = Some(prompt_id.to_string());
+                                        // Signal frontend that queue has been cleared.
+                                        emit(
+                                            "mooshie:queue_update",
+                                            serde_json::json!({ "total": 0_u32 }),
+                                        );
                                     }
+                                    _ => {}
                                 }
-                                "execution_error" => {
-                                    // Prompt failed — release GPU worker so the next generation
-                                    // can proceed. Without this the worker stays in Running state
-                                    // and submit_prompt blocks for 300 s before timing out.
-                                    let resolved = ws_state.prompt_queue.resolve_alias(prompt_id);
-                                    let wid = ws_state.prompt_queue.finish(&resolved);
-                                    let alias_state = Arc::clone(&ws_state);
-                                    let alias_pid = resolved.clone();
-                                    tokio::spawn(async move {
-                                        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                                        alias_state.prompt_queue.cleanup_alias(&alias_pid);
-                                    });
-                                    if let Some(worker_id) = wid {
-                                        ws_state
-                                            .gpu_manager
-                                            .mark_worker_error_then_idle(worker_id)
-                                            .await;
-                                    }
-                                    ws_state.prompt_queue.drain_notify.notify_one();
-                                    // Signal frontend that queue has been cleared.
-                                    emit(
-                                        "mooshie:queue_update",
-                                        serde_json::json!({ "total": 0_u32 }),
-                                    );
-                                }
-                                _ => {}
                             }
+
+                            let event_name = format!("comfyui:{}", event_type);
+                            emit(&event_name, data.clone());
+                        }
+                    }
+                    Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
+                        if data.len() < 4 {
+                            continue;
+                        }
+                        let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+
+                        // Skip binary events if we don't know which prompt they belong to
+                        // (prevents cross-user event leaking via SSE)
+                        if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
+                            continue;
                         }
 
-                        let event_name = format!("comfyui:{}", event_type);
-                        emit(&event_name, data.clone());
-                    }
-                }
-                Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
-                    if data.len() < 4 {
-                        continue;
-                    }
-                    let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-
-                    // Skip binary events if we don't know which prompt they belong to
-                    // (prevents cross-user event leaking via SSE)
-                    if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
-                        continue;
-                    }
-
-                    match event_type {
-                        1 | 2 => {
-                            // PREVIEW_IMAGE or UNENCODED_PREVIEW_IMAGE
-                            // Bytes 4-7: image format (1=JPEG, 2=PNG)
-                            // Bytes 8+: image data
-                            if data.len() < 8 {
-                                continue;
-                            }
-                            let format_type =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
-                            let format = if format_type == 2 { "png" } else { "jpeg" };
-                            let ext = if format_type == 2 { "png" } else { "jpg" };
-                            let image_data = &data[8..];
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
-
-                            // Tauri: inline base64 (fast, in-process)
-                            let b64 = base64::engine::general_purpose::STANDARD.encode(image_data);
-                            let tauri_payload = serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str });
-
-                            // SSE: save to temp file, send reference
-                            let sse_payload = if let Some(temp_filename) =
-                                crate::temp_images::save(image_data, ext)
-                            {
-                                serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
-                            } else {
-                                tauri_payload.clone() // fallback to inline
-                            };
-
-                            emit_split("comfyui:preview", tauri_payload, sse_payload);
-                        }
-                        4 => {
-                            // PREVIEW_IMAGE_WITH_METADATA
-                            if data.len() < 8 {
-                                continue;
-                            }
-                            let meta_len =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
-                            let image_start = 8 + meta_len;
-                            if image_start < data.len() {
-                                let image_data = &data[image_start..];
+                        match event_type {
+                            1 | 2 => {
+                                // PREVIEW_IMAGE or UNENCODED_PREVIEW_IMAGE
+                                // Bytes 4-7: image format (1=JPEG, 2=PNG)
+                                // Bytes 8+: image data
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let format_type =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+                                let format = if format_type == 2 { "png" } else { "jpeg" };
+                                let ext = if format_type == 2 { "png" } else { "jpg" };
+                                let image_data = &data[8..];
                                 let prompt_id_str = current_prompt_id.as_deref().unwrap();
 
+                                // Tauri: inline base64 (fast, in-process)
                                 let b64 =
                                     base64::engine::general_purpose::STANDARD.encode(image_data);
-                                let tauri_payload = serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str });
+                                let tauri_payload = serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str });
 
+                                // SSE: save to temp file, send reference
                                 let sse_payload = if let Some(temp_filename) =
-                                    crate::temp_images::save(image_data, "jpg")
+                                    crate::temp_images::save(image_data, ext)
                                 {
-                                    serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
                                 } else {
-                                    tauri_payload.clone()
+                                    tauri_payload.clone() // fallback to inline
                                 };
 
                                 emit_split("comfyui:preview", tauri_payload, sse_payload);
                             }
-                        }
-                        100 => {
-                            // MOOSHIE_OUTPUT_IMAGE — use shared processing function
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
-                            let img = match process_output_image(&data).await {
-                                Some(img) => img,
-                                None => continue,
-                            };
+                            4 => {
+                                // PREVIEW_IMAGE_WITH_METADATA
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let meta_len =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]])
+                                        as usize;
+                                let image_start = 8 + meta_len;
+                                if image_start < data.len() {
+                                    let image_data = &data[image_start..];
+                                    let prompt_id_str = current_prompt_id.as_deref().unwrap();
 
-                            // Save canonical image to temp dir.
-                            let temp_filename = crate::temp_images::save(&img.image_bytes, img.ext);
+                                    let b64 = base64::engine::general_purpose::STANDARD
+                                        .encode(image_data);
+                                    let tauri_payload = serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str });
 
-                            // For JXL: save the display copy (WebP/PNG) as a second temp file.
-                            let display_temp_filename: Option<String> = if img.format == "jxl" {
-                                img.display_bytes.as_ref().and_then(|db| {
-                                    let ext = if img.display_format == "webp" {
-                                        "webp"
+                                    let sse_payload = if let Some(temp_filename) =
+                                        crate::temp_images::save(image_data, "jpg")
+                                    {
+                                        serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
                                     } else {
-                                        "png"
+                                        tauri_payload.clone()
                                     };
-                                    crate::temp_images::save(db, ext)
-                                })
-                            } else {
-                                None
-                            };
 
-                            log::info!(
+                                    emit_split("comfyui:preview", tauri_payload, sse_payload);
+                                }
+                            }
+                            100 => {
+                                // MOOSHIE_OUTPUT_IMAGE — use shared processing function
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                let img = match process_output_image(&data).await {
+                                    Some(img) => img,
+                                    None => continue,
+                                };
+
+                                // Save canonical image to temp dir.
+                                let temp_filename =
+                                    crate::temp_images::save(&img.image_bytes, img.ext);
+
+                                // For JXL: save the display copy (WebP/PNG) as a second temp file.
+                                let display_temp_filename: Option<String> = if img.format == "jxl" {
+                                    img.display_bytes.as_ref().and_then(|db| {
+                                        let ext = if img.display_format == "webp" {
+                                            "webp"
+                                        } else {
+                                            "png"
+                                        };
+                                        crate::temp_images::save(db, ext)
+                                    })
+                                } else {
+                                    None
+                                };
+
+                                log::info!(
                                 "output_image: format={} jxl_temp={:?} display_temp={:?} display_fmt={} bytes={} display_bytes={}",
                                 img.format, temp_filename, display_temp_filename, img.display_format,
                                 img.image_bytes.len(),
                                 img.display_bytes.as_ref().map(|d| d.len()).unwrap_or(0),
                             );
 
-                            // Tauri desktop: reference temp files only (no inline base64).
-                            // app.emit() silently drops events exceeding ~1-2 MB.
-                            let tauri_payload = if img.format == "jxl" {
-                                match (temp_filename.as_ref(), display_temp_filename.as_ref()) {
-                                    (Some(jxl_f), Some(disp_f)) => serde_json::json!({
-                                        "temp_filename": jxl_f,
-                                        "display_temp_filename": disp_f,
-                                        "format": "jxl",
-                                        "display_format": img.display_format,
-                                        "bit_depth": img.bit_depth,
-                                        "image_bytes": img.image_bytes.len(),
-                                        "encode_ms": img.encode_ms,
-                                        "prompt_id": prompt_id_str,
-                                    }),
-                                    (Some(jxl_f), None) => serde_json::json!({
-                                        "temp_filename": jxl_f,
-                                        "format": "jxl",
-                                        "bit_depth": img.bit_depth,
-                                        "image_bytes": img.image_bytes.len(),
-                                        "encode_ms": img.encode_ms,
-                                        "prompt_id": prompt_id_str,
-                                    }),
-                                    _ => {
-                                        let b64 = base64::engine::general_purpose::STANDARD
-                                            .encode(&img.image_bytes);
-                                        serde_json::json!({
-                                            "jxl_image": b64,
+                                // Tauri desktop: reference temp files only (no inline base64).
+                                // app.emit() silently drops events exceeding ~1-2 MB.
+                                let tauri_payload = if img.format == "jxl" {
+                                    match (temp_filename.as_ref(), display_temp_filename.as_ref()) {
+                                        (Some(jxl_f), Some(disp_f)) => serde_json::json!({
+                                            "temp_filename": jxl_f,
+                                            "display_temp_filename": disp_f,
+                                            "format": "jxl",
+                                            "display_format": img.display_format,
+                                            "bit_depth": img.bit_depth,
+                                            "image_bytes": img.image_bytes.len(),
+                                            "encode_ms": img.encode_ms,
+                                            "prompt_id": prompt_id_str,
+                                        }),
+                                        (Some(jxl_f), None) => serde_json::json!({
+                                            "temp_filename": jxl_f,
                                             "format": "jxl",
                                             "bit_depth": img.bit_depth,
                                             "image_bytes": img.image_bytes.len(),
                                             "encode_ms": img.encode_ms,
                                             "prompt_id": prompt_id_str,
-                                        })
+                                        }),
+                                        _ => {
+                                            let b64 = base64::engine::general_purpose::STANDARD
+                                                .encode(&img.image_bytes);
+                                            serde_json::json!({
+                                                "jxl_image": b64,
+                                                "format": "jxl",
+                                                "bit_depth": img.bit_depth,
+                                                "image_bytes": img.image_bytes.len(),
+                                                "encode_ms": img.encode_ms,
+                                                "prompt_id": prompt_id_str,
+                                            })
+                                        }
                                     }
-                                }
-                            } else if let Some(ref tf) = temp_filename {
-                                serde_json::json!({
-                                    "temp_filename": tf,
-                                    "format": img.format,
-                                    "bit_depth": img.bit_depth,
-                                    "image_bytes": img.image_bytes.len(),
-                                    "encode_ms": img.encode_ms,
-                                    "prompt_id": prompt_id_str,
-                                })
-                            } else {
-                                let b64 = base64::engine::general_purpose::STANDARD
-                                    .encode(&img.image_bytes);
-                                serde_json::json!({
-                                    "image": b64,
-                                    "format": img.format,
-                                    "bit_depth": img.bit_depth,
-                                    "image_bytes": img.image_bytes.len(),
-                                    "encode_ms": img.encode_ms,
-                                    "prompt_id": prompt_id_str,
-                                })
-                            };
+                                } else if let Some(ref tf) = temp_filename {
+                                    serde_json::json!({
+                                        "temp_filename": tf,
+                                        "format": img.format,
+                                        "bit_depth": img.bit_depth,
+                                        "image_bytes": img.image_bytes.len(),
+                                        "encode_ms": img.encode_ms,
+                                        "prompt_id": prompt_id_str,
+                                    })
+                                } else {
+                                    let b64 = base64::engine::general_purpose::STANDARD
+                                        .encode(&img.image_bytes);
+                                    serde_json::json!({
+                                        "image": b64,
+                                        "format": img.format,
+                                        "bit_depth": img.bit_depth,
+                                        "image_bytes": img.image_bytes.len(),
+                                        "encode_ms": img.encode_ms,
+                                        "prompt_id": prompt_id_str,
+                                    })
+                                };
 
-                            // SSE payload: always use temp filename
-                            let sse_payload = if let Some(name) = temp_filename {
-                                serde_json::json!({
-                                    "temp_filename": name,
-                                    "format": img.format,
-                                    "bit_depth": img.bit_depth,
-                                    "image_bytes": img.image_bytes.len(),
-                                    "encode_ms": img.encode_ms,
-                                    "prompt_id": prompt_id_str,
-                                })
-                            } else {
-                                tauri_payload.clone()
-                            };
+                                // SSE payload: always use temp filename
+                                let sse_payload = if let Some(name) = temp_filename {
+                                    serde_json::json!({
+                                        "temp_filename": name,
+                                        "format": img.format,
+                                        "bit_depth": img.bit_depth,
+                                        "image_bytes": img.image_bytes.len(),
+                                        "encode_ms": img.encode_ms,
+                                        "prompt_id": prompt_id_str,
+                                    })
+                                } else {
+                                    tauri_payload.clone()
+                                };
 
-                            emit_split("comfyui:output_image", tauri_payload, sse_payload);
+                                emit_split("comfyui:output_image", tauri_payload, sse_payload);
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
+                    Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
+                        log::warn!("WebSocket closed by server — will reconnect");
+                        break;
+                    }
+                    Err(e) => {
+                        log::error!("WebSocket error: {} — will reconnect", e);
+                        break;
+                    }
+                    _ => {}
                 }
-                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false}),
-                    );
-                    break;
-                }
-                Err(e) => {
-                    log::error!("WebSocket error: {}", e);
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false}),
-                    );
-                    break;
-                }
-                _ => {}
             }
+
+            emit(
+                "comfyui:connection",
+                serde_json::json!({"connected": false}),
+            );
+            backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
         }
     });
 
@@ -552,7 +602,7 @@ pub async fn connect_websocket(
 /// Events are only sent to the broadcast channel (SSE clients).
 /// Handles prompt queue cleanup on completion/error for multi-user isolation.
 pub async fn connect_websocket_headless(
-    state: &AppState,
+    state: &Arc<AppState>,
     event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
 ) -> Result<(), AppError> {
     // Disconnect existing
@@ -569,6 +619,7 @@ pub async fn connect_websocket_headless(
     let ws_url = format!("{}/ws?clientId={}", ws_url, client_id);
 
     let tx = event_tx.clone();
+    let ws_state = Arc::clone(state);
 
     let task = tokio::spawn(async move {
         let emit = |event: &str, payload: serde_json::Value| {
@@ -577,138 +628,172 @@ pub async fn connect_websocket_headless(
                 payload,
             });
         };
-        let result = connect_async(&ws_url).await;
-        let (ws_stream, _) = match result {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("WebSocket connection failed (headless): {}", e);
-                emit(
-                    "comfyui:connection",
-                    serde_json::json!({"connected": false}),
-                );
-                return;
-            }
-        };
-
-        emit("comfyui:connection", serde_json::json!({"connected": true}));
-
-        let (_, mut read) = ws_stream.split();
         let mut current_prompt_id: Option<String> = None;
+        let mut backoff_ms: u64 = 0;
 
-        while let Some(msg) = read.next().await {
-            match msg {
-                Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
-                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
-                        let event_type = parsed["type"].as_str().unwrap_or("unknown");
-                        let data = &parsed["data"];
+        'reconnect: loop {
+            if backoff_ms > 0 {
+                log::info!("WebSocket (headless) reconnecting in {} ms", backoff_ms);
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
 
-                        if let Some(prompt_id) = data["prompt_id"].as_str() {
-                            match event_type {
-                                "execution_start" => {
-                                    current_prompt_id = Some(prompt_id.to_string());
-                                }
-                                "executing" => {
-                                    if data["node"].is_null() {
-                                        if current_prompt_id.as_deref() == Some(prompt_id) {
-                                            current_prompt_id = None;
-                                        }
-                                    } else {
-                                        current_prompt_id = Some(prompt_id.to_string());
-                                    }
-                                }
-                                _ => {}
+                if let Some(pid) = current_prompt_id.clone() {
+                    match ws_state.get_history_for(&pid).await {
+                        Ok(history) => {
+                            let completed =
+                                history.get(&pid).map(|v| !v.is_null()).unwrap_or(false);
+                            if completed {
+                                log::warn!(
+                                    "Prompt {} completed during WS disconnect (headless) — emitting synthetic completion",
+                                    pid
+                                );
+                                emit(
+                                    "comfyui:executing",
+                                    serde_json::json!({"node": null, "prompt_id": pid}),
+                                );
+                                current_prompt_id = None;
                             }
                         }
-
-                        let event_name = format!("comfyui:{}", event_type);
-                        emit(&event_name, data.clone());
+                        Err(e) => log::warn!("History query for {} failed: {}", pid, e),
                     }
                 }
-                Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
-                    if data.len() < 4 {
-                        continue;
-                    }
-                    let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-                    // Skip binary events if we don't know which prompt they belong to
-                    if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
-                        continue;
-                    }
-                    match event_type {
-                        1 | 2 => {
-                            if data.len() < 8 {
-                                continue;
-                            }
-                            let format_type =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
-                            let format = if format_type == 2 { "png" } else { "jpeg" };
-                            let ext = if format_type == 2 { "png" } else { "jpg" };
-                            let image_data = &data[8..];
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
+            }
 
-                            // Headless: always save to temp file (SSE-only path)
-                            let payload = if let Some(temp_filename) =
-                                crate::temp_images::save(image_data, ext)
-                            {
-                                serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
-                            } else {
-                                let b64 =
-                                    base64::engine::general_purpose::STANDARD.encode(image_data);
-                                serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str })
-                            };
-                            emit("comfyui:preview", payload);
-                        }
-                        4 => {
-                            if data.len() < 8 {
-                                continue;
+            let result = connect_async(&ws_url).await;
+            let (ws_stream, _) = match result {
+                Ok(s) => {
+                    backoff_ms = 0;
+                    s
+                }
+                Err(e) => {
+                    log::error!("WebSocket connection failed (headless): {}", e);
+                    emit(
+                        "comfyui:connection",
+                        serde_json::json!({"connected": false}),
+                    );
+                    backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
+                    continue 'reconnect;
+                }
+            };
+
+            emit("comfyui:connection", serde_json::json!({"connected": true}));
+
+            let (_, mut read) = ws_stream.split();
+
+            while let Some(msg) = read.next().await {
+                match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                            let event_type = parsed["type"].as_str().unwrap_or("unknown");
+                            let data = &parsed["data"];
+
+                            if let Some(prompt_id) = data["prompt_id"].as_str() {
+                                match event_type {
+                                    "execution_start" => {
+                                        current_prompt_id = Some(prompt_id.to_string());
+                                    }
+                                    "executing" => {
+                                        if data["node"].is_null() {
+                                            if current_prompt_id.as_deref() == Some(prompt_id) {
+                                                current_prompt_id = None;
+                                            }
+                                        } else {
+                                            current_prompt_id = Some(prompt_id.to_string());
+                                        }
+                                    }
+                                    _ => {}
+                                }
                             }
-                            let meta_len =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
-                            let image_start = 8 + meta_len;
-                            if image_start < data.len() {
-                                let image_data = &data[image_start..];
+
+                            let event_name = format!("comfyui:{}", event_type);
+                            emit(&event_name, data.clone());
+                        }
+                    }
+                    Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
+                        if data.len() < 4 {
+                            continue;
+                        }
+                        let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                        // Skip binary events if we don't know which prompt they belong to
+                        if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
+                            continue;
+                        }
+                        match event_type {
+                            1 | 2 => {
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let format_type =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+                                let format = if format_type == 2 { "png" } else { "jpeg" };
+                                let ext = if format_type == 2 { "png" } else { "jpg" };
+                                let image_data = &data[8..];
                                 let prompt_id_str = current_prompt_id.as_deref().unwrap();
 
+                                // Headless: always save to temp file (SSE-only path)
                                 let payload = if let Some(temp_filename) =
-                                    crate::temp_images::save(image_data, "jpg")
+                                    crate::temp_images::save(image_data, ext)
                                 {
-                                    serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
                                 } else {
                                     let b64 = base64::engine::general_purpose::STANDARD
                                         .encode(image_data);
-                                    serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str })
                                 };
                                 emit("comfyui:preview", payload);
                             }
+                            4 => {
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let meta_len =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]])
+                                        as usize;
+                                let image_start = 8 + meta_len;
+                                if image_start < data.len() {
+                                    let image_data = &data[image_start..];
+                                    let prompt_id_str = current_prompt_id.as_deref().unwrap();
+
+                                    let payload = if let Some(temp_filename) =
+                                        crate::temp_images::save(image_data, "jpg")
+                                    {
+                                        serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    } else {
+                                        let b64 = base64::engine::general_purpose::STANDARD
+                                            .encode(image_data);
+                                        serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    };
+                                    emit("comfyui:preview", payload);
+                                }
+                            }
+                            100 => {
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                let img = match process_output_image(&data).await {
+                                    Some(img) => img,
+                                    None => continue,
+                                };
+                                let payload = build_sse_payload(&img, prompt_id_str);
+                                emit("comfyui:output_image", payload);
+                            }
+                            _ => {}
                         }
-                        100 => {
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
-                            let img = match process_output_image(&data).await {
-                                Some(img) => img,
-                                None => continue,
-                            };
-                            let payload = build_sse_payload(&img, prompt_id_str);
-                            emit("comfyui:output_image", payload);
-                        }
-                        _ => {}
                     }
+                    Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
+                        log::warn!("WebSocket closed by server (headless) — will reconnect");
+                        break;
+                    }
+                    Err(e) => {
+                        log::error!("WebSocket error (headless): {} — will reconnect", e);
+                        break;
+                    }
+                    _ => {}
                 }
-                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false}),
-                    );
-                    break;
-                }
-                Err(e) => {
-                    log::error!("WebSocket error (headless): {}", e);
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false}),
-                    );
-                    break;
-                }
-                _ => {}
             }
+
+            emit(
+                "comfyui:connection",
+                serde_json::json!({"connected": false}),
+            );
+            backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
         }
     });
 
@@ -728,7 +813,7 @@ pub async fn disconnect_websocket(state: &AppState) -> Result<(), AppError> {
 /// Events are broadcast to the shared event_tx channel.
 /// The task handle is stored in the worker so it can be aborted on shutdown.
 pub async fn connect_websocket_for_worker(
-    state: &AppState,
+    state: &Arc<AppState>,
     worker: &std::sync::Arc<super::gpu_manager::GpuWorker>,
     event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
 ) -> Result<(), AppError> {
@@ -748,6 +833,7 @@ pub async fn connect_websocket_for_worker(
 
     let worker_id = worker.id;
     let tx = event_tx;
+    let ws_state = Arc::clone(state);
 
     let task = tokio::spawn(async move {
         let emit = |event: &str, payload: serde_json::Value| {
@@ -756,141 +842,182 @@ pub async fn connect_websocket_for_worker(
                 payload,
             });
         };
-        let result = connect_async(&ws_url).await;
-        let (ws_stream, _) = match result {
-            Ok(s) => s,
-            Err(e) => {
-                log::error!("Worker {} WebSocket connection failed: {}", worker_id, e);
-                emit(
-                    "comfyui:connection",
-                    serde_json::json!({"connected": false, "worker_id": worker_id}),
-                );
-                return;
-            }
-        };
-
-        log::info!("Worker {} WebSocket connected", worker_id);
-        emit(
-            "comfyui:connection",
-            serde_json::json!({"connected": true, "worker_id": worker_id}),
-        );
-
-        let (_, mut read) = ws_stream.split();
         let mut current_prompt_id: Option<String> = None;
+        let mut backoff_ms: u64 = 0;
 
-        while let Some(msg) = read.next().await {
-            match msg {
-                Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
-                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
-                        let event_type = parsed["type"].as_str().unwrap_or("unknown");
-                        let data = &parsed["data"];
+        'reconnect: loop {
+            if backoff_ms > 0 {
+                log::info!(
+                    "Worker {} WebSocket reconnecting in {} ms",
+                    worker_id,
+                    backoff_ms
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
 
-                        if let Some(prompt_id) = data["prompt_id"].as_str() {
-                            match event_type {
-                                "execution_start" => {
-                                    current_prompt_id = Some(prompt_id.to_string());
-                                }
-                                "executing" => {
-                                    if data["node"].is_null() {
-                                        if current_prompt_id.as_deref() == Some(prompt_id) {
-                                            current_prompt_id = None;
-                                        }
-                                    } else {
-                                        current_prompt_id = Some(prompt_id.to_string());
-                                    }
-                                }
-                                _ => {}
+                if let Some(pid) = current_prompt_id.clone() {
+                    match ws_state.get_history_for(&pid).await {
+                        Ok(history) => {
+                            let completed =
+                                history.get(&pid).map(|v| !v.is_null()).unwrap_or(false);
+                            if completed {
+                                log::warn!(
+                                    "Worker {}: prompt {} completed during WS disconnect — emitting synthetic completion",
+                                    worker_id, pid
+                                );
+                                emit(
+                                    "comfyui:executing",
+                                    serde_json::json!({"node": null, "prompt_id": pid}),
+                                );
+                                current_prompt_id = None;
                             }
                         }
-
-                        let event_name = format!("comfyui:{}", event_type);
-                        emit(&event_name, data.clone());
+                        Err(e) => log::warn!("History query for {} failed: {}", pid, e),
                     }
                 }
-                Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
-                    if data.len() < 4 {
-                        continue;
-                    }
-                    let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
-                    if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
-                        continue;
-                    }
-                    match event_type {
-                        1 | 2 => {
-                            if data.len() < 8 {
-                                continue;
-                            }
-                            let format_type =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
-                            let format = if format_type == 2 { "png" } else { "jpeg" };
-                            let ext = if format_type == 2 { "png" } else { "jpg" };
-                            let image_data = &data[8..];
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
+            }
 
-                            let payload = if let Some(temp_filename) =
-                                crate::temp_images::save(image_data, ext)
-                            {
-                                serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
-                            } else {
-                                let b64 =
-                                    base64::engine::general_purpose::STANDARD.encode(image_data);
-                                serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str })
-                            };
-                            emit("comfyui:preview", payload);
-                        }
-                        4 => {
-                            if data.len() < 8 {
-                                continue;
+            let result = connect_async(&ws_url).await;
+            let (ws_stream, _) = match result {
+                Ok(s) => {
+                    backoff_ms = 0;
+                    s
+                }
+                Err(e) => {
+                    log::error!("Worker {} WebSocket connection failed: {}", worker_id, e);
+                    emit(
+                        "comfyui:connection",
+                        serde_json::json!({"connected": false, "worker_id": worker_id}),
+                    );
+                    backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
+                    continue 'reconnect;
+                }
+            };
+
+            log::info!("Worker {} WebSocket connected", worker_id);
+            emit(
+                "comfyui:connection",
+                serde_json::json!({"connected": true, "worker_id": worker_id}),
+            );
+
+            let (_, mut read) = ws_stream.split();
+
+            while let Some(msg) = read.next().await {
+                match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Text(text)) => {
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&text) {
+                            let event_type = parsed["type"].as_str().unwrap_or("unknown");
+                            let data = &parsed["data"];
+
+                            if let Some(prompt_id) = data["prompt_id"].as_str() {
+                                match event_type {
+                                    "execution_start" => {
+                                        current_prompt_id = Some(prompt_id.to_string());
+                                    }
+                                    "executing" => {
+                                        if data["node"].is_null() {
+                                            if current_prompt_id.as_deref() == Some(prompt_id) {
+                                                current_prompt_id = None;
+                                            }
+                                        } else {
+                                            current_prompt_id = Some(prompt_id.to_string());
+                                        }
+                                    }
+                                    _ => {}
+                                }
                             }
-                            let meta_len =
-                                u32::from_be_bytes([data[4], data[5], data[6], data[7]]) as usize;
-                            let image_start = 8 + meta_len;
-                            if image_start < data.len() {
-                                let image_data = &data[image_start..];
+
+                            let event_name = format!("comfyui:{}", event_type);
+                            emit(&event_name, data.clone());
+                        }
+                    }
+                    Ok(tokio_tungstenite::tungstenite::Message::Binary(data)) => {
+                        if data.len() < 4 {
+                            continue;
+                        }
+                        let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                        if current_prompt_id.is_none() && matches!(event_type, 1 | 2 | 4 | 100) {
+                            continue;
+                        }
+                        match event_type {
+                            1 | 2 => {
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let format_type =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+                                let format = if format_type == 2 { "png" } else { "jpeg" };
+                                let ext = if format_type == 2 { "png" } else { "jpg" };
+                                let image_data = &data[8..];
                                 let prompt_id_str = current_prompt_id.as_deref().unwrap();
 
                                 let payload = if let Some(temp_filename) =
-                                    crate::temp_images::save(image_data, "jpg")
+                                    crate::temp_images::save(image_data, ext)
                                 {
-                                    serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    serde_json::json!({ "temp_filename": temp_filename, "format": format, "prompt_id": prompt_id_str })
                                 } else {
                                     let b64 = base64::engine::general_purpose::STANDARD
                                         .encode(image_data);
-                                    serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    serde_json::json!({ "image": b64, "format": format, "prompt_id": prompt_id_str })
                                 };
                                 emit("comfyui:preview", payload);
                             }
+                            4 => {
+                                if data.len() < 8 {
+                                    continue;
+                                }
+                                let meta_len =
+                                    u32::from_be_bytes([data[4], data[5], data[6], data[7]])
+                                        as usize;
+                                let image_start = 8 + meta_len;
+                                if image_start < data.len() {
+                                    let image_data = &data[image_start..];
+                                    let prompt_id_str = current_prompt_id.as_deref().unwrap();
+
+                                    let payload = if let Some(temp_filename) =
+                                        crate::temp_images::save(image_data, "jpg")
+                                    {
+                                        serde_json::json!({ "temp_filename": temp_filename, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    } else {
+                                        let b64 = base64::engine::general_purpose::STANDARD
+                                            .encode(image_data);
+                                        serde_json::json!({ "image": b64, "format": "jpeg", "prompt_id": prompt_id_str })
+                                    };
+                                    emit("comfyui:preview", payload);
+                                }
+                            }
+                            100 => {
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                let img = match process_output_image(&data).await {
+                                    Some(img) => img,
+                                    None => continue,
+                                };
+                                let payload = build_sse_payload(&img, prompt_id_str);
+                                emit("comfyui:output_image", payload);
+                            }
+                            _ => {}
                         }
-                        100 => {
-                            let prompt_id_str = current_prompt_id.as_deref().unwrap();
-                            let img = match process_output_image(&data).await {
-                                Some(img) => img,
-                                None => continue,
-                            };
-                            let payload = build_sse_payload(&img, prompt_id_str);
-                            emit("comfyui:output_image", payload);
-                        }
-                        _ => {}
                     }
+                    Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
+                        log::warn!("Worker {} WebSocket closed — will reconnect", worker_id);
+                        break;
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Worker {} WebSocket error: {} — will reconnect",
+                            worker_id,
+                            e
+                        );
+                        break;
+                    }
+                    _ => {}
                 }
-                Ok(tokio_tungstenite::tungstenite::Message::Close(_)) => {
-                    log::warn!("Worker {} WebSocket closed", worker_id);
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false, "worker_id": worker_id}),
-                    );
-                    break;
-                }
-                Err(e) => {
-                    log::error!("Worker {} WebSocket error: {}", worker_id, e);
-                    emit(
-                        "comfyui:connection",
-                        serde_json::json!({"connected": false, "worker_id": worker_id}),
-                    );
-                    break;
-                }
-                _ => {}
             }
+
+            emit(
+                "comfyui:connection",
+                serde_json::json!({"connected": false, "worker_id": worker_id}),
+            );
+            backoff_ms = (backoff_ms.max(500) * 2).min(30_000);
         }
     });
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -57,6 +57,9 @@ pub struct PromptQueue {
     /// was called (race condition in server mode). `bind_alias` checks this set
     /// and immediately finishes the placeholder if the real_id is found here.
     deferred_finishes: std::sync::RwLock<std::collections::HashSet<String>>,
+    /// Placeholder/real prompt ids explicitly canceled while submission may
+    /// still be racing. Submission tasks check this before binding aliases.
+    cancelled: std::sync::RwLock<std::collections::HashSet<String>>,
 }
 
 impl Default for PromptQueue {
@@ -75,6 +78,7 @@ impl PromptQueue {
             drain_notify: Notify::new(),
             aliases: std::sync::RwLock::new(HashMap::new()),
             deferred_finishes: std::sync::RwLock::new(std::collections::HashSet::new()),
+            cancelled: std::sync::RwLock::new(std::collections::HashSet::new()),
         }
     }
 
@@ -167,12 +171,67 @@ impl PromptQueue {
     /// Remove a prompt entirely (position + ownership).
     /// Only used for explicit cancellation, not completion.
     pub fn remove(&self, prompt_id: &str) {
-        self.owners.write().unwrap().remove(prompt_id);
-        self.worker_map.write().unwrap().remove(prompt_id);
+        self.cancel_and_remove(prompt_id);
+    }
+
+    /// Mark a prompt as canceled and remove its placeholder/aliases from
+    /// internal queue tracking. Returns ids that should be deleted from ComfyUI.
+    pub fn cancel_and_remove(&self, prompt_id: &str) -> Vec<String> {
+        let ids = self.related_ids(prompt_id);
+        {
+            let mut cancelled = self.cancelled.write().unwrap();
+            for id in &ids {
+                cancelled.insert(id.clone());
+            }
+        }
+        {
+            let mut owners = self.owners.write().unwrap();
+            for id in &ids {
+                owners.remove(id);
+            }
+        }
+        {
+            let mut worker_map = self.worker_map.write().unwrap();
+            for id in &ids {
+                worker_map.remove(id);
+            }
+        }
         self.queue
             .write()
             .unwrap()
-            .retain(|(id, _)| id != prompt_id);
+            .retain(|(id, _)| !ids.iter().any(|removed| removed == id));
+        self.aliases
+            .write()
+            .unwrap()
+            .retain(|real, placeholder| !ids.iter().any(|id| id == real || id == placeholder));
+        ids
+    }
+
+    /// Return a prompt id plus its placeholder/real-id aliases.
+    pub fn related_ids(&self, prompt_id: &str) -> Vec<String> {
+        let aliases = self.aliases.read().unwrap();
+        let placeholder = aliases
+            .get(prompt_id)
+            .cloned()
+            .unwrap_or_else(|| prompt_id.to_string());
+        let mut ids = vec![placeholder.clone()];
+        if prompt_id != placeholder {
+            ids.push(prompt_id.to_string());
+        }
+        for (real_id, alias_placeholder) in aliases.iter() {
+            if alias_placeholder == &placeholder && !ids.iter().any(|id| id == real_id) {
+                ids.push(real_id.clone());
+            }
+        }
+        ids
+    }
+
+    /// Whether a placeholder/real prompt id was explicitly canceled.
+    pub fn is_cancelled(&self, prompt_id: &str) -> bool {
+        let cancelled = self.cancelled.read().unwrap();
+        self.related_ids(prompt_id)
+            .iter()
+            .any(|id| cancelled.contains(id))
     }
 
     /// Record which worker is handling a prompt.
@@ -327,6 +386,7 @@ impl PromptQueue {
     pub fn cleanup_alias(&self, placeholder_id: &str) {
         let mut aliases = self.aliases.write().unwrap();
         aliases.retain(|_, v| v != placeholder_id);
+        self.cancelled.write().unwrap().remove(placeholder_id);
     }
 
     /// Clear all queue tracking state (owners, worker_map, queue).
@@ -335,6 +395,7 @@ impl PromptQueue {
         self.queue.write().unwrap().clear();
         self.owners.write().unwrap().clear();
         self.worker_map.write().unwrap().clear();
+        self.cancelled.write().unwrap().clear();
     }
 }
 
@@ -437,7 +498,7 @@ impl AppState {
                 };
                 {
                     let mut result = hp.result.lock().await;
-                    *result = Some(Err("Cancelled by user".to_string()));
+                    *result = Some(Err("generation.error_cancelled".to_string()));
                 }
                 hp.submitted.notify_one();
                 self.prompt_queue.remove(pid);
@@ -463,17 +524,7 @@ impl AppState {
         // 3. Delete the specific prompt (and any aliases) from each targeted
         //    worker's pending queue so it doesn't resume on requeue.
         if let Some(pid) = prompt_id {
-            // Collect all known IDs for this prompt: the placeholder + any real
-            // ComfyUI ids aliased to it.
-            let mut ids_to_delete: Vec<String> = vec![pid.to_string()];
-            {
-                let aliases = self.prompt_queue.aliases.read().unwrap();
-                for (real_id, placeholder) in aliases.iter() {
-                    if placeholder == pid {
-                        ids_to_delete.push(real_id.clone());
-                    }
-                }
-            }
+            let ids_to_delete = self.prompt_queue.cancel_and_remove(pid);
 
             for wid in &target_worker_ids {
                 if let Some(worker) = self.gpu_manager.workers.get(*wid as usize) {
@@ -485,8 +536,6 @@ impl AppState {
                         .await;
                 }
             }
-
-            self.prompt_queue.remove(pid);
             self.broadcast_queue_positions();
         }
 
@@ -505,6 +554,13 @@ impl AppState {
             }
         }
 
+        if prompt_id.is_some() {
+            for wid in &target_worker_ids {
+                self.gpu_manager.mark_worker_error_then_idle(*wid).await;
+            }
+            self.prompt_queue.drain_notify.notify_one();
+        }
+
         Ok(())
     }
 
@@ -520,6 +576,13 @@ impl AppState {
     pub fn broadcast_queue_positions(&self) {
         let queue = self.prompt_queue.queue.read().unwrap();
         let total = queue.len();
+        if total == 0 {
+            self.broadcast(
+                "mooshie:queue_update",
+                serde_json::json!({ "total": 0_u32 }),
+            );
+            return;
+        }
         for (pos, (prompt_id, _owner)) in queue.iter().enumerate() {
             self.broadcast(
                 "mooshie:queue_update",

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -530,6 +530,42 @@ pub async fn start_server(
                         .await;
                     match res {
                         Ok((worker_id, response)) => {
+                            if drain_state.prompt_queue.is_cancelled(&hp.placeholder_id) {
+                                if let Some(worker) =
+                                    drain_state.gpu_manager.workers.get(worker_id as usize)
+                                {
+                                    let _ = drain_state
+                                        .http_client
+                                        .post(format!("{}/queue", worker.base_url))
+                                        .json(
+                                            &serde_json::json!({ "delete": [response.prompt_id] }),
+                                        )
+                                        .send()
+                                        .await;
+                                    let _ =
+                                        drain_state.gpu_manager.interrupt(Some(worker_id)).await;
+                                    let _ = drain_state
+                                        .http_client
+                                        .post(format!("{}/free", worker.base_url))
+                                        .json(&serde_json::json!({
+                                            "unload_models": true,
+                                            "free_memory": true,
+                                        }))
+                                        .send()
+                                        .await;
+                                }
+                                drain_state
+                                    .gpu_manager
+                                    .mark_worker_error_then_idle(worker_id)
+                                    .await;
+                                *hp.result.lock().await =
+                                    Some(Err("generation.error_cancelled".to_string()));
+                                drain_state.broadcast_queue_positions();
+                                drain_state.prompt_queue.drain_notify.notify_one();
+                                hp.submitted.notify_one();
+                                continue;
+                            }
+
                             // Bind alias immediately to prevent race with WebSocket events
                             let was_deferred = drain_state
                                 .prompt_queue
@@ -2043,6 +2079,38 @@ async fn dispatch_command(
                         .await
                     {
                         Ok((worker_id, response)) => {
+                            if bg_state.prompt_queue.is_cancelled(&bg_placeholder) {
+                                if let Some(worker) =
+                                    bg_state.gpu_manager.workers.get(worker_id as usize)
+                                {
+                                    let _ = bg_state
+                                        .http_client
+                                        .post(format!("{}/queue", worker.base_url))
+                                        .json(
+                                            &serde_json::json!({ "delete": [response.prompt_id] }),
+                                        )
+                                        .send()
+                                        .await;
+                                    let _ = bg_state.gpu_manager.interrupt(Some(worker_id)).await;
+                                    let _ = bg_state
+                                        .http_client
+                                        .post(format!("{}/free", worker.base_url))
+                                        .json(&serde_json::json!({
+                                            "unload_models": true,
+                                            "free_memory": true,
+                                        }))
+                                        .send()
+                                        .await;
+                                }
+                                bg_state
+                                    .gpu_manager
+                                    .mark_worker_error_then_idle(worker_id)
+                                    .await;
+                                bg_state.broadcast_queue_positions();
+                                bg_state.prompt_queue.drain_notify.notify_one();
+                                return;
+                            }
+
                             let was_deferred = bg_state
                                 .prompt_queue
                                 .bind_alias(&bg_placeholder, &response.prompt_id);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1398,12 +1398,22 @@
     await Promise.all([
       ipcListen("comfyui:connection", (event: any) => {
         console.log("Connection event:", event.payload);
+        const wasConnected = connection.connected;
         connection.connected = event.payload.connected;
         if (event.payload.connected) {
           startupStatus = "";
           models.refresh().then(() => {
             generation.applyDefaultsIfNeeded(models.checkpoints, models.vaes);
           });
+          // If we just reconnected after a drop, kick the stuck-prompt
+          // reconciler immediately by clearing last-activity timestamps —
+          // the WS may have died mid-generation and we want to finalize
+          // any prompts that have already left ComfyUI's queue.
+          if (!wasConnected && progress.isGenerating) {
+            for (const p of progress.pendingPrompts) {
+              promptLastActivity.set(p.promptId, 0);
+            }
+          }
         }
       }),
       ipcListen("comfyui:server_ready", async () => {
@@ -1441,6 +1451,10 @@
       }),
       ipcListen("mooshie:queue_update", (event: any) => {
         const data = event.payload;
+        if (data.total === 0) {
+          progress.resetQueuePosition();
+          return;
+        }
         if (data.prompt_id && data.position != null && data.total != null) {
           // Restore the prompt to pendingPrompts if this is an initial burst after
           // a page refresh (the in-memory queue was lost but the server still has it).
@@ -1704,15 +1718,17 @@
         const data = event.payload;
         // Build a user-visible error message from the raw error string
         const rawErr = String(data.error ?? "");
-        let toastMsg = "Generation failed";
-        if (rawErr.includes("value_not_in_list") || rawErr.includes("Value not in list") || rawErr.includes("prompt_outputs_failed_validation")) {
-          toastMsg = "Generation failed — a model or VAE may not be configured correctly. Check your model settings.";
+        let toastMsg = locale.t("generation.error_failed");
+        if (rawErr === "generation.error_cancelled") {
+          toastMsg = locale.t("generation.error_cancelled");
+        } else if (rawErr.includes("value_not_in_list") || rawErr.includes("Value not in list") || rawErr.includes("prompt_outputs_failed_validation")) {
+          toastMsg = locale.t("generation.error_model_config");
         } else {
           try {
             const m = rawErr.match(/API error \(\d+\): ([\s\S]+)/);
             if (m) {
               const parsed = JSON.parse(m[1]);
-              if (parsed.error?.message) toastMsg = `Generation failed: ${parsed.error.message}`;
+              if (parsed.error?.message) toastMsg = locale.t("generation.error_failed_message", { message: parsed.error.message });
             }
           } catch { /* ignore parse errors */ }
         }
@@ -2817,7 +2833,7 @@
 {#if artistInsertPending}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 z-[300] flex items-center justify-center bg-black/60"
+    class="fixed inset-0 z-300 flex items-center justify-center bg-black/60"
     onclick={(e) => { if (e.target === e.currentTarget) artistInsert.dismiss(); }}
     onkeydown={(e) => { if (e.key === 'Escape') artistInsert.dismiss(); }}
   >
@@ -2890,7 +2906,7 @@
 {#if dirPickerImage}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 z-[200] flex items-center justify-center bg-black/60"
+    class="fixed inset-0 z-200 flex items-center justify-center bg-black/60"
     onclick={(e) => { if (e.target === e.currentTarget) dirPickerImage = null; }}
     onkeydown={(e) => { if (e.key === 'Escape') dirPickerImage = null; }}
   >

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -114,7 +114,7 @@
 
   /** Left-click: cancel the current generation only, let the queue continue. */
   async function handleCancelCurrent() {
-    const promptId = progress.activePromptId;
+    const promptId = progress.activePromptId ?? progress.pendingPrompts[0]?.promptId;
     await interruptGeneration(promptId ?? undefined);
     if (promptId) progress.removePrompt(promptId);
   }

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -495,6 +495,10 @@ const de: Record<string, string> = {
   "generation.error_no_checkpoint": "Bitte wählen Sie zuerst einen Checkpoint",
   "generation.error_no_image": "Inpainting benötigt ein Eingabebild. Laden Sie eins hoch oder verwenden Sie ein bereitgestelltes Bild.",
   "generation.error_no_mask": "Inpainting benötigt eine Maske. Zeichnen Sie eine im Canvas-Editor oder laden Sie eine hoch.",
+  "generation.error_failed": "Generierung fehlgeschlagen",
+  "generation.error_model_config": "Generierung fehlgeschlagen — ein Modell oder VAE ist möglicherweise nicht richtig konfiguriert. Prüfen Sie die Modelleinstellungen.",
+  "generation.error_failed_message": "Generierung fehlgeschlagen: {message}",
+  "generation.error_cancelled": "Generierung abgebrochen",
   "generation.downloading_facefix": "Face-Detailer-Modell wird heruntergeladen...",
 
   // Session context menu

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -532,6 +532,10 @@ const en: Record<string, string> = {
   "generation.error_no_checkpoint": "Select a checkpoint first",
   "generation.error_no_image": "Inpainting needs an input image. Upload one or use a staged image.",
   "generation.error_no_mask": "Inpainting needs a mask. Paint a mask in Canvas Editor or upload one.",
+  "generation.error_failed": "Generation failed",
+  "generation.error_model_config": "Generation failed — a model or VAE may not be configured correctly. Check your model settings.",
+  "generation.error_failed_message": "Generation failed: {message}",
+  "generation.error_cancelled": "Generation cancelled",
   "generation.downloading_facefix": "Downloading Face Detailer model...",
 
   // Session context menu

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -517,6 +517,10 @@ const es: Record<string, string> = {
   "generation.error_no_checkpoint": "Selecciona un checkpoint primero",
   "generation.error_no_image": "El inpainting necesita una imagen de entrada. Sube una o usa una imagen preparada.",
   "generation.error_no_mask": "El inpainting necesita una máscara. Pinta una máscara en el Editor de lienzo o sube una.",
+  "generation.error_failed": "La generación falló",
+  "generation.error_model_config": "La generación falló — puede que un modelo o VAE no esté configurado correctamente. Revisa la configuración del modelo.",
+  "generation.error_failed_message": "La generación falló: {message}",
+  "generation.error_cancelled": "Generación cancelada",
   "generation.downloading_facefix": "Descargando modelo Face Detailer...",
 
   // Session context menu

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -516,6 +516,10 @@ const fr: Record<string, string> = {
   "generation.error_no_checkpoint": "Sélectionnez d'abord un checkpoint",
   "generation.error_no_image": "L'inpainting nécessite une image d'entrée. Téléversez-en une ou utilisez une image préparée.",
   "generation.error_no_mask": "L'inpainting nécessite un masque. Peignez un masque dans l'éditeur de canevas ou téléversez-en un.",
+  "generation.error_failed": "La génération a échoué",
+  "generation.error_model_config": "La génération a échoué — un modèle ou VAE est peut-être mal configuré. Vérifiez les réglages du modèle.",
+  "generation.error_failed_message": "La génération a échoué : {message}",
+  "generation.error_cancelled": "Génération annulée",
   "generation.downloading_facefix": "Téléchargement du modèle Face Detailer...",
 
   // Session context menu

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -495,6 +495,10 @@ const it: Record<string, string> = {
   "generation.error_no_checkpoint": "Seleziona prima un checkpoint",
   "generation.error_no_image": "L'inpainting richiede un'immagine di input. Caricane una o usa un'immagine preparata.",
   "generation.error_no_mask": "L'inpainting richiede una maschera. Disegna una maschera nel Canvas Editor o caricane una.",
+  "generation.error_failed": "Generazione non riuscita",
+  "generation.error_model_config": "Generazione non riuscita — un modello o VAE potrebbe non essere configurato correttamente. Controlla le impostazioni del modello.",
+  "generation.error_failed_message": "Generazione non riuscita: {message}",
+  "generation.error_cancelled": "Generazione annullata",
   "generation.downloading_facefix": "Download modello Face Detailer...",
 
   // Session context menu
@@ -639,10 +643,12 @@ const it: Record<string, string> = {
   "lora.likes": "Mi piace",
 
   // ── Pannello inferiore ──────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "Checkpoint",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "Checkpoint",
   "checkpoint.search_placeholder": "Cerca checkpoint...",
   "checkpoint.no_results": "Nessun checkpoint trovato",
-  "checkpoint.active": "Attivo",  "bottom_panel.tab.images": "Immagini",
+  "checkpoint.active": "Attivo",
+  "bottom_panel.tab.images": "Immagini",
   "bottom_panel.tab.prompts": "Prompt",
   "bottom_panel.no_images": "Nessuna immagine generata in questa sessione",
   "bottom_panel.no_prompts": "La cronologia prompt apparirà qui dopo la generazione",
@@ -1204,9 +1210,6 @@ const it: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -516,6 +516,10 @@ const ja: Record<string, string> = {
   "generation.error_no_checkpoint": "先にチェックポイントを選択してください",
   "generation.error_no_image": "インペインティングには入力画像が必要です。アップロードするかステージング画像を使用してください。",
   "generation.error_no_mask": "インペインティングにはマスクが必要です。キャンバスエディターでマスクを描くかアップロードしてください。",
+  "generation.error_failed": "生成に失敗しました",
+  "generation.error_model_config": "生成に失敗しました — モデルまたはVAEが正しく設定されていない可能性があります。モデル設定を確認してください。",
+  "generation.error_failed_message": "生成に失敗しました: {message}",
+  "generation.error_cancelled": "生成をキャンセルしました",
   "generation.downloading_facefix": "Face Detailerモデルをダウンロード中...",
 
   // Session context menu
@@ -661,10 +665,12 @@ const ja: Record<string, string> = {
   "lora.likes": "いいね",
 
   // ── 下部パネル ──────────────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "チェックポイント",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "チェックポイント",
   "checkpoint.search_placeholder": "チェックポイントを検索...",
   "checkpoint.no_results": "チェックポイントが見つかりません",
-  "checkpoint.active": "使用中",  "bottom_panel.tab.images": "画像",
+  "checkpoint.active": "使用中",
+  "bottom_panel.tab.images": "画像",
   "bottom_panel.tab.prompts": "プロンプト",
   "bottom_panel.no_images": "このセッションで生成された画像はありません",
   "bottom_panel.no_prompts": "生成後にプロンプト履歴がここに表示されます",
@@ -1229,9 +1235,6 @@ const ja: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -495,6 +495,10 @@ const ko: Record<string, string> = {
   "generation.error_no_checkpoint": "먼저 체크포인트를 선택하세요",
   "generation.error_no_image": "인페인팅에는 입력 이미지가 필요합니다. 업로드하거나 스테이지 이미지를 사용하세요.",
   "generation.error_no_mask": "인페인팅에는 마스크가 필요합니다. 캔버스 에디터에서 마스크를 그리거나 업로드하세요.",
+  "generation.error_failed": "생성 실패",
+  "generation.error_model_config": "생성 실패 — 모델 또는 VAE가 올바르게 설정되지 않았을 수 있습니다. 모델 설정을 확인하세요.",
+  "generation.error_failed_message": "생성 실패: {message}",
+  "generation.error_cancelled": "생성이 취소되었습니다",
   "generation.downloading_facefix": "Face Detailer 모델 다운로드 중...",
 
   // Session context menu
@@ -639,10 +643,12 @@ const ko: Record<string, string> = {
   "lora.likes": "좋아요",
 
   // ── 하단 패널 ──────────────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "체크포인트",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "체크포인트",
   "checkpoint.search_placeholder": "체크포인트 검색...",
   "checkpoint.no_results": "체크포인트를 찾을 수 없습니다",
-  "checkpoint.active": "활성",  "bottom_panel.tab.images": "이미지",
+  "checkpoint.active": "활성",
+  "bottom_panel.tab.images": "이미지",
   "bottom_panel.tab.prompts": "프롬프트",
   "bottom_panel.no_images": "이 세션에서 생성된 이미지 없음",
   "bottom_panel.no_prompts": "생성 후 프롬프트 기록이 여기에 표시됩니다",
@@ -1204,9 +1210,6 @@ const ko: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -495,6 +495,10 @@ const pt: Record<string, string> = {
   "generation.error_no_checkpoint": "Selecione um checkpoint primeiro",
   "generation.error_no_image": "Inpainting precisa de uma imagem de entrada. Envie uma ou use uma imagem preparada.",
   "generation.error_no_mask": "Inpainting precisa de uma máscara. Pinte uma no Editor de Canvas ou envie uma.",
+  "generation.error_failed": "Falha na geração",
+  "generation.error_model_config": "Falha na geração — um modelo ou VAE pode não estar configurado corretamente. Verifique as configurações do modelo.",
+  "generation.error_failed_message": "Falha na geração: {message}",
+  "generation.error_cancelled": "Geração cancelada",
   "generation.downloading_facefix": "Baixando modelo Face Detailer...",
 
   // Session context menu

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -495,6 +495,10 @@ const ru: Record<string, string> = {
   "generation.error_no_checkpoint": "Сначала выберите чекпоинт",
   "generation.error_no_image": "Для инпейнтинга нужно входное изображение. Загрузите или используйте подготовленное.",
   "generation.error_no_mask": "Для инпейнтинга нужна маска. Нарисуйте маску в Холст-редакторе или загрузите.",
+  "generation.error_failed": "Генерация не удалась",
+  "generation.error_model_config": "Генерация не удалась — модель или VAE могут быть настроены неправильно. Проверьте настройки модели.",
+  "generation.error_failed_message": "Генерация не удалась: {message}",
+  "generation.error_cancelled": "Генерация отменена",
   "generation.downloading_facefix": "Скачивание модели Face Detailer...",
 
   // Session context menu
@@ -639,10 +643,12 @@ const ru: Record<string, string> = {
   "lora.likes": "Нравится",
 
   // ── Нижняя панель ───────────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "Чекпоинты",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "Чекпоинты",
   "checkpoint.search_placeholder": "Поиск чекпоинтов...",
   "checkpoint.no_results": "Чекпоинты не найдены",
-  "checkpoint.active": "Активен",  "bottom_panel.tab.images": "Изображения",
+  "checkpoint.active": "Активен",
+  "bottom_panel.tab.images": "Изображения",
   "bottom_panel.tab.prompts": "Промпты",
   "bottom_panel.no_images": "Изображения не сгенерированы в этой сессии",
   "bottom_panel.no_prompts": "История промптов появится здесь после генерации",
@@ -1204,9 +1210,6 @@ const ru: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -495,6 +495,10 @@ const zhTw: Record<string, string> = {
   "generation.error_no_checkpoint": "請先選擇一個檢查點",
   "generation.error_no_image": "局部重繪需要輸入影像。請上傳或使用暫存影像。",
   "generation.error_no_mask": "局部重繪需要遮罩。請在畫布編輯器中繪製或上傳遮罩。",
+  "generation.error_failed": "生成失敗",
+  "generation.error_model_config": "生成失敗 — 模型或 VAE 可能設定不正確。請檢查模型設定。",
+  "generation.error_failed_message": "生成失敗：{message}",
+  "generation.error_cancelled": "生成已取消",
   "generation.downloading_facefix": "正在下載 Face Detailer 模型...",
 
   // Session context menu
@@ -639,10 +643,12 @@ const zhTw: Record<string, string> = {
   "lora.likes": "按讚",
 
   // ── 底部面板 ────────────────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "檢查點",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "檢查點",
   "checkpoint.search_placeholder": "搜尋檢查點...",
   "checkpoint.no_results": "找不到檢查點",
-  "checkpoint.active": "目前",  "bottom_panel.tab.images": "影像",
+  "checkpoint.active": "目前",
+  "bottom_panel.tab.images": "影像",
   "bottom_panel.tab.prompts": "提示詞",
   "bottom_panel.no_images": "本次工作階段未生成影像",
   "bottom_panel.no_prompts": "生成後提示詞歷史將顯示在這裡",
@@ -1204,9 +1210,6 @@ const zhTw: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -495,6 +495,10 @@ const zh: Record<string, string> = {
   "generation.error_no_checkpoint": "请先选择一个检查点",
   "generation.error_no_image": "局部重绘需要输入图像。请上传或使用暂存图像。",
   "generation.error_no_mask": "局部重绘需要蒙版。请在画布编辑器中绘制或上传蒙版。",
+  "generation.error_failed": "生成失败",
+  "generation.error_model_config": "生成失败 — 模型或 VAE 可能配置不正确。请检查模型设置。",
+  "generation.error_failed_message": "生成失败：{message}",
+  "generation.error_cancelled": "生成已取消",
   "generation.downloading_facefix": "正在下载 Face Detailer 模型...",
 
   // Session context menu
@@ -639,10 +643,12 @@ const zh: Record<string, string> = {
   "lora.likes": "点赞",
 
   // ── 底部面板 ────────────────────────────────────────────
-  "bottom_panel.tab.loras": "LoRA",  "bottom_panel.tab.checkpoints": "检查点",
+  "bottom_panel.tab.loras": "LoRA",
+  "bottom_panel.tab.checkpoints": "检查点",
   "checkpoint.search_placeholder": "搜索检查点...",
   "checkpoint.no_results": "未找到检查点",
-  "checkpoint.active": "当前",  "bottom_panel.tab.images": "图像",
+  "checkpoint.active": "当前",
+  "bottom_panel.tab.images": "图像",
   "bottom_panel.tab.prompts": "提示词",
   "bottom_panel.no_images": "本次会话未生成图像",
   "bottom_panel.no_prompts": "生成后提示词历史将显示在这里",
@@ -1204,9 +1210,6 @@ const zh: Record<string, string> = {
   "generation.prompts.negative_flux_disabled": "ignored by Flux models",
   "generation.sampler.flux_guidance_label": "Flux Guidance",
   "generation.sampler.flux_guidance_tip": "Distilled guidance scale used by Flux Dev / Flux 2 Klein. Replaces CFG (which these models ignore). Sweet spot is 2.5–4. Higher = stronger prompt adherence but less natural images.",
-  "bottom_panel.tab.checkpoints": "Checkpoints",
-  "bottom_panel.tab.images": "Images",
-  "gallery.toast.right_click_copy": "Right-click the image and select 'Copy Image'",
 
 };
 


### PR DESCRIPTION
## What's New in v1.1.7

- Recover from ComfyUI WebSocket drops with reconnect/backoff and history-based completion recovery.
- Cleanly cancel multi-GPU generations by clearing aliases, worker queues, internal queue state, and worker reservations.
- Fix fast cancel-and-requeue behavior before an active prompt is announced.
- Route generation failure and cancellation messages through i18n keys across supported locales.
- Remove duplicate locale stubs while preserving translated bottom-panel tab labels.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run build`
- `pre-commit-check` agent passed release gates, including i18n hardcoded-string audit.