### PR TITLE
Stability matrix folders

### DIFF
--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -260,8 +260,12 @@ impl AppState {
                 "unet\\",
                 "diffusion_models/",
                 "diffusion_models\\",
+                "DiffusionModels/", // StabilityMatrix
+                "DiffusionModels\\",
                 "text_encoders/",
                 "text_encoders\\",
+                "TextEncoders/", // StabilityMatrix
+                "TextEncoders\\",
             ],
             "loras" => &[
                 "checkpoints/",

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -75,7 +75,7 @@ fn is_structured_model_dir(path: &std::path::Path) -> bool {
         "checkpoints",
         "Stable-diffusion",
         "Stable-Diffusion",
-        "StableDiffusion",
+        "StableDiffusion", // StabilityMatrix
         "loras",
         "lora",
         "Lora",
@@ -91,11 +91,13 @@ fn is_structured_model_dir(path: &std::path::Path) -> bool {
         "ESRGAN",
         "embeddings",
         "controlnet",
-        "ControlNet",
+        "ControlNet", // StabilityMatrix
         "clip",
         "unet",
         "diffusion_models",
+        "DiffusionModels", // StabilityMatrix
         "text_encoders",
+        "TextEncoders", // StabilityMatrix
     ];
     KNOWN_SUBDIRS.iter().any(|sub| path.join(sub).is_dir())
 }
@@ -570,13 +572,19 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
                             "    dlbackend/comfyui/models/unet\n",
                             "  diffusion_models: |\n",
                             "    diffusion_models\n",
+                            "    DiffusionModels\n",
                             "    models/diffusion_models\n",
+                            "    models/DiffusionModels\n",
                             "    Models/diffusion_models\n",
+                            "    Models/DiffusionModels\n",
                             "    dlbackend/comfyui/models/diffusion_models\n",
                             "  text_encoders: |\n",
                             "    text_encoders\n",
+                            "    TextEncoders\n",
                             "    models/text_encoders\n",
+                            "    models/TextEncoders\n",
                             "    Models/text_encoders\n",
+                            "    Models/TextEncoders\n",
                             "    dlbackend/comfyui/models/text_encoders\n",
                         ),
                         idx = i + 1,

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -348,6 +348,7 @@ fn classify_flat_model_dir(path: &std::path::Path) -> &'static str {
     } else if name.contains("clip")
         || name.contains("text_encoder")
         || name.contains("text-encoder")
+        || name.contains("textencoder") // StabilityMatrix
     {
         "text_encoders"
     } else if name.contains("unet") || name.contains("diffusion") {
@@ -2808,13 +2809,19 @@ pub(crate) fn category_subdirs(category: &str) -> &'static [&'static str] {
         "unet" => &["unet", "models/unet", "Models/unet"],
         "diffusion_models" => &[
             "diffusion_models",
+            "DiffusionModels",
             "models/diffusion_models",
+            "models/DiffusionModels",
             "Models/diffusion_models",
+            "Models/DiffusionModels",
         ],
         "text_encoders" => &[
             "text_encoders",
+            "TextEncoders",
             "models/text_encoders",
+            "models/TextEncoders",
             "Models/text_encoders",
+            "Models/TextEncoders",
         ],
         "ultralytics" => &["ultralytics", "models/ultralytics", "Models/ultralytics"],
         _ => &[],

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -593,7 +593,7 @@
     );
   });
 
-  /** Pair text encoder + CLIPLoader type for a manually picked diffusion/UNET file */
+  /** Pair text encoder + CLIPLoader type for a manually picked diffusion model file */
   function pickSplitModelClip(
     diffusionModel: string,
     encoders: string[],
@@ -698,7 +698,7 @@
       }
     }
 
-    // Locally installed diffusion/UNET weights not in the curated list (e.g. custom Anima fine-tunes)
+    // Locally installed diffusion weights not in the curated list (e.g. custom Anima fine-tunes)
     const excludedDiffusion = recommendedDiffusionFilenames();
     for (const dm of models.diffusionModels) {
       if (excludedDiffusion.has(dm)) continue;
@@ -728,7 +728,7 @@
     showCheckpointDropdown = false;
   }
 
