### PR TITLE
v1.3.8: PyPI mirror setting and optional ControlNet startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## What's New in v1.3.8
+
+### Settings & pip installs
+- **PyPI mirror URL**: optional `pip_index_url` in Settings → Connection for pip/uv installs (ControlNet node requirements, custom nodes, optional packages); works together with the existing network proxy.
+
+### ComfyUI startup
+- **ControlNet nodes optional**: missing ControlNet custom nodes no longer block ComfyUI startup or kill an external instance on your port; failures are logged as warnings and core MooshieUI generation still works.
+- **Resilient ControlNet setup**: per-package install failures during ControlNet node deployment are logged instead of aborting the whole ensure step.
+
+---
+
 ## What's New in v1.3.7
 
 ### Model detection

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+## What's New in v1.3.8
+
+### Settings & pip installs
+- **PyPI mirror URL**: optional `pip_index_url` in Settings → Connection for pip/uv installs (ControlNet node requirements, custom nodes, optional packages); works together with the existing network proxy.
+
+### ComfyUI startup
+- **ControlNet nodes optional**: missing ControlNet custom nodes no longer block ComfyUI startup or kill an external instance on your port; failures are logged as warnings and core MooshieUI generation still works.
+- **Resilient ControlNet setup**: per-package install failures during ControlNet node deployment are logged instead of aborting the whole ensure step.
+
+---
+
 ## What's New in v1.3.7
 
 ### Model detection

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.3.6"
+version = "1.3.8"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -177,6 +177,7 @@ pub async fn ensure_required_controlnet_nodes(
     comfyui_path: &str,
     venv_path: &str,
     network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
 ) -> Result<(), String> {
     let custom_nodes = Path::new(comfyui_path).join("custom_nodes");
     std::fs::create_dir_all(&custom_nodes).map_err(|e| {
@@ -187,11 +188,36 @@ pub async fn ensure_required_controlnet_nodes(
         )
     })?;
 
+    let mut failures = Vec::new();
     for package in REQUIRED_CONTROLNET_PACKAGES {
-        ensure_custom_node_package(&custom_nodes, venv_path, network_proxy, *package).await?;
+        if let Err(e) = ensure_custom_node_package(
+            &custom_nodes,
+            venv_path,
+            network_proxy,
+            pip_index_url,
+            *package,
+        )
+        .await
+        {
+            log::warn!(
+                "ControlNet custom node '{}' setup failed (optional): {}",
+                package.name,
+                e
+            );
+            failures.push(format!("{}: {}", package.name, e));
+        }
     }
 
-    log::info!("Ensured required ControlNet custom node packages");
+    if failures.is_empty() {
+        log::info!("Ensured required ControlNet custom node packages");
+    } else {
+        log::warn!(
+            "Some ControlNet custom node packages could not be installed ({}). \
+             Core MooshieUI generation still works; built-in ControlNet presets may fail until these install. \
+             If pip timed out, set Settings → Connection → PyPI mirror URL (e.g. Tsinghua) in addition to any proxy.",
+            failures.join("; ")
+        );
+    }
     Ok(())
 }
 
@@ -310,6 +336,7 @@ async fn ensure_custom_node_package(
     custom_nodes: &Path,
     venv_path: &str,
     network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
     package: RequiredCustomNodePackage,
 ) -> Result<(), String> {
     let target_dir = custom_nodes.join(package.name);
@@ -338,6 +365,7 @@ async fn ensure_custom_node_package(
             &target_dir,
             venv_path,
             network_proxy,
+            pip_index_url,
             package.name,
         )
         .await?;
@@ -351,6 +379,23 @@ pub(crate) fn apply_network_proxy(cmd: &mut tokio::process::Command, network_pro
         cmd.env("HTTP_PROXY", proxy)
             .env("HTTPS_PROXY", proxy)
             .env("ALL_PROXY", proxy);
+    }
+}
+
+/// Apply proxy env vars and an optional PyPI index to a pip or uv pip command.
+pub(crate) fn apply_pip_install_options(
+    cmd: &mut tokio::process::Command,
+    use_uv: bool,
+    network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
+) {
+    apply_network_proxy(cmd, network_proxy);
+    if let Some(url) = pip_index_url.map(str::trim).filter(|s| !s.is_empty()) {
+        if use_uv {
+            cmd.arg("--index-url").arg(url);
+        } else {
+            cmd.args(["-i", url]);
+        }
     }
 }
 
