### PR TITLE
v1.4.4: Community fixes, model dedupe, fast refine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## What's New in v1.4.4
+
+### Community feedback (issue #232)
+- **Fast refine**: optional Refiner path that skips tiled diffusion and tiled VAE for a quicker upscale when you have enough VRAM (with an Anima warning in the UI).
+- **Artist favourites**: clicking a favourite artist again removes their tag when the prompt uses underscores vs spaces in the gallery name.
+- **Style transfer**: Generate is blocked with a clear message when Untwisting RoPE / Scale-Image nodes are missing; ComfyUI execution errors surface in the UI.
+- **Model previews**: Civitai checkpoint/LoRA cards add Tags, Img2img, and Style ref actions; empty cards show a Thumb/Gallery hint.
+- **Generation queue**: tooltips explain that **Generate (+N)** means jobs already queued and that you can click again to add another.
+
+### Model picker and UI polish
+- **Duplicate models**: merging extra disk folders dedupes by basename and prefers ComfyUI API paths (#242).
+- **LoRA dropdown**: long names wrap instead of truncating (#240).
+- **Quality tags**: badge and auto-tags cover Pony and Nanosaur as well as Anima/Illustrious (#241).
+- **Browser mode**: sidecar thumbnail saves use the shared gallery PNG loader (#237).
+
+---
+
 ## What's New in v1.4.3
 
 ### Prompt tag selection and highlighting

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+## What's New in v1.4.4
+
+### Community feedback (issue #232)
+- **Fast refine**: optional Refiner path that skips tiled diffusion and tiled VAE for a quicker upscale when you have enough VRAM (with an Anima warning in the UI).
+- **Artist favourites**: clicking a favourite artist again removes their tag when the prompt uses underscores vs spaces in the gallery name.
+- **Style transfer**: Generate is blocked with a clear message when Untwisting RoPE / Scale-Image nodes are missing; ComfyUI execution errors surface in the UI.
+- **Model previews**: Civitai checkpoint/LoRA cards add Tags, Img2img, and Style ref actions; empty cards show a Thumb/Gallery hint.
+- **Generation queue**: tooltips explain that **Generate (+N)** means jobs already queued and that you can click again to add another.
+
+### Model picker and UI polish
+- **Duplicate models**: merging extra disk folders dedupes by basename and prefers ComfyUI API paths (#242).
+- **LoRA dropdown**: long names wrap instead of truncating (#240).
+- **Quality tags**: badge and auto-tags cover Pony and Nanosaur as well as Anima/Illustrious (#241).
+- **Browser mode**: sidecar thumbnail saves use the shared gallery PNG loader (#237).
+
+---
+
 ## What's New in v1.4.3
 
 ### Prompt tag selection and highlighting

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Release **v1.4.4** (version bump + changelog only).

### Shipped since v1.4.3
- #243 Issue #232 follow-ups: fast refine, artist toggle, style transfer gates, Civitai preview actions, queue tooltips
- #242 Model picker basename dedupe for extra disk folders
- #240 LoRA dropdown name wrapping
- #241 Quality tag badge for Pony/Nanosaur
- #237 Browser mode sidecar thumbnail build fix

### Bot / PR hygiene (pre-release)
- #239 closed (superseded by #242)
- #234 left open (cobra rebase)
- #238 / #231: merge planned after this release (security + UNET picker)

### Test plan
- [x] `cargo check`
- [x] `npm run build`