### PR TITLE
Fast actions for quality tags badge

### DIFF
--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -8,6 +8,7 @@
   import { promptPresets } from "../../stores/promptPresets.svelte.js";
   import PromptTextarea from "./PromptTextarea.svelte";
   import InfoTip from "../ui/InfoTip.svelte";
+  import QualityTagsEditor from "../settings/QualityTagsEditor.svelte";
   import { parseScheduledPrompt, hasRegionalTags, hasSchedulingTags } from "../../utils/promptSchedule.js";
 
   interface Props {
@@ -31,6 +32,7 @@
   const positiveSegments = $derived(hasPositiveSchedule ? parseScheduledPrompt(generation.positivePrompt).segments : []);
   const negativeSegments = $derived(hasNegativeSchedule ? parseScheduledPrompt(generation.negativePrompt).segments : []);
   let schedulePanelOpen = $state(true);
+  let showQualityTagsModal = $state(false);
 
   /** Artist tags detected in the current positive prompt. */
   const detectedArtists = $derived.by(() => {
@@ -55,6 +57,20 @@
       hour: "2-digit",
       minute: "2-digit",
     });
+  }
+
+  function toggleQualityTags() {
+    generation.autoQualityTags = !generation.autoQualityTags;
+    generation.saveSettings();
+  }
+
+  function openQualityTagsModalFromContextMenu(event: MouseEvent) {
+    event.preventDefault();
+    showQualityTagsModal = true;
+  }
+
+  function openQualityTagsModal() {
+    showQualityTagsModal = true;
   }
 </script>
 
@@ -82,13 +98,12 @@
       {#if qualityTagsSupported}
         <button
           type="button"
-          onclick={() => {
-            generation.autoQualityTags = !generation.autoQualityTags;
-            generation.saveSettings();
-          }}
+          onclick={toggleQualityTags}
+          oncontextmenu={openQualityTagsModalFromContextMenu}
           class="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors cursor-pointer {qualityTagsApplied
             ? 'bg-emerald-600/20 text-emerald-400 border-emerald-600/30 hover:bg-emerald-600/30'
             : 'bg-red-600/15 text-red-300 border-red-600/30 hover:bg-red-600/25'}"
+          title={locale.t('settings.performance.custom_quality_tags')}
         >
           {qualityTagsApplied
             ? locale.t('generation.prompts.quality_applied')
@@ -302,3 +317,33 @@
     </div>
   {/if}
 </div>
+
+{#if showQualityTagsModal}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-label={locale.t('settings.performance.custom_quality_tags')}
+    onclick={(e) => { if (e.target === e.currentTarget) showQualityTagsModal = false; }}
+    onkeydown={(e) => { if (e.key === 'Escape') showQualityTagsModal = false; }}
+  >
+    <div class="flex max-h-[calc(100vh-2rem)] w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-neutral-700 bg-neutral-900 p-4 shadow-2xl">
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h3 class="text-sm font-semibold text-neutral-100">{locale.t('settings.performance.custom_quality_tags')}</h3>
+          <p class="mt-1 text-[10px] text-neutral-500">{locale.t('settings.performance.custom_quality_tags_desc')}</p>
+        </div>
+        <button
+          type="button"
+          onclick={() => { showQualityTagsModal = false; }}
+          class="rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-neutral-600 transition-colors"
+        >
+          {locale.t('common.close')}
+        </button>
+      </div>
+      <div class="min-h-0 overflow-y-auto pr-1">
+        <QualityTagsEditor />
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -59,6 +59,10 @@
     });
   }
 
+  function focusOnMount(node: HTMLElement) {
+    node.focus();
+  }
+
   function toggleQualityTags() {
     generation.autoQualityTags = !generation.autoQualityTags;
     generation.saveSettings();
@@ -66,10 +70,6 @@
 
   function openQualityTagsModalFromContextMenu(event: MouseEvent) {
     event.preventDefault();
-    showQualityTagsModal = true;
-  }
-
-  function openQualityTagsModal() {
     showQualityTagsModal = true;
   }
 </script>
@@ -103,7 +103,7 @@
           class="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors cursor-pointer {qualityTagsApplied
             ? 'bg-emerald-600/20 text-emerald-400 border-emerald-600/30 hover:bg-emerald-600/30'
             : 'bg-red-600/15 text-red-300 border-red-600/30 hover:bg-red-600/25'}"
