### PR TITLE
v1.1.8: Theme palettes and generation reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v1.1.8
+
+### Theme Customization
+- **Paired light and dark palettes** — MooshieUI now supports free, built-in Mooshie, Nord, Solarized, Gruvbox, and Catppuccin palettes, with matching light and dark variants.
+- **Theme controls on desktop and mobile** — the Settings pages now include persisted theme mode and palette selectors, with the palette label routed through the locale system.
+- **Dropdowns follow the active palette** — select boxes, option text, focus rings, and selected-option states now use the active theme colors instead of retaining the Mooshie yellow tint.
+
+### Browser Generation Reliability
+- **Server WebSocket reconnects are idempotent** — repeated browser startup calls now reuse an active ComfyUI WebSocket bridge instead of aborting it mid-generation, preventing lost final output frames.
+- **Final image recovery cache** — preview and final output temp files are cached by prompt ID so the browser UI can recover an image if the final SSE event is missed during a reconnect.
+
+### Model Loading Cleanup
+- **Optional model categories no longer log noisy 500s** — ComfyUI installs without optional `diffusion_models`, `text_encoders`, `clip`, `controlnet`, or `ultralytics` folders now return empty lists for those probes instead of surfacing server errors.
+
+---
+
 ## What's New in v1.1.7
 
 ### Generation Reliability

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v1.1.8
+
+### Theme Customization
+- **Paired light and dark palettes** — MooshieUI now supports free, built-in Mooshie, Nord, Solarized, Gruvbox, and Catppuccin palettes, with matching light and dark variants.
+- **Theme controls on desktop and mobile** — the Settings pages now include persisted theme mode and palette selectors, with the palette label routed through the locale system.
+- **Dropdowns follow the active palette** — select boxes, option text, focus rings, and selected-option states now use the active theme colors instead of retaining the Mooshie yellow tint.
+
+### Browser Generation Reliability
+- **Server WebSocket reconnects are idempotent** — repeated browser startup calls now reuse an active ComfyUI WebSocket bridge instead of aborting it mid-generation, preventing lost final output frames.
+- **Final image recovery cache** — preview and final output temp files are cached by prompt ID so the browser UI can recover an image if the final SSE event is missed during a reconnect.
+
+### Model Loading Cleanup
+- **Optional model categories no longer log noisy 500s** — ComfyUI installs without optional `diffusion_models`, `text_encoders`, `clip`, `controlnet`, or `ultralytics` folders now return empty lists for those probes instead of surfacing server errors.
+
+---
+
 ## What's New in v1.1.7
 
 ### Generation Reliability

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.7"
+version = "1.1.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -6,6 +6,13 @@ use crate::comfyui::types::*;
 use crate::error::AppError;
 use crate::state::AppState;
 
+fn is_optional_model_category(category: &str) -> bool {
+    matches!(
+        category,
+        "diffusion_models" | "text_encoders" | "clip" | "controlnet" | "ultralytics"
+    )
+}
+
 /// Compute SHA256 of a file. Returns lowercase hex. Used to verify downloaded model files.
 pub fn sha256_file(path: &std::path::Path) -> Result<String, AppError> {
     use std::io::Read;
@@ -39,7 +46,18 @@ impl AppState {
     }
 
     pub async fn get_models_list(&self, category: &str) -> Result<Vec<String>, AppError> {
-        let val = self.api_get(&format!("/models/{}", category)).await?;
+        let val = match self.api_get(&format!("/models/{}", category)).await {
+            Ok(value) => value,
+            Err(e) if is_optional_model_category(category) => {
+                log::debug!(
+                    "Optional ComfyUI model category '{}' unavailable: {}",
+                    category,
+                    e
+                );
+                return Ok(Vec::new());
+            }
+            Err(e) => return Err(e),
+        };
         let models: Vec<String> = serde_json::from_value(val)?;
 
         // ComfyUI may return models from wrong categories when external model

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -187,16 +187,51 @@ fn build_sse_payload(img: &ProcessedOutputImage, prompt_id: &str) -> serde_json:
     }
 }
 
