### PR TITLE
v1.1.10: Fix Docker ControlNet node startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,4 +272,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min,ignore-error=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v1.1.10
+
+### Docker ControlNet Startup Fix
+- **Required ControlNet nodes are installed before ComfyUI boots** — the Docker image now bakes in `comfyui_controlnet_aux` and `ComfyUI-Anima-LLLite`, so Anima LLLite generations no longer fail with `Node 'AnimaLLLiteApply' not found` after a pod redeploy.
+- **Startup verification on every managed restart** — MooshieUI now checks required ControlNet and Anima node classes after ComfyUI starts and before reporting the server as ready, catching missing or broken custom-node imports early.
+- **Desktop/server self-healing install path** — managed ComfyUI launches now ensure required ControlNet custom-node packages exist and install their Python requirements when needed.
+
+### Release Pipeline
+- **Docker publish cache export no longer blocks releases** — release Docker builds now use a smaller, non-fatal GitHub Actions cache export while keeping the actual GHCR image push required.
+
+---
+
 ## What's New in v1.1.9
 
 ### Anima LLLite ControlNet

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,21 @@ RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
     uv pip install ultralytics==8.4.34 && \
     uv pip install --force-reinstall --no-deps opencv-python-headless
 
+# Install ControlNet custom-node packages required by MooshieUI presets before
+# ComfyUI ever boots. The server also verifies these node classes after every
+# restart so broken imports fail early instead of at generation time.
+RUN mkdir -p ${COMFYUI_PATH}/custom_nodes && \
+    git clone --depth=1 https://github.com/Fannovel16/comfyui_controlnet_aux.git \
+        ${COMFYUI_PATH}/custom_nodes/comfyui_controlnet_aux && \
+    git clone --depth=1 https://github.com/kohya-ss/ComfyUI-Anima-LLLite.git \
+        ${COMFYUI_PATH}/custom_nodes/ComfyUI-Anima-LLLite && \
+    . ${COMFYUI_PATH}/.venv/bin/activate && \
+    for req in \
+        ${COMFYUI_PATH}/custom_nodes/comfyui_controlnet_aux/requirements.txt \
+        ${COMFYUI_PATH}/custom_nodes/ComfyUI-Anima-LLLite/requirements.txt; do \
+        if [ -f "$req" ]; then uv pip install -r "$req"; fi; \
+    done
+
 # Copy custom nodes (auto-deployed by the binary on startup, but also
 # pre-copy them so they're available even if the binary doesn't run the
 # deploy step — e.g. if ComfyUI is already running)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v1.1.10
+
+### Docker ControlNet Startup Fix
+- **Required ControlNet nodes are installed before ComfyUI boots** — the Docker image now bakes in `comfyui_controlnet_aux` and `ComfyUI-Anima-LLLite`, so Anima LLLite generations no longer fail with `Node 'AnimaLLLiteApply' not found` after a pod redeploy.
+- **Startup verification on every managed restart** — MooshieUI now checks required ControlNet and Anima node classes after ComfyUI starts and before reporting the server as ready, catching missing or broken custom-node imports early.
+- **Desktop/server self-healing install path** — managed ComfyUI launches now ensure required ControlNet custom-node packages exist and install their Python requirements when needed.
+
+### Release Pipeline
+- **Docker publish cache export no longer blocks releases** — release Docker builds now use a smaller, non-fatal GitHub Actions cache export while keeping the actual GHCR image push required.
+
+---
+
 ## What's New in v1.1.9
 
 ### Anima LLLite ControlNet

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -1,7 +1,37 @@
 //! Auto-deploy bundled MooshieUI custom nodes into ComfyUI's custom_nodes directory.
 //! The Python source is embedded at compile time and written to disk before ComfyUI starts.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Copy)]
+struct RequiredCustomNodePackage {
+    name: &'static str,
+    git_url: &'static str,
+    verify_nodes: &'static [&'static str],
+}
+
+const REQUIRED_CONTROLNET_PACKAGES: &[RequiredCustomNodePackage] = &[
+    RequiredCustomNodePackage {
+        name: "comfyui_controlnet_aux",
+        git_url: "https://github.com/Fannovel16/comfyui_controlnet_aux.git",
+        verify_nodes: &[
+            "CannyEdgePreprocessor",
+            "DepthAnythingV2Preprocessor",
+            "OpenposePreprocessor",
+            "LineArtPreprocessor",
+            "ScribblePreprocessor",
+            "HEDPreprocessor",
+            "FakeScribblePreprocessor",
+        ],
+    },
+    RequiredCustomNodePackage {
+        name: "ComfyUI-Anima-LLLite",
+        git_url: "https://github.com/kohya-ss/ComfyUI-Anima-LLLite.git",
+        verify_nodes: &["AnimaLLLiteApply"],
+    },
+];
 
 const MOOSHIE_NODES_INIT: &str = include_str!("mooshie_nodes.py");
 const TILED_DIFFUSION_PY: &str = include_str!("../../../comfyui-nodes/nodes_tiled_diffusion.py");
