### PR TITLE
chore(deps): bump marked to 18.0.2 and konva to 10.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-desktop",
-  "version": "1.2.8",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "1.2.8",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
@@ -17,8 +17,8 @@
         "@tauri-apps/plugin-shell": "^2",
         "@tauri-apps/plugin-store": "^2",
         "@tauri-apps/plugin-updater": "^2.10.1",
-        "konva": "^10.2.3",
-        "marked": "^18.0.0",
+        "konva": "^10.2.5",
+        "marked": "^18.0.2",
         "ntc-ts": "^0.0.8",
         "sortablejs": "^1.15.7",
         "svelte-konva": "^1.0.1"
@@ -1820,9 +1820,9 @@
       }
     },
     "node_modules/konva": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/konva/-/konva-10.2.3.tgz",
-      "integrity": "sha512-NDGeIxm2nsQcp6oqZKS9T764JEi53RpQvpUxV2EK7Awm49fwdd1+EB1Nq1nyspRc0hOAKyKssoTFvPaKwiSUog==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-10.2.5.tgz",
+      "integrity": "sha512-WwBoe/EBhFcv+seL1Wnp3OAOwOFjCY4nCCgpLRrzUzw1IX4lKf/lYhj2Z3qo9P9q2fA3h+OdGDlimSNqZJaY5A==",
       "funding": [
         {
           "type": "patreon",
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
-      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-store": "^2",
     "@tauri-apps/plugin-updater": "^2.10.1",
-    "konva": "^10.2.3",
-    "marked": "^18.0.0",
+    "konva": "^10.2.5",
+    "marked": "^18.0.2",
     "ntc-ts": "^0.0.8",
     "sortablejs": "^1.15.7",
     "svelte-konva": "^1.0.1"


### PR DESCRIPTION
## Summary
- Bump \marked\ 18.0.0 → 18.0.2 and \konva\ 10.2.3 → 10.2.5 (equivalent to Dependabot #112 / #91).
- Dependabot branches were conflicted after #133/#94 landed on main.

## Test plan
- [x] \
pm run build\ passed locally

Supersedes #112 and #91.

Made with [Cursor](https://cursor.com)