### PR TITLE
v1.3.5: Show custom diffusion models in model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v1.3.5
+
+### Model picker
+- **Custom diffusion/UNET models in the checkpoint list**: locally installed files under `diffusion_models/` (and `unet/`) that are not curated presets—such as custom Anima fine-tunes—now appear in the generation model dropdown and wire up split-model CLIP/VAE automatically.
+
+### External ComfyUI
+- **Startup recovery**: improved detection and recovery when another ComfyUI instance is already bound to your port, with clearer server/build parity for headless mode.
+
+---
+
 ## What's New in v1.3.4
 
 ### Release Fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v1.3.5
+
+### Model picker
+- **Custom diffusion/UNET models in the checkpoint list**: locally installed files under `diffusion_models/` (and `unet/`) that are not curated presets—such as custom Anima fine-tunes—now appear in the generation model dropdown and wire up split-model CLIP/VAE automatically.
+
+### External ComfyUI
+- **Startup recovery**: improved detection and recovery when another ComfyUI instance is already bound to your port, with clearer server/build parity for headless mode.
+
+---
+
 ## What's New in v1.3.4
 
 ### Release Fix

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -9,7 +9,7 @@ use crate::state::AppState;
 fn is_optional_model_category(category: &str) -> bool {
     matches!(
         category,
-        "diffusion_models" | "text_encoders" | "clip" | "controlnet" | "ultralytics"
+        "diffusion_models" | "unet" | "text_encoders" | "clip" | "controlnet" | "ultralytics"
     )
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -567,10 +567,78 @@
     );
   });
 
+  /** Diffusion/UNET files already covered by a curated recommended entry */
+  const recommendedDiffusionFilenames = $derived(() => {
+    return new Set(
+      recommendedModels
+        .filter((r) => r.splitModel)
+        .flatMap((r) => {
+          const f = r.splitModel!.diffusionModel;
+          const names = [f.filename];
+          if (f.hash) {
+            const resolved = hashResolved[`${f.category}::${f.hash}`];
+            if (resolved) names.push(resolved);
+          }
+          return names;
+        })
+    );
+  });
+
+  /** Pair text encoder + CLIPLoader type for a manually picked diffusion/UNET file */
+  function pickSplitModelClip(
+    diffusionModel: string,
+    encoders: string[],
+  ): { clip: string; clipType: string } {
+    const dm = diffusionModel.toLowerCase();
+    const looksAnimaOrQwen =
+      dm.includes("anima") || dm.includes("qwen") || dm.includes("wan") || dm.includes("yume");
+    if (looksAnimaOrQwen) {
+      const preferred =
+        encoders.find((e) => e.toLowerCase().includes("qwen_3_06b")) ??
+        encoders.find((e) => e.toLowerCase().includes("qwen"));
+      if (preferred) return { clip: preferred, clipType: "wan" };
+    }
+    if (dm.includes("flux") || dm.includes("klein")) {
+      const qwen8 = encoders.find((e) => {
+        const n = e.toLowerCase();
+        return n.includes("qwen_3_8b") || n.includes("fp4mixed");
+      });
+      if (qwen8) return { clip: qwen8, clipType: "qwen_image" };
+    }
+    if (encoders.length > 0) return { clip: encoders[0], clipType: "wan" };
+    return { clip: "", clipType: "wan" };
+  }
+
+  function pickSplitModelVae(diffusionModel: string, vaes: string[]): string {
+    if (vaes.length === 0) return "";
+    const dm = diffusionModel.toLowerCase();
+    const looksAnimaOrQwen =
+      dm.includes("anima") || dm.includes("qwen") || dm.includes("wan") || dm.includes("yume");
+    const looksFlux = dm.includes("flux") || dm.includes("klein");
+
+    if (looksAnimaOrQwen) {
+      const qwen = vaes.find((v) => v.toLowerCase().includes("qwen"));
+      if (qwen) return qwen;
+    }
+    if (looksFlux) {
+      const flux = vaes.find((v) => v.toLowerCase().includes("flux"));
+      if (flux) return flux;
+    }
+    return vaes.find((v) => v.toLowerCase().includes("sdxl_vae")) ?? vaes[0];
+  }
+
   /** Combine installed checkpoints + recommended models into a single filtered list */
   const filteredItems = $derived(() => {
     const q = checkpointSearch.toLowerCase();
-    const items: { type: "checkpoint" | "recommended"; label: string; value: string; rec?: RecommendedModel; installed: boolean; size?: string; gateHint?: string }[] = [];
+    const items: {
+      type: "checkpoint" | "recommended" | "diffusion";
+      label: string;
+      value: string;
+      rec?: RecommendedModel;
+      installed: boolean;
+      size?: string;
+      gateHint?: string;
+    }[] = [];
 
     // Add recommended models first
     for (const rec of recommendedModels) {
@@ -613,6 +681,20 @@
       }
     }
 
+    // Locally installed diffusion/UNET weights not in the curated list (e.g. custom Anima fine-tunes)
+    const excludedDiffusion = recommendedDiffusionFilenames();
+    for (const dm of models.diffusionModels) {
+      if (excludedDiffusion.has(dm)) continue;
+      if (!q || dm.toLowerCase().includes(q)) {
+        items.push({
+          type: "diffusion",
+          label: dm,
+          value: dm,
+          installed: true,
+        });
+      }
+    }
+
     return items;
   });
 