@@ -383,6 +428,7 @@ async fn install_requirements_if_needed(
     target_dir: &Path,
     venv_path: &str,
     network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
     package_name: &str,
 ) -> Result<(), String> {
     let req_hash = file_sha256(requirements)?;
@@ -406,7 +452,9 @@ async fn install_requirements_if_needed(
         package_name
     );
 
-    let mut command = if let Some(uv_path) = find_uv_bin(venv_path).await {
+    let uv_path = find_uv_bin(venv_path).await;
+    let use_uv = uv_path.is_some();
+    let mut command = if let Some(uv_path) = uv_path {
         let mut command = tokio::process::Command::new(uv_path);
         command
             .args(["pip", "install", "-r"])
@@ -419,7 +467,7 @@ async fn install_requirements_if_needed(
         command
     };
 
-    apply_network_proxy(&mut command, network_proxy);
+    apply_pip_install_options(&mut command, use_uv, network_proxy, pip_index_url);
     let output = command
         .output()
         .await

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -188,6 +188,7 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
                 &config.comfyui_path,
                 &config.venv_path,
                 config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
             )
             .await
             .map_err(AppError::ProcessSpawnFailed)?;
@@ -219,7 +220,14 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             super::nodes::verify_required_controlnet_nodes(&state.http_client, &config.server_url)
                 .await;
 
-        if mooshie_ok.is_ok() && controlnet_ok.is_ok() {
+        if mooshie_ok.is_ok() {
+            if let Err(e) = controlnet_ok {
+                log::warn!(
+                    "ComfyUI at {} is running but optional ControlNet nodes are missing: {}",
+                    config.server_url,
+                    e
+                );
+            }
             log::info!(
                 "ComfyUI already running at {}, skipping spawn",
                 config.server_url
@@ -228,10 +236,10 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             return Ok(StartResult::AlreadyRunning);
         }
 
-        // Stale external ComfyUI: nodes were deployed to disk but the running process
-        // never loaded them. Kill the listener and spawn a managed instance below.
+        // Stale external ComfyUI: MooshieUI nodes were deployed to disk but the running
+        // process never loaded them. Kill the listener and spawn a managed instance below.
         log::warn!(
-            "ComfyUI at {} is missing required nodes — freeing port {} and spawning managed ComfyUI",
+            "ComfyUI at {} is missing required MooshieUI nodes — freeing port {} and spawning managed ComfyUI",
             config.server_url,
             config.server_port
         );
@@ -239,7 +247,7 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             log::warn!("Mooshie node verification: {}", e);
         }
         if let Err(e) = controlnet_ok {
-            log::warn!("ControlNet node verification: {}", e);
+            log::warn!("ControlNet node verification (optional): {}", e);
         }
         wait_for_port_free(state, &health_url, config.server_port).await;
     }
@@ -609,9 +617,14 @@ pub async fn wait_for_ready(state: &AppState, timeout_secs: u64) -> Result<(), A
             super::nodes::verify_required_mooshie_nodes(&state.http_client, &base_url)
                 .await
                 .map_err(AppError::ProcessSpawnFailed)?;
-            super::nodes::verify_required_controlnet_nodes(&state.http_client, &base_url)
-                .await
-                .map_err(AppError::ProcessSpawnFailed)?;
+            if let Err(e) =
+                super::nodes::verify_required_controlnet_nodes(&state.http_client, &base_url).await
+            {
+                log::warn!(
+                    "ControlNet custom nodes not loaded at startup (optional): {}",
+                    e
+                );
+            }
             mark_legacy_worker_idle(state).await;
             return Ok(());
         }
@@ -798,6 +811,7 @@ pub async fn start_worker_process(
                 &config.comfyui_path,
                 &config.venv_path,
                 config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
             )
             .await
             .map_err(AppError::ProcessSpawnFailed)?;
@@ -817,7 +831,16 @@ pub async fn start_worker_process(
             super::nodes::verify_required_controlnet_nodes(&state.http_client, &worker.base_url)
                 .await;
 
-        if mooshie_ok.is_ok() && controlnet_ok.is_ok() {
+        if mooshie_ok.is_ok() {
+            if let Err(e) = controlnet_ok {
+                log::warn!(
+                    "Worker {} (GPU {}): optional ControlNet nodes missing at {}: {}",
+                    worker.id,
+                    worker.gpu_index,
+                    worker.base_url,
+                    e
+                );
+            }
             log::info!(
                 "Worker {} (GPU {}): ComfyUI already running at {}",
                 worker.id,
@@ -832,7 +855,7 @@ pub async fn start_worker_process(
         }
 
         log::warn!(
-            "Worker {} (GPU {}): stale ComfyUI at {} — freeing port {}",
+            "Worker {} (GPU {}): ComfyUI at {} missing MooshieUI nodes — freeing port {}",
             worker.id,
             worker.gpu_index,
             worker.base_url,
@@ -996,9 +1019,11 @@ pub async fn wait_for_worker_ready(
                 super::nodes::verify_required_controlnet_nodes(&state.http_client, &worker.base_url)
                     .await
             {
-                let mut status = worker.status.write().await;
-                *status = WorkerStatus::Error;
-                return Err(AppError::ProcessSpawnFailed(e));
+                log::warn!(
+                    "Worker {}: ControlNet custom nodes not loaded (optional): {}",
+                    worker.id,
+                    e
+                );
             }
             let mut status = worker.status.write().await;
             *status = WorkerStatus::Idle;

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1609,15 +1609,17 @@ pub async fn install_custom_node(
     git_url: String,
     node_name: String,
 ) -> Result<(), AppError> {
-    let (comfyui_path, venv_path, network_proxy) = {
+    let (comfyui_path, venv_path, network_proxy, pip_index_url) = {
         let config = state.config.read().await;
         (
             config.comfyui_path.clone(),
             config.venv_path.clone(),
             config.network_proxy.clone(),
+            config.pip_index_url.clone(),
         )
     };
     let network_proxy = network_proxy.as_deref();
+    let pip_index_url = pip_index_url.as_deref();
     let custom_nodes_dir = std::path::Path::new(&comfyui_path).join("custom_nodes");
     let target_dir = custom_nodes_dir.join(&node_name);
 
@@ -1704,7 +1706,12 @@ pub async fn install_custom_node(
                 .env("VIRTUAL_ENV", &venv_path)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped());
-            crate::comfyui::nodes::apply_network_proxy(&mut cmd, network_proxy);
+            crate::comfyui::nodes::apply_pip_install_options(
+                &mut cmd,
+                true,
+                network_proxy,
+                pip_index_url,
+            );
             cmd.spawn()
                 .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
         } else {
@@ -1718,7 +1725,12 @@ pub async fn install_custom_node(
             cmd.args(["install", "-r", &req_file.to_string_lossy()])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped());
-            crate::comfyui::nodes::apply_network_proxy(&mut cmd, network_proxy);
+            crate::comfyui::nodes::apply_pip_install_options(
+                &mut cmd,
+                false,
+                network_proxy,
+                pip_index_url,
+            );
             cmd.spawn()
                 .map_err(|e| AppError::Other(format!("pip install failed to start: {}", e)))?
         };
@@ -1783,18 +1795,30 @@ pub async fn install_pip_package(
     state: State<'_, Arc<AppState>>,
     package: String,
 ) -> Result<(), AppError> {
-    let venv_path = {
+    let (venv_path, network_proxy, pip_index_url) = {
         let config = state.config.read().await;
-        config.venv_path.clone()
+        (
+            config.venv_path.clone(),
+            config.network_proxy.clone(),
+            config.pip_index_url.clone(),
+        )
     };
+    let network_proxy = network_proxy.as_deref();
+    let pip_index_url = pip_index_url.as_deref();
 
     let uv_path = resolve_uv_bin(&venv_path);
 
     let output = if uv_path.exists() {
-        tokio::process::Command::new(&uv_path)
-            .args(["pip", "install", &package])
-            .env("VIRTUAL_ENV", &venv_path)
-            .output()
+        let mut cmd = tokio::process::Command::new(&uv_path);
+        cmd.args(["pip", "install", &package])
+            .env("VIRTUAL_ENV", &venv_path);
+        crate::comfyui::nodes::apply_pip_install_options(
+            &mut cmd,
+            true,
+            network_proxy,
+            pip_index_url,
+        );
+        cmd.output()
             .await
             .map_err(|e| AppError::Other(format!("uv pip install failed to start: {}", e)))?
     } else {
@@ -1805,9 +1829,15 @@ pub async fn install_pip_package(
         #[cfg(not(target_os = "windows"))]
         let pip_path = venv_base.join("bin").join("pip");
 
-        tokio::process::Command::new(&pip_path)
-            .args(["install", &package])
-            .output()
+        let mut cmd = tokio::process::Command::new(&pip_path);
+        cmd.args(["install", &package]);
+        crate::comfyui::nodes::apply_pip_install_options(
+            &mut cmd,
+            false,
+            network_proxy,
+            pip_index_url,
+        );
+        cmd.output()
             .await
             .map_err(|e| AppError::Other(format!("pip install failed to start: {}", e)))?
     };

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -74,6 +74,9 @@ pub struct AppConfig {
     /// Optional HTTP(S) proxy for git clone and pip when installing ControlNet custom nodes.
     /// Example: `http://127.0.0.1:7890`. Also applied via HTTP_PROXY / HTTPS_PROXY env vars.
     pub network_proxy: Option<String>,
+    /// Optional PyPI index URL for pip/uv installs (e.g. a regional mirror).
+    /// Example: `https://pypi.tuna.tsinghua.edu.cn/simple`
+    pub pip_index_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -119,6 +122,7 @@ impl Default for AppConfig {
             attention_backend: "default".to_string(),
             gpu_workers: vec![],
             network_proxy: None,
+            pip_index_url: None,
         }
     }
 }
@@ -262,10 +266,12 @@ pub fn load_persisted_config() -> AppConfig {
 }
 
 pub(crate) fn normalize_config_fields(config: &mut AppConfig) {
-    match &mut config.network_proxy {
-        Some(p) if p.trim().is_empty() => config.network_proxy = None,
-        Some(p) => *p = p.trim().to_string(),
-        None => {}
+    for field in [&mut config.network_proxy, &mut config.pip_index_url] {
+        match field {
+            Some(p) if p.trim().is_empty() => *field = None,
+            Some(p) => *p = p.trim().to_string(),
+            None => {}
+        }
     }
 }
 

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2614,8 +2614,10 @@ async fn dispatch_command(
             let target_dir = custom_nodes_dir.join(&node_name);
             let venv_path = config.venv_path.clone();
             let network_proxy = config.network_proxy.clone();
+            let pip_index_url = config.pip_index_url.clone();
             drop(config);
             let network_proxy = network_proxy.as_deref();
+            let pip_index_url = pip_index_url.as_deref();
 
             let emit = |step: &str, message: &str, done: bool| {
                 state.broadcast(
@@ -2665,7 +2667,12 @@ async fn dispatch_command(
                     let mut cmd = tokio::process::Command::new(&uv_path);
                     cmd.args(["pip", "install", "-r", &req_file.to_string_lossy()])
                         .env("VIRTUAL_ENV", &venv_path);
-                    crate::comfyui::nodes::apply_network_proxy(&mut cmd, network_proxy);
+                    crate::comfyui::nodes::apply_pip_install_options(
+                        &mut cmd,
+                        true,
+                        network_proxy,
+                        pip_index_url,
+                    );
                     cmd.status()
                         .await
                         .map_err(|e| format!("uv pip install failed: {}", e))?
@@ -2677,7 +2684,12 @@ async fn dispatch_command(
                     let pip_path = venv_base.join("bin").join("pip");
                     let mut cmd = tokio::process::Command::new(&pip_path);
                     cmd.args(["install", "-r", &req_file.to_string_lossy()]);
-                    crate::comfyui::nodes::apply_network_proxy(&mut cmd, network_proxy);
+                    crate::comfyui::nodes::apply_pip_install_options(
+                        &mut cmd,
+                        false,
+                        network_proxy,
+                        pip_index_url,
+                    );
                     cmd.status()
                         .await
                         .map_err(|e| format!("pip install failed: {}", e))?
@@ -2706,15 +2718,25 @@ async fn dispatch_command(
                 .to_string();
             let config = state.config.read().await;
             let venv_path = config.venv_path.clone();
+            let network_proxy = config.network_proxy.clone();
+            let pip_index_url = config.pip_index_url.clone();
             drop(config);
+            let network_proxy = network_proxy.as_deref();
+            let pip_index_url = pip_index_url.as_deref();
 
             let uv_path = crate::commands::api::resolve_uv_bin_pub(&venv_path);
 
             let output = if uv_path.exists() {
-                tokio::process::Command::new(&uv_path)
-                    .args(["pip", "install", &package])
-                    .env("VIRTUAL_ENV", &venv_path)
-                    .output()
+                let mut cmd = tokio::process::Command::new(&uv_path);
+                cmd.args(["pip", "install", &package])
+                    .env("VIRTUAL_ENV", &venv_path);
+                crate::comfyui::nodes::apply_pip_install_options(
+                    &mut cmd,
+                    true,
+                    network_proxy,
+                    pip_index_url,
+                );
+                cmd.output()
                     .await
                     .map_err(|e| format!("uv pip install failed to start: {}", e))?
             } else {
@@ -2723,11 +2745,17 @@ async fn dispatch_command(
                 let pip_path = venv_base.join("Scripts").join("pip.exe");
                 #[cfg(not(target_os = "windows"))]
                 let pip_path = venv_base.join("bin").join("pip");
-                tokio::process::Command::new(&pip_path)
-                    .args(["install", &package])
-                    .output()
+                let mut cmd = tokio::process::Command::new(&pip_path);
+                cmd.args(["install", &package]);
+                crate::comfyui::nodes::apply_pip_install_options(
+                    &mut cmd,
+                    false,
+                    network_proxy,
+                    pip_index_url,
+                );
+                cmd.output()
                     .await
-                    .map_err(|e| format!("pip install failed to start: {}", e))?
+                    .map_err(|e| format!("uv pip install failed to start: {}", e))?
             };
 
             if !output.status.success() {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2755,7 +2755,7 @@ async fn dispatch_command(
                 );
                 cmd.output()
                     .await
-                    .map_err(|e| format!("uv pip install failed to start: {}", e))?
+                    .map_err(|e| format!("pip install failed to start: {}", e))?
             };
 
             if !output.status.success() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { autocomplete, type TagEntry } from "../../stores/autocomplete.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
   import { connection } from "../../stores/connection.svelte.js";
   import { promptPresets } from "../../stores/promptPresets.svelte.js";

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -1515,6 +1515,17 @@
               />
               <p class="text-xs text-neutral-500 mt-1">{locale.t('settings.connection.network_proxy_desc')}</p>
             </div>
+            <div>
+              <label class="block text-xs text-neutral-400 mb-1">{locale.t('settings.connection.pip_index_url')}</label>
+              <input
+                type="text"
+                bind:value={config.pip_index_url}
+                oninput={checkRestartNeeded}
+                class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:outline-none focus:border-indigo-500 transition-colors"
+                placeholder={locale.t('settings.connection.pip_index_placeholder')}
+              />
+              <p class="text-xs text-neutral-500 mt-1">{locale.t('settings.connection.pip_index_url_desc')}</p>
+            </div>
           </div>
           </div>
           {/if}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -186,7 +186,11 @@ const de: Record<string, string> = {
   "settings.connection.port": "Port",
   "settings.connection.network_proxy": "Netzwerk-Proxy (git / pip)",
   "settings.connection.network_proxy_desc":
-    "Optional. Wird verwendet, wenn MooshieUI ControlNet-Custom-Nodes klont oder deren Python-Abhängigkeiten installiert. Beispiel: http://127.0.0.1:7890. Leer lassen für Systemstandard.",
+    "Optional. Wird verwendet, wenn MooshieUI ControlNet-Custom-Nodes per git klont. Beispiel: http://127.0.0.1:7890. Leer lassen für Systemstandard.",
+  "settings.connection.pip_index_url": "PyPI-Spiegel (pip)",
+  "settings.connection.pip_index_url_desc":
+    "Optional. Für alle pip/uv-Installationen. In Regionen mit langsamem pypi.org z. B. https://pypi.tuna.tsinghua.edu.cn/simple. Kann zusammen mit dem Proxy oben genutzt werden.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "Erscheinung",
   "settings.appearance.theme": "Design",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -174,7 +174,11 @@ const en: Record<string, string> = {
   "settings.connection.port": "Port",
   "settings.connection.network_proxy": "Network proxy (git / pip)",
   "settings.connection.network_proxy_desc":
-    "Optional. Used when MooshieUI clones ControlNet custom nodes or installs their Python requirements. Example: http://127.0.0.1:7890. Leave empty to use system defaults.",
+    "Optional. Used when MooshieUI clones ControlNet custom nodes or installs their Python requirements via git. Example: http://127.0.0.1:7890. Leave empty to use system defaults.",
+  "settings.connection.pip_index_url": "PyPI mirror (pip)",
+  "settings.connection.pip_index_url_desc":
+    "Optional. Used for all pip/uv installs (ControlNet node requirements, optional packages). In regions where pypi.org is slow, set a mirror such as https://pypi.tuna.tsinghua.edu.cn/simple. Works together with the proxy above.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   // Appearance
   "settings.appearance.title": "Appearance",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -157,7 +157,10 @@ const es: Record<string, string> = {
   "settings.connection.server_url": "URL del servidor",
   "settings.connection.port": "Puerto",
   "settings.connection.network_proxy": "Proxy de red (git / pip)",
-  "settings.connection.network_proxy_desc": "Opcional. Se usa cuando MooshieUI clona nodos personalizados de ControlNet o instala sus dependencias de Python. Ejemplo: http://127.0.0.1:7890. Déjalo vacío para usar los valores predeterminados del sistema.",
+  "settings.connection.network_proxy_desc": "Opcional. Se usa cuando MooshieUI clona nodos personalizados de ControlNet mediante git. Ejemplo: http://127.0.0.1:7890. Déjalo vacío para usar los valores predeterminados del sistema.",
+  "settings.connection.pip_index_url": "Espejo PyPI (pip)",
+  "settings.connection.pip_index_url_desc": "Opcional. Se usa en todas las instalaciones pip/uv. Si pypi.org es lento, indica un espejo como https://pypi.tuna.tsinghua.edu.cn/simple. Puede combinarse con el proxy anterior.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   // Apariencia
   "settings.appearance.title": "Apariencia",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -186,7 +186,10 @@ const fr: Record<string, string> = {
   "settings.connection.server_url": "URL du serveur",
   "settings.connection.port": "Port",
   "settings.connection.network_proxy": "Proxy réseau (git / pip)",
-  "settings.connection.network_proxy_desc": "Facultatif. Utilisé lorsque MooshieUI clone des nœuds personnalisés ControlNet ou installe leurs dépendances Python. Exemple : http://127.0.0.1:7890. Laissez vide pour utiliser les paramètres système par défaut.",
+  "settings.connection.network_proxy_desc": "Facultatif. Utilisé lorsque MooshieUI clone des nœuds personnalisés ControlNet via git. Exemple : http://127.0.0.1:7890. Laissez vide pour utiliser les paramètres système par défaut.",
+  "settings.connection.pip_index_url": "Miroir PyPI (pip)",
+  "settings.connection.pip_index_url_desc": "Facultatif. Utilisé pour toutes les installations pip/uv. Si pypi.org est lent, indiquez un miroir tel que https://pypi.tuna.tsinghua.edu.cn/simple. Peut être combiné avec le proxy ci-dessus.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   // Apparence
   "settings.appearance.title": "Apparence",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -185,7 +185,10 @@ const it: Record<string, string> = {
   "settings.connection.server_url": "URL del server",
   "settings.connection.port": "Porta",
   "settings.connection.network_proxy": "Proxy di rete (git / pip)",
-  "settings.connection.network_proxy_desc": "Facoltativo. Usato quando MooshieUI clona nodi personalizzati ControlNet o installa le relative dipendenze Python. Esempio: http://127.0.0.1:7890. Lascia vuoto per usare le impostazioni di sistema predefinite.",
+  "settings.connection.network_proxy_desc": "Facoltativo. Usato quando MooshieUI clona nodi personalizzati ControlNet via git. Esempio: http://127.0.0.1:7890. Lascia vuoto per usare le impostazioni di sistema predefinite.",
+  "settings.connection.pip_index_url": "Mirror PyPI (pip)",
+  "settings.connection.pip_index_url_desc": "Facoltativo. Usato per tutte le installazioni pip/uv. Se pypi.org è lento, imposta un mirror come https://pypi.tuna.tsinghua.edu.cn/simple. Può essere usato insieme al proxy sopra.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "Aspetto",
   "settings.appearance.theme": "Tema",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -186,7 +186,10 @@ const ja: Record<string, string> = {
   "settings.connection.server_url": "サーバーURL",
   "settings.connection.port": "ポート",
   "settings.connection.network_proxy": "ネットワークプロキシ（git / pip）",
-  "settings.connection.network_proxy_desc": "任意。MooshieUI が ControlNet カスタムノードをクローンしたり Python 依存関係をインストールする際に使用します。例: http://127.0.0.1:7890。空欄の場合はシステムの既定値を使用します。",
+  "settings.connection.network_proxy_desc": "任意。MooshieUI が ControlNet カスタムノードを git でクローンする際に使用します。例: http://127.0.0.1:7890。空欄の場合はシステムの既定値を使用します。",
+  "settings.connection.pip_index_url": "PyPI ミラー（pip）",
+  "settings.connection.pip_index_url_desc": "任意。すべての pip/uv インストールに使用します。pypi.org が遅い場合は https://pypi.tuna.tsinghua.edu.cn/simple などのミラーを指定できます。上のプロキシと併用できます。",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   // 外観
   "settings.appearance.title": "外観",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -185,7 +185,10 @@ const ko: Record<string, string> = {
   "settings.connection.server_url": "서버 URL",
   "settings.connection.port": "포트",
   "settings.connection.network_proxy": "네트워크 프록시 (git / pip)",
-  "settings.connection.network_proxy_desc": "선택 사항. MooshieUI가 ControlNet 커스텀 노드를 복제하거나 Python 종속성을 설치할 때 사용됩니다. 예: http://127.0.0.1:7890. 비워 두면 시스템 기본값을 사용합니다.",
+  "settings.connection.network_proxy_desc": "선택 사항. MooshieUI가 git으로 ControlNet 커스텀 노드를 복제할 때 사용됩니다. 예: http://127.0.0.1:7890. 비워 두면 시스템 기본값을 사용합니다.",
+  "settings.connection.pip_index_url": "PyPI 미러(pip)",
+  "settings.connection.pip_index_url_desc": "선택 사항. 모든 pip/uv 설치에 사용됩니다. pypi.org가 느리면 https://pypi.tuna.tsinghua.edu.cn/simple 같은 미러를 설정하세요. 위 프록시와 함께 사용할 수 있습니다.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "외관",
   "settings.appearance.theme": "테마",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -185,7 +185,10 @@ const pt: Record<string, string> = {
   "settings.connection.server_url": "URL do Servidor",
   "settings.connection.port": "Porta",
   "settings.connection.network_proxy": "Proxy de rede (git / pip)",
-  "settings.connection.network_proxy_desc": "Opcional. Usado quando o MooshieUI clona nós personalizados do ControlNet ou instala suas dependências Python. Exemplo: http://127.0.0.1:7890. Deixe vazio para usar os padrões do sistema.",
+  "settings.connection.network_proxy_desc": "Opcional. Usado quando o MooshieUI clona nós personalizados do ControlNet via git. Exemplo: http://127.0.0.1:7890. Deixe vazio para usar os padrões do sistema.",
+  "settings.connection.pip_index_url": "Espelho PyPI (pip)",
+  "settings.connection.pip_index_url_desc": "Opcional. Usado em todas as instalações pip/uv. Se pypi.org for lento, defina um espelho como https://pypi.tuna.tsinghua.edu.cn/simple. Pode ser usado junto com o proxy acima.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "Aparência",
   "settings.appearance.theme": "Tema",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -185,7 +185,10 @@ const ru: Record<string, string> = {
   "settings.connection.server_url": "URL сервера",
   "settings.connection.port": "Порт",
   "settings.connection.network_proxy": "Сетевой прокси (git / pip)",
-  "settings.connection.network_proxy_desc": "Необязательно. Используется, когда MooshieUI клонирует пользовательские узлы ControlNet или устанавливает их зависимости Python. Пример: http://127.0.0.1:7890. Оставьте пустым для системных настроек по умолчанию.",
+  "settings.connection.network_proxy_desc": "Необязательно. Используется, когда MooshieUI клонирует пользовательские узлы ControlNet через git. Пример: http://127.0.0.1:7890. Оставьте пустым для системных настроек по умолчанию.",
+  "settings.connection.pip_index_url": "Зеркало PyPI (pip)",
+  "settings.connection.pip_index_url_desc": "Необязательно. Используется для всех установок pip/uv. Если pypi.org медленный, укажите зеркало, например https://pypi.tuna.tsinghua.edu.cn/simple. Можно использовать вместе с прокси выше.",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "Внешний вид",
   "settings.appearance.theme": "Тема",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -185,7 +185,10 @@ const zhTw: Record<string, string> = {
   "settings.connection.server_url": "伺服器 URL",
   "settings.connection.port": "連接埠",
   "settings.connection.network_proxy": "網路代理（git / pip）",
-  "settings.connection.network_proxy_desc": "選用。MooshieUI 複製 ControlNet 自訂節點或安裝其 Python 相依套件時使用。範例：http://127.0.0.1:7890。留空則使用系統預設設定。",
+  "settings.connection.network_proxy_desc": "選用。MooshieUI 透過 git 複製 ControlNet 自訂節點時使用。範例：http://127.0.0.1:7890。留空則使用系統預設設定。",
+  "settings.connection.pip_index_url": "PyPI 鏡像（pip）",
+  "settings.connection.pip_index_url_desc": "選用。用於所有 pip/uv 安裝。在 pypi.org 較慢的地區可填寫鏡像，例如 https://pypi.tuna.tsinghua.edu.cn/simple。可與上方代理同時使用。",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "外觀",
   "settings.appearance.theme": "主題",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -185,7 +185,10 @@ const zh: Record<string, string> = {
   "settings.connection.server_url": "服务器网址",
   "settings.connection.port": "连接端口",
   "settings.connection.network_proxy": "网络代理（git / pip）",
-  "settings.connection.network_proxy_desc": "可选。MooshieUI 克隆 ControlNet 自定义节点或安装其 Python 依赖时使用。示例：http://127.0.0.1:7890。留空则使用系统默认设置。",
+  "settings.connection.network_proxy_desc": "可选。MooshieUI 通过 git 克隆 ControlNet 自定义节点时使用。示例：http://127.0.0.1:7890。留空则使用系统默认设置。",
+  "settings.connection.pip_index_url": "PyPI 镜像（pip）",
+  "settings.connection.pip_index_url_desc": "可选。用于所有 pip/uv 安装（ControlNet 节点依赖、可选包）。在 pypi.org 较慢的地区可填写镜像，例如 https://pypi.tuna.tsinghua.edu.cn/simple。可与上方代理同时使用。",
+  "settings.connection.pip_index_placeholder": "https://pypi.tuna.tsinghua.edu.cn/simple",
 
   "settings.appearance.title": "外观",
   "settings.appearance.theme": "主题",

--- a/src/lib/stores/styles.svelte.ts
+++ b/src/lib/stores/styles.svelte.ts
@@ -15,6 +15,7 @@
 
 const STORAGE_KEY = "mooshieui.styles.v1";
 const ACTIVE_KEY = "mooshieui.styles.active.v1";
+const EXPORT_VERSION = 1;
 
 import { triggerSync } from "../utils/syncTrigger.js";
 
@@ -471,7 +472,7 @@ class StylesStore {
       if (Array.isArray(data?.styles)) {
         const sanitized = data.styles.map(sanitizeStyle).filter(Boolean) as ArtistStyle[];
         this.styles = sanitized;
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, styles: sanitized }));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: EXPORT_VERSION, styles: sanitized }));
       }
       if (Array.isArray(data?.activeIds)) {
         const ids = new Set(this.styles.map((s) => s.id));

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -164,6 +164,8 @@ export interface AppConfig {
   attention_backend: string;
   /** HTTP(S) proxy for git/pip when installing ControlNet custom nodes (optional). */
   network_proxy: string | null;
+  /** PyPI index URL for pip/uv installs, e.g. a regional mirror (optional). */
+  pip_index_url: string | null;
 }
 
 export interface QueueInfo {


### PR DESCRIPTION
## Summary
- Add optional **PyPI mirror URL** (`pip_index_url`) in Settings → Connection; applied to all pip/uv installs (ControlNet nodes, custom nodes, optional packages) alongside the existing network proxy.
- Treat **ControlNet custom nodes as optional** at ComfyUI startup: missing nodes log warnings instead of blocking startup or killing an external ComfyUI on your port.
- **Resilient ControlNet setup**: per-package install failures are logged; core MooshieUI generation continues.

## Test plan
- [ ] Set PyPI mirror in Settings → Connection; verify pip/uv installs use the index URL
- [ ] Start with external ComfyUI missing ControlNet nodes — app should connect without killing the process
- [ ] Core txt2img generation works without ControlNet nodes installed
- [ ] Built-in ControlNet presets still work when nodes are present
