### PR TITLE
v1.3.4: Fix headless server release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.3.4
+
+### Release Fix
+- Fixed the headless server release build by using the library crate path for the ComfyUI startup error payload.
+
+---
+
 ## What's New in v1.3.3
 
 ### External ComfyUI & Startup

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.3.4
+
+### Release Fix
+- Fixed the headless server release build by using the library crate path for the ComfyUI startup error payload.
+
+---
+
 ## What's New in v1.3.3
 
 ### External ComfyUI & Startup

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/server_main.rs
+++ b/src-tauri/src/server_main.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use comfyui_desktop_lib::auth::AuthState;
-use comfyui_desktop_lib::comfyui::{process, websocket};
+use comfyui_desktop_lib::comfyui::{nodes, process, websocket};
 use comfyui_desktop_lib::config::load_persisted_config;
 use comfyui_desktop_lib::state::AppState;
 use comfyui_desktop_lib::{temp_images, webserver};
@@ -138,7 +138,7 @@ async fn main() {
                             let port = state.config.read().await.server_port;
                             state.broadcast(
                                 "comfyui:server_error",
-                                crate::comfyui::nodes::server_error_payload(&e.to_string(), port),
+                                nodes::server_error_payload(&e.to_string(), port),
                             );
                         }
                     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Fix the headless server binary build by importing `nodes` from `comfyui_desktop_lib::comfyui` instead of using `crate::comfyui` from the binary target.
- Bump release metadata to v1.3.4 across package, Cargo, Tauri config, changelog, and release notes.

## Test plan
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo build --release --no-default-features --features server --bin mooshieui-server`
- `npm run build`
- `cargo fmt --check`