@@ -123,4 +153,271 @@ pub fn ensure_mooshie_nodes(comfyui_path: &str) -> Result<(), String> {
         custom_nodes.display()
     );
     Ok(())
+}
+
+/// Ensure all ControlNet custom-node packages used by MooshieUI presets are
+/// present before ComfyUI boots. Requirements are installed once per
+/// requirements.txt content hash, then reinstalled only if the file changes.
+pub async fn ensure_required_controlnet_nodes(
+    comfyui_path: &str,
+    venv_path: &str,
+) -> Result<(), String> {
+    let custom_nodes = Path::new(comfyui_path).join("custom_nodes");
+    std::fs::create_dir_all(&custom_nodes).map_err(|e| {
+        format!(
+            "Failed to create ComfyUI custom_nodes directory at '{}': {}",
+            custom_nodes.display(),
+            e
+        )
+    })?;
+
+    for package in REQUIRED_CONTROLNET_PACKAGES {
+        ensure_custom_node_package(&custom_nodes, venv_path, *package).await?;
+    }
+
+    log::info!("Ensured required ControlNet custom node packages");
+    Ok(())
+}
+
+/// Verify that ComfyUI actually loaded every custom node class required by the
+/// built-in ControlNet presets. Directory presence alone is not enough because
+/// custom-node import failures leave the class missing from /object_info.
+pub async fn verify_required_controlnet_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+) -> Result<(), String> {
+    let mut missing = Vec::new();
+
+    for attempt in 0..5 {
+        missing = missing_required_controlnet_nodes(http_client, base_url).await?;
+        if missing.is_empty() {
+            log::info!("Verified required ControlNet custom node classes");
+            return Ok(());
+        }
+
+        if attempt < 4 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    Err(format!(
+        "Required ControlNet custom nodes failed to load: {}. Check the ComfyUI log for custom-node import errors.",
+        missing.join(", ")
+    ))
+}
+
+async fn ensure_custom_node_package(
+    custom_nodes: &Path,
+    venv_path: &str,
+    package: RequiredCustomNodePackage,
+) -> Result<(), String> {
+    let target_dir = custom_nodes.join(package.name);
+
+    if target_dir.exists() && !target_dir.is_dir() {
+        return Err(format!(
+            "Cannot install required custom node '{}': '{}' exists but is not a directory",
+            package.name,
+            target_dir.display()
+        ));
+    }
+
+    if !target_dir.exists() {
+        log::info!(
+            "Installing required custom node '{}' from {}",
+            package.name,
+            package.git_url
+        );
+        clone_custom_node(package.git_url, &target_dir).await?;
+    }
+
+    let requirements = target_dir.join("requirements.txt");
+    if requirements.exists() {
+        install_requirements_if_needed(&requirements, &target_dir, venv_path, package.name).await?;
+    }
+
+    Ok(())
+}
+
+async fn clone_custom_node(git_url: &str, target_dir: &Path) -> Result<(), String> {
+    let output = tokio::process::Command::new("git")
+        .args(["clone", "--depth=1", git_url])
+        .arg(target_dir)
+        .output()
+        .await
+        .map_err(|e| format!("git clone failed to start for {}: {}", git_url, e))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "git clone failed for {}: {}",
+            git_url,
+            command_output_excerpt(&output)
+        ))
+    }
+}
+
+async fn install_requirements_if_needed(
+    requirements: &Path,
+    target_dir: &Path,
+    venv_path: &str,
+    package_name: &str,
+) -> Result<(), String> {
+    let req_hash = file_sha256(requirements)?;
+    let stamp_path = target_dir.join(".mooshieui-requirements.sha256");
+    if std::fs::read_to_string(&stamp_path)
+        .map(|s| s.trim() == req_hash)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    if venv_path.trim().is_empty() {
+        return Err(format!(
+            "Cannot install requirements for {}: ComfyUI venv_path is empty",
+            package_name
+        ));
+    }
+
+    log::info!(
+        "Installing requirements for required custom node {}",
+        package_name
+    );
+
+    let mut command = if let Some(uv_path) = find_uv_bin(venv_path).await {
+        let mut command = tokio::process::Command::new(uv_path);
+        command
+            .args(["pip", "install", "-r"])
+            .arg(requirements)
+            .env("VIRTUAL_ENV", venv_path);
+        command
+    } else {
+        let mut command = tokio::process::Command::new(resolve_pip_bin(venv_path));
+        command.args(["install", "-r"]).arg(requirements);
+        command
+    };
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| format!("Failed to install requirements for {}: {}", package_name, e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to install requirements for {}: {}",
+            package_name,
+            command_output_excerpt(&output)
+        ));
+    }
+
+    std::fs::write(&stamp_path, req_hash).map_err(|e| {
+        format!(
+            "Failed to write requirements stamp for {} at '{}': {}",
+            package_name,
+            stamp_path.display(),
+            e
+        )
+    })?;
+
+    Ok(())
+}
+
+async fn find_uv_bin(venv_path: &str) -> Option<PathBuf> {
+    let base = Path::new(venv_path)
+        .parent()
+        .unwrap_or(Path::new(venv_path));
+
+    #[cfg(target_os = "windows")]
+    let local_uv = base.join("bin").join("uv.exe");
+    #[cfg(not(target_os = "windows"))]
+    let local_uv = base.join("bin").join("uv");
+
+    if local_uv.exists() {
+        return Some(local_uv);
+    }
+
+    let global_uv = PathBuf::from("uv");
+    let status = tokio::process::Command::new(&global_uv)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+
+    match status {
+        Ok(status) if status.success() => Some(global_uv),
+        _ => None,
+    }
+}
+
+fn resolve_pip_bin(venv_path: &str) -> PathBuf {
+    let venv_base = Path::new(venv_path);
+    #[cfg(target_os = "windows")]
+    {
+        venv_base.join("Scripts").join("pip.exe")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        venv_base.join("bin").join("pip")
+    }
+}
+
+fn file_sha256(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        format!(
+            "Failed to read requirements file '{}': {}",
+            path.display(),
+            e
+        )
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn command_output_excerpt(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = if stderr.trim().is_empty() {
+        stdout
+    } else {
+        stderr
+    };
+    let lines: Vec<&str> = combined.lines().collect();
+    let start = lines.len().saturating_sub(20);
+    let excerpt = lines[start..].join("\n");
+    if excerpt.trim().is_empty() {
+        format!("process exited with {}", output.status)
+    } else {
+        excerpt
+    }
+}
+
+async fn missing_required_controlnet_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Vec<String>, String> {
+    let base_url = base_url.trim_end_matches('/');
+    let mut missing = Vec::new();
+
+    for package in REQUIRED_CONTROLNET_PACKAGES {
+        for node_class in package.verify_nodes {
+            let url = format!("{}/object_info/{}", base_url, node_class);
+            let available = match http_client.get(&url).send().await {
+                Ok(response) if response.status().is_success() => {
+                    let value = response.json::<serde_json::Value>().await.map_err(|e| {
+                        format!("Failed to parse object_info for {}: {}", node_class, e)
+                    })?;
+                    value.get(*node_class).is_some()
+                }
+                _ => false,
+            };
+
+            if !available {
+                missing.push(format!("{} ({})", node_class, package.name));
+            }
+        }
+    }
+
+    Ok(missing)
 }

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -134,7 +134,7 @@ async fn mark_legacy_worker_idle(state: &AppState) {
 /// Spawn the ComfyUI process (or detect an already-running one).
 /// Returns immediately — does NOT wait for the server to become ready.
 pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppError> {
-    let config = state.config.read().await;
+    let config = state.config.read().await.clone();
 
     // Deploy bundled custom nodes whenever we have a valid ComfyUI path,
     // regardless of server mode — the user may have started ComfyUI externally
@@ -146,11 +146,13 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
         if main_exists {
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
                 .map_err(AppError::ProcessSpawnFailed)?;
+            super::nodes::ensure_required_controlnet_nodes(&config.comfyui_path, &config.venv_path)
+                .await
+                .map_err(AppError::ProcessSpawnFailed)?;
         }
     }
 
     if config.server_mode != ServerMode::AutoLaunch {
-        drop(config);
         // Remote mode: assume the configured worker is reachable and mark it
         // idle so `submit_prompt` can dispatch to it.  If the server is
         // actually down, the POST /prompt will surface the error.
@@ -161,11 +163,13 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
     // Check if something is already listening on the target port (e.g. a container)
     let health_url = format!("{}/system_stats", config.server_url);
     if state.http_client.get(&health_url).send().await.is_ok() {
+        super::nodes::verify_required_controlnet_nodes(&state.http_client, &config.server_url)
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
         log::info!(
             "ComfyUI already running at {}, skipping spawn",
             config.server_url
         );
-        drop(config);
         mark_legacy_worker_idle(state).await;
         return Ok(StartResult::AlreadyRunning);
     }
@@ -523,7 +527,8 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
 /// Also checks if the child process has exited early (crash), and if so,
 /// reads the stderr log for diagnostic information.
 pub async fn wait_for_ready(state: &AppState, timeout_secs: u64) -> Result<(), AppError> {
-    let url = format!("{}/system_stats", state.base_url().await);
+    let base_url = state.base_url().await;
+    let url = format!("{}/system_stats", base_url);
     let iterations = timeout_secs * 2; // 500ms per iteration
 
     for i in 0..iterations {
@@ -531,6 +536,9 @@ pub async fn wait_for_ready(state: &AppState, timeout_secs: u64) -> Result<(), A
 
         // Check if the server is responding
         if state.http_client.get(&url).send().await.is_ok() {
+            super::nodes::verify_required_controlnet_nodes(&state.http_client, &base_url)
+                .await
+                .map_err(AppError::ProcessSpawnFailed)?;
             mark_legacy_worker_idle(state).await;
             return Ok(());
         }
@@ -710,7 +718,7 @@ pub async fn start_worker_process(
     state: &AppState,
     worker: &Arc<GpuWorker>,
 ) -> Result<(), AppError> {
-    let config = state.config.read().await;
+    let config = state.config.read().await.clone();
 
     // Deploy custom nodes (same as single-process path)
     if !config.comfyui_path.is_empty() {
@@ -719,6 +727,9 @@ pub async fn start_worker_process(
             .exists();
         if main_exists {
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
+                .map_err(AppError::ProcessSpawnFailed)?;
+            super::nodes::ensure_required_controlnet_nodes(&config.comfyui_path, &config.venv_path)
+                .await
                 .map_err(AppError::ProcessSpawnFailed)?;
         }
     }
@@ -730,6 +741,9 @@ pub async fn start_worker_process(
     // Check if something is already listening on the worker's port
     let health_url = format!("{}/system_stats", worker.base_url);
     if state.http_client.get(&health_url).send().await.is_ok() {
+        super::nodes::verify_required_controlnet_nodes(&state.http_client, &worker.base_url)
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
         log::info!(
             "Worker {} (GPU {}): ComfyUI already running at {}",
             worker.id,
@@ -886,6 +900,14 @@ pub async fn wait_for_worker_ready(
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         if state.http_client.get(&url).send().await.is_ok() {
+            if let Err(e) =
+                super::nodes::verify_required_controlnet_nodes(&state.http_client, &worker.base_url)
+                    .await
+            {
+                let mut status = worker.status.write().await;
+                *status = WorkerStatus::Error;
+                return Err(AppError::ProcessSpawnFailed(e));
+            }
             let mut status = worker.status.write().await;
             *status = WorkerStatus::Idle;
             log::info!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.1.10

### Docker ControlNet Startup Fix
- Bake `comfyui_controlnet_aux` and `ComfyUI-Anima-LLLite` into the Docker image before ComfyUI boots.
- Ensure required ControlNet custom-node packages exist before managed ComfyUI launches, including desktop/server self-healing installs.
- Verify required ControlNet node classes after every managed ComfyUI start/restart before emitting `comfyui:server_ready`.
- Prevent Anima LLLite generations from failing with `Node 'AnimaLLLiteApply' not found` after pod redeploys.

### Release Pipeline
- Change Docker BuildKit cache export from `mode=max` to `mode=min,ignore-error=true` so cache upload cannot hold a release hostage after GHCR image push succeeds.

### Validation
- `cargo fmt --check` — pass
- `cargo check --manifest-path src-tauri/Cargo.toml` — pass
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server --bin mooshieui-server` — pass
- `npm run build` — pass
- Final pre-commit-check agent — pass