-  /** Use a diffusion/UNET file discovered on disk (not in the curated recommended list). */
+  /** Use a diffusion model file discovered on disk (not in the curated recommended list). */
   function selectCustomDiffusion(filename: string) {
     showCheckpointDropdown = false;
     checkpointSearch = "";

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -38,7 +38,7 @@ class ModelsStore {
       // layout) or `clip/` (legacy ComfyUI / Forge layout). Fetch both and
       // merge so the picker doesn't miss encoders in the legacy directory
       // (e.g. `qwen_3_8b_fp4mixed.safetensors` placed under `clip/`).
-      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, unetModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
+      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
         await Promise.all([
           getModels("checkpoints"),
           getModels("vae"),
@@ -47,8 +47,6 @@ class ModelsStore {
           getEmbeddings(),
           getModels("upscale_models"),
           getModels("diffusion_models").catch(() => [] as string[]),
-          // ComfyUI also exposes UNET/diffusion weights under `unet/` on some installs.
-          getModels("unet").catch(() => [] as string[]),
           getModels("text_encoders").catch(() => [] as string[]),
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
@@ -58,7 +56,6 @@ class ModelsStore {
       console.log("ModelsStore: got checkpoints:", checkpoints);
       console.log("ModelsStore: got samplers:", samplerInfo);
 
-      const mergedDiffusion = Array.from(new Set([...(diffusionModels ?? []), ...(unetModels ?? [])]));
       const mergedEncoders = Array.from(new Set([...(textEncoders ?? []), ...(clipEncoders ?? [])]));
 
       [
@@ -77,7 +74,7 @@ class ModelsStore {
         mergeWithDiskModels("loras", loras),
         mergeWithDiskModels("embeddings", embeddings),
         mergeWithDiskModels("upscale_models", upscaleModels),
-        mergeWithDiskModels("diffusion_models", mergedDiffusion),
+        mergeWithDiskModels("diffusion_models", diffusionModels),
         mergeWithDiskModels("text_encoders", mergedEncoders),
         mergeWithDiskModels("controlnet", controlnetModels),
         mergeWithDiskModels("ultralytics", ultralyticsModels),

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -38,7 +38,7 @@ class ModelsStore {
       // layout) or `clip/` (legacy ComfyUI / Forge layout). Fetch both and
       // merge so the picker doesn't miss encoders in the legacy directory
       // (e.g. `qwen_3_8b_fp4mixed.safetensors` placed under `clip/`).
-      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
+      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, unetModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
         await Promise.all([
           getModels("checkpoints"),
           getModels("vae"),
@@ -47,6 +47,8 @@ class ModelsStore {
           getEmbeddings(),
           getModels("upscale_models"),
           getModels("diffusion_models").catch(() => [] as string[]),
+          // ComfyUI also exposes UNET/diffusion weights under `unet/` on some installs.
+          getModels("unet").catch(() => [] as string[]),
           getModels("text_encoders").catch(() => [] as string[]),
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
@@ -56,6 +58,7 @@ class ModelsStore {
       console.log("ModelsStore: got checkpoints:", checkpoints);
       console.log("ModelsStore: got samplers:", samplerInfo);
 
+      const mergedDiffusion = Array.from(new Set([...(diffusionModels ?? []), ...(unetModels ?? [])]));
       const mergedEncoders = Array.from(new Set([...(textEncoders ?? []), ...(clipEncoders ?? [])]));
 
       [
@@ -74,7 +77,7 @@ class ModelsStore {
         mergeWithDiskModels("loras", loras),
         mergeWithDiskModels("embeddings", embeddings),
         mergeWithDiskModels("upscale_models", upscaleModels),
-        mergeWithDiskModels("diffusion_models", diffusionModels),
+        mergeWithDiskModels("diffusion_models", mergedDiffusion),
         mergeWithDiskModels("text_encoders", mergedEncoders),
         mergeWithDiskModels("controlnet", controlnetModels),
         mergeWithDiskModels("ultralytics", ultralyticsModels),


### PR DESCRIPTION
Added Stability Matrix folders (DiffusionModels, TextEncoders) for Shared Model Directories* (extra_model_paths).

Also removed unet from the ModelsStore, because modern ComfyUI versions use diffusion_models folder for this.