### PR TITLE
v1.4.9: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.9
+
+### Fixes and maintenance
+- **Browser mode proxies**: removed LAN authentication from Animadex and CDN proxy routes so artist previews and CDN assets load correctly in browser mode without a session token.
+
+---
+
 ## What's New in v1.4.8
 
 ### LAN and Web Server Security

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.9
+
+### Fixes and maintenance
+- **Browser mode proxies**: removed LAN authentication from Animadex and CDN proxy routes so artist previews and CDN assets load correctly in browser mode without a session token.
+
+---
+
 ## What's New in v1.4.8
 
 ### LAN and Web Server Security

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.8"
+version = "1.4.9"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -215,6 +215,7 @@ fn forbidden_response(msg: &str) -> Response {
 }
 
 /// Remote LAN clients must authenticate; localhost and non-LAN mode stay open.
+#[allow(dead_code)]
 fn require_remote_lan_auth(
     state: &WebState,
     headers: &HeaderMap,
@@ -1645,14 +1646,9 @@ async fn gpu_stats_handler(
 /// Animadex API proxy — characters search/facets only.
 async fn animadex_proxy_handler(
     AxumState(state): AxumState<SharedState>,
-    ConnectInfo(remote): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
     Path(path): Path<String>,
     uri: axum::http::Uri,
 ) -> Response {
-    if let Some(resp) = require_remote_lan_auth(&state, &headers, &remote) {
-        return resp;
-    }
     let clean = path.trim_start_matches('/');
     if !clean.starts_with("api/characters/") {
         return StatusCode::BAD_REQUEST.into_response();
@@ -1694,14 +1690,9 @@ async fn animadex_proxy_handler(
 /// Only proxies from the hardcoded CDN origin; this is NOT an open proxy.
 async fn cdn_proxy_handler(
     AxumState(state): AxumState<SharedState>,
-    ConnectInfo(remote): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
     Path(path): Path<String>,
     uri: axum::http::Uri,
 ) -> Response {
-    if let Some(resp) = require_remote_lan_auth(&state, &headers, &remote) {
-        return resp;
-    }
     let mut target_url = format!("https://cdn.mooshieblob.com/{}", path);
     if let Some(query) = uri.query() {
         target_url.push('?');

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Removed LAN authentication from Animadex and CDN proxy routes so artist previews and CDN assets load correctly in browser mode without a session token.

## Test plan
- [ ] Browser mode: artist previews and CDN assets load without login
- [ ] LAN mode: other protected routes still require authentication

Made with [Cursor](https://cursor.com)