### PR TITLE
v1.2.8: Browser mode image save reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## What's New in v1.2.8
+
+### Browser Mode Image Saves
+- **Generated images no longer disappear after save**: browser-mode temp images stay available long enough for gallery persistence, manual saves, and retrying clients instead of turning into late 404s.
+- **Save and export actions recover from stale temp URLs**: generated image actions now fall back to the in-session blob when a temp handoff has expired.
+- **JXL export metadata is preserved**: JXL-to-PNG save and copy paths keep generation metadata while using the safer browser-mode fallback pipeline.
+
+### Artist Gallery
+- **CDN previews work in browser mode**: artist gallery images now route through the embedded CDN proxy when needed, avoiding browser CORS failures.
+- **CDN proxy URLs keep query strings**: proxied CDN requests now preserve the original query parameters for future cache and asset variants.
+
+### Generation Reliability and Hardening
+- **Stale blob retries are cleaned up**: thumbnail retry timers are cancelled when image URLs change, preventing old revoked blob URLs from retrying forever.
+- **Reconnect recovery is more immediate**: SSE reconnects now force pending prompts through the recovery check so missed outputs are picked up sooner.
+- **Queue updates stay accurate after errors**: execution errors emit the real remaining queue positions instead of clearing unrelated prompts.
+- **Model metadata lookups reject unsafe paths**: model category and filename inputs are validated before filesystem access in desktop and browser mode.
+- **Temporary output recovery caches now expire**: cached output references remain available for missed-event recovery, then clear automatically to avoid long-session memory growth.
+
+---
+
 ## What's New in v1.2.7
 
 ### Ordered Wildcard Cancellation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+## What's New in v1.2.8
+
+### Browser Mode Image Saves
+- **Generated images no longer disappear after save**: browser-mode temp images stay available long enough for gallery persistence, manual saves, and retrying clients instead of turning into late 404s.
+- **Save and export actions recover from stale temp URLs**: generated image actions now fall back to the in-session blob when a temp handoff has expired.
+- **JXL export metadata is preserved**: JXL-to-PNG save and copy paths keep generation metadata while using the safer browser-mode fallback pipeline.
+
+### Artist Gallery
+- **CDN previews work in browser mode**: artist gallery images now route through the embedded CDN proxy when needed, avoiding browser CORS failures.
+- **CDN proxy URLs keep query strings**: proxied CDN requests now preserve the original query parameters for future cache and asset variants.
+
+### Generation Reliability and Hardening
+- **Stale blob retries are cleaned up**: thumbnail retry timers are cancelled when image URLs change, preventing old revoked blob URLs from retrying forever.
+- **Reconnect recovery is more immediate**: SSE reconnects now force pending prompts through the recovery check so missed outputs are picked up sooner.
+- **Queue updates stay accurate after errors**: execution errors emit the real remaining queue positions instead of clearing unrelated prompts.
+- **Model metadata lookups reject unsafe paths**: model category and filename inputs are validated before filesystem access in desktop and browser mode.
+- **Temporary output recovery caches now expire**: cached output references remain available for missed-event recovery, then clear automatically to avoid long-session memory growth.
+
+---
+
 ## What's New in v1.2.7
 
 ### Ordered Wildcard Cancellation

--- a/cargo_check.txt
+++ b/cargo_check.txt
@@ -1,1 +1,0 @@
-error: could not find `Cargo.toml` in `D:\Repos\MooshieUI` or any parent directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-desktop",
-  "version": "1.1.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "1.1.7",
+      "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.2.7"
+version = "1.2.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -418,11 +418,31 @@ pub async fn connect_websocket(
                                                 .await;
                                         }
                                         ws_state.prompt_queue.drain_notify.notify_one();
-                                        // Signal frontend that queue has been cleared.
-                                        emit(
-                                            "mooshie:queue_update",
-                                            serde_json::json!({ "total": 0_u32 }),
-                                        );
+                                        let updates: Vec<serde_json::Value> = {
+                                            let queue = ws_state.prompt_queue.queue.read().unwrap();
+                                            let total = queue.len();
+                                            queue
+                                                .iter()
+                                                .enumerate()
+                                                .map(|(pos, (pid, _))| {
+                                                    serde_json::json!({
+                                                        "prompt_id": pid,
+                                                        "position": pos,
+                                                        "total": total,
+                                                    })
+                                                })
+                                                .collect()
+                                        };
+                                        if updates.is_empty() {
+                                            emit(
+                                                "mooshie:queue_update",
+                                                serde_json::json!({ "total": 0_u32 }),
+                                            );
+                                        } else {
+                                            for payload in updates {
+                                                emit("mooshie:queue_update", payload);
+                                            }
+                                        }
                                     }
                                     _ => {}
                                 }

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -194,6 +194,31 @@ pub struct ModelInstallDir {
     pub label: String,
 }
 
