### PR TITLE
v1.2.2: prompt scheduling fixes, JXL metadata, UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - **Edge download fix** — JXL downloads in Edge now use a correct `Content-Disposition` filename, fixing the truncated/garbled filename issue.
 
 ### Generation UI
-- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible with their state persisted.
+- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible.
 - **Tag autocomplete toggle** — a new Settings switch lets you disable prompt-field tag suggestions entirely. Translated across all 11 locales.
 - **Artist gallery tag insertion** — artist tags inserted from the gallery now convert underscores to spaces before being added to the prompt.
 - **Session image grid overlap fix** — image cards in the bottom session strip no longer overlap at the larger card-size slider values; the grid layout is stable across the full 48–160 px range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## What's New in v1.2.2
+
+### Prompt Scheduling Fixes
+- **SwarmUI `<fromto[N]:A||B>` empty-side handling** — schedules like `<fromto[10]:cat||>` or `<fromto[10]:||dog>` now parse correctly: the empty half is treated as no prompt for that timestep range instead of being rejected.
+- **Double-encoding fix** — the `before` and `after` halves of a `<fromto>` block are no longer also appended to the base prompt. Scheduling now produces a clean swap at the cutoff step instead of bleeding both halves across all steps.
+
+### JXL Pipeline
+- **Metadata preserved on save/copy** — "Save Image As…" and "Copy to Clipboard" for JXL gallery images now re-embed the generation parameters into the PNG export. The server-side JXL→PNG transcode previously stripped metadata; the frontend now re-injects it according to your metadata mode setting.
+- **Browser-mode JXL support** — the embedded web server now dispatches `load_gallery_image_display` and `load_gallery_image_png` so Firefox and other non-JXL browsers can view and export JXL gallery images.
+- **Edge download fix** — JXL downloads in Edge now use a correct `Content-Disposition` filename, fixing the truncated/garbled filename issue.
+
+### Generation UI
+- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible with their state persisted.
+- **Tag autocomplete toggle** — a new Settings switch lets you disable prompt-field tag suggestions entirely. Translated across all 11 locales.
+- **Artist gallery tag insertion** — artist tags inserted from the gallery now convert underscores to spaces before being added to the prompt.
+- **Session image grid overlap fix** — image cards in the bottom session strip no longer overlap at the larger card-size slider values; the grid layout is stable across the full 48–160 px range.
+
+---
+
 ## What's New in v1.2.1
 
 ### Bug Fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 - **Edge download fix** — JXL downloads in Edge now use a correct `Content-Disposition` filename, fixing the truncated/garbled filename issue.
 
 ### Generation UI
-- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible with their state persisted.
+- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible.
 - **Tag autocomplete toggle** — a new Settings switch lets you disable prompt-field tag suggestions entirely. Translated across all 11 locales.
 - **Artist gallery tag insertion** — artist tags inserted from the gallery now convert underscores to spaces before being added to the prompt.
 - **Session image grid overlap fix** — image cards in the bottom session strip no longer overlap at the larger card-size slider values; the grid layout is stable across the full 48–160 px range.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+## What's New in v1.2.2
