### PR TITLE
v1.3.10: Harden Animadex and LoRA metadata flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,20 @@ jobs:
               --repo "${{ github.repository }}" \
               --title "MooshieUI ${TAG}" \
               --notes-file /tmp/release-body.md
-            gh release upload "${TAG}" \
+            upload_log="$(mktemp)"
+            if ! gh release upload "${TAG}" \
               --repo "${{ github.repository }}" \
               --clobber \
-              /tmp/release-files/*
+              /tmp/release-files/* >"${upload_log}" 2>&1; then
+              if grep -qi "immutable release" "${upload_log}"; then
+                echo "Release ${TAG} is immutable; keeping existing release assets."
+              else
+                cat "${upload_log}"
+                rm -f "${upload_log}"
+                exit 1
+              fi
+            fi
+            rm -f "${upload_log}"
           else
             gh release create "${TAG}" \
               --repo "${{ github.repository }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v1.3.10
+
+### Characters and LoRA metadata stability
+- **Animadex search hardening**: character and facet lookups now debounce more aggressively, cancel stale in-flight requests, and avoid short facet-query spam to reduce 429 rate limits.
+- **LoRA metadata flood protection**: LoRA gallery now detects access-denied responses, stops queueing repeated failing requests, and shows a clear retryable warning state instead of log spam.
+- **Browser auth parity for metadata lookup**: `get_lora_civitai_info` and checkpoint metadata lookup are no longer gated behind Model Hub access, so authenticated users can load local model metadata without 403s.
+
+### Generation dependency verification
+- **Face Detailer dependency check**: added backend `check_python_import` plumbing and frontend validation so MooshieUI verifies `ultralytics` imports successfully after install before continuing generation.
+- **Improved generation error messaging**: generation failures now surface localized, explicit error text.
+
+### Release workflow resilience
+- **Immutable release handling**: release workflow now tolerates immutable GitHub release assets by skipping clobber failures only for that case while still failing on real upload errors.
+
+---
+
 ## What's New in v1.3.9
 
 ### Mobile UI (browser / LAN)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v1.3.10
+
+### Characters and LoRA metadata stability
+- **Animadex search hardening**: character and facet lookups now debounce more aggressively, cancel stale in-flight requests, and avoid short facet-query spam to reduce 429 rate limits.
+- **LoRA metadata flood protection**: LoRA gallery now detects access-denied responses, stops queueing repeated failing requests, and shows a clear retryable warning state instead of log spam.
+- **Browser auth parity for metadata lookup**: `get_lora_civitai_info` and checkpoint metadata lookup are no longer gated behind Model Hub access, so authenticated users can load local model metadata without 403s.
+
+### Generation dependency verification
+- **Face Detailer dependency check**: added backend `check_python_import` plumbing and frontend validation so MooshieUI verifies `ultralytics` imports successfully after install before continuing generation.
+- **Improved generation error messaging**: generation failures now surface localized, explicit error text.
+
+### Release workflow resilience
+- **Immutable release handling**: release workflow now tolerates immutable GitHub release assets by skipping clobber failures only for that case while still failing on real upload errors.
+
+---
+
 ## What's New in v1.3.9
 
 ### Mobile UI (browser / LAN)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.3.9"
+version = "1.3.10"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.3.9"
+version = "1.3.10"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1620,6 +1620,20 @@ pub fn resolve_uv_bin_pub(venv_path: &str) -> std::path::PathBuf {
     resolve_uv_bin(venv_path)
 }
 
+/// Resolve the Python executable path from the venv path.
+pub fn resolve_venv_python_bin(venv_path: &str) -> std::path::PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        std::path::Path::new(venv_path)
+            .join("Scripts")
+            .join("python.exe")
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::path::Path::new(venv_path).join("bin").join("python")
+    }
+}
+
 /// Check if a custom node package is installed on disk (directory exists in custom_nodes/).
 #[cfg(feature = "desktop")]
 #[tauri::command]
@@ -1887,6 +1901,28 @@ pub async fn install_pip_package(
 
     log::info!("Installed pip package: {}", package);
     Ok(())
+}
+
+/// Verify that a Python module can be imported inside the ComfyUI virtual environment.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn check_python_import(
+    state: State<'_, Arc<AppState>>,
+    module: String,
+) -> Result<bool, AppError> {
+    let venv_path = {
+        let config = state.config.read().await;
+        config.venv_path.clone()
+    };
+
+    let python_path = resolve_venv_python_bin(&venv_path);
+    let output = tokio::process::Command::new(&python_path)
+        .args(["-c", &format!("import {}", module)])
+        .output()
+        .await
+        .map_err(|e| AppError::Other(format!("python import check failed to start: {}", e)))?;
+
+    Ok(output.status.success())
 }
 
 /// Search for a model file by SHA256 hash (full or AutoV2) within a model category directory.

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1634,6 +1634,18 @@ pub fn resolve_venv_python_bin(venv_path: &str) -> std::path::PathBuf {
     }
 }
 
+/// Validate a Python module name for `python -c "import <module>"`.
+pub fn is_valid_python_module_name(module: &str) -> bool {
+    let module = module.trim();
+    !module.is_empty()
+        && !module.starts_with('.')
+        && !module.ends_with('.')
+        && !module.contains("..")
+        && module
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+}
+
 /// Check if a custom node package is installed on disk (directory exists in custom_nodes/).
 #[cfg(feature = "desktop")]
 #[tauri::command]
@@ -1910,6 +1922,11 @@ pub async fn check_python_import(
     state: State<'_, Arc<AppState>>,
     module: String,
 ) -> Result<bool, AppError> {
+    let module = module.trim().to_string();
+    if !is_valid_python_module_name(&module) {
+        return Err(AppError::Other("Invalid module name".into()));
+    }
+
     let venv_path = {
         let config = state.config.read().await;
         config.venv_path.clone()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -401,6 +401,7 @@ pub fn run() {
             commands::api::is_custom_node_installed,
             commands::api::install_custom_node,
             commands::api::install_pip_package,
+            commands::api::check_python_import,
             commands::websocket::connect_ws,
             commands::websocket::disconnect_ws,
             commands::workflow::generate,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2811,7 +2811,14 @@ async fn dispatch_command(
             Ok(serde_json::json!(null))
         }
         "check_python_import" => {
-            let module = args["module"].as_str().ok_or("Missing module")?.to_string();
+            let module = args["module"]
+                .as_str()
+                .ok_or("Missing module")?
+                .trim()
+                .to_string();
+            if !crate::commands::api::is_valid_python_module_name(&module) {
+                return Err("Invalid module name".into());
+            }
             let config = state.config.read().await;
             let venv_path = config.venv_path.clone();
             drop(config);

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -183,8 +183,6 @@ const MODELHUB_COMMANDS: &[&str] = &[
     "civitai_lookup_hash",
     "download_model",
     "get_model_install_dirs",
-    "get_lora_civitai_info",
-    "get_checkpoint_civitai_info",
 ];
 
 fn is_modelhub_command(command: &str) -> bool {
@@ -2811,6 +2809,21 @@ async fn dispatch_command(
             }
             log::info!("Installed pip package (browser mode): {}", package);
             Ok(serde_json::json!(null))
+        }
+        "check_python_import" => {
+            let module = args["module"].as_str().ok_or("Missing module")?.to_string();
+            let config = state.config.read().await;
+            let venv_path = config.venv_path.clone();
+            drop(config);
+
+            let python_path = crate::commands::api::resolve_venv_python_bin(&venv_path);
+            let output = tokio::process::Command::new(&python_path)
+                .args(["-c", &format!("import {}", module)])
+                .output()
+                .await
+                .map_err(|e| format!("python import check failed to start: {}", e))?;
+
+            Ok(serde_json::json!(output.status.success()))
         }
 
         // --- Model info (server has filesystem access to models) ---

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/animadex/client.ts
+++ b/src/lib/animadex/client.ts
@@ -12,9 +12,9 @@ function apiUrl(path: string): string {
   return `${ANIMADEX_ORIGIN}api/characters${path}`;
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
   const fetchFn = animadexFetch ?? globalThis.fetch.bind(globalThis);
-  const res = await fetchFn(url, { credentials: "omit" });
+  const res = await fetchFn(url, { credentials: "omit", signal });
   if (!res.ok) {
     throw new Error(`animadex: ${url} returned ${res.status}`);
   }
@@ -40,9 +40,10 @@ function buildSearchParams(params: CharacterSearchParams): string {
 
 export async function searchCharacters(
   params: CharacterSearchParams,
+  signal?: AbortSignal,
 ): Promise<CharacterSearchResponse> {
   const qs = buildSearchParams(params);
-  return fetchJson<CharacterSearchResponse>(apiUrl(`/search?${qs}`));
+  return fetchJson<CharacterSearchResponse>(apiUrl(`/search?${qs}`), signal);
 }
 
 export async function loadCharacterFacets(): Promise<CharacterFacetsResponse> {
@@ -52,7 +53,8 @@ export async function loadCharacterFacets(): Promise<CharacterFacetsResponse> {
 export async function searchCharacterFacet(
   facet: CharacterFilterFacetName,
   query: string,
+  signal?: AbortSignal,
 ): Promise<FacetSearchResponse> {
   const q = encodeURIComponent(query.trim());
-  return fetchJson<FacetSearchResponse>(apiUrl(`/facet/${facet}?q=${q}`));
+  return fetchJson<FacetSearchResponse>(apiUrl(`/facet/${facet}?q=${q}`), signal);
 }

--- a/src/lib/animadex/components/CharacterExplorer.svelte
+++ b/src/lib/animadex/components/CharacterExplorer.svelte
@@ -244,8 +244,8 @@
   function onFacetSearchInput(name: CharacterFilterFacetName, value: string) {
     facetQuery = { ...facetQuery, [name]: value };
     if (!SEARCHABLE_FACETS.has(name)) return;
-    if (value.trim().length > 0 && value.trim().length < 2) return;
     if (facetDebounce[name] !== undefined) window.clearTimeout(facetDebounce[name]);
+    if (value.trim().length > 0 && value.trim().length < 2) return;
     facetDebounce[name] = window.setTimeout(() => {
       void reloadFacetOptions(name);
       facetDebounce[name] = undefined;

--- a/src/lib/animadex/components/CharacterExplorer.svelte
+++ b/src/lib/animadex/components/CharacterExplorer.svelte
@@ -82,6 +82,8 @@
 
   let searchDebounce: number | null = null;
   let facetDebounce: Partial<Record<CharacterFilterFacetName, number>> = {};
+  let searchController: AbortController | null = null;
+  let facetControllers: Partial<Record<CharacterFilterFacetName, AbortController>> = {};
   let searchSeq = 0;
 
   let scrollContainer = $state<HTMLDivElement | null>(null);
@@ -101,6 +103,8 @@
 
   async function runSearch(targetPage = 1) {
     const seq = ++searchSeq;
+    searchController?.abort();
+    searchController = new AbortController();
     loading = true;
     error = null;
     page = targetPage;
@@ -112,7 +116,7 @@
         page: targetPage,
         filters: filterSnapshot(),
         lorasOnly,
-      });
+      }, searchController.signal);
       if (seq !== searchSeq) return;
       results = data.results;
       total = data.total;
@@ -120,6 +124,7 @@
       lightboxIndex = -1;
     } catch (err) {
       if (seq !== searchSeq) return;
+      if (err instanceof DOMException && err.name === "AbortError") return;
       error = err instanceof Error ? err.message : String(err);
       results = [];
     } finally {
@@ -152,12 +157,24 @@
   }
 
   async function reloadFacetOptions(name: CharacterFilterFacetName) {
+    facetControllers[name]?.abort();
+    const controller = new AbortController();
+    facetControllers[name] = controller;
     try {
-      const data = await searchCharacterFacet(name, facetQuery[name] ?? "");
+      const data = await searchCharacterFacet(
+        name,
+        facetQuery[name] ?? "",
+        controller.signal,
+      );
       facetOptions = { ...facetOptions, [name]: data.values };
       facetTotals = { ...facetTotals, [name]: data.total };
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       /* keep current list */
+    } finally {
+      if (facetControllers[name] === controller) {
+        facetControllers[name] = undefined;
+      }
     }
   }
 
