### PR TITLE
v1.2.7: Fix ordered wildcard cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v1.2.7
+
+### Ordered Wildcard Cancellation
+- **Left-click now skips the current ordered wildcard item**: ordered wildcard runs keep moving after skipping only the active item instead of canceling the whole batch.
+- **Right-click now cancels the full ordered wildcard run**: full-run cancellation invalidates stale async submissions, clears the visible queue immediately, and uses the backend user-scoped cancel path.
+- **Canceled ordered runs no longer revive stale UI state**: token guards prevent late generation responses from re-enabling old runs or enqueueing canceled prompts after a new generation starts.
+
+---
+
 ## What's New in v1.2.6
 
 ### Ordered Wildcard Cancellation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v1.2.7
+
+### Ordered Wildcard Cancellation
+- **Left-click now skips the current ordered wildcard item**: ordered wildcard runs keep moving after skipping only the active item instead of canceling the whole batch.
+- **Right-click now cancels the full ordered wildcard run**: full-run cancellation invalidates stale async submissions, clears the visible queue immediately, and uses the backend user-scoped cancel path.
+- **Canceled ordered runs no longer revive stale UI state**: token guards prevent late generation responses from re-enabling old runs or enqueueing canceled prompts after a new generation starts.
+
+---
+
 ## What's New in v1.2.6
 
 ### Ordered Wildcard Cancellation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.6"
+version = "1.2.7"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -20,13 +20,19 @@
   let isSubmitting = $state(false);
   let orderedRunPromptIds = $state<string[]>([]);
   let orderedRunCancelRequested = $state(false);
+  let submitRunToken = 0;
+  let orderedRunToken = 0;
   const orderedWildcardRun = $derived(promptPresets.orderedWildcardRun);
   const orderedWildcardRunCount = $derived(compare.enabled && compare.cellCount > 1 ? 0 : (orderedWildcardRun?.count ?? 0));
   const pendingOrderedRunIds = $derived(orderedRunPromptIds.filter((id) => progress.pendingPrompts.some((prompt) => prompt.promptId === id)));
 
-  async function submitGeneration(params: GenerationParams): Promise<string> {
+  async function requestGeneration(params: GenerationParams) {
     const result = await generate(params);
     params.seed = result.seed;
+    return result;
+  }
+
+  function trackGeneration(params: GenerationParams, result: Awaited<ReturnType<typeof requestGeneration>>): string {
     progress.enqueue(result.prompt_id, params.upscale_enabled, params.mode, params);
     if (result.queue_position != null && result.queue_total != null) {
       progress.updateQueuePosition(result.prompt_id, result.queue_position, result.queue_total);
@@ -34,14 +40,25 @@
     return result.prompt_id;
   }
 
+  async function submitGeneration(params: GenerationParams): Promise<string> {
+    return trackGeneration(params, await requestGeneration(params));
+  }
+
+  function finishSubmitRun(runToken: number) {
+    if (runToken === submitRunToken) {
+      isSubmitting = false;
+    }
+  }
+
   async function handleGenerate() {
     if (isSubmitting) return;
+    const runToken = ++submitRunToken;
     isSubmitting = true;
     errorMsg = null;
 
     if (!generation.checkpoint) {
       errorMsg = locale.t('generation.error_no_checkpoint');
-      isSubmitting = false;
+      finishSubmitRun(runToken);
       return;
     }
 
@@ -121,10 +138,12 @@
       await submitGeneration(params);
       generation.saveSettings();
     } catch (e) {
-      console.error("Generation failed:", e);
-      errorMsg = String(e);
+      if (runToken === submitRunToken) {
+        console.error("Generation failed:", e);
+        errorMsg = String(e);
+      }
     } finally {
-      isSubmitting = false;
+      finishSubmitRun(runToken);
     }
   }
 
@@ -135,10 +154,11 @@
     if (choices.length === 0) return;
 
     generation.saveCurrentPromptToHistory();
+    const runToken = ++orderedRunToken;
     orderedRunPromptIds = [];
     orderedRunCancelRequested = false;
     for (let i = 0; i < count; i++) {
-      if (orderedRunCancelRequested) break;
+      if (orderedRunCancelRequested || runToken !== orderedRunToken) break;
       const choiceIndex = (run.nextIndex + i) % choices.length;
       const fixedPresetChoices = new Map([[run.presetId, choices[choiceIndex]]]);
       const params = generation.toParams({ fixedPresetChoices });
@@ -150,21 +170,34 @@
         "output_bit_depth:",
         params.output_bit_depth,
       );
-      const promptId = await submitGeneration(params);
-      orderedRunPromptIds.push(promptId);
-      if (orderedRunCancelRequested) {
-        await cancelOrderedPromptIds([promptId]);
+      let result: Awaited<ReturnType<typeof requestGeneration>>;
+      try {
+        result = await requestGeneration(params);
+      } catch (e) {
+        if (orderedRunCancelRequested || runToken !== orderedRunToken) break;
+        throw e;
+      }
+      if (orderedRunCancelRequested || runToken !== orderedRunToken) {
+        try { await interruptGeneration(result.prompt_id); } catch { /* already gone */ }
+        break;
+      }
+      const promptId = trackGeneration(params, result);
+      orderedRunPromptIds = [...orderedRunPromptIds, promptId];
+      if (orderedRunCancelRequested || runToken !== orderedRunToken) {
+        await cancelPromptIds([promptId], true);
         break;
       }
       promptPresets.setOrderedWildcardIndex(run.presetId, choiceIndex + 1);
     }
-    generation.saveSettings();
+    if (runToken === orderedRunToken) {
+      generation.saveSettings();
+    }
   }
 
