### PR TITLE
Revert src/lib/stores/models.svelte.ts from d6e778120c23fd03f98726a4097d1b949306fbb0

### DIFF
--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -1,20 +1,4 @@
-import { getModels, getSamplers, getEmbeddings, listModelFiles } from "../utils/api.js";
-
-/** Merge ComfyUI /models API results with on-disk files from configured paths. */
-async function mergeWithDiskModels(category: string, apiModels: string[]): Promise<string[]> {
-  const safeApiModels = apiModels ?? [];
-  try {
-    const disk = await listModelFiles(category);
-    const names = (disk ?? [])
-      .filter((f) => f && typeof f.filename === "string")
-      .map((f) => f.filename);
-    return Array.from(new Set([...safeApiModels, ...names])).sort((a, b) =>
-      a.localeCompare(b, undefined, { sensitivity: "base" }),
-    );
-  } catch {
-    return safeApiModels;
-  }
-}
+import { getModels, getSamplers, getEmbeddings } from "../utils/api.js";
 
 class ModelsStore {
   checkpoints = $state<string[]>([]);
@@ -46,7 +30,7 @@ class ModelsStore {
           getSamplers(),
           getEmbeddings(),
           getModels("upscale_models"),
-          getModels("diffusion_models").catch(() => [] as string[]),
+          getModels("diffusion_models"),
           getModels("text_encoders").catch(() => [] as string[]),
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
@@ -56,31 +40,19 @@ class ModelsStore {
       console.log("ModelsStore: got checkpoints:", checkpoints);
       console.log("ModelsStore: got samplers:", samplerInfo);
 
-      const mergedEncoders = Array.from(new Set([...(textEncoders ?? []), ...(clipEncoders ?? [])]));
-
-      [
-        this.checkpoints,
-        this.vaes,
-        this.loras,
-        this.embeddings,
-        this.upscaleModels,
-        this.diffusionModels,
-        this.textEncoders,
-        this.controlnetModels,
-        this.ultralyticsModels,
-      ] = await Promise.all([
-        mergeWithDiskModels("checkpoints", checkpoints),
-        mergeWithDiskModels("vae", vaes),
-        mergeWithDiskModels("loras", loras),
-        mergeWithDiskModels("embeddings", embeddings),
-        mergeWithDiskModels("upscale_models", upscaleModels),
-        mergeWithDiskModels("diffusion_models", diffusionModels),
-        mergeWithDiskModels("text_encoders", mergedEncoders),
-        mergeWithDiskModels("controlnet", controlnetModels),
-        mergeWithDiskModels("ultralytics", ultralyticsModels),
-      ]);
+      this.checkpoints = checkpoints;
+      this.vaes = vaes;
+      this.loras = loras;
       this.samplers = samplerInfo.samplers;
       this.schedulers = samplerInfo.schedulers;
+      this.embeddings = embeddings;
+      this.upscaleModels = upscaleModels;
+      this.diffusionModels = diffusionModels;
+      // De-duplicate by basename — ComfyUI sometimes returns the same file under
+      // both `clip` and `text_encoders` when both directories are mapped.
+      this.textEncoders = Array.from(new Set([...textEncoders, ...clipEncoders]));
+      this.controlnetModels = controlnetModels;
+      this.ultralyticsModels = ultralyticsModels;
     } catch (e) {
       console.error("Failed to refresh models:", e);
     } finally {

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -30,7 +30,7 @@ class ModelsStore {
           getSamplers(),
           getEmbeddings(),
           getModels("upscale_models"),
-          getModels("diffusion_models"),
+          getModels("diffusion_models").catch(() => [] as string[]),
           getModels("text_encoders").catch(() => [] as string[]),
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),


### PR DESCRIPTION
Revert src/lib/stores/models.svelte.ts from d6e778120c23fd03f98726a4097d1b949306fbb0

Reverts the src/lib/stores/models.svelte.ts portion of:
v1.4.2: remote cloud onboarding, extra model paths, and model picker fixes ([#227](https://github.com/Mooshieblob1/MooshieUI/issues/227))

This pr resolves this issue:
<img width="405" height="329" alt="1" src="https://github.com/user-attachments/assets/40bde16d-d348-4874-a3d8-869f4ef3beb0" />

