### PR TITLE
v1.2.1: Suppress external ComfyUI toast in server/browser mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.2.1
+
+### Bug Fix
+- **External ComfyUI toast suppressed in server/browser mode** — the "Another ComfyUI is already running" warning toast now only appears in the desktop (Tauri) app. In Docker/LAN browser mode a pre-running ComfyUI is expected, so the toast was noise and has been silenced.
+
+---
+
 ## What's New in v1.2.0
 
 ### Anima Base v1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.2.1
+
+### Bug Fix
+- **External ComfyUI toast suppressed in server/browser mode** — the "Another ComfyUI is already running" warning toast now only appears in the desktop (Tauri) app. In Docker/LAN browser mode a pre-running ComfyUI is expected, so the toast was noise and has been silenced.
+
+---
+
 ## What's New in v1.2.0
 
 ### Anima Base v1.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1473,7 +1473,7 @@
         startupStatus = locale.t("app.status.starting_comfyui");
       } else if (result === "already_running") {
         startupStatus = locale.t("app.status.connecting");
-        showExternalComfyToast("already_running");
+        if (isTauri) showExternalComfyToast("already_running");
         await refreshAlreadyRunningComfyui();
       } else if (result === "skipped") {
         startupStatus = locale.t("app.status.connecting");


### PR DESCRIPTION
## What's New in v1.2.1

### Bug Fix
- **External ComfyUI toast suppressed in server/browser mode** — the "Another ComfyUI is already running" warning toast now only appears in the desktop (Tauri) app. In Docker/LAN browser mode a pre-running ComfyUI is expected, so the toast was noise and has been silenced.