-          title={locale.t('settings.performance.custom_quality_tags')}
+          title={locale.t('generation.prompts.quality_badge_hint')}
         >
           {qualityTagsApplied
             ? locale.t('generation.prompts.quality_applied')
@@ -320,7 +320,9 @@
 
 {#if showQualityTagsModal}
   <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+    use:focusOnMount
+    tabindex="-1"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 outline-none"
     role="dialog"
     aria-modal="true"
     aria-label={locale.t('settings.performance.custom_quality_tags')}

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -22,6 +22,10 @@
   const hasRegionalPrompting = $derived(
     hasRegionalTags(generation.positivePrompt) || generation.regionalPrompts.length > 0,
   );
+  const qualityTagsSupported = $derived(
+    generation.isAnima || generation.isIllustrious || generation.isPony || generation.isNanosaur,
+  );
+  const qualityTagsApplied = $derived(qualityTagsSupported && generation.autoQualityTags);
   const hasNegativeSchedule = $derived(hasSchedulingTags(generation.negativePrompt));
   const hasAnySchedule = $derived(hasPositiveSchedule || hasNegativeSchedule);
   const positiveSegments = $derived(hasPositiveSchedule ? parseScheduledPrompt(generation.positivePrompt).segments : []);
@@ -75,8 +79,21 @@
         <label class="text-xs text-neutral-400">{locale.t('generation.prompts.positive')}<InfoTip text={locale.t('generation.prompts.positive_tip')} /></label>
       </div>
       <div class="flex items-center justify-end gap-1.5 flex-wrap min-w-0">
-      {#if generation.isAnima || generation.isIllustrious}
-        <span class="shrink-0 text-[10px] px-2 py-0.5 rounded-full bg-emerald-600/20 text-emerald-400 border border-emerald-600/30">{locale.t('generation.prompts.quality_applied')}</span>
+      {#if qualityTagsSupported}
+        <button
+          type="button"
+          onclick={() => {
+            generation.autoQualityTags = !generation.autoQualityTags;
+            generation.saveSettings();
+          }}
+          class="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors cursor-pointer {qualityTagsApplied
+            ? 'bg-emerald-600/20 text-emerald-400 border-emerald-600/30 hover:bg-emerald-600/30'
+            : 'bg-red-600/15 text-red-300 border-red-600/30 hover:bg-red-600/25'}"
+        >
+          {qualityTagsApplied
+            ? locale.t('generation.prompts.quality_applied')
+            : locale.t('generation.prompts.quality_disabled')}
+        </button>
       {/if}
       {#each styles.activeStyles as activeStyle (activeStyle.id)}
         <button

--- a/src/lib/components/settings/QualityTagsEditor.svelte
+++ b/src/lib/components/settings/QualityTagsEditor.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { generation, DEFAULT_ANIMA_POSITIVE_QUALITY, DEFAULT_ANIMA_NEGATIVE_QUALITY, DEFAULT_ILLUSTRIOUS_POSITIVE_QUALITY, DEFAULT_ILLUSTRIOUS_NEGATIVE_QUALITY, DEFAULT_PONY_POSITIVE_QUALITY, DEFAULT_PONY_NEGATIVE_QUALITY, DEFAULT_NANOSAUR_POSITIVE_QUALITY, DEFAULT_NANOSAUR_NEGATIVE_QUALITY } from "../../stores/generation.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+
+  interface Props {
+    showWarning?: boolean;
+  }
+
+  let { showWarning = true }: Props = $props();
+
+  function resetDefaults() {
+    generation.customAnimaPositiveQuality = DEFAULT_ANIMA_POSITIVE_QUALITY;
+    generation.customAnimaNegativeQuality = DEFAULT_ANIMA_NEGATIVE_QUALITY;
+    generation.customIllustriousPositiveQuality = DEFAULT_ILLUSTRIOUS_POSITIVE_QUALITY;
+    generation.customIllustriousNegativeQuality = DEFAULT_ILLUSTRIOUS_NEGATIVE_QUALITY;
+    generation.customPonyPositiveQuality = DEFAULT_PONY_POSITIVE_QUALITY;
+    generation.customPonyNegativeQuality = DEFAULT_PONY_NEGATIVE_QUALITY;
+    generation.customNanosaurPositiveQuality = DEFAULT_NANOSAUR_POSITIVE_QUALITY;
+    generation.customNanosaurNegativeQuality = DEFAULT_NANOSAUR_NEGATIVE_QUALITY;
+    generation.saveSettings();
+  }
+</script>
+
+<div class="rounded-lg border border-amber-500/20 bg-neutral-950/50 p-3 space-y-3">
+  {#if showWarning}
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <svg class="w-3.5 h-3.5 text-amber-400/80 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <p class="text-[10px] text-amber-400/80">{locale.t('settings.performance.quality_tags_warning')}</p>
+      </div>
+      <button
+        type="button"
+        onclick={resetDefaults}
+        class="text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer whitespace-nowrap ml-3"
+      >
+        {locale.t('settings.performance.reset_defaults')}
+      </button>
+    </div>
+  {/if}
+
+  <!-- Anima Tags -->
+  <div class="space-y-1.5">
+    <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.anima')}</p>
+    <div>
+      <label for="anima-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
+      <textarea
+        id="anima-pos-quality"
+        bind:value={generation.customAnimaPositiveQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.positive_example')}
+      ></textarea>
+    </div>
+    <div>
+      <label for="anima-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
+      <textarea
+        id="anima-neg-quality"
+        bind:value={generation.customAnimaNegativeQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.negative_example')}
+      ></textarea>
+    </div>
+  </div>
+
+  <!-- Illustrious/NoobAI Tags -->
+  <div class="space-y-1.5">
+    <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.illustrious')}</p>
+    <div>
+      <label for="illustrious-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
+      <textarea
+        id="illustrious-pos-quality"
+        bind:value={generation.customIllustriousPositiveQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.positive_example')}
+      ></textarea>
+    </div>
+    <div>
+      <label for="illustrious-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
+      <textarea
+        id="illustrious-neg-quality"
+        bind:value={generation.customIllustriousNegativeQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.negative_bad_example')}
+      ></textarea>
+    </div>
+  </div>
+
+  <!-- Pony Tags -->
+  <div class="space-y-1.5">
+    <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">Pony</p>
+    <div>
+      <label for="pony-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
+      <textarea
+        id="pony-pos-quality"
+        bind:value={generation.customPonyPositiveQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.positive_example')}
+      ></textarea>
+    </div>
+    <div>
+      <label for="pony-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
+      <textarea
+        id="pony-neg-quality"
+        bind:value={generation.customPonyNegativeQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.negative_example')}
+      ></textarea>
+    </div>
+  </div>
+
+  <!-- Nanosaur Tags -->
+  <div class="space-y-1.5">
+    <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.nanosaur')}</p>
+    <div>
+      <label for="nanosaur-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
+      <textarea
+        id="nanosaur-pos-quality"
+        bind:value={generation.customNanosaurPositiveQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.positive_example')}
+      ></textarea>
+    </div>
+    <div>
+      <label for="nanosaur-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
+      <textarea
+        id="nanosaur-neg-quality"
+        bind:value={generation.customNanosaurNegativeQuality}
+        onblur={() => generation.saveSettings()}
+        rows="2"
+        class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
+        placeholder={locale.t('settings.prompt.negative_example')}
+      ></textarea>
+    </div>
+  </div>
+</div>

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -4,7 +4,7 @@
   import type { ReleaseNote, ImportResult, AttentionBackendStatus } from "../../utils/api.js";
   import { connection } from "../../stores/connection.svelte.js";
   import { autocomplete } from "../../stores/autocomplete.svelte.js";
-  import { generation, DEFAULT_ANIMA_POSITIVE_QUALITY, DEFAULT_ANIMA_NEGATIVE_QUALITY, DEFAULT_ILLUSTRIOUS_POSITIVE_QUALITY, DEFAULT_ILLUSTRIOUS_NEGATIVE_QUALITY, DEFAULT_NANOSAUR_POSITIVE_QUALITY, DEFAULT_NANOSAUR_NEGATIVE_QUALITY } from "../../stores/generation.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
   import { accessibility } from "../../stores/accessibility.svelte.js";
   import { locale, LOCALE_OPTIONS } from "../../stores/locale.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
@@ -12,6 +12,7 @@
   import ModelManagerModal from "./ModelManagerModal.svelte";
   import GpuStatusPanel from "./GpuStatusPanel.svelte";
   import ModelRequestsPanel from "./ModelRequestsPanel.svelte";
+  import QualityTagsEditor from "./QualityTagsEditor.svelte";
   import { ipcInvoke, ipcListen, isTauri, isBrowserMode, authHeaders, clearAuthToken } from "../../utils/ipc.js";
   import {
     applyTheme,
@@ -2451,109 +2452,7 @@
           </div>
 
           {#if showCustomQualityTags}
-          <div class="rounded-lg border border-amber-500/20 bg-neutral-950/50 p-3 space-y-3">
-            <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <svg class="w-3.5 h-3.5 text-amber-400/80 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-                <p class="text-[10px] text-amber-400/80">{locale.t('settings.performance.quality_tags_warning')}</p>
-              </div>
-              <button
-                onclick={() => {
-                  generation.customAnimaPositiveQuality = DEFAULT_ANIMA_POSITIVE_QUALITY;
-                  generation.customAnimaNegativeQuality = DEFAULT_ANIMA_NEGATIVE_QUALITY;
-                  generation.customIllustriousPositiveQuality = DEFAULT_ILLUSTRIOUS_POSITIVE_QUALITY;
-                  generation.customIllustriousNegativeQuality = DEFAULT_ILLUSTRIOUS_NEGATIVE_QUALITY;
-                  generation.customNanosaurPositiveQuality = DEFAULT_NANOSAUR_POSITIVE_QUALITY;
-                  generation.customNanosaurNegativeQuality = DEFAULT_NANOSAUR_NEGATIVE_QUALITY;
-                  generation.saveSettings();
-                }}
-                class="text-[10px] text-indigo-400 hover:text-indigo-300 transition-colors cursor-pointer whitespace-nowrap ml-3"
-              >
-                {locale.t('settings.performance.reset_defaults')}
-              </button>
-            </div>
-
-            <!-- Anima Tags -->
-            <div class="space-y-1.5">
-              <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.anima')}</p>
-              <div>
-                <label for="anima-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
-                <textarea
-                  id="anima-pos-quality"
-                  bind:value={generation.customAnimaPositiveQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.positive_example')}
-                ></textarea>
-              </div>
-              <div>
-                <label for="anima-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
-                <textarea
-                  id="anima-neg-quality"
-                  bind:value={generation.customAnimaNegativeQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.negative_example')}
-                ></textarea>
-              </div>
-            </div>
-
-            <!-- Illustrious/NoobAI Tags -->
-            <div class="space-y-1.5">
-              <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.illustrious')}</p>
-              <div>
-                <label for="illustrious-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
-                <textarea
-                  id="illustrious-pos-quality"
-                  bind:value={generation.customIllustriousPositiveQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.positive_example')}
-                ></textarea>
-              </div>
-              <div>
-                <label for="illustrious-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
-                <textarea
-                  id="illustrious-neg-quality"
-                  bind:value={generation.customIllustriousNegativeQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.negative_bad_example')}
-                ></textarea>
-              </div>
-            </div>
-
-            <!-- Nanosaur Tags -->
-            <div class="space-y-1.5">
-              <p class="text-[10px] text-neutral-500 font-medium uppercase tracking-wide">{locale.t('settings.performance.nanosaur')}</p>
-              <div>
-                <label for="nanosaur-pos-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.positive')}</label>
-                <textarea
-                  id="nanosaur-pos-quality"
-                  bind:value={generation.customNanosaurPositiveQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.positive_example')}
-                ></textarea>
-              </div>
-              <div>
-                <label for="nanosaur-neg-quality" class="text-[10px] text-neutral-500">{locale.t('settings.performance.negative')}</label>
-                <textarea
-                  id="nanosaur-neg-quality"
-                  bind:value={generation.customNanosaurNegativeQuality}
-                  onblur={() => generation.saveSettings()}
-                  rows="2"
-                  class="w-full mt-0.5 px-2 py-1.5 bg-neutral-900 border border-neutral-700 rounded-lg text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none focus:border-indigo-500/50 resize-y"
-                  placeholder={locale.t('settings.prompt.negative_example')}
-                ></textarea>
-              </div>
-            </div>
-          </div>
+          <QualityTagsEditor />
           {/if}
           {/if}
           </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -464,6 +464,7 @@ const de: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} Segment(e)",
   "generation.prompts.quality_applied": "Qualitäts-Prompt angewendet",
   "generation.prompts.quality_disabled": "Qualitäts-Prompts deaktiviert",
+  "generation.prompts.quality_badge_hint": "Linksklick schaltet Qualitäts-Tags um. Rechtsklick öffnet die Anpassung.",
   "generation.prompts.anima_artist_tip": "Tipp: Künstler-Tags beginnen mit @ (z.B. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -463,6 +463,7 @@ const de: Record<string, string> = {
   "generation.prompts.scheduling": "Prompt-Planung",
   "generation.prompts.scheduling_segments": "{count} Segment(e)",
   "generation.prompts.quality_applied": "Qualitäts-Prompt angewendet",
+  "generation.prompts.quality_disabled": "Qualitäts-Prompts deaktiviert",
   "generation.prompts.anima_artist_tip": "Tipp: Künstler-Tags beginnen mit @ (z.B. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -471,6 +471,7 @@ const en: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} segment(s)",
   "generation.prompts.quality_applied": "Quality prompts applied",
   "generation.prompts.quality_disabled": "Quality prompts disabled",
+  "generation.prompts.quality_badge_hint": "Left-click to toggle quality tags. Right-click to customize them.",
   "generation.prompts.anima_artist_tip": "Tip: Start artist tags with @ (e.g. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -470,6 +470,7 @@ const en: Record<string, string> = {
   "generation.prompts.scheduling": "Prompt Scheduling",
   "generation.prompts.scheduling_segments": "{count} segment(s)",
   "generation.prompts.quality_applied": "Quality prompts applied",
+  "generation.prompts.quality_disabled": "Quality prompts disabled",
   "generation.prompts.anima_artist_tip": "Tip: Start artist tags with @ (e.g. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -447,6 +447,7 @@ const es: Record<string, string> = {
   "generation.prompts.scheduling": "Programación de Prompt",
   "generation.prompts.scheduling_segments": "{count} segmento(s)",
   "generation.prompts.quality_applied": "Etiquetas de calidad aplicadas",
+  "generation.prompts.quality_disabled": "Etiquetas de calidad desactivadas",
   "generation.prompts.anima_artist_tip": "Consejo: Comienza las etiquetas de artista con @ (ej. @nombre_artista)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -448,6 +448,7 @@ const es: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} segmento(s)",
   "generation.prompts.quality_applied": "Etiquetas de calidad aplicadas",
   "generation.prompts.quality_disabled": "Etiquetas de calidad desactivadas",
+  "generation.prompts.quality_badge_hint": "Clic izquierdo para alternar las etiquetas de calidad. Clic derecho para personalizarlas.",
   "generation.prompts.anima_artist_tip": "Consejo: Comienza las etiquetas de artista con @ (ej. @nombre_artista)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -458,6 +458,7 @@ const fr: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} segment(s)",
   "generation.prompts.quality_applied": "Prompts de qualité appliqués",
   "generation.prompts.quality_disabled": "Prompts de qualité désactivés",
+  "generation.prompts.quality_badge_hint": "Clic gauche pour activer/désactiver les tags de qualité. Clic droit pour les personnaliser.",
   "generation.prompts.anima_artist_tip": "Astuce : Commencez les tags d'artiste par @ (ex. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -457,6 +457,7 @@ const fr: Record<string, string> = {
   "generation.prompts.scheduling": "Planification de Prompt",
   "generation.prompts.scheduling_segments": "{count} segment(s)",
   "generation.prompts.quality_applied": "Prompts de qualité appliqués",
+  "generation.prompts.quality_disabled": "Prompts de qualité désactivés",
   "generation.prompts.anima_artist_tip": "Astuce : Commencez les tags d'artiste par @ (ex. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -448,6 +448,7 @@ const it: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} segmento/i",
   "generation.prompts.quality_applied": "Tag qualità applicati",
   "generation.prompts.quality_disabled": "Tag qualità disattivati",
+  "generation.prompts.quality_badge_hint": "Clic sinistro per attivare/disattivare i tag qualità. Clic destro per personalizzarli.",
   "generation.prompts.anima_artist_tip": "Suggerimento: I tag artista iniziano con @ (es. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -447,6 +447,7 @@ const it: Record<string, string> = {
   "generation.prompts.scheduling": "Pianificazione Prompt",
   "generation.prompts.scheduling_segments": "{count} segmento/i",
   "generation.prompts.quality_applied": "Tag qualità applicati",
+  "generation.prompts.quality_disabled": "Tag qualità disattivati",
   "generation.prompts.anima_artist_tip": "Suggerimento: I tag artista iniziano con @ (es. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -457,6 +457,7 @@ const ja: Record<string, string> = {
   "generation.prompts.scheduling": "プロンプトスケジューリング",
   "generation.prompts.scheduling_segments": "{count} セグメント",
   "generation.prompts.quality_applied": "品質プロンプト適用済み",
+  "generation.prompts.quality_disabled": "品質プロンプト無効",
   "generation.prompts.anima_artist_tip": "ヒント：アーティストタグは@で始めてください（例：@artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -458,6 +458,7 @@ const ja: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} セグメント",
   "generation.prompts.quality_applied": "品質プロンプト適用済み",
   "generation.prompts.quality_disabled": "品質プロンプト無効",
+  "generation.prompts.quality_badge_hint": "左クリックで品質タグを切り替え、右クリックでカスタマイズします。",
   "generation.prompts.anima_artist_tip": "ヒント：アーティストタグは@で始めてください（例：@artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -448,6 +448,7 @@ const ko: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count}개 세그먼트",
   "generation.prompts.quality_applied": "품질 프롬프트 적용됨",
   "generation.prompts.quality_disabled": "품질 프롬프트 비활성화됨",
+  "generation.prompts.quality_badge_hint": "왼쪽 클릭으로 품질 태그를 전환하고, 오른쪽 클릭으로 설정을 엽니다.",
   "generation.prompts.anima_artist_tip": "팁: 아티스트 태그는 @로 시작하세요 (예: @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -447,6 +447,7 @@ const ko: Record<string, string> = {
   "generation.prompts.scheduling": "프롬프트 스케줄링",
   "generation.prompts.scheduling_segments": "{count}개 세그먼트",
   "generation.prompts.quality_applied": "품질 프롬프트 적용됨",
+  "generation.prompts.quality_disabled": "품질 프롬프트 비활성화됨",
   "generation.prompts.anima_artist_tip": "팁: 아티스트 태그는 @로 시작하세요 (예: @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -447,6 +447,7 @@ const pt: Record<string, string> = {
   "generation.prompts.scheduling": "Agendamento de Prompt",
   "generation.prompts.scheduling_segments": "{count} segmento(s)",
   "generation.prompts.quality_applied": "Prompts de qualidade aplicados",
+  "generation.prompts.quality_disabled": "Prompts de qualidade desativados",
   "generation.prompts.anima_artist_tip": "Dica: Tags de artista começam com @ (ex: @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -448,6 +448,7 @@ const pt: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} segmento(s)",
   "generation.prompts.quality_applied": "Prompts de qualidade aplicados",
   "generation.prompts.quality_disabled": "Prompts de qualidade desativados",
+  "generation.prompts.quality_badge_hint": "Clique com o botão esquerdo para alternar as tags de qualidade. Clique com o botão direito para personalizá-las.",
   "generation.prompts.anima_artist_tip": "Dica: Tags de artista começam com @ (ex: @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -447,6 +447,7 @@ const ru: Record<string, string> = {
   "generation.prompts.scheduling": "Расписание промптов",
   "generation.prompts.scheduling_segments": "{count} сегмент(ов)",
   "generation.prompts.quality_applied": "Теги качества применены",
+  "generation.prompts.quality_disabled": "Теги качества отключены",
   "generation.prompts.anima_artist_tip": "Совет: Теги художников начинаются с @ (напр. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -448,6 +448,7 @@ const ru: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} сегмент(ов)",
   "generation.prompts.quality_applied": "Теги качества применены",
   "generation.prompts.quality_disabled": "Теги качества отключены",
+  "generation.prompts.quality_badge_hint": "ЛКМ переключает теги качества. ПКМ открывает их настройку.",
   "generation.prompts.anima_artist_tip": "Совет: Теги художников начинаются с @ (напр. @artist_name)",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -448,6 +448,7 @@ const zhTw: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} 個片段",
   "generation.prompts.quality_applied": "品質提示已套用",
   "generation.prompts.quality_disabled": "品質提示已停用",
+  "generation.prompts.quality_badge_hint": "左鍵切換品質標籤，右鍵開啟自訂設定。",
   "generation.prompts.anima_artist_tip": "提示：藝術家標籤以 @ 開頭（例如 @artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -447,6 +447,7 @@ const zhTw: Record<string, string> = {
   "generation.prompts.scheduling": "提示詞排程",
   "generation.prompts.scheduling_segments": "{count} 個片段",
   "generation.prompts.quality_applied": "品質提示已套用",
+  "generation.prompts.quality_disabled": "品質提示已停用",
   "generation.prompts.anima_artist_tip": "提示：藝術家標籤以 @ 開頭（例如 @artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -448,6 +448,7 @@ const zh: Record<string, string> = {
   "generation.prompts.scheduling_segments": "{count} 个片段",
   "generation.prompts.quality_applied": "质量提示已应用",
   "generation.prompts.quality_disabled": "质量提示已禁用",
+  "generation.prompts.quality_badge_hint": "左键切换质量标签，右键打开自定义设置。",
   "generation.prompts.anima_artist_tip": "提示：艺术家标签以 @ 开头（例如 @artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -447,6 +447,7 @@ const zh: Record<string, string> = {
   "generation.prompts.scheduling": "提示词调度",
   "generation.prompts.scheduling_segments": "{count} 个片段",
   "generation.prompts.quality_applied": "质量提示已应用",
+  "generation.prompts.quality_disabled": "质量提示已禁用",
   "generation.prompts.anima_artist_tip": "提示：艺术家标签以 @ 开头（例如 @artist_name）",
   "generation.prompt.category_all": "All",
   "generation.prompt.category_general": "General",


### PR DESCRIPTION
Added quality_disabled badge + left-click toggle (6aae2ef511e8dbe4833d16dd7411d0354121f535).

<img width="493" height="86" alt="1" src="https://github.com/user-attachments/assets/5503f4c8-71d0-434f-8647-e0bb3120c172" />

___

Also opens Customize quality tags with right click on the quality tags badge (16576b48d56468b46ef3ef8b75d1d0fd88474e1e).

<img width="509" height="1084" alt="2" src="https://github.com/user-attachments/assets/e99d4559-d66f-4dea-bfac-fd763899408f" />
