### PR TITLE
v1.3.6: Fix release Docker publish disk space

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # The CUDA + PyTorch runtime image needs ~20+ GB during build. Ubuntu
+      # runners ship with Android/.NET/tool caches that can exhaust disk and
+      # kill docker buildx mid-push (v1.3.5 failed with "No space left on device").
+      - name: Free disk space for Docker build
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          sudo docker system prune -af || true
+          df -h
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.3.6
+
+### Release / CI
+- **Docker publish fix**: release workflow now frees runner disk space before building the GHCR server image, fixing v1.3.5 CI failures caused by `No space left on device` during the CUDA/PyTorch Docker build.
+
+---
+
 ## What's New in v1.3.5
 
 ### Model picker

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.3.6
+
+### Release / CI
+- **Docker publish fix**: release workflow now frees runner disk space before building the GHCR server image, fixing v1.3.5 CI failures caused by `No space left on device` during the CUDA/PyTorch Docker build.
+
+---
+
 ## What's New in v1.3.5
 
 ### Model picker

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.3.4"
+version = "1.3.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.5"
+version = "1.3.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Free GitHub Actions runner disk before the GHCR Docker image build (fixes v1.3.5 workflow failure: No space left on device during docker-publish)
- Version bump to 1.3.6 (same app bits as 1.3.5; CI-only fix)

## Test plan
- [ ] Merge and tag v1.3.6
- [ ] Build & Release workflow completes including docker-publish

Made with [Cursor](https://cursor.com)