### PR TITLE
chore(deps): bump docker/metadata-action to v6.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
 
       - name: Extract version metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ steps.docker-vars.outputs.image }}
           tags: |


### PR DESCRIPTION
Validated: npm run build + cargo check. Supersedes #90.

Made with [Cursor](https://cursor.com)