+
+### Prompt Scheduling Fixes
+- **SwarmUI `<fromto[N]:A||B>` empty-side handling** — schedules like `<fromto[10]:cat||>` or `<fromto[10]:||dog>` now parse correctly: the empty half is treated as no prompt for that timestep range instead of being rejected.
+- **Double-encoding fix** — the `before` and `after` halves of a `<fromto>` block are no longer also appended to the base prompt. Scheduling now produces a clean swap at the cutoff step instead of bleeding both halves across all steps.
+
+### JXL Pipeline
+- **Metadata preserved on save/copy** — "Save Image As…" and "Copy to Clipboard" for JXL gallery images now re-embed the generation parameters into the PNG export. The server-side JXL→PNG transcode previously stripped metadata; the frontend now re-injects it according to your metadata mode setting.
+- **Browser-mode JXL support** — the embedded web server now dispatches `load_gallery_image_display` and `load_gallery_image_png` so Firefox and other non-JXL browsers can view and export JXL gallery images.
+- **Edge download fix** — JXL downloads in Edge now use a correct `Content-Disposition` filename, fixing the truncated/garbled filename issue.
+
+### Generation UI
+- **Collapsible recommendation panels** — the Anima, Illustrious, and NanoSaur recommended-settings boxes in Sampler Settings are now collapsible with their state persisted.
+- **Tag autocomplete toggle** — a new Settings switch lets you disable prompt-field tag suggestions entirely. Translated across all 11 locales.
+- **Artist gallery tag insertion** — artist tags inserted from the gallery now convert underscores to spaces before being added to the prompt.
+- **Session image grid overlap fix** — image cards in the bottom session strip no longer overlap at the larger card-size slider values; the grid layout is stable across the full 48–160 px range.
+
+---
+
 ## What's New in v1.2.1
 
 ### Bug Fix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1092,6 +1092,17 @@ async fn gallery_image_handler(
             // (which don't ship with a JXL decoder) can still render the image.
             // The canonical `.jxl` file on disk is untouched.
             if lower.ends_with(".jxl") {
+                // Suggest a `.webp` filename when the browser saves the image
+                // (right-click → "Save Image As"). Without this, Edge silently
+                // saves the file with the URL's `.jxl` extension even though
+                // the bytes are WebP.
+                let webp_filename = {
+                    let stem = filename
+                        .rsplit_once('.')
+                        .map(|(s, _)| s)
+                        .unwrap_or(&filename);
+                    format!("{}.webp", stem)
+                };
                 let transcode = tokio::task::spawn_blocking(move || {
                     commands::api::transcode_jxl_to_webp(&data)
                 })
@@ -1102,6 +1113,10 @@ async fn gallery_image_handler(
                         [
                             ("content-type", "image/webp".to_string()),
                             ("cache-control", "no-cache".to_string()),
+                            (
+                                "content-disposition",
+                                format!("inline; filename=\"{}\"", webp_filename),
+                            ),
                         ],
                         webp,
                     )
@@ -1942,6 +1957,58 @@ async fn dispatch_command(
             let path = dir.join(&filename);
             let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
             Ok(serde_json::json!(bytes))
+        }
+        "load_gallery_image_display" => {
+            // JXL → WebP transcode so non-JXL browsers (Firefox, Edge, Chrome)
+            // can render the image. Other formats are returned as-is.
+            let filename = args["filename"]
+                .as_str()
+                .ok_or("Missing filename")?
+                .to_string();
+            if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+                return Err("Invalid filename".into());
+            }
+            let dir = user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
+            let path = dir.join(&filename);
+            let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+            let out = if filename.to_ascii_lowercase().ends_with(".jxl") {
+                tokio::task::spawn_blocking(move || commands::api::transcode_jxl_to_webp(&bytes))
+                    .await
+                    .map_err(|e| format!("Task panicked: {}", e))?
+                    .map_err(|e| e.to_string())?
+            } else {
+                bytes
+            };
+            Ok(serde_json::json!(out))
+        }
+        "load_gallery_image_png" => {
+            // JXL → PNG transcode for downloading / clipboard. PNG keeps
+            // metadata intact and is supported everywhere.
+            let filename = args["filename"]
+                .as_str()
+                .ok_or("Missing filename")?
+                .to_string();
+            if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+                return Err("Invalid filename".into());
+            }
+            let dir = user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
+            let path = dir.join(&filename);
+            let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
+            let out = if filename.to_ascii_lowercase().ends_with(".jxl") {
+                tokio::task::spawn_blocking(move || -> Result<Vec<u8>, String> {
+                    let img = commands::api::decode_gallery_image(&bytes)?;
+                    let mut buf = std::io::Cursor::new(Vec::new());
+                    img.write_to(&mut buf, image::ImageFormat::Png)
+                        .map_err(|e| format!("PNG encode failed: {}", e))?;
+                    Ok(buf.into_inner())
+                })
+                .await
+                .map_err(|e| format!("Task panicked: {}", e))?
+                .map_err(|e| e.to_string())?
+            } else {
+                bytes
+            };
+            Ok(serde_json::json!(out))
         }
         "get_gallery_image_path" => {
             let filename = args["filename"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -344,9 +344,9 @@
           {:else}
             <div class="grid gap-2 flex-1 min-h-0 overflow-y-auto px-2 py-2" style="grid-template-columns: repeat(auto-fill, minmax({imageCardSize}px, 1fr)); align-content: start;">
               {#each filteredSessionImages as image}
-                <div class="group relative aspect-square rounded-lg overflow-hidden border border-neutral-800 hover:border-indigo-500 transition-colors" oncontextmenu={(e) => { if (oncontextmenu) { e.preventDefault(); oncontextmenu(image, e.clientX, e.clientY); } }}>
+                <div class="group relative w-full rounded-lg overflow-hidden border border-neutral-800 hover:border-indigo-500 transition-colors" style="aspect-ratio: 1 / 1;" oncontextmenu={(e) => { if (oncontextmenu) { e.preventDefault(); oncontextmenu(image, e.clientX, e.clientY); } }}>
               <button
-                class="w-full h-full"
+                class="absolute inset-0 w-full h-full"
                 onclick={() => gallery.openLightbox(image)}
               >
                 <img

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -13,6 +13,10 @@
   const hasSihRecommendation = $derived(activeModelName.includes("sih") || activeModelName.includes("σih"));
   const hasNanosaurRecommendation = $derived(generation.isNanosaur || activeModelName.includes("nanosaur"));
 
+  let animaRecOpen = $state(true);
+  let sihRecOpen = $state(true);
+  let nanosaurRecOpen = $state(true);
+
   function recommendedStepRange() {
     const sampler = generation.samplerName.toLowerCase();
     if (sampler.includes("euler")) return { min: 18, max: 28 };
@@ -91,53 +95,71 @@
 
 <div class="space-y-3">
   {#if hasAnimaRecommendation}
-    <div class="rounded-lg border border-indigo-700/50 bg-indigo-900/15 p-2.5">
-      <div class="flex items-start justify-between gap-2">
-        <div>
-          <p class="text-xs text-indigo-300 font-medium">{locale.t('generation.sampler.anima_recommended')}</p>
-          <p class="text-[11px] text-neutral-300 mt-0.5">{locale.t('generation.sampler.anima_hint')}</p>
+    <div class="rounded-lg border border-indigo-700/50 bg-indigo-900/15 overflow-hidden">
+      <button
+        class="w-full flex items-center justify-between px-2.5 py-2 text-left"
+        onclick={() => (animaRecOpen = !animaRecOpen)}
+      >
+        <p class="text-xs text-indigo-300 font-medium">{locale.t('generation.sampler.anima_recommended')}</p>
+        <svg class="w-3 h-3 text-indigo-400 shrink-0 transition-transform {animaRecOpen ? '' : '-rotate-90'}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      {#if animaRecOpen}
+        <div class="flex items-start justify-between gap-2 px-2.5 pb-2.5">
+          <p class="text-[11px] text-neutral-300">{locale.t('generation.sampler.anima_hint')}</p>
+          <button
+            class="shrink-0 px-2 py-1 text-[10px] rounded border border-indigo-500/70 text-indigo-200 hover:border-indigo-400 hover:text-indigo-100 transition-colors"
+            onclick={applyAnimaRecommendation}
+          >
+            {locale.t('common.apply')}
+          </button>
         </div>
-        <button
-          class="px-2 py-1 text-[10px] rounded border border-indigo-500/70 text-indigo-200 hover:border-indigo-400 hover:text-indigo-100 transition-colors"
-          onclick={applyAnimaRecommendation}
-        >
-          {locale.t('common.apply')}
-        </button>
-      </div>
+      {/if}
     </div>
   {/if}
 
   {#if hasSihRecommendation}
-    <div class="rounded-lg border border-neutral-700 bg-neutral-900/60 p-2.5">
-      <div class="flex items-start justify-between gap-2">
-        <div>
-          <p class="text-xs text-neutral-300 font-medium">{locale.t('generation.sampler.sih_recommended')}</p>
-          <p class="text-[11px] text-neutral-400 mt-0.5">{locale.t('generation.sampler.sih_hint')}</p>
+    <div class="rounded-lg border border-neutral-700 bg-neutral-900/60 overflow-hidden">
+      <button
+        class="w-full flex items-center justify-between px-2.5 py-2 text-left"
+        onclick={() => (sihRecOpen = !sihRecOpen)}
+      >
+        <p class="text-xs text-neutral-300 font-medium">{locale.t('generation.sampler.sih_recommended')}</p>
+        <svg class="w-3 h-3 text-neutral-500 shrink-0 transition-transform {sihRecOpen ? '' : '-rotate-90'}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      {#if sihRecOpen}
+        <div class="flex items-start justify-between gap-2 px-2.5 pb-2.5">
+          <p class="text-[11px] text-neutral-400">{locale.t('generation.sampler.sih_hint')}</p>
+          <button
+            class="shrink-0 px-2 py-1 text-[10px] rounded border border-neutral-600 text-neutral-300 hover:border-neutral-500 hover:text-neutral-200 transition-colors"
+            onclick={applySihRecommendation}
+          >
+            {locale.t('common.apply')}
+          </button>
         </div>
-        <button
-          class="px-2 py-1 text-[10px] rounded border border-neutral-600 text-neutral-300 hover:border-neutral-500 hover:text-neutral-200 transition-colors"
-          onclick={applySihRecommendation}
-        >
-          {locale.t('common.apply')}
-        </button>
-      </div>
+      {/if}
     </div>
   {/if}
 
   {#if hasNanosaurRecommendation}
-    <div class="rounded-lg border border-emerald-700/50 bg-emerald-900/15 p-2.5">
-      <div class="flex items-start justify-between gap-2">
-        <div>
-          <p class="text-xs text-emerald-300 font-medium">{locale.t('generation.sampler.nanosaur_recommended')}</p>
-          <p class="text-[11px] text-neutral-300 mt-0.5">{locale.t('generation.sampler.nanosaur_hint')}</p>
+    <div class="rounded-lg border border-emerald-700/50 bg-emerald-900/15 overflow-hidden">
+      <button
+        class="w-full flex items-center justify-between px-2.5 py-2 text-left"
+        onclick={() => (nanosaurRecOpen = !nanosaurRecOpen)}
+      >
+        <p class="text-xs text-emerald-300 font-medium">{locale.t('generation.sampler.nanosaur_recommended')}</p>
+        <svg class="w-3 h-3 text-emerald-500 shrink-0 transition-transform {nanosaurRecOpen ? '' : '-rotate-90'}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </button>
+      {#if nanosaurRecOpen}
+        <div class="flex items-start justify-between gap-2 px-2.5 pb-2.5">
+          <p class="text-[11px] text-neutral-300">{locale.t('generation.sampler.nanosaur_hint')}</p>
+          <button
+            class="shrink-0 px-2 py-1 text-[10px] rounded border border-emerald-500/70 text-emerald-200 hover:border-emerald-400 hover:text-emerald-100 transition-colors"
+            onclick={applyNanosaurRecommendation}
+          >
+            {locale.t('common.apply')}
+          </button>
         </div>
-        <button
-          class="px-2 py-1 text-[10px] rounded border border-emerald-500/70 text-emerald-200 hover:border-emerald-400 hover:text-emerald-100 transition-colors"
-          onclick={applyNanosaurRecommendation}
-        >
-          {locale.t('common.apply')}
-        </button>
-      </div>
+      {/if}
     </div>
   {/if}
 

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -2260,6 +2260,22 @@
 
           {#if !collapsed.autocomplete}
           <div class="px-5 pb-5 space-y-4">
+            <!-- Enabled toggle -->
+            <label class="flex items-center justify-between gap-3 cursor-pointer">
+              <div>
+                <p class="text-sm text-neutral-200">{locale.t('settings.autocomplete.enabled')}</p>
+                <p class="text-[11px] text-neutral-500 mt-0.5">{locale.t('settings.autocomplete.enabled_desc')}</p>
+              </div>
+              <button
+                class="relative w-10 h-5 rounded-full transition-colors shrink-0 {autocomplete.enabled ? 'bg-indigo-600' : 'bg-neutral-700'}"
+                onclick={() => { autocomplete.enabled = !autocomplete.enabled; autocomplete.saveSettings(); }}
+                role="switch"
+                aria-checked={autocomplete.enabled}
+              >
+                <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform {autocomplete.enabled ? 'translate-x-5' : ''}"></span>
+              </button>
+            </label>
+
             {#if isAdmin}
             <!-- Current source -->
             <div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -996,6 +996,8 @@ const de: Record<string, string> = {
   "settings.autocomplete.fetch": "Abrufen",
   "settings.autocomplete.fetching": "Wird geladen...",
   "settings.autocomplete.reset_builtin": "Auf integrierte Danbooru-Tags zurücksetzen",
+  "settings.autocomplete.enabled": "Tag-Autovervollständigung aktivieren",
+  "settings.autocomplete.enabled_desc": "Tag-Vorschläge beim Tippen im Prompt-Feld anzeigen.",
   "settings.interrogator.thresholds_desc": "Steuert die Konfidenzschwellen für den Bild-Interrogator (pixai-tagger). Niedrigere Werte geben mehr Tags zurück, höhere Werte sind selektiver.",
   "settings.interrogator.more_tags": "Mehr Tags",
   "settings.interrogator.fewer_tags": "Weniger Tags",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1090,6 +1090,8 @@ const en: Record<string, string> = {
   "settings.autocomplete.fetch": "Fetch",
   "settings.autocomplete.fetching": "Loading...",
   "settings.autocomplete.reset_builtin": "Reset to built-in Danbooru tags",
+  "settings.autocomplete.enabled": "Enable tag autocomplete",
+  "settings.autocomplete.enabled_desc": "Show tag suggestions while typing in the prompt box.",
 
   "settings.interrogator.thresholds_desc": "Controls confidence thresholds for the image interrogator (pixai-tagger). Lower values return more tags, higher values are more selective.",
   "settings.interrogator.more_tags": "More tags",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1027,6 +1027,8 @@ const es: Record<string, string> = {
   "settings.autocomplete.fetch": "Obtener",
   "settings.autocomplete.fetching": "Cargando...",
   "settings.autocomplete.reset_builtin": "Restablecer a tags Danbooru integrados",
+  "settings.autocomplete.enabled": "Activar autocompletado de etiquetas",
+  "settings.autocomplete.enabled_desc": "Mostrar sugerencias de etiquetas al escribir en el cuadro de texto.",
   "settings.interrogator.thresholds_desc": "Controla los umbrales de confianza del interrogador de imágenes (pixai-tagger). Valores más bajos devuelven más tags, valores más altos son más selectivos.",
   "settings.interrogator.more_tags": "Más tags",
   "settings.interrogator.fewer_tags": "Menos tags",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1021,6 +1021,8 @@ const fr: Record<string, string> = {
   "settings.autocomplete.fetch": "Récupérer",
   "settings.autocomplete.fetching": "Chargement...",
   "settings.autocomplete.reset_builtin": "Réinitialiser aux tags Danbooru intégrés",
+  "settings.autocomplete.enabled": "Activer la complétion automatique des tags",
+  "settings.autocomplete.enabled_desc": "Afficher des suggestions de tags lors de la saisie dans la zone de prompt.",
   "settings.interrogator.thresholds_desc": "Contrôle les seuils de confiance de l'interrogateur d'images (pixai-tagger). Des valeurs plus basses retournent plus de tags, des valeurs plus élevées sont plus sélectives.",
   "settings.interrogator.more_tags": "Plus de tags",
   "settings.interrogator.fewer_tags": "Moins de tags",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -996,6 +996,8 @@ const it: Record<string, string> = {
   "settings.autocomplete.fetch": "Recupera",
   "settings.autocomplete.fetching": "Caricamento...",
   "settings.autocomplete.reset_builtin": "Ripristina ai tag Danbooru integrati",
+  "settings.autocomplete.enabled": "Abilita completamento automatico tag",
+  "settings.autocomplete.enabled_desc": "Mostra suggerimenti di tag durante la digitazione nel campo prompt.",
   "settings.interrogator.thresholds_desc": "Controlla le soglie di confidenza dell'interrogatore di immagini (pixai-tagger). Valori più bassi restituiscono più tag, valori più alti sono più selettivi.",
   "settings.interrogator.more_tags": "Più tag",
   "settings.interrogator.fewer_tags": "Meno tag",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1021,6 +1021,8 @@ const ja: Record<string, string> = {
   "settings.autocomplete.fetch": "取得",
   "settings.autocomplete.fetching": "読み込み中...",
   "settings.autocomplete.reset_builtin": "組み込みDanbooruタグにリセット",
+  "settings.autocomplete.enabled": "タグ自動補完を有効にする",
+  "settings.autocomplete.enabled_desc": "プロンプト入力中にタグ候補を表示します。",
   "settings.interrogator.thresholds_desc": "画像インテロゲーター（pixai-tagger）の信頼度しきい値を制御します。低い値はより多くのタグを返し、高い値はより選択的です。",
   "settings.interrogator.more_tags": "タグを増やす",
   "settings.interrogator.fewer_tags": "タグを減らす",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -996,6 +996,8 @@ const ko: Record<string, string> = {
   "settings.autocomplete.fetch": "가져오기",
   "settings.autocomplete.fetching": "로딩 중...",
   "settings.autocomplete.reset_builtin": "기본 Danbooru 태그로 재설정",
+  "settings.autocomplete.enabled": "태그 자동완성 활성화",
+  "settings.autocomplete.enabled_desc": "프롬프트 입력 중 태그 제안을 표시합니다.",
   "settings.interrogator.thresholds_desc": "이미지 인터로게이터(pixai-tagger)의 신뢰도 임계값을 제어합니다. 낮은 값은 더 많은 태그를 반환하고, 높은 값은 더 선택적입니다.",
   "settings.interrogator.more_tags": "태그 늘리기",
   "settings.interrogator.fewer_tags": "태그 줄이기",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -996,6 +996,8 @@ const pt: Record<string, string> = {
   "settings.autocomplete.fetch": "Buscar",
   "settings.autocomplete.fetching": "Carregando...",
   "settings.autocomplete.reset_builtin": "Redefinir para tags Danbooru integradas",
+  "settings.autocomplete.enabled": "Ativar autocompletar de tags",
+  "settings.autocomplete.enabled_desc": "Mostrar sugestões de tags ao digitar no campo de prompt.",
   "settings.interrogator.thresholds_desc": "Controla os limites de confiança do interrogador de imagens (pixai-tagger). Valores mais baixos retornam mais tags, valores mais altos são mais seletivos.",
   "settings.interrogator.more_tags": "Mais tags",
   "settings.interrogator.fewer_tags": "Menos tags",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -996,6 +996,8 @@ const ru: Record<string, string> = {
   "settings.autocomplete.fetch": "Получить",
   "settings.autocomplete.fetching": "Загрузка...",
   "settings.autocomplete.reset_builtin": "Сбросить к встроенным тегам Danbooru",
+  "settings.autocomplete.enabled": "Включить автодополнение тегов",
+  "settings.autocomplete.enabled_desc": "Показывать предложения тегов при вводе в поле подсказки.",
   "settings.interrogator.thresholds_desc": "Управляет порогами доверия для интеррогатора изображений (pixai-tagger). Низкие значения возвращают больше тегов, высокие — более избирательны.",
   "settings.interrogator.more_tags": "Больше тегов",
   "settings.interrogator.fewer_tags": "Меньше тегов",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -996,6 +996,8 @@ const zhTw: Record<string, string> = {
   "settings.autocomplete.fetch": "取得",
   "settings.autocomplete.fetching": "載入中...",
   "settings.autocomplete.reset_builtin": "重置為內建 Danbooru 標籤",
+  "settings.autocomplete.enabled": "啟用標籤自動完成",
+  "settings.autocomplete.enabled_desc": "在提示框中輸入時顯示標籤建議。",
   "settings.interrogator.thresholds_desc": "控制圖像詢問器（pixai-tagger）的信心閾值。較低的值傳回更多標籤，較高的值更具選擇性。",
   "settings.interrogator.more_tags": "更多標籤",
   "settings.interrogator.fewer_tags": "更少標籤",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -996,6 +996,8 @@ const zh: Record<string, string> = {
   "settings.autocomplete.fetch": "获取",
   "settings.autocomplete.fetching": "加载中...",
   "settings.autocomplete.reset_builtin": "重置为内置 Danbooru 标签",
+  "settings.autocomplete.enabled": "启用标签自动补全",
+  "settings.autocomplete.enabled_desc": "在提示框中输入时显示标签建议。",
   "settings.interrogator.thresholds_desc": "控制图像询问器（pixai-tagger）的置信度阈值。较低的值返回更多标签，较高的值更具选择性。",
   "settings.interrogator.more_tags": "更多标签",
   "settings.interrogator.fewer_tags": "更少标签",

--- a/src/lib/stores/artistInsert.svelte.ts
+++ b/src/lib/stores/artistInsert.svelte.ts
@@ -26,7 +26,11 @@ class ArtistInsertStore {
    * The `tag` may be provided with or without a leading `@`.
    */
   request(tag: string): void {
-    const withAt = "@" + tag.replace(/^@/, "");
+    // Strip leading @, convert underscores to spaces (danbooru convention),
+    // then re-prefix with @. Escaped parens \( \) are left intact so prompts
+    // round-trip correctly through the scheduler/highlight parser.
+    const cleaned = tag.replace(/^@+/, "").replace(/_/g, " ").trim();
+    const withAt = "@" + cleaned;
     const existing = generation.positivePrompt.trim();
     const existingArtistTags = existing
       .split(",")
@@ -42,6 +46,9 @@ class ArtistInsertStore {
   }
 
   apply(withAt: string, mode: "add" | "replace"): void {
+    // Defensive: normalize underscores → spaces in case a caller passes
+    // a raw danbooru-style tag rather than going through request().
+    const cleaned = "@" + withAt.replace(/^@+/, "").replace(/_/g, " ").trim();
     const existing = generation.positivePrompt.trim();
     let newPrompt: string;
     if (mode === "replace") {
@@ -50,9 +57,9 @@ class ArtistInsertStore {
         .map((s) => s.trim())
         .filter((s) => !s.startsWith("@"))
         .join(", ");
-      newPrompt = stripped ? `${withAt}, ${stripped}` : withAt;
+      newPrompt = stripped ? `${cleaned}, ${stripped}` : cleaned;
     } else {
-      newPrompt = existing ? `${withAt}, ${existing}` : withAt;
+      newPrompt = existing ? `${cleaned}, ${existing}` : cleaned;
     }
     generation.positivePrompt = newPrompt;
     generation.saveSettings();

--- a/src/lib/stores/autocomplete.svelte.ts
+++ b/src/lib/stores/autocomplete.svelte.ts
@@ -29,6 +29,8 @@ class AutocompleteStore {
   sourceUrl = $state("");
   /** Display name of uploaded file */
   sourceFileName = $state("");
+  /** Whether tag autocomplete is enabled */
+  enabled = $state(true);
   /** Whether a custom taglist is currently loading */
   loading = $state(false);
   /** Error message if loading failed */
@@ -76,6 +78,7 @@ class AutocompleteStore {
   }
 
   search(queryText: string, limit = this.maxResults): TagEntry[] {
+    if (!this.enabled) return [];
     const normalizedQuery = this.normalizeQuery(queryText);
     if (!normalizedQuery) return [];
 
@@ -103,6 +106,7 @@ class AutocompleteStore {
       this._storeReady = true;
       const saved = await ipcStore.get<Record<string, any>>(STORE_KEY);
       if (saved) {
+        if (saved.enabled === false) this.enabled = false;
         if (saved.maxResults) this.maxResults = saved.maxResults;
         if (saved.sourceMode) this.sourceMode = saved.sourceMode;
         if (saved.sourceUrl) this.sourceUrl = saved.sourceUrl;
@@ -127,6 +131,7 @@ class AutocompleteStore {
     if (!this._storeReady) return;
     try {
       await ipcStore.set(STORE_KEY, {
+        enabled: this.enabled,
         maxResults: this.maxResults,
         sourceMode: this.sourceMode,
         sourceUrl: this.sourceUrl,

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -664,6 +664,17 @@ class GalleryStore {
         bytes = await getOutputImage(image.filename, image.subfolder);
       }
 
+      // JXL → PNG transcode strips embedded metadata. Re-embed from the
+      // in-memory metadata so the exported PNG carries the original prompt /
+      // workflow info (parity with saveImageToDir).
+      if (isJxlGallery && image.metadata) {
+        try {
+          bytes = await embedPngMetadataBytes(bytes, image.metadata, generation.metadataMode);
+        } catch (e) {
+          console.warn("Failed to embed PNG metadata into JXL export:", e);
+        }
+      }
+
       // Replace .jxl with .png in the suggested filename — the file is exported as PNG.
       const defaultFilename = isJxlGallery
         ? image.filename.replace(/\.jxl$/i, ".png")
@@ -768,6 +779,28 @@ class GalleryStore {
         // Step 1: Try server-side native clipboard (preserves full PNG with metadata).
         // May fail on headless servers without xclip/wl-copy — fall through to browser API.
         if (galleryFilename) {
+          // JXL: the server-side clipboard handler can't paste raw JXL as an
+          // image, and the standard fetch path serves WebP (no metadata).
+          // Explicitly transcode to PNG + re-embed metadata so paste targets
+          // get a usable, metadata-bearing image.
+          if (galleryFilename.endsWith(".jxl")) {
+            try {
+              let pngBytes = await loadGalleryImagePng(galleryFilename);
+              if (image.metadata) {
+                try {
+                  pngBytes = await embedPngMetadataBytes(pngBytes, image.metadata, generation.metadataMode);
+                } catch (e) {
+                  console.warn("Failed to embed PNG metadata into JXL clipboard copy:", e);
+                }
+              }
+              const pngBlob = new Blob([new Uint8Array(pngBytes)], { type: "image/png" });
+              await this.writeBlobToClipboard(pngBlob);
+              this.showToast(locale.t("gallery.toast.copied"), "success");
+              return;
+            } catch (e) {
+              console.warn("JXL clipboard transcode failed, falling back:", e);
+            }
+          }
           try {
             const path = await getGalleryImagePath(galleryFilename);
             await copyImageToClipboard(path);
@@ -821,7 +854,15 @@ class GalleryStore {
         if (image.gallery_filename.endsWith(".jxl")) {
           // JXL can't be pasted as an image from the raw file path —
           // transcode to PNG first and copy bytes via native clipboard.
-          const pngBytes = await loadGalleryImagePng(image.gallery_filename);
+          // PNG transcode strips metadata, so re-embed it client-side.
+          let pngBytes = await loadGalleryImagePng(image.gallery_filename);
+          if (image.metadata) {
+            try {
+              pngBytes = await embedPngMetadataBytes(pngBytes, image.metadata, generation.metadataMode);
+            } catch (e) {
+              console.warn("Failed to embed PNG metadata into JXL clipboard copy:", e);
+            }
+          }
           await copyBytesToClipboard(pngBytes, "png");
         } else {
           const path = await getGalleryImagePath(image.gallery_filename);

--- a/src/lib/utils/promptSchedule.ts
+++ b/src/lib/utils/promptSchedule.ts
@@ -34,6 +34,8 @@ export interface ParsedPrompt {
 /**
  * Split a SwarmUI fromto content string by the most unique separator.
  * Priority: || > | > ,
+ * Either side may be empty (e.g. `<fromto[0.5]:||after>` is valid and produces
+ * only the "after" segment). Returns null only when BOTH sides are empty.
  */
 function splitSwarmContent(content: string): [string, string] | null {
   let parts: string[];
@@ -44,7 +46,8 @@ function splitSwarmContent(content: string): [string, string] | null {
   } else {
     parts = content.split(",").map((s) => s.trim());
   }
-  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  if (parts.length !== 2) return null;
+  if (!parts[0] && !parts[1]) return null;
   return [parts[0], parts[1]];
 }
 
@@ -124,10 +127,12 @@ export function parseScheduledPrompt(raw: string): ParsedPrompt {
       }
 
       const [before, after] = parts;
-      segments.push({ text: before, start: 0, end: timestep });
-      segments.push({ text: after, start: timestep, end: 1.0 });
-      // Keep both texts in baseText for metadata
-      baseText += `${before}, ${after}`;
+      if (before) segments.push({ text: before, start: 0, end: timestep });
+      if (after) segments.push({ text: after, start: timestep, end: 1.0 });
+      // Do NOT add the inner halves to baseText — they should only apply within
+      // their scheduled timestep range. Otherwise both halves would be active
+      // across the full sampling duration (via the base conditioning) AND added
+      // again during their window, which is not what fromto means.
     }
   }
 


### PR DESCRIPTION
## What's New in v1.2.2

### Prompt Scheduling Fixes
- SwarmUI `<fromto[N]:A||B>` empty-side handling — `<fromto[10]:cat||>` / `<fromto[10]:||dog>` now parse correctly.
- Double-encoding fix — `before`/`after` halves no longer also leak into the base prompt across all steps.

### JXL Pipeline
- Generation metadata preserved on "Save Image As…" and "Copy to Clipboard" for JXL gallery images (re-embedded into the PNG export).
- Browser-mode JXL support — `load_gallery_image_display` and `load_gallery_image_png` now dispatched through the embedded web server.
- Edge download `Content-Disposition` filename fix.

### Generation UI
- Collapsible Anima / Illustrious / NanoSaur recommendation panels in Sampler Settings.
- New "Tag autocomplete enabled" toggle in Settings (translated across all 11 locales).
- Artist gallery tag insertion now converts underscores to spaces.
- Session image grid no longer overlaps at large card sizes.