### PR TITLE
v1.2.6: Fix ordered wildcard cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v1.2.6
+
+### Ordered Wildcard Cancellation
+- **Left-click cancel recovers cleanly**: cancelling an ordered wildcard run now wakes backend held-prompt tasks, removes queued prompts, and leaves MooshieUI ready for another generation.
+- **Canceled previews no longer freeze the generation pane**: active prompt cancellation now clears the live preview, progress, active node, and queue state.
+
+---
+
 ## What's New in v1.2.5
 
 ### Prompt Preset Wildcards

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v1.2.6
+
+### Ordered Wildcard Cancellation
+- **Left-click cancel recovers cleanly**: cancelling an ordered wildcard run now wakes backend held-prompt tasks, removes queued prompts, and leaves MooshieUI ready for another generation.
+- **Canceled previews no longer freeze the generation pane**: active prompt cancellation now clears the live preview, progress, active node, and queue state.
+
+---
+
 ## What's New in v1.2.5
 
 ### Prompt Preset Wildcards

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -247,6 +247,14 @@ impl AppState {
             }
         }
 
+        for hp in self.prompt_queue.take_held_related_to(&ids_to_delete) {
+            {
+                let mut result = hp.result.lock().await;
+                *result = Some(Err("generation.error_cancelled".to_string()));
+            }
+            hp.submitted.notify_one();
+        }
+
         if !ids_to_delete.is_empty() {
             for worker in &self.gpu_manager.workers {
                 let _ = self

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::process::Child;
@@ -205,6 +205,36 @@ impl PromptQueue {
             .unwrap()
             .retain(|real, placeholder| !ids.iter().any(|id| id == real || id == placeholder));
         ids
+    }
+
+    /// Remove held prompts matching any placeholder/real id and return them
+    /// so callers can wake their waiting submission tasks with a cancellation.
+    pub fn take_held_related_to(&self, prompt_ids: &[String]) -> Vec<HeldPrompt> {
+        if prompt_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let id_set: HashSet<String> = prompt_ids.iter().cloned().collect();
+        let mut held = self.held.lock().unwrap();
+        let mut kept: Vec<HeldPrompt> = Vec::with_capacity(held.len());
+        let mut taken: Vec<HeldPrompt> = Vec::new();
+
+        for hp in held.drain(..) {
+            let is_match = id_set.contains(&hp.placeholder_id)
+                || self
+                    .related_ids(&hp.placeholder_id)
+                    .iter()
+                    .any(|id| id_set.contains(id));
+
+            if is_match {
+                taken.push(hp);
+            } else {
+                kept.push(hp);
+            }
+        }
+
+        *held = kept;
+        taken
     }
 
     /// Return a prompt id plus its placeholder/real-id aliases.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -260,9 +260,22 @@ class ProgressStore {
 
   /** Remove a specific prompt from the queue (e.g. on error). */
   removePrompt(promptId: string) {
+    const wasActive = this.activePromptId === promptId;
     this.pendingPrompts = this.pendingPrompts.filter((p) => p.promptId !== promptId);
-    if (this.activePromptId === promptId) {
+
+    if (wasActive || this.pendingPrompts.length === 0) {
       this.activePromptId = null;
+      this.currentStep = 0;
+      this.totalSteps = 0;
+      this.currentNode = null;
+      this.previewImage = null;
+      this.samplingPass = 0;
+      this._lastProgressNode = null;
+    }
+
+    if (this.pendingPrompts.length === 0) {
+      this.queuePosition = null;
+      this.queueTotal = 0;
     }
   }
 


### PR DESCRIPTION
## Changes\n- Fix left-click cancel recovery for ordered wildcard runs by waking canceled held prompt tasks.\n- Clear active preview and progress state after canceling the active prompt so the generation pane is ready for new work.\n- Bump MooshieUI to v1.2.6 and update release notes.\n\n## Validation\n- Skipped local checks per request.