### PR TITLE
v1.4.3: prompt tag selection fixes and model gallery release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## What's New in v1.4.3
+
+### Prompt tag selection and highlighting
+- **Schedule block boundaries**: MooshieUI `<from|to|range:…>…</…>` and SwarmUI `<fromto[…]:…>` blocks are treated as inert ranges so commas inside scheduled text no longer break clickable tag selection.
+- **Expression tags (`:<`)**: colon-escaped angle tags (e.g. `:<`) stay clickable alongside schedule syntax, building on the v1.4.2 follow-up parser work.
+- **Weighted tags with `<` in content**: parenthetical weights like `(tag:<broken:1.2)` parse correctly for click-to-select overlays.
+- **Autocomplete in syntax blocks**: prompt autocomplete respects inert schedule, preset, LoRA, and region blocks—not only Swarm `fromto`.
+
+### Model gallery and picker
+- **Checkpoint and LoRA galleries**: richer grid cards with preview navigation, metadata actions, and sorting helpers.
+- **Model selector**: improved dropdown UX and Pony quality-tag quick actions via shared `QualityTagsEditor`.
+- **Stability Matrix paths**: extra model folders from Stability Matrix-style layouts resolve correctly.
+
+### Build and platform
+- **Arch AppImage support**: Linux packaging scripts and Tauri wrapper updates for Arch-based AppImage builds.
+
+---
+
 ## What's New in v1.4.2
 
 ### Remote / cloud ComfyUI onboarding

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+## What's New in v1.4.3
+
+### Prompt tag selection and highlighting
+- **Schedule block boundaries**: MooshieUI `<from|to|range:…>…</…>` and SwarmUI `<fromto[…]:…>` blocks are treated as inert ranges so commas inside scheduled text no longer break clickable tag selection.
+- **Expression tags (`:<`)**: colon-escaped angle tags (e.g. `:<`) stay clickable alongside schedule syntax, building on the v1.4.2 follow-up parser work.
+- **Weighted tags with `<` in content**: parenthetical weights like `(tag:<broken:1.2)` parse correctly for click-to-select overlays.
+- **Autocomplete in syntax blocks**: prompt autocomplete respects inert schedule, preset, LoRA, and region blocks—not only Swarm `fromto`.
+
+### Model gallery and picker
+- **Checkpoint and LoRA galleries**: richer grid cards with preview navigation, metadata actions, and sorting helpers.
+- **Model selector**: improved dropdown UX and Pony quality-tag quick actions via shared `QualityTagsEditor`.
+- **Stability Matrix paths**: extra model folders from Stability Matrix-style layouts resolve correctly.
+
+### Build and platform
+- **Arch AppImage support**: Linux packaging scripts and Tauri wrapper updates for Arch-based AppImage builds.
+
+---
+
 ## What's New in v1.4.2
 
 ### Remote / cloud ComfyUI onboarding

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -5,7 +5,12 @@
   import { locale } from "../../stores/locale.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
   import { promptPresets } from "../../stores/promptPresets.svelte.js";
