### PR TITLE
v1.4.5: Fixes, contributing docs, blobnuc release CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## What's New in v1.4.5
+
+### Fixes and maintenance
+- **PNG export**: saved files use the correct `.png` extension (#221).
+- **Theme import**: existing themes are preserved when importing a theme pack (#224).
+- **Browser mode**: sidecar thumbnail saves are scoped to the gallery and no longer accept unsafe paths (#238).
+
+### Docs and CI
+- **Contributing**: added `CONTRIBUTING.md` and a README link (#245).
+- **Release CI**: Linux desktop build, server binary, and Docker image publish on the `blobnuc` self-hosted runner for official Mooshieblob1 releases; forks and other actors stay on GitHub-hosted runners (#247).
+- **Deps**: `@sveltejs/vite-plugin-svelte` 6.2.4 (#208).
+
+---
+
 ## What's New in v1.4.4
 
 ### Community feedback (issue #232)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+## What's New in v1.4.5
+
+### Fixes and maintenance
+- **PNG export**: saved files use the correct `.png` extension (#221).
+- **Theme import**: existing themes are preserved when importing a theme pack (#224).
+- **Browser mode**: sidecar thumbnail saves are scoped to the gallery and no longer accept unsafe paths (#238).
+
+### Docs and CI
+- **Contributing**: added `CONTRIBUTING.md` and a README link (#245).
+- **Release CI**: Linux desktop build, server binary, and Docker image publish on the `blobnuc` self-hosted runner for official Mooshieblob1 releases; forks and other actors stay on GitHub-hosted runners (#247).
+- **Deps**: `@sveltejs/vite-plugin-svelte` 6.2.4 (#208).
+
+---
+
 ## What's New in v1.4.4
 
 ### Community feedback (issue #232)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.4"
+version = "1.4.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- **v1.4.5** — patch release for changes since **v1.4.4** (tag already shipped; immutable).
- PNG export extension fix (#221), theme import preservation (#224), browser sidecar SSRF/gallery scoping (#238).
- Contributing guide (#245), blobnuc self-hosted release CI for Mooshieblob1 (#247), vite-plugin-svelte 6.2.4 (#208).

## Bot triage

| PR | Verdict | Notes |
|----|---------|-------|
| #234 (open) | Defer | Separate feature PR; not in this release |
| #247 | — | No bot comments |

## Test plan

- [x] `cargo check` passed locally
- [x] `npm run build` passed locally
- [ ] GlassWorm CI green
- [ ] Tag `v1.4.5` after merge → Build & Release on blobnuc (Linux/docker)
