### PR TITLE
chore: optimize Svelte 5 artist selection rendering and harden Windows listening socket check

### DIFF
--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -780,5 +780,10 @@ mod tests {
 
         let line_es = "  TCP    0.0.0.0:8188           0.0.0.0:0              ESCUCHANDO      4242";
         assert_eq!(parse_netstat_listening_pid(line_es, 8188), Some(4242));
+
+        // Established connection (foreign port is non-zero/non-asterisk) - should be ignored
+        let line_est =
+            "  TCP    127.0.0.1:8188         127.0.0.1:52132        ESTABLISHED     4242";
+        assert_eq!(parse_netstat_listening_pid(line_est, 8188), None);
     }
 }

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -12,7 +12,7 @@ pub async fn comfyui_health_ok(http_client: &reqwest::Client, health_url: &str) 
     }
 }
 
-/// Parse a Windows `netstat -ano` line and return the PID when it is a TCP socket and the local port matches exactly.
+/// Parse a Windows `netstat -ano` line and return the PID when it is a TCP socket, the local port matches exactly, and it is in a listening state (foreign port is 0 or *).
 #[cfg(target_os = "windows")]
 pub(crate) fn parse_netstat_listening_pid(line: &str, port: u16) -> Option<u32> {
     let parts: Vec<&str> = line.split_whitespace().collect();
@@ -25,6 +25,12 @@ pub(crate) fn parse_netstat_listening_pid(line: &str, port: u16) -> Option<u32> 
     let local_addr = parts[1];
     let port_str = local_addr.rsplit(':').next()?;
     if port_str.parse::<u16>().ok()? != port {
+        return None;
+    }
+    // Verify it is a listening socket by checking that the foreign port is 0 or *
+    let foreign_addr = parts[2];
+    let foreign_port = foreign_addr.rsplit(':').next()?;
+    if foreign_port != "0" && foreign_port != "*" {
         return None;
     }
     parts.last()?.parse().ok()

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -285,13 +285,19 @@
 
   let scrollContainer = $state<HTMLDivElement | null>(null);
 
+  const detectedArtists = $derived.by(() => {
+    if (gallery.artistIndexReady && gallery.artistTagIndex.size > 0) {
+      return detectArtistsInPrompt(generation.positivePrompt, gallery.artistTagIndex);
+    }
+    return [];
+  });
+
   function isArtistInPrompt(tag: string): boolean {
     if (gallery.artistIndexReady && gallery.artistTagIndex.size > 0) {
-      const detected = detectArtistsInPrompt(generation.positivePrompt, gallery.artistTagIndex);
       const normalizedTag = tag.replace(/^@+/, "").toLowerCase().replace(/\s+/g, "_");
       const targetHit = gallery.artistTagIndex.get(normalizedTag);
       if (targetHit) {
-        return detected.some((d) => d.slug === targetHit.slug);
+        return detectedArtists.some((d) => d.slug === targetHit.slug);
       }
     }
     // Simple fallback

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -250,13 +250,19 @@
     return tag.replace(/^@/, "").replace(/\\([()[\]]])/g, "$1").replace(/_/g, " ");
   }
 
+  const detectedArtists = $derived.by(() => {
+    if (gallery.artistIndexReady && gallery.artistTagIndex.size > 0) {
+      return detectArtistsInPrompt(generation.positivePrompt, gallery.artistTagIndex);
+    }
+    return [];
+  });
+
   function isArtistInPrompt(tag: string): boolean {
     if (gallery.artistIndexReady && gallery.artistTagIndex.size > 0) {
-      const detected = detectArtistsInPrompt(generation.positivePrompt, gallery.artistTagIndex);
       const normalizedTag = tag.replace(/^@+/, "").toLowerCase().replace(/\s+/g, "_");
       const targetHit = gallery.artistTagIndex.get(normalizedTag);
       if (targetHit) {
-        return detected.some((d) => d.slug === targetHit.slug);
+        return detectedArtists.some((d) => d.slug === targetHit.slug);
       }
     }
     // Simple fallback


### PR DESCRIPTION
Follow-up fixes for 1.4.6 release. Optimizes the Svelte 5 artist selection check using derived properties to prevent redundant prompt-parsing operations on every artist card. Hardens Windows listening socket PID detection by checking that the foreign port is 0 or *, preventing false positives on established sockets.