+fn cache_temp_event(
+    state: &Arc<AppState>,
+    event: &str,
+    prompt_id: &str,
+    payload: &serde_json::Value,
+) {
+    let Some(temp_filename) = payload.get("temp_filename").and_then(|v| v.as_str()) else {
+        return;
+    };
+    let ids = state.prompt_queue.related_ids(prompt_id);
+    match event {
+        "comfyui:preview" => {
+            let mut previews = state.last_preview_by_prompt.write().unwrap();
+            for id in ids {
+                previews.insert(id, temp_filename.to_string());
+            }
+        }
+        "comfyui:output_image" => {
+            let mut outputs = state.output_image_cache.write().unwrap();
+            for id in ids {
+                let entry = outputs.entry(id).or_default();
+                if !entry.iter().any(|existing| existing == temp_filename) {
+                    entry.push(temp_filename.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(feature = "desktop")]
 pub async fn connect_websocket(
     app_handle: AppHandle,
     state: Arc<AppState>,
     event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
 ) -> Result<(), AppError> {
-    // Disconnect existing
-    let mut handle = state.ws_handle.lock().await;
-    if let Some(h) = handle.take() {
-        h.abort();
+    {
+        let mut handle = state.ws_handle.lock().await;
+        if handle.as_ref().map(|h| !h.is_finished()).unwrap_or(false) {
+            log::debug!("ComfyUI WebSocket already connected; skipping reconnect");
+            return Ok(());
+        }
+        if let Some(h) = handle.take() {
+            h.abort();
+        }
     }
 
     let base_url = state.base_url().await;
@@ -222,6 +257,9 @@ pub async fn connect_websocket(
         // Split emit: send full payload to Tauri (in-process), lightweight to SSE
         let emit_split =
             |event: &str, tauri_payload: serde_json::Value, sse_payload: serde_json::Value| {
+                if let Some(prompt_id) = sse_payload.get("prompt_id").and_then(|v| v.as_str()) {
+                    cache_temp_event(&ws_state, event, prompt_id, &sse_payload);
+                }
                 let _ = app.emit(event, tauri_payload);
                 let _ = tx.send(crate::state::BroadcastEvent {
                     event: event.to_string(),
@@ -594,7 +632,7 @@ pub async fn connect_websocket(
         }
     });
 
-    *handle = Some(task);
+    *state.ws_handle.lock().await = Some(task);
     Ok(())
 }
 
@@ -605,10 +643,15 @@ pub async fn connect_websocket_headless(
     state: &Arc<AppState>,
     event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
 ) -> Result<(), AppError> {
-    // Disconnect existing
-    let mut handle = state.ws_handle.lock().await;
-    if let Some(h) = handle.take() {
-        h.abort();
+    {
+        let mut handle = state.ws_handle.lock().await;
+        if handle.as_ref().map(|h| !h.is_finished()).unwrap_or(false) {
+            log::debug!("ComfyUI WebSocket (headless) already connected; skipping reconnect");
+            return Ok(());
+        }
+        if let Some(h) = handle.take() {
+            h.abort();
+        }
     }
 
     let base_url = state.base_url().await;
@@ -623,6 +666,9 @@ pub async fn connect_websocket_headless(
 
     let task = tokio::spawn(async move {
         let emit = |event: &str, payload: serde_json::Value| {
+            if let Some(prompt_id) = payload.get("prompt_id").and_then(|v| v.as_str()) {
+                cache_temp_event(&ws_state, event, prompt_id, &payload);
+            }
             let _ = tx.send(crate::state::BroadcastEvent {
                 event: event.to_string(),
                 payload,
@@ -797,7 +843,7 @@ pub async fn connect_websocket_headless(
         }
     });
 
-    *handle = Some(task);
+    *state.ws_handle.lock().await = Some(task);
     Ok(())
 }
 
@@ -817,9 +863,15 @@ pub async fn connect_websocket_for_worker(
     worker: &std::sync::Arc<super::gpu_manager::GpuWorker>,
     event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
 ) -> Result<(), AppError> {
-    // Disconnect existing WS for this worker
     {
         let mut handle = worker.ws_handle.lock().await;
+        if handle.as_ref().map(|h| !h.is_finished()).unwrap_or(false) {
+            log::debug!(
+                "Worker {} WebSocket already connected; skipping reconnect",
+                worker.id
+            );
+            return Ok(());
+        }
         if let Some(h) = handle.take() {
             h.abort();
         }
@@ -837,6 +889,9 @@ pub async fn connect_websocket_for_worker(
 
     let task = tokio::spawn(async move {
         let emit = |event: &str, payload: serde_json::Value| {
+            if let Some(prompt_id) = payload.get("prompt_id").and_then(|v| v.as_str()) {
+                cache_temp_event(&ws_state, event, prompt_id, &payload);
+            }
             let _ = tx.send(crate::state::BroadcastEvent {
                 event: event.to_string(),
                 payload,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -43,8 +43,10 @@ pub struct AppConfig {
     pub keep_alive: bool,
     /// Automatically start ComfyUI when the app launches (default: true)
     pub auto_start: bool,
-    /// UI theme: "dark", "light"
+    /// UI theme mode: "dark", "light"
     pub theme: String,
+    /// UI color palette shared across dark and light modes.
+    pub theme_palette: String,
     /// UI font scale multiplier (1.0 = default)
     pub font_scale: f64,
     pub setup_complete: bool,
@@ -100,6 +102,7 @@ impl Default for AppConfig {
             keep_alive: false,
             auto_start: true,
             theme: "dark".to_string(),
+            theme_palette: "mooshie".to_string(),
             font_scale: 1.0,
             setup_complete: false,
             extra_model_paths: None,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -427,11 +427,11 @@ pub struct AppState {
     /// Multi-GPU worker manager — distributes prompts across N GPU backends.
     pub gpu_manager: GpuManager,
     /// Tracks output temp filenames by placeholder prompt_id for recovery.
-    /// Populated by the cleanup reactor when `comfyui:output_image` fires;
+    /// Populated by the WebSocket bridge when `comfyui:output_image` fires;
     /// consumed (and cleared) by `recover_prompt_outputs`.
     pub output_image_cache: std::sync::RwLock<HashMap<String, Vec<String>>>,
     /// Tracks the last live-preview temp_filename per placeholder prompt_id.
-    /// Updated by the cleanup reactor on every `comfyui:preview` event.
+    /// Updated by the WebSocket bridge on every `comfyui:preview` event.
     /// Sent to clients that reconnect mid-generation via the SSE initial burst.
     pub last_preview_by_prompt: std::sync::RwLock<HashMap<String, String>>,
 }

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -355,6 +355,42 @@ pub fn spawn_stuck_worker_watchdog(state: Arc<AppState>) {
     tokio::spawn(watchdog_fut);
 }
 
+async fn has_active_comfyui_ws_bridge(state: &Arc<AppState>) -> bool {
+    {
+        let mut handle = state.ws_handle.lock().await;
+        let finished = handle.as_ref().map(|h| h.is_finished()).unwrap_or(false);
+        if finished {
+            handle.take();
+        } else if handle.is_some() {
+            return true;
+        }
+    }
+
+    for worker in &state.gpu_manager.workers {
+        let mut handle = worker.ws_handle.lock().await;
+        let finished = handle.as_ref().map(|h| h.is_finished()).unwrap_or(false);
+        if finished {
+            handle.take();
+        } else if handle.is_some() {
+            return true;
+        }
+    }
+
+    false
+}
+
+async fn ensure_comfyui_ws_bridge(
+    state: &Arc<AppState>,
+    event_tx: tokio::sync::broadcast::Sender<crate::state::BroadcastEvent>,
+) -> Result<(), crate::error::AppError> {
+    if has_active_comfyui_ws_bridge(state).await {
+        log::debug!("ComfyUI WebSocket bridge already active; skipping reconnect");
+        return Ok(());
+    }
+
+    crate::comfyui::websocket::connect_websocket_headless(state, event_tx).await
+}
+
 pub async fn start_server(
     state: Arc<AppState>,
     port: u16,
@@ -1569,15 +1605,15 @@ async fn dispatch_command(
         }
         "start_comfyui" => {
             use crate::comfyui::process::{self, StartResult};
-            use crate::comfyui::websocket;
             let result = process::start_comfyui_process(&state)
                 .await
                 .map_err(|e| e.to_string())?;
             let event_tx = state.event_tx.clone();
             match result {
                 StartResult::AlreadyRunning => {
-                    // Connect websocket so progress events flow to SSE
-                    if let Err(e) = websocket::connect_websocket_headless(&state, event_tx).await {
+                    // Ensure progress events flow to SSE without disrupting an
+                    // existing bridge for an in-flight generation.
+                    if let Err(e) = ensure_comfyui_ws_bridge(&state, event_tx.clone()).await {
                         log::error!("Failed to connect WebSocket (headless): {}", e);
                     }
                     state.broadcast("comfyui:server_ready", serde_json::json!(null));
@@ -1589,12 +1625,10 @@ async fn dispatch_command(
                         match process::wait_for_ready(&state_clone, 120).await {
                             Ok(()) => {
                                 log::info!("ComfyUI server is ready (browser mode)");
-                                // Connect websocket so progress events flow to SSE
-                                if let Err(e) = websocket::connect_websocket_headless(
-                                    &state_clone,
-                                    event_tx.clone(),
-                                )
-                                .await
+                                // Ensure progress events flow to SSE without
+                                // replacing an existing bridge.
+                                if let Err(e) =
+                                    ensure_comfyui_ws_bridge(&state_clone, event_tx.clone()).await
                                 {
                                     log::error!("Failed to connect WebSocket (headless): {}", e);
                                 }
@@ -1619,8 +1653,8 @@ async fn dispatch_command(
                     Ok(serde_json::json!("spawned"))
                 }
                 StartResult::Skipped => {
-                    // Remote mode — connect websocket directly
-                    if let Err(e) = websocket::connect_websocket_headless(&state, event_tx).await {
+                    // Remote mode — connect websocket directly if no bridge is active.
+                    if let Err(e) = ensure_comfyui_ws_bridge(&state, event_tx.clone()).await {
                         log::error!("Failed to connect WebSocket (headless): {}", e);
                     }
                     state.broadcast("comfyui:server_ready", serde_json::json!(null));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,6 +28,7 @@
   import logoUrl from "./lib/assets/logo.png";
 
   import { lazyThumbnail } from "./lib/utils/lazyThumbnail.js";
+  import { applyTheme } from "./lib/utils/theme.js";
   import ContextMenu from "./lib/components/ui/ContextMenu.svelte";
   import type { ContextMenuItem } from "./lib/components/ui/ContextMenu.svelte";
   import InterrogateModal from "./lib/components/generation/InterrogateModal.svelte";
@@ -46,8 +47,10 @@
   const MAX_INPUT_PIXELS = 1024 * 1024;
   let lastProgressEventAt = 0;
 
+  type PendingOutputImage = { blob: Blob; url: string; tempFilename?: string };
+
   /** Images received via WebSocket during generation, keyed by prompt_id. */
-  let pendingOutputImages = new Map<string, Array<{ blob: Blob; url: string; tempFilename?: string }>>();
+  let pendingOutputImages = new Map<string, PendingOutputImage[]>();
   /** In-flight output_image fetch promises per prompt_id (for SSE race-condition avoidance). */
   let pendingOutputFetches = new Map<string, Promise<void>[]>();
   /** Wait for pending fetches with a hard time limit to prevent hanging. */
@@ -55,6 +58,27 @@
   async function awaitFetchesWithTimeout(fetches: Promise<void>[]): Promise<void> {
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, FETCH_TIMEOUT_MS));
     await Promise.race([Promise.allSettled(fetches), timeout]);
+  }
+
+  async function recoverCachedOutputImages(promptId: string): Promise<PendingOutputImage[]> {
+    const images: PendingOutputImage[] = [];
+    try {
+      const recovered = await recoverPromptOutputs(promptId);
+      for (const imgRef of recovered.images) {
+        try {
+          const resp = await fetch(
+            `/internal-api/_temp_image/${encodeURIComponent(imgRef.temp_filename)}`,
+            { headers: authHeaders() },
+          );
+          if (resp.ok) {
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            images.push({ blob, url, tempFilename: imgRef.temp_filename });
+          }
+        } catch { /* individual image fetch failed */ }
+      }
+    } catch { /* recovery command failed */ }
+    return images;
   }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
   let sseReconnectHandler: (() => void) | null = null;
@@ -226,10 +250,6 @@
     };
     const tKey = keyMap[key];
     return tKey ? locale.t(tKey) : key;
-  }
-
-  function applyTheme(theme: string) {
-    document.documentElement.classList.toggle("light", theme === "light");
   }
 
   function applyFontScale(scale: number) {
@@ -1382,7 +1402,7 @@
     // Apply UI preferences (theme, font scale) immediately
     try {
       const cfg = await getConfig();
-      applyTheme(cfg.theme);
+      applyTheme(cfg.theme, cfg.theme_palette);
       applyFontScale(cfg.font_scale);
       autoStartEnabled = cfg.auto_start !== false;
     } catch {
@@ -1694,8 +1714,11 @@
           const item = progress.completePrompt(promptId);
           promptLastActivity.delete(promptId);
           if (item) {
-            const images = pendingOutputImages.get(promptId) ?? [];
+            let images = pendingOutputImages.get(promptId) ?? [];
             pendingOutputImages.delete(promptId);
+            if (images.length === 0) {
+              images = await recoverCachedOutputImages(promptId);
+            }
             finalizeOutputImages(promptId, item.mode, item.wasUpscaled, item.params, images);
 
             // Track grid batch completion — stitch when all cells are done
@@ -1795,24 +1818,9 @@
 
               if (images.length === 0) {
                 // SSE event was likely dropped during a reconnect — the image was
-                // saved to a temp file on the server and cached by the cleanup
-                // reactor.  Try to recover it before giving up.
-                try {
-                  const recovered = await recoverPromptOutputs(p.promptId);
-                  for (const imgRef of recovered.images) {
-                    try {
-                      const resp = await fetch(
-                        `/internal-api/_temp_image/${encodeURIComponent(imgRef.temp_filename)}`,
-                        { headers: authHeaders() },
-                      );
-                      if (resp.ok) {
-                        const blob = await resp.blob();
-                        const url = URL.createObjectURL(blob);
-                        images.push({ blob, url, tempFilename: imgRef.temp_filename });
-                      }
-                    } catch { /* individual image fetch failed */ }
-                  }
-                } catch { /* recovery command failed */ }
+                // saved to a temp file on the server and cached by the
+                // WebSocket bridge.  Try to recover it before giving up.
+                images = await recoverCachedOutputImages(p.promptId);
               }
 
               if (images.length > 0) {

--- a/src/app.css
+++ b/src/app.css
@@ -3,39 +3,169 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --accent: #ffcc00;
-  --accent-hover: #e6b800;
+  --theme-accent-foreground: #111111;
 
-  /* Remap existing indigo/purple utility usage to the logo palette. */
-  --color-indigo-50: #fffdf0;
-  --color-indigo-100: #fff8d1;
-  --color-indigo-200: #ffef9e;
-  --color-indigo-300: #ffe680;
-  --color-indigo-400: #ffd54d;
-  --color-indigo-500: #ffcc00;
-  --color-indigo-600: #cc9900;
-  --color-indigo-700: #a37a00;
-  --color-indigo-800: #7a5c00;
-  --color-indigo-900: #5c4600;
-  --color-indigo-950: #3d2f00;
+  --color-neutral-50: #fafafa;
+  --color-neutral-100: #f5f5f5;
+  --color-neutral-200: #e5e5e5;
+  --color-neutral-300: #d4d4d4;
+  --color-neutral-400: #a3a3a3;
+  --color-neutral-500: #737373;
+  --color-neutral-600: #525252;
+  --color-neutral-700: #404040;
+  --color-neutral-800: #262626;
+  --color-neutral-900: #171717;
+  --color-neutral-950: #0a0a0a;
 
-  --color-purple-50: #fffdf0;
-  --color-purple-100: #fff8d1;
-  --color-purple-200: #ffef9e;
-  --color-purple-300: #ffe680;
-  --color-purple-400: #ffd54d;
-  --color-purple-500: #ffcc00;
-  --color-purple-600: #cc9900;
-  --color-purple-700: #a37a00;
-  --color-purple-800: #7a5c00;
-  --color-purple-900: #5c4600;
-  --color-purple-950: #3d2f00;
+  --theme-accent-50: #fffdf0;
+  --theme-accent-100: #fff8d1;
+  --theme-accent-200: #ffef9e;
+  --theme-accent-300: #ffe680;
+  --theme-accent-400: #ffd54d;
+  --theme-accent-500: #ffcc00;
+  --theme-accent-600: #cc9900;
+  --theme-accent-700: #a37a00;
+  --theme-accent-800: #7a5c00;
+  --theme-accent-900: #5c4600;
+  --theme-accent-950: #3d2f00;
+
+  --accent: var(--theme-accent-500);
+  --accent-hover: var(--theme-accent-400);
+
+  /* Remap existing indigo/purple utility usage to the active palette. */
+  --color-indigo-50: var(--theme-accent-50);
+  --color-indigo-100: var(--theme-accent-100);
+  --color-indigo-200: var(--theme-accent-200);
+  --color-indigo-300: var(--theme-accent-300);
+  --color-indigo-400: var(--theme-accent-400);
+  --color-indigo-500: var(--theme-accent-500);
+  --color-indigo-600: var(--theme-accent-600);
+  --color-indigo-700: var(--theme-accent-700);
+  --color-indigo-800: var(--theme-accent-800);
+  --color-indigo-900: var(--theme-accent-900);
+  --color-indigo-950: var(--theme-accent-950);
+
+  --color-purple-50: var(--theme-accent-50);
+  --color-purple-100: var(--theme-accent-100);
+  --color-purple-200: var(--theme-accent-200);
+  --color-purple-300: var(--theme-accent-300);
+  --color-purple-400: var(--theme-accent-400);
+  --color-purple-500: var(--theme-accent-500);
+  --color-purple-600: var(--theme-accent-600);
+  --color-purple-700: var(--theme-accent-700);
+  --color-purple-800: var(--theme-accent-800);
+  --color-purple-900: var(--theme-accent-900);
+  --color-purple-950: var(--theme-accent-950);
 }
 
-/* Improve contrast on yellow highlight surfaces that currently use text-white. */
+html[data-palette="nord"] {
+  --theme-accent-foreground: #f8fafc;
+  --color-neutral-50: #eceff4;
+  --color-neutral-100: #e5e9f0;
+  --color-neutral-200: #d8dee9;
+  --color-neutral-300: #cbd5e1;
+  --color-neutral-400: #94a3b8;
+  --color-neutral-500: #64748b;
+  --color-neutral-600: #4c566a;
+  --color-neutral-700: #434c5e;
+  --color-neutral-800: #3b4252;
+  --color-neutral-900: #2e3440;
+  --color-neutral-950: #1f2430;
+  --theme-accent-50: #eff6ff;
+  --theme-accent-100: #dbeafe;
+  --theme-accent-200: #bfdbfe;
+  --theme-accent-300: #93c5fd;
+  --theme-accent-400: #60a5fa;
+  --theme-accent-500: #5e81ac;
+  --theme-accent-600: #4c78a8;
+  --theme-accent-700: #3b638d;
+  --theme-accent-800: #2f4f70;
+  --theme-accent-900: #273f5a;
+  --theme-accent-950: #172554;
+}
+
+html[data-palette="solarized"] {
+  --theme-accent-foreground: #fdf6e3;
+  --color-neutral-50: #fdf6e3;
+  --color-neutral-100: #eee8d5;
+  --color-neutral-200: #d8d0b5;
+  --color-neutral-300: #93a1a1;
+  --color-neutral-400: #839496;
+  --color-neutral-500: #657b83;
+  --color-neutral-600: #586e75;
+  --color-neutral-700: #194652;
+  --color-neutral-800: #073642;
+  --color-neutral-900: #002f3a;
+  --color-neutral-950: #002b36;
+  --theme-accent-50: #e1f7fb;
+  --theme-accent-100: #c6edf5;
+  --theme-accent-200: #8bd8e8;
+  --theme-accent-300: #4fc3db;
+  --theme-accent-400: #2aaec8;
+  --theme-accent-500: #268bd2;
+  --theme-accent-600: #2176b3;
+  --theme-accent-700: #1c5f91;
+  --theme-accent-800: #17496f;
+  --theme-accent-900: #12374f;
+  --theme-accent-950: #0b2537;
+}
+
+html[data-palette="gruvbox"] {
+  --theme-accent-foreground: #1d2021;
+  --color-neutral-50: #fbf1c7;
+  --color-neutral-100: #ebdbb2;
+  --color-neutral-200: #d5c4a1;
+  --color-neutral-300: #bdae93;
+  --color-neutral-400: #a89984;
+  --color-neutral-500: #928374;
+  --color-neutral-600: #665c54;
+  --color-neutral-700: #504945;
+  --color-neutral-800: #3c3836;
+  --color-neutral-900: #282828;
+  --color-neutral-950: #1d2021;
+  --theme-accent-50: #fff4d6;
+  --theme-accent-100: #fbe5ad;
+  --theme-accent-200: #f4c982;
+  --theme-accent-300: #eeb05a;
+  --theme-accent-400: #e6983c;
+  --theme-accent-500: #d79921;
+  --theme-accent-600: #b57614;
+  --theme-accent-700: #925f12;
+  --theme-accent-800: #704a11;
+  --theme-accent-900: #56380d;
+  --theme-accent-950: #332008;
+}
+
+html[data-palette="catppuccin"] {
+  --theme-accent-foreground: #f5e0dc;
+  --color-neutral-50: #cdd6f4;
+  --color-neutral-100: #bac2de;
+  --color-neutral-200: #a6adc8;
+  --color-neutral-300: #9399b2;
+  --color-neutral-400: #7f849c;
+  --color-neutral-500: #6c7086;
+  --color-neutral-600: #585b70;
+  --color-neutral-700: #45475a;
+  --color-neutral-800: #313244;
+  --color-neutral-900: #1e1e2e;
+  --color-neutral-950: #11111b;
+  --theme-accent-50: #f5e0ff;
+  --theme-accent-100: #ead1ff;
+  --theme-accent-200: #dcbdfc;
+  --theme-accent-300: #cba6f7;
+  --theme-accent-400: #b794f4;
+  --theme-accent-500: #a78bfa;
+  --theme-accent-600: #8b6bd8;
+  --theme-accent-700: #7552bc;
+  --theme-accent-800: #5f3f98;
+  --theme-accent-900: #493176;
+  --theme-accent-950: #2f1f4d;
+}
+
+/* Improve contrast on accent highlight surfaces that currently use text-white. */
 [class*="bg-indigo-"][class*="text-white"],
 [class*="bg-purple-"][class*="text-white"] {
-  color: #111111 !important;
+  color: var(--theme-accent-foreground) !important;
 }
 
 html, body, #app {
@@ -77,10 +207,27 @@ html {
   color-scheme: dark;
 }
 
-select, option {
-  background-color: #262626 !important;
-  color: #f5f5f5 !important;
+select,
+option {
+  background-color: var(--color-neutral-800) !important;
+  color: var(--color-neutral-100) !important;
   color-scheme: dark;
+}
+
+select {
+  border-color: var(--color-neutral-700) !important;
+}
+
+select:focus,
+select:focus-visible {
+  border-color: var(--theme-accent-500) !important;
+  outline: 2px solid color-mix(in srgb, var(--theme-accent-500) 30%, transparent);
+  outline-offset: 0;
+}
+
+option:checked {
+  background-color: var(--theme-accent-600) !important;
+  color: var(--theme-accent-foreground) !important;
 }
 
 ::-webkit-scrollbar { width: 8px; }
@@ -143,6 +290,7 @@ input[type="range"]::-webkit-slider-thumb {
 /* ─── Light mode ─── */
 html.light {
   color-scheme: light;
+  --theme-accent-foreground: #111111;
   --color-neutral-950: #fafafa;
   --color-neutral-900: #f5f5f5;
   --color-neutral-800: #e5e5e5;
@@ -156,9 +304,113 @@ html.light {
   --color-neutral-50: #0a0a0a;
 }
 
+html.light[data-palette="nord"] {
+  --theme-accent-foreground: #f8fafc;
+  --color-neutral-950: #f8fafc;
+  --color-neutral-900: #eceff4;
+  --color-neutral-800: #e5e9f0;
+  --color-neutral-700: #d8dee9;
+  --color-neutral-600: #94a3b8;
+  --color-neutral-500: #64748b;
+  --color-neutral-400: #4c566a;
+  --color-neutral-300: #434c5e;
+  --color-neutral-200: #3b4252;
+  --color-neutral-100: #2e3440;
+  --color-neutral-50: #1f2430;
+  --theme-accent-50: #eff6ff;
+  --theme-accent-100: #dbeafe;
+  --theme-accent-200: #bfdbfe;
+  --theme-accent-300: #93c5fd;
+  --theme-accent-400: #60a5fa;
+  --theme-accent-500: #4c78a8;
+  --theme-accent-600: #3b638d;
+  --theme-accent-700: #2f4f70;
+  --theme-accent-800: #273f5a;
+  --theme-accent-900: #1e334a;
+  --theme-accent-950: #172554;
+}
+
+html.light[data-palette="solarized"] {
+  --theme-accent-foreground: #fdf6e3;
+  --color-neutral-950: #fdf6e3;
+  --color-neutral-900: #eee8d5;
+  --color-neutral-800: #e3dbc7;
+  --color-neutral-700: #d8d0b5;
+  --color-neutral-600: #93a1a1;
+  --color-neutral-500: #839496;
+  --color-neutral-400: #657b83;
+  --color-neutral-300: #586e75;
+  --color-neutral-200: #174652;
+  --color-neutral-100: #073642;
+  --color-neutral-50: #002b36;
+  --theme-accent-50: #e1f7fb;
+  --theme-accent-100: #c6edf5;
+  --theme-accent-200: #8bd8e8;
+  --theme-accent-300: #4fc3db;
+  --theme-accent-400: #2aaec8;
+  --theme-accent-500: #268bd2;
+  --theme-accent-600: #2176b3;
+  --theme-accent-700: #1c5f91;
+  --theme-accent-800: #17496f;
+  --theme-accent-900: #12374f;
+  --theme-accent-950: #0b2537;
+}
+
+html.light[data-palette="gruvbox"] {
+  --theme-accent-foreground: #1d2021;
+  --color-neutral-950: #fbf1c7;
+  --color-neutral-900: #ebdbb2;
+  --color-neutral-800: #d5c4a1;
+  --color-neutral-700: #bdae93;
+  --color-neutral-600: #a89984;
+  --color-neutral-500: #928374;
+  --color-neutral-400: #665c54;
+  --color-neutral-300: #504945;
+  --color-neutral-200: #3c3836;
+  --color-neutral-100: #282828;
+  --color-neutral-50: #1d2021;
+  --theme-accent-50: #fff4d6;
+  --theme-accent-100: #fbe5ad;
+  --theme-accent-200: #f4c982;
+  --theme-accent-300: #eeb05a;
+  --theme-accent-400: #e6983c;
+  --theme-accent-500: #d79921;
+  --theme-accent-600: #b57614;
+  --theme-accent-700: #925f12;
+  --theme-accent-800: #704a11;
+  --theme-accent-900: #56380d;
+  --theme-accent-950: #332008;
+}
+
+html.light[data-palette="catppuccin"] {
+  --theme-accent-foreground: #11111b;
+  --color-neutral-950: #eff1f5;
+  --color-neutral-900: #e6e9ef;
+  --color-neutral-800: #ccd0da;
+  --color-neutral-700: #bcc0cc;
+  --color-neutral-600: #9ca0b0;
+  --color-neutral-500: #7c7f93;
+  --color-neutral-400: #6c6f85;
+  --color-neutral-300: #5c5f77;
+  --color-neutral-200: #4c4f69;
+  --color-neutral-100: #313244;
+  --color-neutral-50: #1e1e2e;
+  --theme-accent-50: #f4e8ff;
+  --theme-accent-100: #ead6ff;
+  --theme-accent-200: #d9b8ff;
+  --theme-accent-300: #c6a0f6;
+  --theme-accent-400: #b18be6;
+  --theme-accent-500: #8839ef;
+  --theme-accent-600: #7c3aed;
+  --theme-accent-700: #6d28d9;
+  --theme-accent-800: #5b21b6;
+  --theme-accent-900: #4c1d95;
+  --theme-accent-950: #2e1065;
+}
+
 html.light select, html.light option {
-  background-color: #e5e5e5 !important;
-  color: #171717 !important;
+  background-color: var(--color-neutral-800) !important;
+  color: var(--color-neutral-100) !important;
   color-scheme: light;
 }
 
@@ -166,38 +418,37 @@ html.light ::-webkit-scrollbar-thumb { background: #d4d4d4; }
 html.light ::-webkit-scrollbar-thumb:hover { background: #a3a3a3; }
 
 html.light .accent-indigo-500 {
-  accent-color: #ffcf1f;
+  accent-color: var(--theme-accent-500);
 }
 
 /* Light-mode slider rails: keep unfilled area light and readable. */
 html.light input[type="range"] {
-  accent-color: #ffcf1f;
+  accent-color: var(--theme-accent-500);
 }
 
-/* Brighten yellow action buttons in light mode. */
 html.light .bg-indigo-600,
 html.light .bg-purple-600 {
-  background-color: #ffcf1f !important;
+  background-color: var(--theme-accent-600) !important;
 }
 
 html.light .bg-indigo-500,
 html.light .bg-purple-500 {
-  background-color: #ffd84d !important;
+  background-color: var(--theme-accent-500) !important;
 }
 
 html.light .bg-indigo-700,
 html.light .bg-purple-700 {
-  background-color: #f4bf00 !important;
+  background-color: var(--theme-accent-700) !important;
 }
 
 html.light .hover\:bg-indigo-500:hover,
 html.light .hover\:bg-purple-500:hover {
-  background-color: #ffe066 !important;
+  background-color: var(--theme-accent-500) !important;
 }
 
 html.light .hover\:bg-indigo-600:hover,
 html.light .hover\:bg-purple-600:hover {
-  background-color: #ffd84d !important;
+  background-color: var(--theme-accent-600) !important;
 }
 
 html.light .text-neutral-500 {
@@ -239,12 +490,11 @@ html.light [class*="text-red-"] {
   color: #991b1b !important;
 }
 
-/* Indigo text maps to yellow in this theme; darken it for light mode readability. */
 html.light .text-indigo-300,
 html.light .text-indigo-400,
 html.light .text-indigo-500,
 html.light [class*="text-indigo-"] {
-  color: #7a5c00 !important;
+  color: var(--theme-accent-700) !important;
 }
 
 /* Preserve legibility for the "Quality prompts applied" style chip in light mode. */

--- a/src/lib/components/mobile/MobileSettingsPage.svelte
+++ b/src/lib/components/mobile/MobileSettingsPage.svelte
@@ -2,7 +2,10 @@
   import { LOCALE_OPTIONS, locale, type Locale } from "../../stores/locale.svelte.js";
   import { connection } from "../../stores/connection.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
+  import type { AppConfig } from "../../types/index.js";
+  import { getConfig, updateConfig } from "../../utils/api.js";
   import { clearAuthToken } from "../../utils/ipc.js";
+  import { applyTheme, THEME_PALETTES } from "../../utils/theme.js";
   import {
     getForceDesktopOverride,
     setForceDesktopOverride,
@@ -13,6 +16,7 @@
   const appVersion = __APP_VERSION__ ?? "dev";
 
   let forceDesktop = $state(getForceDesktopOverride());
+  let config = $state<AppConfig | null>(null);
 
   function tt(key: string, fb: string) {
     const v = locale.t(key);
@@ -36,11 +40,31 @@
     window.location.reload();
   }
 
+  async function loadConfig() {
+    try {
+      config = await getConfig();
+    } catch {
+      config = null;
+    }
+  }
+
+  async function saveTheme() {
+    if (!config) return;
+    applyTheme(config.theme, config.theme_palette);
+    try {
+      await updateConfig(config);
+    } catch {}
+  }
+
   async function logout() {
     if (!confirm(tt("settings.confirm_logout", "Sign out?"))) return;
     clearAuthToken();
     window.location.reload();
   }
+
+  $effect(() => {
+    void loadConfig();
+  });
 </script>
 
 <div class="h-full flex flex-col bg-neutral-950">
@@ -65,6 +89,37 @@
           {/each}
         </select>
       </label>
+      {#if config}
+        <div class="grid grid-cols-2 gap-2">
+          <label for="mobile-theme-mode" class="block">
+            <span class="text-sm text-neutral-200">{tt("settings.appearance.theme", "Theme")}</span>
+            <select
+              id="mobile-theme-mode"
+              name="theme-mode"
+              bind:value={config.theme}
+              onchange={saveTheme}
+              class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2.5 text-sm text-neutral-100"
+            >
+              <option value="dark">{tt("settings.appearance.theme_dark", "Dark")}</option>
+              <option value="light">{tt("settings.appearance.theme_light", "Light")}</option>
+            </select>
+          </label>
+          <label for="mobile-theme-palette" class="block">
+            <span class="text-sm text-neutral-200">{tt("settings.appearance.palette", "Palette")}</span>
+            <select
+              id="mobile-theme-palette"
+              name="theme-palette"
+              bind:value={config.theme_palette}
+              onchange={saveTheme}
+              class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2.5 text-sm text-neutral-100"
+            >
+              {#each THEME_PALETTES as palette}
+                <option value={palette.value}>{palette.label}</option>
+              {/each}
+            </select>
+          </label>
+        </div>
+      {/if}
       <div class="flex items-center justify-between gap-3">
         <div class="flex-1">
           <p class="text-sm text-neutral-200">

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -11,6 +11,7 @@
   import OpenModelFolders from "./OpenModelFolders.svelte";
   import GpuStatusPanel from "./GpuStatusPanel.svelte";
   import { ipcInvoke, ipcListen, isTauri, isBrowserMode, authHeaders, clearAuthToken } from "../../utils/ipc.js";
+  import { applyTheme, THEME_PALETTES } from "../../utils/theme.js";
   import { onMount, onDestroy } from "svelte";
   import { marked } from "marked";
   import { clearArtistImageCache, getArtistImageCacheCount } from "../../artist-gallery/imageCache.js";
@@ -957,10 +958,6 @@
     }
   }
 
-  function applyTheme(theme: string) {
-    document.documentElement.classList.toggle("light", theme === "light");
-  }
-
   function applyFontScale(scale: number) {
     document.documentElement.style.setProperty("--font-scale", String(scale));
   }
@@ -1474,14 +1471,31 @@
           <div class="px-5 pb-5 space-y-4">
           <div class="grid grid-cols-2 gap-3">
             <div>
-              <label class="block text-xs text-neutral-400 mb-1">{locale.t('settings.appearance.theme')}</label>
+              <label for="theme-mode" class="block text-xs text-neutral-400 mb-1">{locale.t('settings.appearance.theme')}</label>
               <select
+                id="theme-mode"
+                name="theme-mode"
                 bind:value={config.theme}
-                onchange={() => { if (config) { applyTheme(config.theme); autoSave(); } }}
+                onchange={() => { if (config) { applyTheme(config.theme, config.theme_palette); autoSave(); } }}
                 class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
               >
                 <option value="dark">{locale.t('settings.appearance.theme_dark')}</option>
                 <option value="light">{locale.t('settings.appearance.theme_light')}</option>
+              </select>
+            </div>
+
+            <div>
+              <label for="theme-palette" class="block text-xs text-neutral-400 mb-1">{locale.t('settings.appearance.palette')}</label>
+              <select
+                id="theme-palette"
+                name="theme-palette"
+                bind:value={config.theme_palette}
+                onchange={() => { if (config) { applyTheme(config.theme, config.theme_palette); autoSave(); } }}
+                class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+              >
+                {#each THEME_PALETTES as palette}
+                  <option value={palette.value}>{palette.label}</option>
+                {/each}
               </select>
             </div>
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -122,6 +122,7 @@ const de: Record<string, string> = {
   "settings.appearance.theme": "Design",
   "settings.appearance.theme_dark": "Dunkel",
   "settings.appearance.theme_light": "Hell",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Schriftgröße",
   "settings.appearance.color_vision": "Farbsehsimulator",
   "settings.appearance.sim_none": "Keine",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -125,6 +125,7 @@ const en: Record<string, string> = {
   "settings.appearance.theme": "Theme",
   "settings.appearance.theme_dark": "Dark",
   "settings.appearance.theme_light": "Light",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Font Scale",
   "settings.appearance.color_vision": "Color Vision Simulator",
   "settings.appearance.sim_none": "None",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -124,6 +124,7 @@ const es: Record<string, string> = {
   "settings.appearance.theme": "Tema",
   "settings.appearance.theme_dark": "Oscuro",
   "settings.appearance.theme_light": "Claro",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Escala de fuente",
   "settings.appearance.color_vision": "Simulador de visión del color",
   "settings.appearance.sim_none": "Ninguno",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -124,6 +124,7 @@ const fr: Record<string, string> = {
   "settings.appearance.theme": "Thème",
   "settings.appearance.theme_dark": "Sombre",
   "settings.appearance.theme_light": "Clair",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Taille de police",
   "settings.appearance.color_vision": "Simulateur de vision des couleurs",
   "settings.appearance.sim_none": "Aucun",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -122,6 +122,7 @@ const it: Record<string, string> = {
   "settings.appearance.theme": "Tema",
   "settings.appearance.theme_dark": "Scuro",
   "settings.appearance.theme_light": "Chiaro",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Dimensione carattere",
   "settings.appearance.color_vision": "Simulatore daltonismo",
   "settings.appearance.sim_none": "Nessuno",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -124,6 +124,7 @@ const ja: Record<string, string> = {
   "settings.appearance.theme": "テーマ",
   "settings.appearance.theme_dark": "ダーク",
   "settings.appearance.theme_light": "ライト",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "フォントサイズ",
   "settings.appearance.color_vision": "色覚シミュレーター",
   "settings.appearance.sim_none": "なし",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -122,6 +122,7 @@ const ko: Record<string, string> = {
   "settings.appearance.theme": "테마",
   "settings.appearance.theme_dark": "다크",
   "settings.appearance.theme_light": "라이트",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "글꼴 크기",
   "settings.appearance.color_vision": "색각 시뮬레이터",
   "settings.appearance.sim_none": "없음",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -122,6 +122,7 @@ const pt: Record<string, string> = {
   "settings.appearance.theme": "Tema",
   "settings.appearance.theme_dark": "Escuro",
   "settings.appearance.theme_light": "Claro",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Tamanho da Fonte",
   "settings.appearance.color_vision": "Simulador de Visão de Cores",
   "settings.appearance.sim_none": "Nenhum",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -122,6 +122,7 @@ const ru: Record<string, string> = {
   "settings.appearance.theme": "Тема",
   "settings.appearance.theme_dark": "Тёмная",
   "settings.appearance.theme_light": "Светлая",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "Размер шрифта",
   "settings.appearance.color_vision": "Симулятор цветового зрения",
   "settings.appearance.sim_none": "Нет",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -122,6 +122,7 @@ const zhTw: Record<string, string> = {
   "settings.appearance.theme": "主題",
   "settings.appearance.theme_dark": "深色",
   "settings.appearance.theme_light": "淺色",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "字型大小",
   "settings.appearance.color_vision": "色覺模擬器",
   "settings.appearance.sim_none": "無",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -122,6 +122,7 @@ const zh: Record<string, string> = {
   "settings.appearance.theme": "主题",
   "settings.appearance.theme_dark": "深夜模式",
   "settings.appearance.theme_light": "日间模式",
+  "settings.appearance.palette": "Palette",
   "settings.appearance.font_scale": "字体大小",
   "settings.appearance.color_vision": "色觉色差模拟模式(色盲模式)",
   "settings.appearance.sim_none": "无",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -143,6 +143,7 @@ export interface AppConfig {
   vram_mode: string;
   keep_alive: boolean;
   theme: string;
+  theme_palette: string;
   font_scale: number;
   setup_complete: boolean;
   extra_model_paths: string | null;

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -1,0 +1,28 @@
+export type ThemeMode = "dark" | "light";
+export type ThemePalette = "mooshie" | "nord" | "solarized" | "gruvbox" | "catppuccin";
+
+export const THEME_PALETTES: Array<{ value: ThemePalette; label: string }> = [
+  { value: "mooshie", label: "Mooshie" },
+  { value: "nord", label: "Nord" },
+  { value: "solarized", label: "Solarized" },
+  { value: "gruvbox", label: "Gruvbox" },
+  { value: "catppuccin", label: "Catppuccin" },
+];
+
+export function normalizeThemeMode(value: string | null | undefined): ThemeMode {
+  return value === "light" ? "light" : "dark";
+}
+
+export function normalizeThemePalette(value: string | null | undefined): ThemePalette {
+  return THEME_PALETTES.some((palette) => palette.value === value)
+    ? (value as ThemePalette)
+    : "mooshie";
+}
+
+export function applyTheme(mode: string | null | undefined, palette?: string | null): void {
+  const themeMode = normalizeThemeMode(mode);
+  const themePalette = normalizeThemePalette(palette);
+  const root = document.documentElement;
+  root.classList.toggle("light", themeMode === "light");
+  root.dataset.palette = themePalette;
+}


### PR DESCRIPTION
## Changes
- Add persisted free light/dark theme palettes for Mooshie, Nord, Solarized, Gruvbox, and Catppuccin.
- Add desktop and mobile theme palette controls with the new palette label routed through i18n.
- Make dropdown boxes, focus rings, and selected option states follow the active theme palette.
- Prevent browser/server startup calls from aborting an active ComfyUI WebSocket bridge mid-generation.
- Cache final output temp images so browser clients can recover missed final output events.
- Return empty lists for unavailable optional ComfyUI model categories instead of noisy `/internal-api/get_models` 500s.

## Validation
- Pre-commit-check agent: passed, including i18n hardcoded-string gate.
- `Select-String -Pattern "1.1.8" package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json`: all three matched.
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed.
- `npm run build`: passed.