@@ -166,7 +183,7 @@
     searchDebounce = window.setTimeout(() => {
       void runSearch(targetPage);
       searchDebounce = null;
-    }, 150);
+    }, 320);
   }
 
   function onQueryInput(value: string) {
@@ -227,11 +244,12 @@
   function onFacetSearchInput(name: CharacterFilterFacetName, value: string) {
     facetQuery = { ...facetQuery, [name]: value };
     if (!SEARCHABLE_FACETS.has(name)) return;
+    if (value.trim().length > 0 && value.trim().length < 2) return;
     if (facetDebounce[name] !== undefined) window.clearTimeout(facetDebounce[name]);
     facetDebounce[name] = window.setTimeout(() => {
       void reloadFacetOptions(name);
       facetDebounce[name] = undefined;
-    }, 220);
+    }, 360);
   }
 
   function toggleFacetCollapsed(name: CharacterFilterFacetName) {
@@ -270,6 +288,10 @@
     void loadFacets().then(() => runSearch(1));
     return () => {
       if (searchDebounce !== null) window.clearTimeout(searchDebounce);
+      searchController?.abort();
+      for (const name of CHARACTER_FILTER_FACETS) {
+        facetControllers[name]?.abort();
+      }
     };
   });
 </script>

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -53,6 +53,7 @@
 
   async function ensureFacefixPythonDependency() {
     if (isBrowserMode) return;
+    if (await checkPythonImport("ultralytics")) return;
     await installPipPackage("ultralytics==8.4.34");
     const importOk = await checkPythonImport("ultralytics");
     if (!importOk) {

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -3,7 +3,14 @@
   import { progress } from "../../stores/progress.svelte.js";
   import { canvas } from "../../stores/canvas.svelte.js";
   import { compare } from "../../stores/compare.svelte.js";
-  import { generate, interruptGeneration, deleteQueueItem, installPipPackage, downloadModel } from "../../utils/api.js";
+  import {
+    generate,
+    interruptGeneration,
+    deleteQueueItem,
+    installPipPackage,
+    downloadModel,
+    checkPythonImport,
+  } from "../../utils/api.js";
   import { models } from "../../stores/models.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
@@ -42,6 +49,15 @@
 
   async function submitGeneration(params: GenerationParams): Promise<string> {
     return trackGeneration(params, await requestGeneration(params));
+  }
+
+  async function ensureFacefixPythonDependency() {
+    if (isBrowserMode) return;
+    await installPipPackage("ultralytics==8.4.34");
+    const importOk = await checkPythonImport("ultralytics");
+    if (!importOk) {
+      throw new Error("Face Detailer dependency check failed: unable to import ultralytics.");
+    }
   }
 
   function finishSubmitRun(runToken: number) {
@@ -114,9 +130,7 @@
           generation.facefixDetector = detector;
           await models.refresh();
         }
-        if (!isBrowserMode) {
-          await installPipPackage("ultralytics==8.4.34");
-        }
+        await ensureFacefixPythonDependency();
       }
 
       // Anima models produce poor results below 1024 — clamp to 1024² area preserving aspect ratio
@@ -140,7 +154,8 @@
     } catch (e) {
       if (runToken === submitRunToken) {
         console.error("Generation failed:", e);
-        errorMsg = String(e);
+        const message = e instanceof Error ? e.message : String(e);
+        errorMsg = locale.t("generation.error_failed_message", { message });
       }
     } finally {
       finishSubmitRun(runToken);

--- a/src/lib/components/generation/LoraGallery.svelte
+++ b/src/lib/components/generation/LoraGallery.svelte
@@ -53,6 +53,18 @@
   let selectedLora = $state<string | null>(null);
   let imageIndex = $state<Record<string, number>>({});
   let searchQuery = $state("");
+  let loraInfoAccessBlocked = $state<string | null>(null);
+
+  function isAccessDeniedError(message: string): boolean {
+    const text = message.toLowerCase();
+    return (
+      text.includes(" 403") ||
+      text.includes("status 403") ||
+      text.includes("forbidden") ||
+      text.includes("permission") ||
+      text.includes("access to the model hub")
+    );
+  }
 
   function saveCache() {
     try {
@@ -107,6 +119,7 @@
   let fetching = false;
 
   function enqueueFetch(filename: string) {
+    if (loraInfoAccessBlocked) return;
     if (cache[filename] || loading[filename] || fetchedSet.has(filename)) return;
     fetchedSet.add(filename);
     fetchQueue.push(filename);
@@ -136,13 +149,19 @@
         saveCache();
       }
     } catch (e) {
-      errors = { ...errors, [filename]: String(e) };
+      const message = e instanceof Error ? e.message : String(e);
+      errors = { ...errors, [filename]: message };
+      if (isAccessDeniedError(message)) {
+        loraInfoAccessBlocked = message;
+        fetchQueue = [];
+      }
     } finally {
       loading = { ...loading, [filename]: false };
     }
   }
 
   function refetchLora(filename: string) {
+    loraInfoAccessBlocked = null;
     fetchedSet.delete(filename);
     delete cache[filename];
     cache = { ...cache };
@@ -269,6 +288,23 @@
     </div>
   </div>
 
+  {#if loraInfoAccessBlocked}
+    <div class="mx-2 mb-1.5 rounded border border-amber-700/50 bg-amber-950/40 px-2 py-1.5 text-[11px] text-amber-200">
+      <div class="flex items-center justify-between gap-2">
+        <p class="truncate" title={loraInfoAccessBlocked}>{loraInfoAccessBlocked}</p>
+        <button
+          type="button"
+          class="shrink-0 text-amber-100 underline hover:text-white"
+          onclick={() => {
+            loraInfoAccessBlocked = null;
+          }}
+        >
+          {locale.t("common.retry")}
+        </button>
+      </div>
+    </div>
+  {/if}
+
   {#if models.loras.length === 0}
     <div class="flex items-center justify-center flex-1 text-neutral-500 text-xs">
       <p>{locale.t('lora.no_loras')}</p>
@@ -284,6 +320,7 @@
         {@const info = getInfo(loraName)}
         {@const isLoading = loading[loraName]}
         {@const error = errors[loraName]}
+        {@const accessDenied = !!error && isAccessDeniedError(error)}
         {@const imgUrl = currentImageUrl(loraName)}
         {@const resolvedUrl = imgUrl ? (resolvedImages[imgUrl] ?? null) : null}
         {@const imgCount = info?.civitai_images?.length ?? 0}
@@ -347,7 +384,13 @@
             {:else if error}
               <div class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-2">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-neutral-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-                <span class="text-[10px] text-neutral-600 text-center" title={error}>{error.includes('not found') ? error : locale.t('lora.not_on_civitai')}</span>
+                <span class="text-[10px] text-neutral-600 text-center" title={error}>
+                  {error.includes('not found')
+                    ? error
+                    : accessDenied
+                      ? error
+                      : locale.t('lora.not_on_civitai')}
+                </span>
                 <button
                   class="text-[10px] text-indigo-400 hover:text-indigo-300"
                   onclick={(e) => { e.stopPropagation(); refetchLora(loraName); }}

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -599,6 +599,10 @@ export async function installPipPackage(packageName: string): Promise<void> {
   return ipcInvoke("install_pip_package", { package: packageName });
 }
 
+export async function checkPythonImport(module: string): Promise<boolean> {
+  return ipcInvoke("check_python_import", { module });
+}
+
 export interface AttentionBackendStatus {
   current: string;
   venv_packages: string[];


### PR DESCRIPTION
## Summary
- Bump release version to `1.3.10` across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, and prepend `CHANGELOG.md` + `RELEASE_NOTES.md`.
- Harden Animadex/LoRA data fetching in browser mode: cancel stale character/facet requests, reduce bursty queries, and add a LoRA metadata access-denied circuit breaker UI.
- Fix backend/browser command routing for metadata and dependency checks: allow local `get_lora_civitai_info`/`get_checkpoint_civitai_info` for authenticated users and add `check_python_import` wiring used by Face Detailer dependency verification.
- Improve release CI robustness by tolerating immutable-release asset upload conflicts without masking real upload failures.

## Validation
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run build`
- `cargo fmt --check`
- `cargo clippy` (warnings only; no new blocking failures)

Made with [Cursor](https://cursor.com)