-  import { renderHighlightedPrompt, hasSchedulingTags, hasPresetTokens } from "../../utils/promptSchedule.js";
+  import {
+    renderHighlightedPrompt,
+    hasSchedulingTags,
+    hasPresetTokens,
+    findPromptInertRangeContaining,
+  } from "../../utils/promptSchedule.js";
   import {
     getPromptClickableSegments,
     type PromptClickableSegment,
@@ -96,23 +101,22 @@
     const pos = textareaEl.selectionStart;
     const text = value;
 
-    // Check if cursor is inside a <fromto[...]...> block — if so, use block
-    // boundaries instead of comma-splitting (commas are part of fromto syntax).
-    const fromtoRe = new RegExp(`${SYNTAX_ANGLE_LOOKBEHIND}<fromto\\[[^\\]]*\\]:[^>]*>`, "g");
-    let ftMatch: RegExpExecArray | null;
-    while ((ftMatch = fromtoRe.exec(text)) !== null) {
-      const ftStart = ftMatch.index;
-      const ftEnd = ftStart + ftMatch[0].length;
-      if (pos > ftStart && pos <= ftEnd) {
-        // Cursor is inside this fromto block — use the whole block as the fragment
-        const token = text.substring(ftStart, ftEnd);
-        const leadingWhitespace = token.match(/^\s*/)?.[0].length ?? 0;
-        const trailingWhitespace = token.match(/\s*$/)?.[0].length ?? 0;
-        const trimmedStart = ftStart + leadingWhitespace;
-        const trimmedEnd = Math.max(trimmedStart, ftEnd - trailingWhitespace);
-        const fragment = text.substring(trimmedStart, trimmedEnd);
-        return { fragment, start: ftStart, end: ftEnd, trimmedStart, trimmedEnd };
-      }
+    // Scheduling, preset, LoRA, and region blocks use commas inside their syntax.
+    const inertRange = findPromptInertRangeContaining(text, pos);
+    if (inertRange) {
+      const token = text.substring(inertRange.start, inertRange.end);
+      const leadingWhitespace = token.match(/^\s*/)?.[0].length ?? 0;
+      const trailingWhitespace = token.match(/\s*$/)?.[0].length ?? 0;
+      const trimmedStart = inertRange.start + leadingWhitespace;
+      const trimmedEnd = Math.max(trimmedStart, inertRange.end - trailingWhitespace);
+      const fragment = text.substring(trimmedStart, trimmedEnd);
+      return {
+        fragment,
+        start: inertRange.start,
+        end: inertRange.end,
+        trimmedStart,
+        trimmedEnd,
+      };
     }
 
     // Find the start of the current tag (after the last comma before cursor)

--- a/src/lib/utils/promptClickableRanges.ts
+++ b/src/lib/utils/promptClickableRanges.ts
@@ -1,3 +1,10 @@
+import {
+  getPromptInertRanges,
+  isInsidePromptInertRange,
+  type PromptTextRange,
+} from "./promptInertRanges.ts";
+import { hasUnescapedSyntaxAngles, isBackslashEscaped } from "./promptSyntaxEscape.ts";
+
 export type PromptClickableSegmentKind = "text" | "tag" | "weighted";
 
 export interface PromptClickableSegment {
@@ -16,12 +23,6 @@ interface OpenToken {
   index: number;
   char: "(" | "{" | "[";
 }
-
-import {
-  hasUnescapedSyntaxAngles,
-  isBackslashEscaped,
-  isSyntaxAngleOpen,
-} from "./promptSyntaxEscape.ts";
 
 const WEIGHT_SUFFIX_RE = /^\d*\.?\d+$/;
 
@@ -42,7 +43,7 @@ function isWeightedExpression(raw: string, start: number, end: number): boolean 
   let parenDepth = 0;
   let bracketDepth = 0;
   let braceDepth = 0;
-  let angleDepth = 0;
+  let lastValidColon = -1;
 
   for (let i = start + 1; i < end - 1; i++) {
     if (isBackslashEscaped(raw, i)) continue;
@@ -72,37 +73,28 @@ function isWeightedExpression(raw: string, start: number, end: number): boolean 
       braceDepth -= 1;
       continue;
     }
-    if (isSyntaxAngleOpen(raw, i)) {
-      angleDepth += 1;
-      continue;
-    }
-    if (ch === ">" && angleDepth > 0) {
-      angleDepth -= 1;
-      continue;
-    }
 
     if (
       ch === ":" &&
       parenDepth === 0 &&
       bracketDepth === 0 &&
-      braceDepth === 0 &&
-      angleDepth === 0
+      braceDepth === 0
     ) {
-      const left = raw.slice(start + 1, i).trim();
       const right = raw.slice(i + 1, end - 1).trim();
-      if (left.length > 0 && WEIGHT_SUFFIX_RE.test(right)) {
-        return true;
+      if (right.length > 0 && WEIGHT_SUFFIX_RE.test(right)) {
+        lastValidColon = i;
       }
     }
   }
 
-  return false;
+  if (lastValidColon === -1) return false;
+  const left = raw.slice(start + 1, lastValidColon).trim();
+  return left.length > 0;
 }
 
-function getWeightedRanges(raw: string): Range[] {
+function getWeightedRanges(raw: string, inertRanges: readonly PromptTextRange[]): Range[] {
   const stack: OpenToken[] = [];
   const candidates: Range[] = [];
-  let angleDepth = 0;
 
   const openForClose: Record<string, OpenToken["char"]> = {
     ")": "(",
@@ -114,21 +106,10 @@ function getWeightedRanges(raw: string): Range[] {
     raw.slice(start + 1, end - 1).trim().length > 0;
 
   for (let i = 0; i < raw.length; i++) {
+    if (isInsidePromptInertRange(i, inertRanges)) continue;
     if (isBackslashEscaped(raw, i)) continue;
 
     const ch = raw[i];
-    if (isSyntaxAngleOpen(raw, i)) {
-      angleDepth += 1;
-      continue;
-    }
-    if (ch === ">" && angleDepth > 0) {
-      angleDepth -= 1;
-      continue;
-    }
-    if (angleDepth > 0) {
-      continue;
-    }
-
     if (ch === "(" || ch === "{" || ch === "[") {
       stack.push({ index: i, char: ch });
       continue;
@@ -175,41 +156,79 @@ function isPlainClickableToken(token: string): boolean {
   return true;
 }
 
-function pushGapSegments(segments: PromptClickableSegment[], raw: string, start: number, end: number) {
+function pushTokenSegments(
+  segments: PromptClickableSegment[],
+  raw: string,
+  rangeStart: number,
+  rangeEnd: number,
+) {
+  if (rangeStart >= rangeEnd) return;
+
+  let trimmedStart = rangeStart;
+  while (trimmedStart < rangeEnd && /\s/.test(raw[trimmedStart])) {
+    trimmedStart += 1;
+  }
+
+  let trimmedEnd = rangeEnd;
+  while (trimmedEnd > trimmedStart && /\s/.test(raw[trimmedEnd - 1])) {
+    trimmedEnd -= 1;
+  }
+
+  pushSegment(segments, rangeStart, trimmedStart, "text", false);
+  if (trimmedStart < trimmedEnd) {
+    const token = raw.slice(trimmedStart, trimmedEnd);
+    if (isPlainClickableToken(token)) {
+      pushSegment(segments, trimmedStart, trimmedEnd, "tag", true);
+    } else {
+      pushSegment(segments, trimmedStart, trimmedEnd, "text", false);
+    }
+  }
+  pushSegment(segments, trimmedEnd, rangeEnd, "text", false);
+}
+
+function pushGapSegments(
+  segments: PromptClickableSegment[],
+  raw: string,
+  start: number,
+  end: number,
+  inertRanges: readonly PromptTextRange[],
+) {
+  if (start >= end) return;
+
+  let cursor = start;
+  for (const inert of inertRanges) {
+    if (inert.end <= start || inert.start >= end) continue;
+
+    const inertStart = Math.max(start, inert.start);
+    const inertEnd = Math.min(end, inert.end);
+    if (inertStart > cursor) {
+      pushSplittableGap(segments, raw, cursor, inertStart, inertRanges);
+    }
+    pushSegment(segments, inertStart, inertEnd, "text", false);
+    cursor = inertEnd;
+  }
+
+  if (cursor < end) {
+    pushSplittableGap(segments, raw, cursor, end, inertRanges);
+  }
+}
+
+function pushSplittableGap(
+  segments: PromptClickableSegment[],
+  raw: string,
+  start: number,
+  end: number,
+  inertRanges: readonly PromptTextRange[],
+) {
   if (start >= end) return;
 
   let tokenStart = start;
   let parenDepth = 0;
   let bracketDepth = 0;
   let braceDepth = 0;
-  let angleDepth = 0;
-
-  const pushToken = (rangeStart: number, rangeEnd: number) => {
-    if (rangeStart >= rangeEnd) return;
-
-    let trimmedStart = rangeStart;
-    while (trimmedStart < rangeEnd && /\s/.test(raw[trimmedStart])) {
-      trimmedStart += 1;
-    }
-
-    let trimmedEnd = rangeEnd;
-    while (trimmedEnd > trimmedStart && /\s/.test(raw[trimmedEnd - 1])) {
-      trimmedEnd -= 1;
-    }
-
-    pushSegment(segments, rangeStart, trimmedStart, "text", false);
-    if (trimmedStart < trimmedEnd) {
-      const token = raw.slice(trimmedStart, trimmedEnd);
-      if (isPlainClickableToken(token)) {
-        pushSegment(segments, trimmedStart, trimmedEnd, "tag", true);
-      } else {
-        pushSegment(segments, trimmedStart, trimmedEnd, "text", false);
-      }
-    }
-    pushSegment(segments, trimmedEnd, rangeEnd, "text", false);
-  };
 
   for (let i = start; i < end; i++) {
+    if (isInsidePromptInertRange(i, inertRanges)) continue;
     if (!isBackslashEscaped(raw, i)) {
       const ch = raw[i];
       if (ch === "(") parenDepth += 1;
@@ -218,38 +237,36 @@ function pushGapSegments(segments: PromptClickableSegment[], raw: string, start:
       else if (ch === "]" && bracketDepth > 0) bracketDepth -= 1;
       else if (ch === "{") braceDepth += 1;
       else if (ch === "}" && braceDepth > 0) braceDepth -= 1;
-      else if (isSyntaxAngleOpen(raw, i)) angleDepth += 1;
-      else if (ch === ">" && angleDepth > 0) angleDepth -= 1;
       else if (
         ch === "," &&
         parenDepth === 0 &&
         bracketDepth === 0 &&
-        braceDepth === 0 &&
-        angleDepth === 0
+        braceDepth === 0
       ) {
-        pushToken(tokenStart, i);
+        pushTokenSegments(segments, raw, tokenStart, i);
         pushSegment(segments, i, i + 1, "text", false);
         tokenStart = i + 1;
       }
     }
   }
 
-  pushToken(tokenStart, end);
+  pushTokenSegments(segments, raw, tokenStart, end);
 }
 
 export function getPromptClickableSegments(raw: string): PromptClickableSegment[] {
   if (!raw) return [];
 
+  const inertRanges = getPromptInertRanges(raw);
   const segments: PromptClickableSegment[] = [];
-  const weightedRanges = getWeightedRanges(raw);
+  const weightedRanges = getWeightedRanges(raw, inertRanges);
   let cursor = 0;
 
   for (const range of weightedRanges) {
-    pushGapSegments(segments, raw, cursor, range.start);
+    pushGapSegments(segments, raw, cursor, range.start, inertRanges);
     pushSegment(segments, range.start, range.end, "weighted", true);
     cursor = range.end;
   }
 
-  pushGapSegments(segments, raw, cursor, raw.length);
+  pushGapSegments(segments, raw, cursor, raw.length, inertRanges);
   return segments;
 }

--- a/src/lib/utils/promptInertRanges.ts
+++ b/src/lib/utils/promptInertRanges.ts
@@ -1,0 +1,113 @@
+import { SYNTAX_ANGLE_LOOKBEHIND } from "./promptSyntaxEscape.ts";
+
+/**
+ * Shared detection for prompt syntax blocks that should not participate in
+ * comma-split tag selection or naive angle-bracket depth tracking.
+ */
+
+export interface PromptTextRange {
+  start: number;
+  end: number;
+}
+
+/** MooshieUI + SwarmUI scheduling syntax. */
+export const PROMPT_SCHEDULE_REGEX = new RegExp(
+  `${SYNTAX_ANGLE_LOOKBEHIND}<(?:(from|to|range):(\\d+(?:\\.\\d+)?)(?::(\\d+(?:\\.\\d+)?))?>([ \\s\\S]*?)<\\/\\1>|fromto\\[(\\d+(?:\\.\\d+)?)\\]:([^>]+)>)`,
+  "g",
+);
+
+/** Match `@preset:<slug>` directives. Slug = lowercase alnum + underscore. */
+export const PROMPT_PRESET_TOKEN_REGEX = /@preset:([a-z0-9_]+)/gi;
+
+export const PROMPT_LORA_TOKEN_REGEX = new RegExp(
+  `${SYNTAX_ANGLE_LOOKBEHIND}<lora:\\s*[^>]+>`,
+  "gi",
+);
+
+export const PROMPT_REGION_TAG_REGEX = new RegExp(
+  `${SYNTAX_ANGLE_LOOKBEHIND}<region:(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)>([\\s\\S]*?)<\\/region>`,
+  "gi",
+);
+
+function mergePromptTextRanges(ranges: PromptTextRange[]): PromptTextRange[] {
+  if (ranges.length === 0) return [];
+  ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: PromptTextRange[] = [];
+  for (const range of ranges) {
+    const last = merged[merged.length - 1];
+    if (!last || range.start > last.end) {
+      merged.push({ ...range });
+      continue;
+    }
+    last.end = Math.max(last.end, range.end);
+  }
+  return merged;
+}
+
+function collectRegexRanges(raw: string, regex: RegExp): PromptTextRange[] {
+  const ranges: PromptTextRange[] = [];
+  regex.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(raw)) !== null) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
+}
+
+/**
+ * Ranges that should not participate in comma-split tag selection or weight
+ * parsing — scheduling blocks, presets, LoRA tags, and regional tags.
+ */
+export function getPromptInertRanges(raw: string): PromptTextRange[] {
+  if (!raw) return [];
+
+  const ranges: PromptTextRange[] = [
+    ...collectRegexRanges(raw, PROMPT_SCHEDULE_REGEX),
+  ];
+
+  if (raw.includes("@preset:")) {
+    ranges.push(...collectRegexRanges(raw, PROMPT_PRESET_TOKEN_REGEX));
+  }
+  if (raw.includes("<lora:")) {
+    ranges.push(...collectRegexRanges(raw, PROMPT_LORA_TOKEN_REGEX));
+  }
+  if (raw.includes("<region:")) {
+    ranges.push(...collectRegexRanges(raw, PROMPT_REGION_TAG_REGEX));
+  }
+
+  return mergePromptTextRanges(ranges);
+}
+
+export function isInsidePromptInertRange(
+  index: number,
+  ranges: readonly PromptTextRange[],
+): boolean {
+  let lo = 0;
+  let hi = ranges.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const range = ranges[mid];
+    if (index < range.start) {
+      hi = mid - 1;
+    } else if (index >= range.end) {
+      lo = mid + 1;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function findPromptInertRangeContaining(
+  raw: string,
+  position: number,
+  ranges?: readonly PromptTextRange[],
+): PromptTextRange | null {
+  const list = ranges ?? getPromptInertRanges(raw);
+  for (const range of list) {
+    if (position > range.start && position <= range.end) {
+      return range;
+    }
+  }
+  return null;
+}

--- a/src/lib/utils/promptSchedule.ts
+++ b/src/lib/utils/promptSchedule.ts
@@ -1,5 +1,16 @@
 import type { PromptSegment } from "../types/index.js";
-import { SYNTAX_ANGLE_LOOKBEHIND } from "./promptSyntaxEscape.ts";
+import {
+  PROMPT_PRESET_TOKEN_REGEX,
+  PROMPT_REGION_TAG_REGEX,
+  PROMPT_SCHEDULE_REGEX,
+} from "./promptInertRanges.js";
+
+export {
+  findPromptInertRangeContaining,
+  getPromptInertRanges,
+  isInsidePromptInertRange,
+  type PromptTextRange,
+} from "./promptInertRanges.js";
 
 /**
  * Regex patterns for scheduling tag types:
@@ -13,22 +24,7 @@ import { SYNTAX_ANGLE_LOOKBEHIND } from "./promptSyntaxEscape.ts";
  * - <fromto[0.5]:before, after>  — "before" from 0% to 50%, "after" from 50% to 100%
  *   Separators: comma, | or ||
  */
-const SCHEDULE_REGEX =
-  new RegExp(`${SYNTAX_ANGLE_LOOKBEHIND}<(from|to|range):(\\d+(?:\\.\\d+)?)(?::(\\d+(?:\\.\\d+)?))?>([ \\s\\S]*?)<\\/\\1>`, "g");
-
-const SWARM_FROMTO_REGEX =
-  new RegExp(`${SYNTAX_ANGLE_LOOKBEHIND}<fromto\\[(\\d+(?:\\.\\d+)?)\\]:([^>]+)>`, "g");
-
-/**
- * Combined regex matching both syntaxes.
- * Used for highlight rendering and tag detection (single-pass over text).
- * Numeric values must be valid decimals (e.g. 0.5, 1) — not malformed like 1.2.3.
- */
-const COMBINED_REGEX =
-  new RegExp(
-    `${SYNTAX_ANGLE_LOOKBEHIND}<(?:(from|to|range):(\\d+(?:\\.\\d+)?)(?::(\\d+(?:\\.\\d+)?))?>([ \\s\\S]*?)<\\/\\1>|fromto\\[(\\d+(?:\\.\\d+)?)\\]:([^>]+)>)`,
-    "g",
-  );
+const COMBINED_REGEX = PROMPT_SCHEDULE_REGEX;
 
 export interface ParsedPrompt {
   baseText: string;
@@ -246,7 +242,7 @@ export function renderHighlightedPrompt(raw: string, knownPresetSlugs?: Readonly
 }
 
 /** Match `@preset:<slug>` directives. Slug = lowercase alnum + underscore. */
-const PRESET_TOKEN_REGEX = /@preset:([a-z0-9_]+)/gi;
+const PRESET_TOKEN_REGEX = PROMPT_PRESET_TOKEN_REGEX;
 
 /**
  * Highlight `@preset:<slug>` tokens within an arbitrary plain-text segment.
@@ -305,10 +301,7 @@ export interface PositiveRegionPrompt {
   height: number;
 }
 
-const REGION_TAG_REGEX = new RegExp(
-  `${SYNTAX_ANGLE_LOOKBEHIND}<region:(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)\\s*,\\s*(\\d*\\.?\\d+)>([\\s\\S]*?)<\\/region>`,
-  "gi",
-);
+const REGION_TAG_REGEX = PROMPT_REGION_TAG_REGEX;
 
 /**
  * Parse syntax-first regional prompt tags:

--- a/tests/promptClickableRanges.test.ts
+++ b/tests/promptClickableRanges.test.ts
@@ -93,3 +93,27 @@ test("treats colon-escaped expression tags like :< as normal clickable tags", ()
     { kind: "tag", clickable: true, text: "smile" },
   ]);
 });
+
+test("keeps commas inside MooshieUI schedule blocks from splitting tags", () => {
+  const raw = "<from:0.2>blue eyes, green hair</from>, masterpiece";
+  const summary = summarize(getPromptClickableSegments(raw), raw);
+
+  assert.deepEqual(summary, [
+    { kind: "text", clickable: false, text: "<from:0.2>blue eyes, green hair</from>" },
+    { kind: "text", clickable: false, text: "," },
+    { kind: "text", clickable: false, text: " " },
+    { kind: "tag", clickable: true, text: "masterpiece" },
+  ]);
+});
+
+test("treats weighted tags with angle-bracket content before the weight colon as clickable", () => {
+  const raw = "(tag:<broken:1.2), normal tag";
+  const summary = summarize(getPromptClickableSegments(raw), raw);
+
+  assert.deepEqual(summary, [
+    { kind: "weighted", clickable: true, text: "(tag:<broken:1.2)" },
+    { kind: "text", clickable: false, text: "," },
+    { kind: "text", clickable: false, text: " " },
+    { kind: "tag", clickable: true, text: "normal tag" },
+  ]);
+});


### PR DESCRIPTION
## Summary

- Fix prompt clickable overlay and autocomplete for schedule blocks (MooshieUI \<from|to|range>\ and Swarm \romto\), preserving upstream \:<\ expression-tag handling.
- Treat weighted tags with angle-bracket content before the weight colon as one clickable range.
- Version bump to 1.4.3 across package.json, Cargo.toml, and tauri.conf.json.
- Release notes cover model gallery, quality tags editor, Stability Matrix paths, and Arch AppImage work merged since v1.4.2.

## Bot triage (pre-release sweep)

| PR | Status | Verdict |
|----|--------|---------|
| #234, #231, #224, #221 | Draft | Skip — not release-blocking |
| #208 dependabot | Open | Defer — deps bump, not in this release |
| #235 (merged) | Merged | Shipped on main; this release adds inert-range follow-up |

## Test plan

- [x] \
pm run build\
- [x] \cargo check\
- [x] \
ode --experimental-strip-types --test tests/promptClickableRanges.test.ts\ (8/8)
- [ ] GlassWorm CI on release PR


Made with [Cursor](https://cursor.com)