### PR TITLE
Apply Gemini review follow-ups for artist lookup and prompt textarea

### DIFF
--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -115,35 +115,6 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
     return searchPromise;
   }
 
-  async function getArtist(slugOrTag: string): Promise<ArtistEntry | null> {
-    if (!slugOrTag) return null;
-    const trimmed = slugOrTag.trim();
-    let slug = trimmed;
-
-    // Keep raw slug lookup intact, but also try the normalized tag form directly
-    // before falling back to the large search index.
-    const directSlugs = [trimmed];
-    const normalized = normalizeTag(trimmed);
-    if (normalized && normalized !== trimmed) {
-      directSlugs.push(normalized);
-    }
-
-    for (const directSlug of directSlugs) {
-      const shard = await loadShard(bucketForSlug(directSlug)).catch(() => null);
-      if (shard?.entries[directSlug]) return shard.entries[directSlug];
-    }
-
-    // Resolve through the search index.
-    await loadSearchIndex();
-    const key = normalizeTag(trimmed);
-    const resolvedSlug = tagToSlug.get(key) ?? tagToSlug.get(trimmed.toLowerCase());
-    if (!resolvedSlug) return null;
-    slug = resolvedSlug;
-    const bucket = slugToBucket.get(slug) ?? bucketForSlug(slug);
-    const shard2 = await loadShard(bucket);
-    return shard2.entries[slug] ?? null;
-  }
-
   async function getArtistDirect(slugOrTag: string): Promise<ArtistEntry | null> {
     if (!slugOrTag) return null;
     const trimmed = slugOrTag.trim();
@@ -158,6 +129,23 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
       if (shard?.entries[directSlug]) return shard.entries[directSlug];
     }
     return null;
+  }
+
+  async function getArtist(slugOrTag: string): Promise<ArtistEntry | null> {
+    if (!slugOrTag) return null;
+    const trimmed = slugOrTag.trim();
+
+    const direct = await getArtistDirect(trimmed);
+    if (direct) return direct;
+
+    // Resolve through the search index.
+    await loadSearchIndex();
+    const key = normalizeTag(trimmed);
+    const resolvedSlug = tagToSlug.get(key) ?? tagToSlug.get(trimmed.toLowerCase());
+    if (!resolvedSlug) return null;
+    const bucket = slugToBucket.get(resolvedSlug) ?? bucketForSlug(resolvedSlug);
+    const shard2 = await loadShard(bucket);
+    return shard2.entries[resolvedSlug] ?? null;
   }
 
   function normalizeQuery(text: string): string {

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -657,7 +657,7 @@
       bind:value
       {placeholder}
       {rows}
-      class="w-full border border-neutral-700 rounded-lg px-3 py-2 text-sm leading-5 text-neutral-100 placeholder-neutral-500 resize-y focus:outline-none focus:border-indigo-500 transition-colors {minHeight} {showBackdrop ? 'bg-transparent' : 'bg-neutral-800'}"
+      class="w-full border border-neutral-700 rounded-lg px-3 py-2 text-sm leading-5 text-neutral-100 placeholder-neutral-500 resize-y focus:outline-none focus:border-indigo-500 transition-colors break-words {minHeight} {showBackdrop ? 'bg-transparent' : 'bg-neutral-800'}"
       style="position: relative; z-index: 1; {resizeStyle}{showBackdrop ? 'caret-color: #e5e5e5;' : ''}"
       onkeydown={handleKeydown}
       oninput={handleInput}
@@ -679,7 +679,7 @@
           {#if segment.clickable}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <span
-              class="pointer-events-auto cursor-pointer rounded-[4px] transition-colors [box-decoration-break:clone] [-webkit-box-decoration-break:clone] {selectionStart === segment.start && selectionEnd === segment.end
+              class="pointer-events-auto cursor-pointer rounded-[4px] transition-colors box-decoration-clone {selectionStart === segment.start && selectionEnd === segment.end
                 ? segment.kind === 'weighted'
                   ? 'bg-amber-400/28 shadow-[inset_0_0_0_1px_rgba(252,211,77,0.8),0_0_10px_rgba(251,191,36,0.35)]'
                   : 'bg-indigo-400/24 shadow-[inset_0_0_0_1px_rgba(165,180,252,0.8),0_0_10px_rgba(129,140,248,0.35)]'


### PR DESCRIPTION
## Summary
- Reuse \getArtistDirect\ inside \getArtist\ to remove duplicate shard lookup logic (PR #216 review).
- Add \reak-words\ on the prompt textarea so tag/weight overlays wrap identically (PR #217 review).
- Replace arbitrary box-decoration Tailwind with \ox-decoration-clone\.

## Test plan
- [ ] Open generation page with tag/weight overlay enabled; verify long tokens align between textarea and highlights.
- [ ] Artist tag click still resolves entries via slug and search index.


Made with [Cursor](https://cursor.com)