@@ -626,6 +708,20 @@
     generation.applyModelSpecificPreset(name);
     checkpointSearch = "";
     showCheckpointDropdown = false;
+  }
+
+  /** Use a diffusion/UNET file discovered on disk (not in the curated recommended list). */
+  function selectCustomDiffusion(filename: string) {
+    showCheckpointDropdown = false;
+    checkpointSearch = "";
+    const { clip, clipType } = pickSplitModelClip(filename, models.textEncoders);
+    generation.useSplitModel = true;
+    generation.diffusionModel = filename;
+    generation.clipModel = clip || null;
+    generation.clipType = clipType;
+    generation.vae = pickSplitModelVae(filename, models.vaes);
+    generation.checkpoint = filename;
+    generation.applyModelSpecificPreset(filename);
   }
 
   async function selectRecommended(rec: RecommendedModel) {
@@ -863,6 +959,13 @@
                 {#if item.size}
                   <span class="text-[10px] text-neutral-500 shrink-0">{item.size}</span>
                 {/if}
+              </button>
+            {:else if item.type === "diffusion"}
+              <button
+                class="w-full text-left px-3 py-1.5 text-sm text-neutral-200 hover:bg-neutral-700 truncate"
+                onclick={() => selectCustomDiffusion(item.value)}
+              >
+                {item.label}
               </button>
             {:else}
               <button

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -22,7 +22,7 @@ class ModelsStore {
       // layout) or `clip/` (legacy ComfyUI / Forge layout). Fetch both and
       // merge so the picker doesn't miss encoders in the legacy directory
       // (e.g. `qwen_3_8b_fp4mixed.safetensors` placed under `clip/`).
-      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
+      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, unetModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
         await Promise.all([
           getModels("checkpoints"),
           getModels("vae"),
@@ -31,6 +31,8 @@ class ModelsStore {
           getEmbeddings(),
           getModels("upscale_models"),
           getModels("diffusion_models").catch(() => [] as string[]),
+          // ComfyUI also exposes UNET/diffusion weights under `unet/` on some installs.
+          getModels("unet").catch(() => [] as string[]),
           getModels("text_encoders").catch(() => [] as string[]),
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
@@ -47,7 +49,7 @@ class ModelsStore {
       this.schedulers = samplerInfo.schedulers;
       this.embeddings = embeddings;
       this.upscaleModels = upscaleModels;
-      this.diffusionModels = diffusionModels;
+      this.diffusionModels = Array.from(new Set([...diffusionModels, ...unetModels]));
       // De-duplicate by basename — ComfyUI sometimes returns the same file under
       // both `clip` and `text_encoders` when both directories are mapped.
       this.textEncoders = Array.from(new Set([...textEncoders, ...clipEncoders]));


### PR DESCRIPTION
## Summary
- List locally installed diffusion_models/ and unet/ weights in the generation checkpoint dropdown (fixes custom Anima fine-tunes like animayume_v05 not appearing while Model Manager sees them)
- Auto-wire split-model CLIP/VAE when selecting a custom diffusion file
- Treat unet as optional ComfyUI model category for discovery
- Includes external ComfyUI startup recovery from #179

## Test plan
- [ ] Place a custom .safetensors next to anima-base in diffusion_models/
- [ ] Restart MooshieUI and confirm it appears in the checkpoint dropdown
- [ ] Select it and run txt2img with Anima CLIP/VAE present
- [ ] cargo check + npm run build pass

Made with [Cursor](https://cursor.com)