-  /** Left-click: cancel the active ordered run, otherwise cancel the current generation. */
+  /** Left-click: skip the current ordered item, otherwise cancel the current generation. */
   async function handleCancelCurrent() {
-    if (pendingOrderedRunIds.length > 0 || (isSubmitting && orderedWildcardRunCount > 1)) {
-      await handleCancelOrderedRun();
+    if (pendingOrderedRunIds.length > 0) {
+      await handleSkipOrderedPrompt();
       return;
     }
     const promptId = progress.activePromptId ?? progress.pendingPrompts[0]?.promptId;
@@ -172,22 +205,25 @@
     if (promptId) progress.removePrompt(promptId);
   }
 
-  async function handleCancelOrderedRun() {
-    orderedRunCancelRequested = true;
-    await cancelOrderedPromptIds([...pendingOrderedRunIds]);
+  async function handleSkipOrderedPrompt() {
+    const promptId = progress.activePromptId && pendingOrderedRunIds.includes(progress.activePromptId)
+      ? progress.activePromptId
+      : pendingOrderedRunIds[0];
+    if (!promptId) return;
+    await cancelPromptIds([promptId], true);
   }
 
-  async function cancelOrderedPromptIds(idsToCancel: string[]) {
+  async function cancelPromptIds(idsToCancel: string[], interruptActive = false) {
     if (idsToCancel.length === 0) return;
-    const activeOrderedId = progress.activePromptId && idsToCancel.includes(progress.activePromptId)
+    const activePromptId = progress.activePromptId && idsToCancel.includes(progress.activePromptId)
       ? progress.activePromptId
       : null;
 
-    if (activeOrderedId) {
-      await interruptGeneration(activeOrderedId);
+    if (interruptActive && activePromptId) {
+      await interruptGeneration(activePromptId);
     }
     for (const promptId of idsToCancel) {
-      if (promptId === activeOrderedId) continue;
+      if (promptId === activePromptId) continue;
       try { await deleteQueueItem(promptId); } catch { /* already removed */ }
     }
     for (const promptId of idsToCancel) {
@@ -199,16 +235,19 @@
   /** Right-click: cancel current + clear the entire queue. */
   async function handleCancelAll(e: MouseEvent) {
     e.preventDefault();
-    const promptIds = progress.pendingPrompts.map((p) => p.promptId);
-    const activeId = progress.activePromptId;
-    await interruptGeneration(activeId ?? undefined);
-    for (const pid of promptIds) {
-      try { await deleteQueueItem(pid); } catch { /* already removed */ }
-    }
-    progress.cancelAll();
     orderedRunCancelRequested = true;
+    submitRunToken++;
+    orderedRunToken++;
+    progress.cancelAll();
     orderedRunPromptIds = [];
     compare.clearGridBatch();
+    try {
+      await interruptGeneration();
+    } catch (e) {
+      console.error("Failed to cancel queued generations:", e);
+    } finally {
+      isSubmitting = false;
+    }
   }
 
   /** Generate all grid cells sequentially with a shared seed, then stitch into a grid. */


### PR DESCRIPTION
- Fix ordered wildcard left-click behavior so it skips only the current item.\n- Fix right-click behavior so it cancels the full ordered wildcard run.\n- Guard canceled ordered runs against stale async generation responses.\n\nLocal checks skipped per request.