+pub(crate) fn is_safe_path_component(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed != value {
+        return false;
+    }
+
+    let path = std::path::Path::new(trimmed);
+    let mut components = path.components();
+    matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none()
+}
+
+pub(crate) fn is_safe_relative_model_path(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed != value {
+        return false;
+    }
+
+    let path = std::path::Path::new(trimmed);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
 /// Returns all directories where a model of the given category can be installed.
 /// Always includes the primary app directory; also includes any extra_model_paths
 /// subdirectories for the category that already exist on disk.
@@ -203,6 +228,10 @@ pub async fn get_model_install_dirs(
     state: State<'_, Arc<AppState>>,
     category: String,
 ) -> Result<Vec<ModelInstallDir>, AppError> {
+    if !is_safe_path_component(&category) {
+        return Err(AppError::Other("Invalid model category".into()));
+    }
+
     let config = state.config.read().await;
     let comfyui_path = config.comfyui_path.clone();
     let extra_model_paths = config.extra_model_paths.clone();
@@ -1439,6 +1468,10 @@ pub async fn find_model_by_hash(
     category: String,
     hash: String,
 ) -> Result<Option<String>, AppError> {
+    if !is_safe_path_component(&category) {
+        return Err(AppError::Other("Invalid model category".into()));
+    }
+
     let config = state.config.read().await;
     if config.comfyui_path.is_empty() {
         return Ok(None);
@@ -1491,6 +1524,13 @@ pub async fn hash_model_file(
     category: String,
     filename: String,
 ) -> Result<ModelHashResult, AppError> {
+    if !is_safe_path_component(&category) {
+        return Err(AppError::Other("Invalid model category".into()));
+    }
+    if !is_safe_relative_model_path(&filename) {
+        return Err(AppError::Other("Invalid model filename".into()));
+    }
+
     let config = state.config.read().await;
     if config.comfyui_path.is_empty() {
         return Err(AppError::Other("ComfyUI path not configured".into()));
@@ -1500,7 +1540,7 @@ pub async fn hash_model_file(
         .join(&category)
         .join(&filename);
 
-    if !path.exists() {
+    if !path.is_file() {
         return Err(AppError::Other(format!("File not found: {}", filename)));
     }
     let sha256 = full_sha256(&path)?;
@@ -1780,6 +1820,13 @@ pub async fn read_modelspec(
     category: String,
     filename: String,
 ) -> Result<Option<std::collections::HashMap<String, String>>, AppError> {
+    if !is_safe_path_component(&category) {
+        return Err(AppError::Other("Invalid model category".into()));
+    }
+    if !is_safe_relative_model_path(&filename) {
+        return Err(AppError::Other("Invalid model filename".into()));
+    }
+
     let config = state.config.read().await;
     if config.comfyui_path.is_empty() {
         return Err(AppError::Other("ComfyUI path not configured".into()));
@@ -1789,7 +1836,7 @@ pub async fn read_modelspec(
         .join(&category)
         .join(&filename);
 
-    if !path.exists() {
+    if !path.is_file() {
         return Err(AppError::Other(format!("File not found: {}", filename)));
     }
 
@@ -2076,6 +2123,10 @@ pub(crate) fn resolve_model_path(
     category: &str,
     filename: &str,
 ) -> Option<std::path::PathBuf> {
+    if !is_safe_path_component(category) || !is_safe_relative_model_path(filename) {
+        return None;
+    }
+
     // Primary ComfyUI directory always uses the canonical category name
     let primary = std::path::Path::new(comfyui_path)
         .join("models")

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -139,17 +139,19 @@ impl PromptQueue {
             // Skip past one prompt from each other user after our last prompt
             let mut insert_pos = last_own_idx + 1;
             let mut other_seen = std::collections::HashSet::new();
-            for i in insert_pos..queue.len() {
-                let (_, ref owner) = queue[i];
+            let mut scan_pos = insert_pos;
+            while scan_pos < queue.len() {
+                let (_, ref owner) = queue[scan_pos];
                 if *owner != username {
                     other_seen.insert(owner.clone());
-                    insert_pos = i + 1;
+                    insert_pos = scan_pos + 1;
                     if other_seen.len() >= num_users - 1 {
                         break;
                     }
                 } else {
                     break;
                 }
+                scan_pos += 1;
             }
 
             queue.insert(insert_pos, (prompt_id.to_string(), username));
@@ -517,15 +519,13 @@ impl AppState {
         // 1. If a specific prompt is being cancelled and it's still held
         //    locally (never submitted to ComfyUI), cancel it there and stop.
         if let Some(pid) = prompt_id {
-            let held_index = {
-                let held = self.prompt_queue.held.lock().unwrap();
-                held.iter().position(|hp| hp.placeholder_id == pid)
+            let held_prompt = {
+                let mut held = self.prompt_queue.held.lock().unwrap();
+                held.iter()
+                    .position(|hp| hp.placeholder_id == pid)
+                    .map(|idx| held.remove(idx))
             };
-            if let Some(idx) = held_index {
-                let hp = {
-                    let mut held = self.prompt_queue.held.lock().unwrap();
-                    held.remove(idx)
-                };
+            if let Some(hp) = held_prompt {
                 {
                     let mut result = hp.result.lock().await;
                     *result = Some(Err("generation.error_cancelled".to_string()));

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -44,6 +44,7 @@ pub struct WebState {
 pub type SharedState = Arc<WebState>;
 
 type BackgroundTask = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+const TEMP_EVENT_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 
 #[cfg(feature = "desktop")]
 fn spawn_background(task: BackgroundTask) {
@@ -53,6 +54,22 @@ fn spawn_background(task: BackgroundTask) {
 #[cfg(not(feature = "desktop"))]
 fn spawn_background(task: BackgroundTask) {
     tokio::spawn(task);
+}
+
+fn schedule_temp_event_cache_cleanup(state: Arc<AppState>, prompt_ids: Vec<String>) {
+    if prompt_ids.is_empty() {
+        return;
+    }
+
+    spawn_background(Box::pin(async move {
+        tokio::time::sleep(TEMP_EVENT_CACHE_TTL).await;
+        let mut outputs = state.output_image_cache.write().unwrap();
+        let mut previews = state.last_preview_by_prompt.write().unwrap();
+        for prompt_id in prompt_ids {
+            outputs.remove(&prompt_id);
+            previews.remove(&prompt_id);
+        }
+    }));
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +256,8 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
                         "comfyui:executing" => {
                             if evt.payload.get("node").is_some_and(|n| n.is_null()) {
                                 if let Some(pid) = prompt_id {
+                                    let temp_cache_ids =
+                                        cleanup_state.prompt_queue.related_ids(&pid);
                                     let owner = cleanup_state.prompt_queue.owner_of(&pid);
                                     log::info!(
                                         "[gen] completed prompt={} user={}",
@@ -256,11 +275,16 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
                                     });
                                     cleanup_state.broadcast_queue_positions();
                                     cleanup_state.prompt_queue.drain_notify.notify_one();
+                                    schedule_temp_event_cache_cleanup(
+                                        cleanup_state.clone(),
+                                        temp_cache_ids,
+                                    );
                                 }
                             }
                         }
                         "comfyui:execution_error" => {
                             if let Some(pid) = prompt_id {
+                                let temp_cache_ids = cleanup_state.prompt_queue.related_ids(&pid);
                                 let owner = cleanup_state.prompt_queue.owner_of(&pid);
                                 log::warn!(
                                     "[gen] error prompt={} user={}",
@@ -281,6 +305,10 @@ pub fn spawn_prompt_cleanup_reactor(state: Arc<AppState>) {
                                 });
                                 cleanup_state.broadcast_queue_positions();
                                 cleanup_state.prompt_queue.drain_notify.notify_one();
+                                schedule_temp_event_cache_cleanup(
+                                    cleanup_state.clone(),
+                                    temp_cache_ids,
+                                );
                             }
                         }
                         _ => {}
@@ -1347,8 +1375,13 @@ async fn gpu_stats_handler(
 async fn cdn_proxy_handler(
     AxumState(state): AxumState<SharedState>,
     Path(path): Path<String>,
+    uri: axum::http::Uri,
 ) -> Response {
-    let target_url = format!("https://cdn.mooshieblob.com/{}", path);
+    let mut target_url = format!("https://cdn.mooshieblob.com/{}", path);
+    if let Some(query) = uri.query() {
+        target_url.push('?');
+        target_url.push_str(query);
+    }
     match state.app.http_client.get(&target_url).send().await {
         Ok(resp) => {
             let status = resp.status();
@@ -2408,8 +2441,9 @@ async fn dispatch_command(
                 metadata.as_ref(),
                 metadata_mode.as_deref(),
             )?;
-            // Clean up temp file after successful save
-            crate::temp_images::remove(&temp_filename);
+            // Keep the temp file available briefly for clients that still hold
+            // the temp URL or race a manual save against gallery persistence.
+            // Periodic cleanup handles expiry.
             Ok(serde_json::json!(result))
         }
         "delete_gallery_image" => {
@@ -2637,6 +2671,10 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing category")?
                 .to_string();
+            if !crate::commands::api::is_safe_path_component(&category) {
+                return Err("Invalid model category".into());
+            }
+
             let config = state.config.read().await;
             let comfyui_path = config.comfyui_path.clone();
             let extra_model_paths = config.extra_model_paths.clone();
@@ -2673,6 +2711,10 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing category")?
                 .to_string();
+            if !crate::commands::api::is_safe_path_component(&category) {
+                return Err("Invalid model category".into());
+            }
+
             let config = state.config.read().await;
             if config.comfyui_path.is_empty() {
                 return Err("ComfyUI path not configured".into());
@@ -2729,6 +2771,13 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing filename")?
                 .to_string();
+            if !crate::commands::api::is_safe_path_component(&category) {
+                return Err("Invalid model category".into());
+            }
+            if !crate::commands::api::is_safe_relative_model_path(&filename) {
+                return Err("Invalid model filename".into());
+            }
+
             let config = state.config.read().await;
             if config.comfyui_path.is_empty() {
                 return Err("ComfyUI path not configured".into());
@@ -2739,7 +2788,7 @@ async fn dispatch_command(
                 .join(&filename);
             drop(config);
 
-            if !path.exists() {
+            if !path.is_file() {
                 return Err(format!("File not found: {}", filename));
             }
             let result = tokio::task::spawn_blocking(move || {
@@ -2761,6 +2810,13 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing filename")?
                 .to_string();
+            if !crate::commands::api::is_safe_path_component(&category) {
+                return Err("Invalid model category".into());
+            }
+            if !crate::commands::api::is_safe_relative_model_path(&filename) {
+                return Err("Invalid model filename".into());
+            }
+
             let config = state.config.read().await;
             if config.comfyui_path.is_empty() {
                 return Err("ComfyUI path not configured".into());
@@ -2771,7 +2827,7 @@ async fn dispatch_command(
                 .join(&filename);
             drop(config);
 
-            if !path.exists() {
+            if !path.is_file() {
                 return Err(format!("File not found: {}", filename));
             }
             if !filename.ends_with(".safetensors") {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1122,9 +1122,10 @@
 
     // If a style was just applied to the prompt and it doesn't have a thumbnail yet,
     // automatically assign this generation's primary image to it.
-    if (stylesStore.pendingStyleForThumbnail && newImages.length > 0) {
+    if (stylesStore.pendingStyleForThumbnail) {
       const styleId = stylesStore.pendingStyleForThumbnail;
       stylesStore.pendingStyleForThumbnail = null; // Clear immediately
+      if (newImages.length === 0) return;
 
       const firstImage = newImages[0];
       const persistPromise = gallery.getPersistPromise(firstImage);
@@ -1198,6 +1199,10 @@
       // Revoke old blob URL and update the image
       const oldUrl = image.url;
       image.url = newUrl;
+      image.sessionBlob = newBlob;
+      image.tempFilename = newTempFilename;
+      image.displayTempFilename = undefined;
+      image.file_size_bytes = newBlob.size;
 
       // If the lightbox is showing this image's old blob URL, upgrade it
       if (gallery.lightboxOpen && gallery.lightboxUrl === oldUrl) {
@@ -1208,10 +1213,15 @@
       // load the revoked blob URL via displayImage / lastOutputImage.
       if (oldUrl) {
         progress.replaceOutputUrl(oldUrl, newUrl);
-        URL.revokeObjectURL(oldUrl);
+        window.setTimeout(() => {
+          if (!gallery.sessionImages.some((img) => img.url === oldUrl)) {
+            URL.revokeObjectURL(oldUrl);
+          }
+        }, 30_000);
       }
 
       // Trigger Svelte reactivity so lazyThumbnail actions pick up the new URL
+      gallery.images = [...gallery.images];
       gallery.sessionImages = [...gallery.sessionImages];
     } catch (e) {
       // Non-critical — the image is still visible, just without embedded metadata
@@ -1874,9 +1884,7 @@
       if (progress.isGenerating && connection.connected) {
         // Reset last-activity timestamps so the reconciler doesn't skip prompts
         for (const p of progress.pendingPrompts) {
-          if (!promptLastActivity.has(p.promptId)) {
-            promptLastActivity.set(p.promptId, 0);
-          }
+          promptLastActivity.set(p.promptId, 0);
         }
       }
     };

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -7,6 +7,7 @@
   import type { ArtistSearchHit } from "../types.js";
   import ArtistLightbox from "./ArtistLightbox.svelte";
   import FavouritesManager from "./FavouritesManager.svelte";
+  import { proxiedCdnUrl } from "../../utils/cdnFetch.js";
 
   interface Props {
     manifestUrl: string;
@@ -127,7 +128,9 @@
     store.lightboxIndex = index;
     // Background: fetch full shard entry to patch in aliases once loaded
     store.client.getArtist(hit.slug).then((full) => {
-      if (full && store.lightboxEntry?.slug === hit.slug) store.lightboxEntry = full;
+      if (full && store.lightboxEntry?.slug === hit.slug) {
+        store.lightboxEntry = { ...full, imageUrl: proxiedCdnUrl(full.imageUrl) };
+      }
     }).catch(() => {});
   }
 

--- a/src/lib/artist-gallery/imageCache.ts
+++ b/src/lib/artist-gallery/imageCache.ts
@@ -16,6 +16,8 @@
  *   <img use:cachedSrc={entry.imageUrl} alt={entry.tag} />
  */
 
+import { proxiedCdnUrl } from "../utils/cdnFetch.js";
+
 /** Cache storage bucket name.  Bump the version suffix to bust stale caches. */
 const CACHE_NAME = "anima-artist-images-v1";
 
@@ -53,10 +55,12 @@ export async function fetchCachedArtistImage(url: string): Promise<string> {
 }
 
 async function _doFetch(url: string): Promise<string> {
+  const requestUrl = proxiedCdnUrl(url);
+
   if (hasCacheApi()) {
     try {
       const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match(url);
+      const cached = await cache.match(requestUrl);
       if (cached) {
         const blob = await cached.blob();
         const blobUrl = URL.createObjectURL(blob);
@@ -68,13 +72,13 @@ async function _doFetch(url: string): Promise<string> {
     }
   }
 
-  const response = await fetch(url, { mode: "cors", credentials: "omit" });
+  const response = await fetch(requestUrl, { credentials: "omit" });
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
   if (hasCacheApi()) {
     try {
       const cache = await caches.open(CACHE_NAME);
-      await cache.put(url, response.clone());
+      await cache.put(requestUrl, response.clone());
     } catch {
       // Cache write failed — non-fatal.
     }

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -1,5 +1,5 @@
 import { createArtistGalleryClient } from "./client.js";
-import { cdnFetch } from "../utils/cdnFetch.js";
+import { cdnFetch, proxiedCdnUrl } from "../utils/cdnFetch.js";
 import { isBrowserMode } from "../utils/ipc.js";
 import type {
   ArtistEntry,
@@ -123,7 +123,8 @@ export class ArtistGalleryStore {
   async openArtist(slugOrTag: string): Promise<void> {
     this.activeLoading = true;
     try {
-      this.activeArtist = await this.client.getArtist(slugOrTag);
+      const artist = await this.client.getArtist(slugOrTag);
+      this.activeArtist = artist ? { ...artist, imageUrl: proxiedCdnUrl(artist.imageUrl) } : null;
     } catch (err) {
       console.error("artist-gallery: openArtist failed", err);
       this.activeArtist = null;

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -75,7 +75,8 @@ async function showSaveDialog(defaultPath: string, extensions: string[]): Promis
 
 /** Trigger a file download in the browser using a temporary anchor element. */
 function triggerBrowserDownload(data: Uint8Array, filename: string, mimeType: string) {
-  const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
   const blob = new Blob([buffer], { type: mimeType });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -85,6 +86,17 @@ function triggerBrowserDownload(data: Uint8Array, filename: string, mimeType: st
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+async function blobToBytes(blob: Blob): Promise<number[]> {
+  const buffer = await blob.arrayBuffer();
+  return Array.from(new Uint8Array(buffer));
+}
+
+function pngBlobFromBytes(bytes: number[]): Blob {
+  const buffer = new ArrayBuffer(bytes.length);
+  new Uint8Array(buffer).set(bytes);
+  return new Blob([buffer], { type: "image/png" });
 }
 
 const GALLERY_BOARDS_KEY = "mooshieui.gallery.boards.v1";
@@ -462,17 +474,30 @@ class GalleryStore {
         // Prefer temp-file save when available — avoids serialising multi-MB
         // images as JSON number arrays through the IPC bridge.
         if (tempFilename) {
-          galleryFilename = await saveToGalleryTemp(
-            tempFilename,
-            img.filename,
-            img.prompt_id,
-            img.generation_mode,
-            metadata,
-            metadataMode,
-          );
-        } else if (blob && !isBrowserMode) {
-          const buf = await blob.arrayBuffer();
-          const bytes = Array.from(new Uint8Array(buf));
+          try {
+            galleryFilename = await saveToGalleryTemp(
+              tempFilename,
+              img.filename,
+              img.prompt_id,
+              img.generation_mode,
+              metadata,
+              metadataMode,
+            );
+          } catch (tempError) {
+            if (!blob) throw tempError;
+            console.warn("[persistImages] temp save failed; falling back to in-memory blob:", tempError);
+            const bytes = await blobToBytes(blob);
+            galleryFilename = await saveToGalleryBytes(
+              bytes,
+              img.filename,
+              img.prompt_id,
+              img.generation_mode,
+              metadata,
+              metadataMode,
+            );
+          }
+        } else if (blob) {
+          const bytes = await blobToBytes(blob);
           console.log("[persistImages] saveToGalleryBytes — filename:", img.filename, "blobType:", blob.type, "bytes:", bytes.length);
           galleryFilename = await saveToGalleryBytes(
             bytes,
@@ -496,6 +521,8 @@ class GalleryStore {
         img.gallery_filename = galleryFilename;
         img.thumbnailUrl = await thumbnailUrl(galleryFilename);
         img.fullImageUrl = await fullImageUrl(galleryFilename);
+        img.tempFilename = undefined;
+        img.displayTempFilename = undefined;
         resolvers[i]!(galleryFilename);
       } catch (e) {
         console.error("Failed to save image to gallery:", e);
@@ -654,7 +681,7 @@ class GalleryStore {
     if (this.saving) return;
     this.saving = true;
     try {
-      let bytes: number[];
+      let bytes: number[] | null = null;
       const isJxlGallery = image.gallery_filename?.endsWith(".jxl") ?? false;
       const isJxlExport = isJxlGallery
         || image.filename.toLowerCase().endsWith(".jxl")
@@ -665,36 +692,45 @@ class GalleryStore {
         bytes = isJxlGallery
           ? await loadGalleryImagePng(image.gallery_filename)
           : await loadGalleryImage(image.gallery_filename);
-      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
-        // Browser-mode session image: prefer the pre-built display WebP (for JXL)
-        // over fetching the raw temp with ?format=webp, which fails for JXL files.
-        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
-        bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
       } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
         bytes = await this._blobToPngBytes(image.sessionBlob);
+      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
+        // Browser-mode JXL needs the pre-built display copy. If the temp file
+        // has expired, fall back to the session blob/display URL already held by the client.
+        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
+        try {
+          bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
+        } catch (tempError) {
+          console.warn("Temp image fetch failed; falling back to session image:", tempError);
+          if (image.url) {
+            bytes = await this._blobUrlToPngBytes(image.url);
+          } else if (image.sessionBlob) {
+            bytes = await blobToBytes(image.sessionBlob);
+          } else {
+            throw tempError;
+          }
+        }
       } else if (image.url) {
         // Session image: WebP (JXL display copy) or PNG blob — canvas-convert to PNG.
         let blob: Blob | null = null;
         try {
           const response = await fetch(image.url);
+          if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
           blob = await response.blob();
         } catch {
-          blob = null;
-        }
-        if (!blob && image.url.startsWith("blob:")) {
           bytes = await this._blobUrlToPngBytes(image.url);
-        } else if (blob?.type === "image/webp") {
+        }
+        if (blob?.type === "image/webp") {
           bytes = await this._blobUrlToPngBytes(image.url);
         } else if (blob) {
-          bytes = Array.from(new Uint8Array(await blob.arrayBuffer()));
-        } else {
-          throw new Error("Image URL is no longer available");
+          bytes = await blobToBytes(blob);
         }
       } else {
         bytes = await getOutputImage(image.filename, image.subfolder);
       }
+      if (!bytes) throw new Error("Image bytes unavailable");
 
-      // JXL → PNG transcode strips embedded metadata. Re-embed from the
+      // JXL -> PNG transcode strips embedded metadata. Re-embed from the
       // in-memory metadata so the exported PNG carries the original prompt /
       // workflow info (parity with saveImageToDir).
       if (isJxlExport && image.metadata) {
@@ -732,6 +768,7 @@ class GalleryStore {
       let blob: Blob | null = null;
       try {
         const response = await fetch(blobUrl);
+        if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
         blob = await response.blob();
       } catch {
         blob = null;
@@ -742,7 +779,7 @@ class GalleryStore {
       } else if (blob?.type === "image/webp") {
         saveBytes = await this._blobUrlToPngBytes(blobUrl);
       } else if (blob) {
-        saveBytes = Array.from(new Uint8Array(await blob.arrayBuffer()));
+        saveBytes = await blobToBytes(blob);
       } else {
         throw new Error("Image URL is no longer available");
       }
@@ -766,7 +803,7 @@ class GalleryStore {
   /** Save an image directly to a specific directory (manual save mode). Embeds metadata. */
   async saveImageToDir(image: OutputImage, dir: string) {
     try {
-      let bytes: number[];
+      let bytes: number[] | null = null;
       const isJxlGallery = image.gallery_filename?.endsWith(".jxl") ?? false;
       const isJxlExport = isJxlGallery
         || image.filename.toLowerCase().endsWith(".jxl")
@@ -777,34 +814,43 @@ class GalleryStore {
         bytes = isJxlGallery
           ? await loadGalleryImagePng(image.gallery_filename)
           : await loadGalleryImage(image.gallery_filename);
-      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
-        // Browser-mode session image: prefer the pre-built display WebP (for JXL)
-        // over fetching the raw temp with ?format=webp, which fails for JXL files.
-        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
-        bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
       } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
         bytes = await this._blobToPngBytes(image.sessionBlob);
+      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
+        // Browser-mode JXL needs the pre-built display copy. If the temp file
+        // has expired, fall back to the session blob/display URL already held by the client.
+        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
+        try {
+          bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
+        } catch (tempError) {
+          console.warn("Temp image fetch failed; falling back to session image:", tempError);
+          if (image.url) {
+            bytes = await this._blobUrlToPngBytes(image.url);
+          } else if (image.sessionBlob) {
+            bytes = await blobToBytes(image.sessionBlob);
+          } else {
+            throw tempError;
+          }
+        }
       } else if (image.url) {
         // Session image (WebP display blob or PNG) — canvas-convert to PNG.
         let blob: Blob | null = null;
         try {
           const response = await fetch(image.url);
+          if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
           blob = await response.blob();
         } catch {
-          blob = null;
-        }
-        if (!blob && image.url.startsWith("blob:")) {
           bytes = await this._blobUrlToPngBytes(image.url);
-        } else if (blob?.type === "image/webp") {
+        }
+        if (blob?.type === "image/webp") {
           bytes = await this._blobUrlToPngBytes(image.url);
         } else if (blob) {
-          bytes = Array.from(new Uint8Array(await blob.arrayBuffer()));
-        } else {
-          throw new Error("Image URL is no longer available");
+          bytes = await blobToBytes(blob);
         }
       } else {
         bytes = await getOutputImage(image.filename, image.subfolder);
       }
+      if (!bytes) throw new Error("Image bytes unavailable");
       // Use .png extension for JXL exports so the saved file matches its contents.
       const filename = isJxlExport
         ? (image.filename || `image_${Date.now()}.jxl`).replace(/\.jxl$/i, ".png")
@@ -848,7 +894,6 @@ class GalleryStore {
               pngBytes = await loadGalleryImagePng(galleryFilename);
             } catch (e) {
               console.warn("JXL gallery transcode failed, falling back to display copy:", e);
-              // Server can't decode JXL — use the pre-built WebP display copy instead.
               const displayUrl = image.displayTempFilename
                 ? tempImageUrl(image.displayTempFilename)
                 : image.url;
@@ -868,8 +913,7 @@ class GalleryStore {
                   console.warn("Failed to embed PNG metadata into JXL clipboard copy:", e);
                 }
               }
-              const pngBlob = new Blob([new Uint8Array(pngBytes)], { type: "image/png" });
-              await this.writeBlobToClipboard(pngBlob);
+              await this.writeBlobToClipboard(pngBlobFromBytes(pngBytes));
               this.showToast(locale.t("gallery.toast.copied"), "success");
               return;
             }
@@ -1053,7 +1097,7 @@ class GalleryStore {
 
   private async _blobToPngBytes(blob: Blob): Promise<number[]> {
     if (blob.type === "image/png" || blob.type === "image/jpeg") {
-      return Array.from(new Uint8Array(await blob.arrayBuffer()));
+      return blobToBytes(blob);
     }
     const url = URL.createObjectURL(blob);
     try {

--- a/src/lib/utils/cdnFetch.ts
+++ b/src/lib/utils/cdnFetch.ts
@@ -11,21 +11,26 @@
  * those requests through the `cdn_proxy_fetch` Tauri command, which uses the
  * shared reqwest client on the Rust side and isn't subject to CORS.
  *
- * Image loads via `<img src>` bypass CORS and work in both modes without any
- * special handling — only JSON `fetch` calls need this adapter.
+ * Plain `<img src>` loads can display CDN images, but cached image fetches and
+ * JSON requests still need the proxy in browser/server mode.
  */
-import { ipcInvoke, isTauri } from "./ipc.js";
+import { ipcInvoke, isBrowserMode, isTauri } from "./ipc.js";
 
 const CDN_PREFIX = "https://cdn.mooshieblob.com/";
 
+export function proxiedCdnUrl(url: string): string {
+  if (isBrowserMode && url.startsWith(CDN_PREFIX)) {
+    return `/internal-api/_cdn/${url.slice(CDN_PREFIX.length)}`;
+  }
+  return url;
+}
+
 /**
  * A drop-in `fetch` for the artist gallery client. In app mode, CDN URLs are
- * routed through the `cdn_proxy_fetch` Tauri command; everything else falls
- * back to the platform `fetch`. In browser/server mode we don't need an
- * adapter — callers can pass `undefined` and default `fetch` does the right
- * thing.
+ * routed through the `cdn_proxy_fetch` Tauri command. In browser/server mode,
+ * CDN URLs are rewritten to the embedded `/internal-api/_cdn/...` proxy.
  */
-export const cdnFetch: typeof fetch | undefined = isTauri
+export const cdnFetch: typeof fetch | undefined = isTauri || isBrowserMode
   ? (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const url =
         typeof input === "string"
@@ -35,6 +40,9 @@ export const cdnFetch: typeof fetch | undefined = isTauri
             : input.url;
 
       if (url.startsWith(CDN_PREFIX)) {
+        if (isBrowserMode) {
+          return globalThis.fetch(proxiedCdnUrl(url), init);
+        }
         try {
           const path = url.slice(CDN_PREFIX.length);
           const body = await ipcInvoke<string>("cdn_proxy_fetch", { path });

--- a/src/lib/utils/lazyThumbnail.ts
+++ b/src/lib/utils/lazyThumbnail.ts
@@ -42,6 +42,7 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
     if (retryCount < MAX_RETRIES) {
       retryCount++;
       retryTimer = setTimeout(() => {
+        retryTimer = null;
         // Force reload by busting any cache with a retry param
         const src = getSrc();
         if (src) {
@@ -74,6 +75,10 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
     update(newOpts: LazyThumbnailOpts) {
       current = newOpts;
       retryCount = 0;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
       applySrc();
     },
     destroy() {


### PR DESCRIPTION
## Summary
- Fix browser-mode generated image save/display races that could leave temp images returning 404 after gallery persistence.
- Add session blob fallbacks for save/export/copy flows while preserving JXL metadata behavior.
- Route browser-mode artist gallery CDN fetches through the embedded proxy and preserve CDN query strings.
- Address release-audit findings: model metadata path validation, reconnect recovery, queue updates after errors, held-prompt cancellation race, temp event cache cleanup, and removal of tracked local build output.

## Validation
- Pre-commit-check agent: PASS
- `cargo check --manifest-path src-tauri/Cargo.toml`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS

## Audit Notes
- Reviewed stale remote branches, open Dependabot PRs, and historical Gemini/Copilot comments.
- Fixed current correctness/security items that still applied to the tree.
- Deferred unrelated dependency upgrade PRs and older style/performance suggestions that are not release blockers.