### PR TITLE
Fix manual save metadata embed and per-user gallery paths

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1130,7 +1130,8 @@ pub async fn read_image_metadata(
 ) -> Result<Option<std::collections::HashMap<String, String>>, AppError> {
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .ok_or_else(|| AppError::Other(format!("Gallery image not found: {}", filename)))?;
     let bytes = std::fs::read(&path)?;
     crate::metadata::read_image_metadata(&bytes).map_err(AppError::Other)
 }
@@ -1229,7 +1230,8 @@ pub async fn load_gallery_image(filename: String) -> Result<Vec<u8>, AppError> {
     }
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .ok_or_else(|| AppError::Other(format!("Gallery image not found: {}", filename)))?;
     let bytes = std::fs::read(&path)?;
     Ok(bytes)
 }
@@ -1245,7 +1247,8 @@ pub async fn load_gallery_image_png(filename: String) -> Result<Vec<u8>, AppErro
     }
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .ok_or_else(|| AppError::Other(format!("Gallery image not found: {}", filename)))?;
     let bytes = std::fs::read(&path)?;
     if filename.ends_with(".jxl") {
         let png = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, String> {
@@ -1274,7 +1277,8 @@ pub async fn load_gallery_image_display(filename: String) -> Result<Vec<u8>, App
     }
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .ok_or_else(|| AppError::Other(format!("Gallery image not found: {}", filename)))?;
     let bytes = std::fs::read(&path)?;
     if filename.ends_with(".jxl") {
         let webp = tokio::task::spawn_blocking(move || transcode_jxl_to_webp(&bytes))
@@ -1299,17 +1303,44 @@ pub async fn read_temp_image(filename: String) -> Result<Vec<u8>, AppError> {
         .ok_or_else(|| AppError::Other(format!("Temp image not found: {}", filename)))
 }
 
+/// Locate a gallery file under the root gallery dir or `users/{username}/` subdirs.
+pub fn resolve_gallery_image_path(
+    base_dir: &std::path::Path,
+    filename: &str,
+) -> Option<std::path::PathBuf> {
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return None;
+    }
+    let direct = base_dir.join(filename);
+    if direct.is_file() {
+        return Some(direct);
+    }
+    let users_dir = base_dir.join("users");
+    if !users_dir.is_dir() {
+        return None;
+    }
+    let entries = std::fs::read_dir(&users_dir).ok()?;
+    for entry in entries.flatten() {
+        if !entry.file_type().ok().is_some_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let candidate = entry.path().join(filename);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
 /// Generate a WebP thumbnail for a gallery image. Used by the `thumbnail://` protocol.
 pub fn generate_thumbnail(
     gallery_dir: &std::path::Path,
     filename: &str,
     max_size: u32,
 ) -> Result<Vec<u8>, String> {
-    // Reject path traversal attempts — filename must be a plain basename.
-    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
-        return Err("Invalid filename".to_string());
-    }
-    let path = gallery_dir.join(filename);
+    let path = resolve_gallery_image_path(gallery_dir, filename).ok_or_else(|| {
+        "Read failed: The system cannot find the file specified.".to_string()
+    })?;
     let bytes = std::fs::read(&path).map_err(|e| format!("Read failed: {}", e))?;
 
     let img = decode_gallery_image(&bytes)?;
@@ -1354,13 +1385,8 @@ pub fn transcode_jxl_to_webp(bytes: &[u8]) -> Result<Vec<u8>, String> {
 pub async fn get_gallery_image_path(filename: String) -> Result<String, AppError> {
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
-    if !path.exists() {
-        return Err(AppError::Other(format!(
-            "Gallery image not found: {}",
-            filename
-        )));
-    }
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .ok_or_else(|| AppError::Other(format!("Gallery image not found: {}", filename)))?;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -1369,11 +1395,10 @@ pub async fn get_gallery_image_path(filename: String) -> Result<String, AppError
 pub async fn delete_gallery_image(filename: String) -> Result<(), AppError> {
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
-    let path = dir.join(&filename);
-    if path.exists() {
+    if let Some(path) = resolve_gallery_image_path(&dir, &filename) {
         std::fs::remove_file(&path)?;
+        crate::gallery_index::remove(&path);
     }
-    crate::gallery_index::remove(&path);
     Ok(())
 }
 
@@ -1386,15 +1411,14 @@ pub async fn rename_gallery_image(
     let dir = crate::config::gallery_dir()
         .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
 
-    let old_path = dir.join(&old_filename);
-    if !old_path.exists() {
-        return Err(AppError::Other(format!(
-            "Gallery image not found: {}",
-            old_filename
-        )));
-    }
+    let old_path = resolve_gallery_image_path(&dir, &old_filename).ok_or_else(|| {
+        AppError::Other(format!("Gallery image not found: {}", old_filename))
+    })?;
 
-    let new_path = dir.join(&new_filename);
+    let new_path = old_path
+        .parent()
+        .ok_or_else(|| AppError::Other("Invalid gallery path".into()))?
+        .join(&new_filename);
     if new_path.exists() {
         return Err(AppError::Other(format!(
             "Target gallery filename already exists: {}",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -308,7 +308,19 @@ pub fn run() {
                     }
                 };
 
-                let file_path = gallery_dir.join(&filename);
+                let file_path = match commands::api::resolve_gallery_image_path(&gallery_dir, &filename) {
+                    Some(p) => p,
+                    None => {
+                        log::warn!("Gallery image read failed for '{}': not found", filename);
+                        responder.respond(
+                            tauri::http::Response::builder()
+                                .status(404)
+                                .body(b"Not found".to_vec())
+                                .unwrap(),
+                        );
+                        return;
+                    }
+                };
                 match std::fs::read(&file_path) {
                     Ok(data) => {
                         // Detect content type from extension

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -93,6 +93,21 @@ async function blobToBytes(blob: Blob): Promise<number[]> {
   return Array.from(new Uint8Array(buffer));
 }
 
+/** True when bytes are a PNG file (not JPEG/WebP mislabeled as PNG). */
+function isPngBytes(bytes: ArrayLike<number>): boolean {
+  return (
+    bytes.length >= 8
+    && bytes[0] === 0x89
+    && bytes[1] === 0x50
+    && bytes[2] === 0x4e
+    && bytes[3] === 0x47
+    && bytes[4] === 0x0d
+    && bytes[5] === 0x0a
+    && bytes[6] === 0x1a
+    && bytes[7] === 0x0a
+  );
+}
+
 function pngBlobFromBytes(bytes: number[]): Blob {
   const buffer = new ArrayBuffer(bytes.length);
   new Uint8Array(buffer).set(bytes);
@@ -703,41 +718,26 @@ class GalleryStore {
         } catch (tempError) {
           console.warn("Temp image fetch failed; falling back to session image:", tempError);
           if (image.url) {
-            bytes = await this._blobUrlToPngBytes(image.url);
+            bytes = await this._fetchUrlToPngBytes(image.url);
           } else if (image.sessionBlob) {
-            bytes = await blobToBytes(image.sessionBlob);
+            bytes = await this._blobToPngBytes(image.sessionBlob);
           } else {
             throw tempError;
           }
         }
       } else if (image.url) {
-        // Session image: WebP (JXL display copy) or PNG blob — canvas-convert to PNG.
-        let blob: Blob | null = null;
-        try {
-          const response = await fetch(image.url);
-          if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
-          blob = await response.blob();
-        } catch {
-          bytes = await this._blobUrlToPngBytes(image.url);
-        }
-        if (blob?.type === "image/webp") {
-          bytes = await this._blobUrlToPngBytes(image.url);
-        } else if (blob) {
-          bytes = await blobToBytes(blob);
-        }
+        bytes = await this._fetchUrlToPngBytes(image.url);
       } else {
         bytes = await getOutputImage(image.filename, image.subfolder);
       }
       if (!bytes) throw new Error("Image bytes unavailable");
 
-      // JXL -> PNG transcode strips embedded metadata. Re-embed from the
-      // in-memory metadata so the exported PNG carries the original prompt /
-      // workflow info (parity with saveImageToDir).
-      if (isJxlExport && image.metadata) {
+      bytes = await this._ensurePngBytes(bytes);
+      if (image.metadata) {
         try {
           bytes = await embedPngMetadataBytes(bytes, image.metadata, generation.metadataMode);
         } catch (e) {
-          console.warn("Failed to embed PNG metadata into JXL export:", e);
+          console.warn("Failed to embed PNG metadata into export:", e);
         }
       }
 
@@ -776,10 +776,8 @@ class GalleryStore {
 
       if (!blob && blobUrl.startsWith("blob:")) {
         saveBytes = await this._blobUrlToPngBytes(blobUrl);
-      } else if (blob?.type === "image/webp") {
-        saveBytes = await this._blobUrlToPngBytes(blobUrl);
       } else if (blob) {
-        saveBytes = await blobToBytes(blob);
+        saveBytes = await this._blobToPngBytes(blob);
       } else {
         throw new Error("Image URL is no longer available");
       }
@@ -827,30 +825,18 @@ class GalleryStore {
           if (image.url) {
             bytes = await this._blobUrlToPngBytes(image.url);
           } else if (image.sessionBlob) {
-            bytes = await blobToBytes(image.sessionBlob);
+            bytes = await this._blobToPngBytes(image.sessionBlob);
           } else {
             throw tempError;
           }
         }
       } else if (image.url) {
-        // Session image (WebP display blob or PNG) — canvas-convert to PNG.
-        let blob: Blob | null = null;
-        try {
-          const response = await fetch(image.url);
-          if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
-          blob = await response.blob();
-        } catch {
-          bytes = await this._blobUrlToPngBytes(image.url);
-        }
-        if (blob?.type === "image/webp") {
-          bytes = await this._blobUrlToPngBytes(image.url);
-        } else if (blob) {
-          bytes = await blobToBytes(blob);
-        }
+        bytes = await this._fetchUrlToPngBytes(image.url);
       } else {
         bytes = await getOutputImage(image.filename, image.subfolder);
       }
       if (!bytes) throw new Error("Image bytes unavailable");
+      bytes = await this._ensurePngBytes(bytes);
       // Use .png extension for JXL exports so the saved file matches its contents.
       const filename = isJxlExport
         ? (image.filename || `image_${Date.now()}.jxl`).replace(/\.jxl$/i, ".png")
@@ -1095,9 +1081,28 @@ class GalleryStore {
     });
   }
 
+  /** Fetch a URL and return PNG bytes (canvas-converts WebP/JPEG/mislabeled blobs). */
+  private async _fetchUrlToPngBytes(url: string): Promise<number[]> {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`Failed to fetch image: ${response.status}`);
+      return this._blobToPngBytes(await response.blob());
+    } catch {
+      return this._blobUrlToPngBytes(url);
+    }
+  }
+
+  /** Ensure bytes are PNG before metadata embed (re-encode JPEG/WebP/mislabeled PNG). */
+  private async _ensurePngBytes(bytes: number[]): Promise<number[]> {
+    if (isPngBytes(bytes)) return bytes;
+    const blob = new Blob([new Uint8Array(bytes)]);
+    return this._blobToPngBytes(blob);
+  }
+
   private async _blobToPngBytes(blob: Blob): Promise<number[]> {
-    if (blob.type === "image/png" || blob.type === "image/jpeg") {
-      return blobToBytes(blob);
+    if (blob.type === "image/png") {
+      const bytes = await blobToBytes(blob);
+      if (isPngBytes(bytes)) return bytes;
     }
     const url = URL.createObjectURL(blob);
     try {


### PR DESCRIPTION
Summary: Always convert to PNG before metadata embed on manual save and Save As. Resolve gallery files under users/username subdirs for thumbnails and gallery protocol.

Made with [Cursor](https://cursor.com)