### PR TITLE
v1.2.4: JXL save fix, JXL copy metadata, dep bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## What's New in v1.2.4
+
+### JXL Image Save Fix (Browser/Server Mode)
+- Fixed a **500 error** when saving a JXL-format generation from the preview menu in browser/server mode. The server was asked to transcode the raw `.jxl` temp file on-the-fly, which it cannot do. MooshieUI now uses the pre-built WebP display copy (already served for preview) for the save operation, eliminating the error entirely.
+
+### JXL Clipboard Copy — Metadata Now Included
+- Copying a JXL session image to the clipboard now correctly re-embeds generation metadata (prompt, sampler, seed, etc.) into the PNG. Previously the clipboard copy went through a canvas round-trip that stripped all metadata; it now falls back gracefully to the pre-built display copy with full metadata intact when the gallery transcoder is unavailable.
+
+### Dependency Updates
+- Bumped `rusqlite`, `axum`, `open`, and `zip` to their latest stable releases.
+
+---
+
 ## What's New in v1.2.3
 
 ### Port Conflict — Kill & Restart

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## What's New in v1.2.4
+
+### JXL Image Save Fix (Browser/Server Mode)
+- Fixed a **500 error** when saving a JXL-format generation from the preview menu in browser/server mode. The server was asked to transcode the raw `.jxl` temp file on-the-fly, which it cannot do. MooshieUI now uses the pre-built WebP display copy (already served for preview) for the save operation, eliminating the error entirely.
+
+### JXL Clipboard Copy — Metadata Now Included
+- Copying a JXL session image to the clipboard now correctly re-embeds generation metadata (prompt, sampler, seed, etc.) into the PNG. Previously the clipboard copy went through a canvas round-trip that stripped all metadata; it now falls back gracefully to the pre-built display copy with full metadata intact when the gallery transcoder is unavailable.
+
+### Dependency Updates
+- Bumped `rusqlite`, `axum`, `open`, and `zip` to their latest stable releases.
+
+---
+
 ## What's New in v1.2.3
 
 ### Port Conflict — Kill & Restart

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -665,10 +665,11 @@ class GalleryStore {
         bytes = isJxlGallery
           ? await loadGalleryImagePng(image.gallery_filename)
           : await loadGalleryImage(image.gallery_filename);
-      } else if (isBrowserMode && image.tempFilename) {
-        // Browser-mode session image: use the server temp file directly instead
-        // of fetching blob: URLs, which some proxied browser contexts reject.
-        bytes = await this._tempImageToPngBytes(image.tempFilename, image.filename);
+      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
+        // Browser-mode session image: prefer the pre-built display WebP (for JXL)
+        // over fetching the raw temp with ?format=webp, which fails for JXL files.
+        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
+        bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
       } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
         bytes = await this._blobToPngBytes(image.sessionBlob);
       } else if (image.url) {
@@ -776,8 +777,11 @@ class GalleryStore {
         bytes = isJxlGallery
           ? await loadGalleryImagePng(image.gallery_filename)
           : await loadGalleryImage(image.gallery_filename);
-      } else if (isBrowserMode && image.tempFilename) {
-        bytes = await this._tempImageToPngBytes(image.tempFilename, image.filename);
+      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
+        // Browser-mode session image: prefer the pre-built display WebP (for JXL)
+        // over fetching the raw temp with ?format=webp, which fails for JXL files.
+        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
+        bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
       } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
         bytes = await this._blobToPngBytes(image.sessionBlob);
       } else if (image.url) {
@@ -839,8 +843,24 @@ class GalleryStore {
           // Explicitly transcode to PNG + re-embed metadata so paste targets
           // get a usable, metadata-bearing image.
           if (galleryFilename.endsWith(".jxl")) {
+            let pngBytes: number[] | null = null;
             try {
-              let pngBytes = await loadGalleryImagePng(galleryFilename);
+              pngBytes = await loadGalleryImagePng(galleryFilename);
+            } catch (e) {
+              console.warn("JXL gallery transcode failed, falling back to display copy:", e);
+              // Server can't decode JXL — use the pre-built WebP display copy instead.
+              const displayUrl = image.displayTempFilename
+                ? tempImageUrl(image.displayTempFilename)
+                : image.url;
+              if (displayUrl) {
+                try {
+                  pngBytes = await this._blobUrlToPngBytes(displayUrl);
+                } catch (e2) {
+                  console.warn("JXL display copy fallback also failed:", e2);
+                }
+              }
+            }
+            if (pngBytes) {
               if (image.metadata) {
                 try {
                   pngBytes = await embedPngMetadataBytes(pngBytes, image.metadata, generation.metadataMode);
@@ -852,8 +872,6 @@ class GalleryStore {
               await this.writeBlobToClipboard(pngBlob);
               this.showToast(locale.t("gallery.toast.copied"), "success");
               return;
-            } catch (e) {
-              console.warn("JXL clipboard transcode failed, falling back:", e);
             }
           }
           try {


### PR DESCRIPTION
## v1.2.4

### JXL Image Save Fix (Browser/Server Mode)
- Fixed a **500 error** when saving a JXL-format generation from the preview menu in browser/server mode. The server was asked to transcode the raw `.jxl` temp file on-the-fly, which it cannot do. MooshieUI now uses the pre-built WebP display copy (already served for preview) for the save operation.

### JXL Clipboard Copy — Metadata Now Included
- Copying a JXL session image to the clipboard now correctly re-embeds generation metadata (prompt, sampler, seed, etc.) into the PNG. Previously the clipboard copy went through a canvas round-trip that stripped all metadata; it now falls back gracefully to the pre-built display copy with full metadata intact when the gallery transcoder is unavailable.

### Dependency Updates
- Bumped `rusqlite`, `axum`, `open`, and `zip` to their latest stable releases.