### PR TITLE
v1.3.7: Detect Anima-family models via ModelSpec and CivitAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.3.7
+
+### Model detection
+- **Anima-family model detection**: custom Wan/Anima fine-tunes (e.g. `animayume`) are recognized via filename heuristics, ModelSpec/Wan tensor layout, and CivitAI hash `baseModel` lookup — Anima autocomplete tags and `@artist` prompts apply automatically when metadata loads.
+
+---
+
 ## What's New in v1.3.6
 
 ### Release / CI

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.3.7
+
+### Model detection
+- **Anima-family model detection**: custom Wan/Anima fine-tunes (e.g. `animayume`) are recognized via filename heuristics, ModelSpec/Wan tensor layout, and CivitAI hash `baseModel` lookup — Anima autocomplete tags and `@artist` prompts apply automatically when metadata loads.
+
+---
+
 ## What's New in v1.3.6
 
 ### Release / CI

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.6"
+version = "1.3.7"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2311,6 +2311,14 @@ fn infer_architecture_from_keys(header: &serde_json::Map<String, Value>) -> Opti
         return Some("hunyuandit".to_string());
     }
 
+    // Wan 2.1 / Anima (DiT transformer blocks with cross-attn — not classic UNet)
+    let has_wan_blocks = keys.iter().any(|k| {
+        k.starts_with("blocks.") && (k.contains(".cross_attn.") || k.contains(".self_attn."))
+    });
+    if has_wan_blocks {
+        return Some("wan2.1".to_string());
+    }
+
     // Stable Cascade: has "down_blocks" + "up_blocks" with "clip_txt_mapper"
     if keys.iter().any(|k| k.contains("clip_txt_mapper")) {
         return Some("stable_cascade".to_string());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -3,7 +3,7 @@
   import { models } from "../../stores/models.svelte.js";
   import { autocomplete } from "../../stores/autocomplete.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
-  import { downloadModel, findModelByHash, hashModelFile, readModelSpec, type ModelSpec, getComputeCapability } from "../../utils/api.js";
+  import { downloadModel, findModelByHash, hashModelFile, readModelSpec, lookupCivitaiBaseModel, type ModelSpec, getComputeCapability } from "../../utils/api.js";
   import { ipcListen } from "../../utils/ipc.js";
   import { onMount, onDestroy } from "svelte";
   import InfoTip from "../ui/InfoTip.svelte";
@@ -295,23 +295,31 @@
     modelSpecUnavailable = false;
     try {
       const spec = await readModelSpec(category, filename);
+      let civitaiBaseModel: string | null = null;
+      if (spec?.hash) {
+        civitaiBaseModel = await lookupCivitaiBaseModel(spec.hash);
+      }
       if (spec && Object.keys(spec).length > 0) {
         modelSpec = spec;
-        // Update generation store with authoritative architecture from modelspec
-        if (spec.architecture) {
-          generation.modelspecArchitecture = spec.architecture;
-        } else {
-          generation.modelspecArchitecture = null;
-        }
+        generation.applyModelMetadata({
+          modelspecArchitecture: spec.architecture ?? null,
+          civitaiBaseModel,
+        });
       } else {
         modelSpec = null;
         modelSpecUnavailable = true;
-        generation.modelspecArchitecture = null;
+        generation.applyModelMetadata({
+          modelspecArchitecture: null,
+          civitaiBaseModel,
+        });
       }
     } catch {
       modelSpec = null;
       modelSpecUnavailable = true;
-      generation.modelspecArchitecture = null;
+      generation.applyModelMetadata({
+        modelspecArchitecture: null,
+        civitaiBaseModel: null,
+      });
     } finally {
       modelSpecLoading = false;
     }
@@ -591,7 +599,11 @@
   ): { clip: string; clipType: string } {
     const dm = diffusionModel.toLowerCase();
     const looksAnimaOrQwen =
-      dm.includes("anima") || dm.includes("qwen") || dm.includes("wan") || dm.includes("yume");
+      generation.isAnima ||
+      dm.includes("anima") ||
+      dm.includes("qwen") ||
+      dm.includes("wan") ||
+      dm.includes("yume");
     if (looksAnimaOrQwen) {
       const preferred =
         encoders.find((e) => e.toLowerCase().includes("qwen_3_06b")) ??
@@ -613,7 +625,11 @@
     if (vaes.length === 0) return "";
     const dm = diffusionModel.toLowerCase();
     const looksAnimaOrQwen =
-      dm.includes("anima") || dm.includes("qwen") || dm.includes("wan") || dm.includes("yume");
+      generation.isAnima ||
+      dm.includes("anima") ||
+      dm.includes("qwen") ||
+      dm.includes("wan") ||
+      dm.includes("yume");
     const looksFlux = dm.includes("flux") || dm.includes("klein");
 
     if (looksAnimaOrQwen) {
@@ -705,6 +721,7 @@
     generation.clipModel = null;
     generation.clipType = null;
     generation.checkpoint = name;
+    generation.applyModelMetadata({ modelspecArchitecture: null, civitaiBaseModel: null });
     generation.applyModelSpecificPreset(name);
     checkpointSearch = "";
     showCheckpointDropdown = false;

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -3,6 +3,7 @@ import { triggerSync } from "../utils/syncTrigger.js";
 import { parseScheduledPrompt } from "../utils/promptSchedule.js";
 import type { LoraEntry } from "../types/index.js";
 import { autocomplete } from "./autocomplete.svelte.js";
+import { signalsIndicateAnima } from "../utils/modelFamily.js";
 import { styles } from "./styles.svelte.js";
 import { promptPresets } from "./promptPresets.svelte.js";
 
@@ -289,6 +290,8 @@ class GenerationStore {
 
   /** Architecture detected from modelspec metadata, or null if not yet read. */
   modelspecArchitecture = $state<string | null>(null);
+  /** CivitAI `baseModel` from hash lookup — used to detect Anima fine-tunes without "anima" in the filename. */
+  civitaiBaseModel = $state<string | null>(null);
 
   get mode(): GenerationMode {
     return this._mode;
@@ -410,9 +413,37 @@ class GenerationStore {
     return this.isSd3 || this.isFlux || this.isAuraFlow || this.isMugen || this.isNanosaur;
   }
 
+  private modelFamilySignals() {
+    return {
+      filename: this.diffusionModel ?? this.checkpoint,
+      modelspecArchitecture: this.modelspecArchitecture,
+      civitaiBaseModel: this.civitaiBaseModel,
+    };
+  }
+
+  /**
+   * Apply modelspec / CivitAI metadata after async load and refresh autocomplete tags.
+   */
+  applyModelMetadata(meta: {
+    modelspecArchitecture?: string | null;
+    civitaiBaseModel?: string | null;
+  }) {
+    if (meta.modelspecArchitecture !== undefined) {
+      this.modelspecArchitecture = meta.modelspecArchitecture;
+    }
+    if (meta.civitaiBaseModel !== undefined) {
+      this.civitaiBaseModel = meta.civitaiBaseModel;
+    }
+    autocomplete.notifyModelChanged(this.isAnima);
+  }
+
   /** Detect the base model architecture from modelspec (authoritative) or filename (fallback). */
   get detectedArchitecture(): "sdxl" | "illustrious" | "sd15" | "sd3" | "flux" | "pony" | "auraflow" | "pixart" | "hunyuandit" | "cascade" | "kolors" | "mugen" | "nanosaur" | "anima" | "unknown" {
     const name = (this.diffusionModel ?? this.checkpoint ?? "").toLowerCase();
+
+    if (signalsIndicateAnima(this.modelFamilySignals())) {
+      return "anima";
+    }
 
     // 1. Use modelspec architecture if available (definitive)
     if (this.modelspecArchitecture) {
@@ -420,7 +451,7 @@ class GenerationStore {
       // Nanosaur (custom DiT — check before other heuristics)
       if (name.includes("nanosaur")) return "nanosaur";
       // Anima (Wan2.1 fine-tune with AnimaLLLite)
-      if (name.includes("anima") || arch.includes("anima")) return "anima";
+      if (name.includes("anima") || arch.includes("anima") || arch.includes("wan")) return "anima";
       // Mugen (Flux2VAE SDXL — check before noob/illustrious since Mugen traces back to NoobAI)
       if (name.includes("mugen")) return "mugen";
       // Illustrious/NoobAI family (they report as SDXL arch but need special ControlNets)
@@ -450,7 +481,7 @@ class GenerationStore {
     // Nanosaur (custom DiT — check before other heuristics)
     if (name.includes("nanosaur")) return "nanosaur";
     // Anima (Wan2.1 fine-tune with AnimaLLLite)
-    if (name.includes("anima")) return "anima";
+    if (name.includes("anima") || name.includes("yume")) return "anima";
     // Mugen (Flux2VAE SDXL — check before noob/illustrious since Mugen traces back to NoobAI)
     if (name.includes("mugen")) return "mugen";
     // Illustrious/NoobAI/vpred SDXL variants
@@ -596,7 +627,14 @@ class GenerationStore {
     const name = (modelName ?? this.diffusionModel ?? this.checkpoint ?? "").toLowerCase();
     if (!name) return;
 
-    const isAnima = name.includes("anima") || name.includes("qwen") || name.includes("wan");
+    const isAnima =
+      signalsIndicateAnima({
+        filename: modelName ?? this.diffusionModel ?? this.checkpoint,
+        modelspecArchitecture: this.modelspecArchitecture,
+        civitaiBaseModel: this.civitaiBaseModel,
+      }) ||
+      name.includes("qwen") ||
+      name.includes("wan");
     autocomplete.notifyModelChanged(isAnima);
 
     // Nanosaur — custom 1.2B DiT, flow matching, euler/simple, CFG 7

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -203,6 +203,17 @@ export async function civitaiLookupHash(
   return ipcInvoke("civitai_lookup_hash", { hash });
 }
 
+/** CivitAI `baseModel` for a version hash, or null if not found / lookup failed. */
+export async function lookupCivitaiBaseModel(hash: string): Promise<string | null> {
+  try {
+    const data = await civitaiLookupHash(hash);
+    const bm = data.baseModel;
+    return typeof bm === "string" ? bm : null;
+  } catch {
+    return null;
+  }
+}
+
 export type CivitaiModelType =
   | "Checkpoint"
   | "LORA"

--- a/src/lib/utils/modelFamily.ts
+++ b/src/lib/utils/modelFamily.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared heuristics for detecting model families (especially Anima / Wan2.1 fine-tunes
+ * like animayume that may not include "anima" in the filename).
+ */
+
+export type ModelFamily =
+  | "sdxl"
+  | "illustrious"
+  | "sd15"
+  | "sd3"
+  | "flux"
+  | "pony"
+  | "auraflow"
+  | "pixart"
+  | "hunyuandit"
+  | "cascade"
+  | "kolors"
+  | "mugen"
+  | "nanosaur"
+  | "anima"
+  | "unknown";
+
+export interface ModelFamilySignals {
+  /** Checkpoint filename, diffusion UNET filename, or curated display label */
+  filename?: string | null;
+  modelspecArchitecture?: string | null;
+  /** CivitAI `baseModel` from hash lookup (e.g. "Wan Video 2.1") */
+  civitaiBaseModel?: string | null;
+  /** modelspec.tags comma-separated string */
+  modelspecTags?: string | null;
+}
+
+/** True when CivitAI lists the version under an Anima / Wan video base. */
+export function civitaiBaseModelIndicatesAnima(baseModel: string | null | undefined): boolean {
+  if (!baseModel) return false;
+  const bm = baseModel.toLowerCase();
+  return (
+    bm.includes("anima") ||
+    bm.includes("wan video") ||
+    bm.includes("wan 2") ||
+    bm.includes("wan2") ||
+    bm.includes("wan 2.1") ||
+    bm === "wan"
+  );
+}
+
+/** True when modelspec architecture / tags describe Anima or Wan2.1. */
+export function modelspecIndicatesAnima(
+  architecture: string | null | undefined,
+  tags?: string | null,
+): boolean {
+  const arch = (architecture ?? "").toLowerCase();
+  if (arch.includes("anima") || arch.includes("wan")) return true;
+  const tagStr = (tags ?? "").toLowerCase();
+  if (tagStr.includes("anima")) return true;
+  return false;
+}
+
+/** Filename / label heuristics for local Anima-family checkpoints and UNET files. */
+export function filenameIndicatesAnima(name: string | null | undefined): boolean {
+  if (!name) return false;
+  const n = name.toLowerCase();
+  if (n.includes("nanosaur") || n.includes("mugen")) return false;
+  if (n.includes("anima")) return true;
+  // Fine-tunes such as animayume_v05.safetensors
+  if (n.includes("yume")) return true;
+  return false;
+}
+
+/** Combined signal — modelspec, CivitAI hash metadata, or filename. */
+export function signalsIndicateAnima(signals: ModelFamilySignals): boolean {
+  if (filenameIndicatesAnima(signals.filename)) return true;
+  if (modelspecIndicatesAnima(signals.modelspecArchitecture, signals.modelspecTags)) return true;
+  if (civitaiBaseModelIndicatesAnima(signals.civitaiBaseModel)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Detect Anima/Wan2.1 fine-tunes (e.g. animayume) via filename, ModelSpec architecture, Wan DiT tensor keys, and CivitAI hash baseModel lookup
- Refresh Anima autocomplete tags when model metadata finishes loading

## Test plan
- [ ] Select animayume or similar custom diffusion model — Anima tags appear after metadata load
- [ ] Model without anima in name but CivitAI base Wan Video — Anima tags apply
- [ ] cargo check + npm run build pass

Made with [Cursor](https://cursor.com)