### PR TITLE
Fix LAN auth gaps, browser cached-image SSRF, and session migration data loss

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -386,12 +386,16 @@ impl AuthState {
             .find(|a| a.username.eq_ignore_ascii_case(&username))
             .ok_or_else(|| "Invalid username or password".to_string())?;
 
-        if !is_legacy_sha256(&account.password_hash) {
-            return Ok(false);
+        // Verify the password before revealing anything about the stored hash
+        // format, so this endpoint can't be used to probe account state.
+        if !verify_password(password, &account.password_hash) {
+            return Err("Invalid username or password".to_string());
         }
 
-        if !verify_password(password, &account.password_hash) {
-            return Err("Current password is incorrect".to_string());
+        if !is_legacy_sha256(&account.password_hash) {
+            drop(db);
+            self.clear_login_attempts(&username);
+            return Ok(false);
         }
 
         account.password_hash = hash_password(password);
@@ -859,30 +863,48 @@ fn migrate_plaintext_session_keys(
         .collect()
 }
 
-fn load_sessions() -> Result<HashMap<String, SessionEntry>, String> {
-    let path = sessions_db_path().ok_or("No app data dir")?;
-    if !path.exists() {
-        return Ok(HashMap::new());
-    }
-    let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
-    if let Ok(store) = serde_json::from_str::<SessionsStore>(&content) {
-        if store.version >= SESSIONS_FORMAT_VERSION {
-            return Ok(store.sessions);
+struct LoadedSessions {
+    sessions: HashMap<String, SessionEntry>,
+    needs_save: bool,
+}
+
+fn content_looks_like_sessions_store(content: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(content)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_object()
+                .map(|object| object.contains_key("version") || object.contains_key("sessions"))
+        })
+        .unwrap_or(false)
+}
+
+fn parse_sessions_content(content: &str) -> Result<LoadedSessions, String> {
+    if content_looks_like_sessions_store(content) {
+        if let Ok(store) = serde_json::from_str::<SessionsStore>(content) {
+            if store.version >= SESSIONS_FORMAT_VERSION {
+                return Ok(LoadedSessions {
+                    sessions: store.sessions,
+                    needs_save: false,
+                });
+            }
+            return Ok(LoadedSessions {
+                sessions: migrate_plaintext_session_keys(store.sessions),
+                needs_save: true,
+            });
         }
-        let migrated = migrate_plaintext_session_keys(store.sessions);
-        let _ = save_sessions(&migrated);
-        return Ok(migrated);
     }
     // Legacy v1: token → SessionEntry (plaintext token keys)
-    if let Ok(entries) = serde_json::from_str::<HashMap<String, SessionEntry>>(&content) {
-        let migrated = migrate_plaintext_session_keys(entries);
-        let _ = save_sessions(&migrated);
-        return Ok(migrated);
+    if let Ok(entries) = serde_json::from_str::<HashMap<String, SessionEntry>>(content) {
+        return Ok(LoadedSessions {
+            sessions: migrate_plaintext_session_keys(entries),
+            needs_save: true,
+        });
     }
     // Legacy v0: token → username string
-    if let Ok(legacy) = serde_json::from_str::<HashMap<String, String>>(&content) {
+    if let Ok(legacy) = serde_json::from_str::<HashMap<String, String>>(content) {
         let now = Utc::now().to_rfc3339();
-        let migrated: HashMap<String, SessionEntry> = legacy
+        let sessions = legacy
             .into_iter()
             .map(|(token, username)| {
                 (
@@ -894,10 +916,25 @@ fn load_sessions() -> Result<HashMap<String, SessionEntry>, String> {
                 )
             })
             .collect();
-        let _ = save_sessions(&migrated);
-        return Ok(migrated);
+        return Ok(LoadedSessions {
+            sessions,
+            needs_save: true,
+        });
     }
     Err("Failed to parse sessions.json".to_string())
+}
+
+fn load_sessions() -> Result<HashMap<String, SessionEntry>, String> {
+    let path = sessions_db_path().ok_or("No app data dir")?;
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let loaded = parse_sessions_content(&content)?;
+    if loaded.needs_save {
+        let _ = save_sessions(&loaded.sessions);
+    }
+    Ok(loaded.sessions)
 }
 
 fn save_sessions(sessions: &HashMap<String, SessionEntry>) -> Result<(), String> {
@@ -913,4 +950,150 @@ fn save_sessions(sessions: &HashMap<String, SessionEntry>) -> Result<(), String>
     std::fs::write(&path, json).map_err(|e| e.to_string())?;
     restrict_private_file_permissions(&path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session_entry(username: &str) -> SessionEntry {
+        SessionEntry {
+            username: username.to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn legacy_session_entry_map_is_migrated_without_being_treated_as_empty_store() {
+        let token = "0123456789abcdef";
+        let content = serde_json::json!({
+            token: {
+                "username": "Alice",
+                "created_at": "2026-01-01T00:00:00Z"
+            }
+        })
+        .to_string();
+
+        let loaded = parse_sessions_content(&content).expect("legacy sessions should parse");
+        let token_hash = hash_session_token(token);
+
+        assert!(loaded.needs_save);
+        assert_eq!(loaded.sessions.len(), 1);
+        assert!(!loaded.sessions.contains_key(token));
+        assert_eq!(
+            loaded
+                .sessions
+                .get(&token_hash)
+                .map(|entry| entry.username.as_str()),
+            Some("Alice")
+        );
+    }
+
+    #[test]
+    fn current_empty_session_store_loads_without_migration() {
+        let content = serde_json::json!({
+            "version": SESSIONS_FORMAT_VERSION,
+            "sessions": {}
+        })
+        .to_string();
+
+        let loaded = parse_sessions_content(&content).expect("current sessions should parse");
+
+        assert!(!loaded.needs_save);
+        assert!(loaded.sessions.is_empty());
+    }
+
+    #[test]
+    fn old_versioned_session_store_migrates_plaintext_keys() {
+        let token = "fedcba9876543210";
+        let content = serde_json::json!({
+            "version": 1,
+            "sessions": {
+                token: {
+                    "username": "Bob",
+                    "created_at": "2026-01-01T00:00:00Z"
+                }
+            }
+        })
+        .to_string();
+
+        let loaded = parse_sessions_content(&content).expect("old sessions store should parse");
+        let token_hash = hash_session_token(token);
+
+        assert!(loaded.needs_save);
+        assert_eq!(loaded.sessions.len(), 1);
+        assert_eq!(
+            loaded
+                .sessions
+                .get(&token_hash)
+                .map(|entry| entry.username.as_str()),
+            Some("Bob")
+        );
+    }
+
+    #[test]
+    fn current_session_store_preserves_hashed_keys() {
+        let token_hash = hash_session_token("already-hashed-token");
+        let content = serde_json::to_string(&SessionsStore {
+            version: SESSIONS_FORMAT_VERSION,
+            sessions: HashMap::from([(token_hash.clone(), session_entry("Carol"))]),
+        })
+        .expect("sessions store should serialize");
+
+        let loaded = parse_sessions_content(&content).expect("current sessions should parse");
+
+        assert!(!loaded.needs_save);
+        assert_eq!(
+            loaded
+                .sessions
+                .get(&token_hash)
+                .map(|entry| entry.username.as_str()),
+            Some("Carol")
+        );
+    }
+
+    fn test_account(username: &str, password_hash: String) -> Account {
+        Account {
+            username: username.to_string(),
+            password_hash,
+            must_change_password: false,
+            role: "user".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            last_online: None,
+            storage_limit_bytes: DEFAULT_STORAGE_LIMIT,
+            can_use_modelhub: false,
+        }
+    }
+
+    fn auth_with_accounts(accounts: Vec<Account>) -> AuthState {
+        AuthState {
+            db: RwLock::new(AuthDatabase {
+                accounts,
+                legacy_password_grace_deadline: None,
+                legacy_password_announcement_sent: false,
+            }),
+            sessions: RwLock::new(HashMap::new()),
+            last_activity: RwLock::new(HashMap::new()),
+            login_attempts: RwLock::new(HashMap::new()),
+        }
+    }
+
+    #[test]
+    fn password_upgrade_checks_password_before_hash_format() {
+        let auth = auth_with_accounts(vec![test_account("alice", hash_password("correct"))]);
+
+        let missing = auth
+            .upgrade_password_encryption("missing", "wrong")
+            .unwrap_err();
+        let wrong_password = auth
+            .upgrade_password_encryption("alice", "wrong")
+            .unwrap_err();
+        assert_eq!(missing, "Invalid username or password");
+        assert_eq!(wrong_password, "Invalid username or password");
+
+        let already_modern = auth
+            .upgrade_password_encryption("alice", "correct")
+            .expect("correct password should be accepted");
+        assert!(!already_modern);
+    }
 }

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2461,7 +2461,7 @@ fn is_allowed_civitai_image_host(host: &str) -> bool {
     )
 }
 
-fn parse_civitai_image_url(url: &str) -> Result<reqwest::Url, AppError> {
+pub(crate) fn parse_civitai_image_url(url: &str) -> Result<reqwest::Url, AppError> {
     let parsed = reqwest::Url::parse(url.trim())
         .map_err(|e| AppError::Other(format!("Invalid CivitAI image URL: {}", e)))?;
     if parsed.scheme() != "https" {
@@ -2478,7 +2478,10 @@ fn parse_civitai_image_url(url: &str) -> Result<reqwest::Url, AppError> {
     Ok(parsed)
 }
 
-async fn fetch_civitai_image_bytes(state: &AppState, url: &str) -> Result<Vec<u8>, AppError> {
+pub(crate) async fn fetch_civitai_image_bytes(
+    state: &AppState,
+    url: &str,
+) -> Result<Vec<u8>, AppError> {
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -2544,6 +2547,15 @@ mod sidecar_thumbnail_tests {
         assert!(parse_civitai_image_url("http://127.0.0.1:8188/view").is_err());
         assert!(parse_civitai_image_url("https://169.254.169.254/latest/meta-data").is_err());
         assert!(parse_civitai_image_url("https://civitai.com.evil.test/example.png").is_err());
+    }
+
+    #[test]
+    fn cached_image_fetch_uses_same_civitai_only_url_policy() {
+        // `fetch_cached_image` is exposed through browser-mode LAN auth; this
+        // policy must keep it from becoming a server-side request primitive.
+        assert!(parse_civitai_image_url("https://www.civitai.com/images/123").is_ok());
+        assert!(parse_civitai_image_url("https://localhost/admin").is_err());
+        assert!(parse_civitai_image_url("file:///etc/passwd").is_err());
     }
 }
 
@@ -4082,7 +4094,7 @@ pub async fn append_frontend_logs(lines: Vec<String>) -> Result<(), AppError> {
 }
 
 /// Detect the MIME type of image bytes from magic bytes.
-fn detect_image_mime(bytes: &[u8]) -> &'static str {
+pub(crate) fn detect_image_mime(bytes: &[u8]) -> &'static str {
     if bytes.starts_with(b"\x89PNG") {
         "image/png"
     } else if bytes.starts_with(b"\xff\xd8") {
@@ -4109,6 +4121,10 @@ pub async fn fetch_cached_image(
     url: String,
 ) -> Result<String, AppError> {
     use base64::{engine::general_purpose::STANDARD, Engine};
+
+    // This backend fetch carries the user's CivitAI token, so keep it scoped to
+    // CivitAI image hosts and validate redirects before touching the cache.
+    parse_civitai_image_url(&url)?;
 
     // Build a stable cache filename from the URL hash.
     let mut hasher = sha2::Sha256::new();
@@ -4142,36 +4158,7 @@ pub async fn fetch_cached_image(
     }
 
     // Cache miss — fetch through the backend so auth headers are applied.
-    let civitai_api_key = {
-        let config = state.config.read().await;
-        config.civitai_api_key.clone()
-    };
-
-    let mut req = state
-        .http_client
-        .get(&url)
-        .header("User-Agent", "MooshieUI/0.5.7");
-    if let Some(key) = civitai_api_key.filter(|v| !v.trim().is_empty()) {
-        req = req.bearer_auth(key);
-    }
-
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| AppError::Other(format!("Image fetch failed: {}", e)))?;
-
-    if !resp.status().is_success() {
-        return Err(AppError::Other(format!(
-            "Image fetch returned HTTP {}",
-            resp.status()
-        )));
-    }
-
-    let bytes = resp
-        .bytes()
-        .await
-        .map_err(|e| AppError::Other(format!("Failed to read image bytes: {}", e)))?
-        .to_vec();
+    let bytes = fetch_civitai_image_bytes(state.inner().as_ref(), &url).await?;
 
     // Persist to disk cache (best-effort; ignore write errors).
     let _ = std::fs::write(&cache_path, &bytes);

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -149,6 +149,57 @@ fn resolve_username(state: &WebState, headers: &HeaderMap, remote: &SocketAddr) 
     None
 }
 
+fn query_param<'a>(query: &'a str, name: &str) -> Option<&'a str> {
+    let prefix = format!("{}=", name);
+    query.split('&').find_map(|p| p.strip_prefix(&prefix))
+}
+
+fn username_for_token(state: &WebState, token: &str) -> Option<Option<String>> {
+    let username = state.auth.validate_token(token)?;
+    if state.auth.get_account_role(&username).as_deref() == Some("admin") {
+        Some(None)
+    } else {
+        Some(Some(username))
+    }
+}
+
+/// Resolve a LAN gallery/temp-image user from either Authorization or ?token=.
+/// Missing or invalid remote LAN credentials must fail closed; `None` is only
+/// valid for localhost/non-LAN mode or an authenticated admin account.
+fn resolve_username_with_query_token(
+    state: &WebState,
+    headers: &HeaderMap,
+    remote: &SocketAddr,
+    query: &str,
+) -> Option<Option<String>> {
+    if !state.lan_enabled || is_localhost(remote) {
+        return Some(None);
+    }
+
+    if resolve_role(state, headers, remote) != UserRole::Anonymous {
+        return Some(resolve_username(state, headers, remote));
+    }
+
+    if let Some(token) = query_param(query, "token") {
+        if let Some(username) = username_for_token(state, token) {
+            return Some(username);
+        }
+    }
+
+    None
+}
+
+/// Gallery files we list, count against storage quotas, and expire — must stay
+/// in sync with the formats `save_to_gallery` can write (JXL included).
+fn is_gallery_image_filename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".webp")
+        || lower.ends_with(".jxl")
+}
+
 /// Commands that moderators (and admins) can execute.
 /// Moderators have full operational access; filesystem/server panels are
 /// hidden in the UI for mods but all commands are permitted at the API level.
@@ -1268,20 +1319,35 @@ async fn heartbeat_handler(AxumState(state): AxumState<SharedState>) -> StatusCo
 }
 
 /// Heartbeat stop — browser sends this via sendBeacon on page unload.
-async fn heartbeat_stop_handler(AxumState(state): AxumState<SharedState>) -> StatusCode {
+async fn heartbeat_stop_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    req: axum::extract::Request,
+) -> Response {
+    let query = req.uri().query().unwrap_or("");
+    let username = match resolve_username_with_query_token(&state, &headers, &remote, query) {
+        Some(username) => username,
+        None => return unauthorized_response("Authentication required"),
+    };
+
     // If we've already switched to app mode, ignore the stop signal.
     if state
         .app
         .app_mode_active
         .load(std::sync::atomic::Ordering::SeqCst)
     {
-        return StatusCode::OK;
+        return StatusCode::OK.into_response();
     }
-    // Cancel any in-progress generation. Do not backdate last_heartbeat: sendBeacon
-    // also fires on refresh/navigation, which would kill browser mode before the
-    // new page can post its first heartbeat. The 120s watchdog handles real tab close.
-    let _ = state.app.gpu_manager.interrupt(None).await;
-    StatusCode::OK
+
+    // Cancel in-progress generation. Remote LAN users must only stop their own
+    // prompts; localhost keeps the legacy browser-mode "stop everything" behavior.
+    if state.lan_enabled && !is_localhost(&remote) {
+        let _ = state.app.interrupt_user_prompts(username.as_deref()).await;
+    } else {
+        let _ = state.app.gpu_manager.interrupt(None).await;
+    }
+    StatusCode::OK.into_response()
 }
 
 /// Gallery thumbnail endpoint.
@@ -1309,19 +1375,10 @@ async fn thumbnail_handler(
         .and_then(|s| s.parse().ok())
         .unwrap_or(256);
 
-    // Try auth from headers first, then from ?token= query param (for <img> tags)
-    let username = {
-        let from_headers = resolve_username(&state, &headers, &remote);
-        if from_headers.is_some() {
-            from_headers
-        } else if !is_localhost(&remote) && state.lan_enabled {
-            query
-                .split('&')
-                .find_map(|p| p.strip_prefix("token="))
-                .and_then(|t| state.auth.validate_token(t))
-        } else {
-            None
-        }
+    // Try auth from headers first, then from ?token= query param (for <img> tags).
+    let username = match resolve_username_with_query_token(&state, &headers, &remote, query) {
+        Some(username) => username,
+        None => return unauthorized_response("Authentication required"),
     };
     let gallery_dir = match user_gallery_dir(username.as_deref()) {
         Some(d) => d,
@@ -1363,19 +1420,10 @@ async fn gallery_image_handler(
 
     let query = req.uri().query().unwrap_or("");
 
-    // Auth: try headers first, then ?token= query param
-    let username = {
-        let from_headers = resolve_username(&state, &headers, &remote);
-        if from_headers.is_some() {
-            from_headers
-        } else if !is_localhost(&remote) && state.lan_enabled {
-            query
-                .split('&')
-                .find_map(|p| p.strip_prefix("token="))
-                .and_then(|t| state.auth.validate_token(t))
-        } else {
-            None
-        }
+    // Auth: try headers first, then ?token= query param.
+    let username = match resolve_username_with_query_token(&state, &headers, &remote, query) {
+        Some(username) => username,
+        None => return unauthorized_response("Authentication required"),
     };
     let gallery_dir = match user_gallery_dir(username.as_deref()) {
         Some(d) => d,
@@ -1466,21 +1514,7 @@ async fn temp_image_handler(
 ) -> Response {
     // Auth check (same as thumbnail handler)
     let query = req.uri().query().unwrap_or("");
-    let username = {
-        let from_headers = resolve_username(&state, &headers, &remote);
-        if from_headers.is_some() {
-            from_headers
-        } else if !is_localhost(&remote) && state.lan_enabled {
-            query
-                .split('&')
-                .find_map(|p| p.strip_prefix("token="))
-                .and_then(|t| state.auth.validate_token(t))
-        } else {
-            None
-        }
-    };
-    let role = resolve_role(&state, &headers, &remote);
-    if role == UserRole::Anonymous && username.is_none() && !is_localhost(&remote) {
+    if resolve_username_with_query_token(&state, &headers, &remote, query).is_none() {
         return unauthorized_response("Authentication required");
     }
 
@@ -1804,6 +1838,19 @@ async fn command_handler(
 ///
 /// `username` is `Some("bob")` for authenticated LAN users, `None` for admin/localhost.
 /// Gallery commands use this to isolate per-user image storage.
+fn ensure_prompt_owned(
+    state: &AppState,
+    prompt_id: &str,
+    username: Option<&str>,
+) -> Result<(), String> {
+    let caller = username.map(str::to_string);
+    if state.prompt_queue.is_owned_by(prompt_id, &caller) {
+        Ok(())
+    } else {
+        Err("Prompt does not belong to the current user".to_string())
+    }
+}
+
 async fn dispatch_command(
     state: Arc<AppState>,
     auth: &Arc<AuthState>,
@@ -2078,6 +2125,34 @@ async fn dispatch_command(
             };
             resolve(&mut running);
             resolve(&mut pending);
+
+            // Regular LAN users must not see other users' prompt ids from the
+            // shared ComfyUI queue. Admins/moderators keep the global view.
+            let caller = username.map(str::to_string);
+            let is_privileged = match username {
+                None => true,
+                Some(u) => matches!(
+                    auth.get_account_role(u).as_deref(),
+                    Some("admin") | Some("moderator")
+                ),
+            };
+            if !is_privileged {
+                running.retain(|entry| {
+                    entry
+                        .as_array()
+                        .and_then(|a| a.get(1))
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|pid| state.prompt_queue.is_owned_by(pid, &caller))
+                });
+                pending.retain(|entry| {
+                    entry
+                        .as_array()
+                        .and_then(|a| a.get(1))
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|pid| state.prompt_queue.is_owned_by(pid, &caller))
+                });
+            }
+
             // Include tracked placeholders that haven't been submitted to a
             // ComfyUI worker yet (background submission in flight, or held in
             // the fair queue). Without this, the frontend reconciler falsely
@@ -2095,7 +2170,12 @@ async fn dispatch_command(
                 .collect();
             let tracked: Vec<String> = {
                 let q = state.prompt_queue.queue.read().unwrap();
-                q.iter().map(|(pid, _)| pid.clone()).collect()
+                q.iter()
+                    .filter(|(pid, _)| {
+                        is_privileged || state.prompt_queue.is_owned_by(pid, &caller)
+                    })
+                    .map(|(pid, _)| pid.clone())
+                    .collect()
             };
             const SUBMISSION_SHIELD_SECS: u64 = 120;
             for pid in tracked {
@@ -2117,15 +2197,6 @@ async fn dispatch_command(
                 }
             }
 
-            // Check if caller is privileged (admin or moderator) — can see usernames.
-            // username=None means localhost (always admin).
-            let is_privileged = match username {
-                None => true,
-                Some(u) => matches!(
-                    auth.get_account_role(u).as_deref(),
-                    Some("admin") | Some("moderator")
-                ),
-            };
             // Build ordered queue positions from our internal fair-queue tracker.
             // This is separate from ComfyUI's queue and reflects round-robin ordering.
             let queue_positions: Vec<serde_json::Value> = {
@@ -2133,6 +2204,9 @@ async fn dispatch_command(
                 queue
                     .iter()
                     .enumerate()
+                    .filter(|(_, (id, _))| {
+                        is_privileged || state.prompt_queue.is_owned_by(id, &caller)
+                    })
                     .map(|(pos, (id, owner))| {
                         if is_privileged {
                             serde_json::json!({
@@ -2157,6 +2231,7 @@ async fn dispatch_command(
         }
         "get_history" => {
             let prompt_id = args["promptId"].as_str().ok_or("Missing promptId")?;
+            ensure_prompt_owned(&state, prompt_id, username)?;
             let result = state
                 .get_history_for(prompt_id)
                 .await
@@ -2170,6 +2245,7 @@ async fn dispatch_command(
             // broadcast — so even if the SSE client missed the event, the image
             // temp file was already saved.
             let prompt_id = args["promptId"].as_str().ok_or("Missing promptId")?;
+            ensure_prompt_owned(&state, prompt_id, username)?;
             let ids = state.prompt_queue.related_ids(prompt_id);
             let mut cached = Vec::new();
             {
@@ -2195,10 +2271,7 @@ async fn dispatch_command(
         }
         "interrupt_generation" => {
             if let Some(prompt_id) = args["promptId"].as_str() {
-                let caller = username.map(str::to_string);
-                if !state.prompt_queue.is_owned_by(prompt_id, &caller) {
-                    return Err("Prompt does not belong to the current user".to_string());
-                }
+                ensure_prompt_owned(&state, prompt_id, username)?;
                 state
                     .interrupt_prompt(Some(prompt_id))
                     .await
@@ -2284,11 +2357,7 @@ async fn dispatch_command(
                         return None;
                     }
                     let name = entry.file_name().to_string_lossy().into_owned();
-                    if name.ends_with(".png")
-                        || name.ends_with(".jpg")
-                        || name.ends_with(".jpeg")
-                        || name.ends_with(".webp")
-                    {
+                    if is_gallery_image_filename(&name) {
                         Some((entry.metadata().ok()?.modified().ok()?, name))
                     } else {
                         None
@@ -2314,11 +2383,7 @@ async fn dispatch_command(
                         return None;
                     }
                     let name = entry.file_name().to_string_lossy().into_owned();
-                    if !(name.ends_with(".png")
-                        || name.ends_with(".jpg")
-                        || name.ends_with(".jpeg")
-                        || name.ends_with(".webp"))
-                    {
+                    if !is_gallery_image_filename(&name) {
                         return None;
                     }
                     let metadata = entry.metadata().ok()?;
@@ -2655,6 +2720,7 @@ async fn dispatch_command(
         }
         "delete_queue_item" => {
             let prompt_id = args["promptId"].as_str().ok_or("Missing promptId")?;
+            ensure_prompt_owned(&state, prompt_id, username)?;
             state
                 .delete_queue_items(vec![prompt_id.to_string()])
                 .await
@@ -2905,20 +2971,20 @@ async fn dispatch_command(
             let dir = user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
             let path = dir.join(&filename);
             let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
-            let result = crate::metadata::read_png_metadata(&bytes).map_err(|e| e.to_string())?;
+            let result = crate::metadata::read_image_metadata(&bytes).map_err(|e| e.to_string())?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "read_image_metadata_bytes" => {
             let image_bytes: Vec<u8> = serde_json::from_value(args["imageBytes"].clone())
                 .map_err(|e| format!("Invalid imageBytes: {}", e))?;
             let result =
-                crate::metadata::read_png_metadata(&image_bytes).map_err(|e| e.to_string())?;
+                crate::metadata::read_image_metadata(&image_bytes).map_err(|e| e.to_string())?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "read_image_metadata_path" => {
             let path = args["path"].as_str().ok_or("Missing path")?.to_string();
             let bytes = std::fs::read(&path).map_err(|e| e.to_string())?;
-            let result = crate::metadata::read_png_metadata(&bytes).map_err(|e| e.to_string())?;
+            let result = crate::metadata::read_image_metadata(&bytes).map_err(|e| e.to_string())?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "embed_png_metadata_bytes" => {
@@ -3763,16 +3829,16 @@ async fn dispatch_command(
         }
         "fetch_cached_image" => {
             let url = args["url"].as_str().ok_or("Missing url")?.to_string();
-            let resp = state
-                .http_client
-                .get(&url)
-                .send()
+            let bytes = commands::api::fetch_civitai_image_bytes(state.as_ref(), &url)
                 .await
                 .map_err(|e| e.to_string())?;
-            let bytes = resp.bytes().await.map_err(|e| e.to_string())?;
             use base64::{engine::general_purpose::STANDARD, Engine};
-            let b64 = STANDARD.encode(&bytes);
-            Ok(serde_json::json!(b64))
+            let mime = commands::api::detect_image_mime(&bytes);
+            Ok(serde_json::json!(format!(
+                "data:{};base64,{}",
+                mime,
+                STANDARD.encode(&bytes)
+            )))
         }
 
         // --- ComfyUI node checks ---
@@ -4728,9 +4794,15 @@ async fn auth_set_role_handler(
                 .into_response();
         }
     };
-    // Moderators cannot promote to admin — only admins can do that
-    if new_role == "admin" && role != UserRole::Admin {
-        return forbidden_response("Only admins can promote accounts to admin.");
+    if role == UserRole::Moderator {
+        if let Some(target_role) = state.auth.get_account_role(username) {
+            if target_role == "admin" || target_role == "moderator" {
+                return forbidden_response("Moderators can only manage regular user accounts.");
+            }
+        }
+        if new_role == "admin" || new_role == "moderator" {
+            return forbidden_response("Only admins can grant elevated roles.");
+        }
     }
     match state.auth.set_account_role(username, new_role) {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response(),
@@ -5078,11 +5150,7 @@ async fn storage_info_handler(
                     continue;
                 }
                 let name = entry.file_name().to_string_lossy().into_owned();
-                if !(name.ends_with(".png")
-                    || name.ends_with(".jpg")
-                    || name.ends_with(".jpeg")
-                    || name.ends_with(".webp"))
-                {
+                if !is_gallery_image_filename(&name) {
                     continue;
                 }
                 if let Ok(meta) = entry.metadata() {
@@ -5213,11 +5281,7 @@ fn cleanup_expired_images(auth: &AuthState) {
                 continue;
             }
             let name = file_entry.file_name().to_string_lossy().into_owned();
-            if !(name.ends_with(".png")
-                || name.ends_with(".jpg")
-                || name.ends_with(".jpeg")
-                || name.ends_with(".webp"))
-            {
+            if !is_gallery_image_filename(&name) {
                 continue;
             }
             if let Ok(meta) = file_entry.metadata() {

--- a/src/lib/utils/ipc.ts
+++ b/src/lib/utils/ipc.ts
@@ -220,7 +220,11 @@ export function startHeartbeat() {
   // Send heartbeat before unload to give a final ping
   window.addEventListener("beforeunload", () => {
     // Use sendBeacon for reliability during page close
-    navigator.sendBeacon("/internal-api/_heartbeat_stop");
+    const token = getAuthToken();
+    const url = token
+      ? `/internal-api/_heartbeat_stop?token=${encodeURIComponent(token)}`
+      : "/internal-api/_heartbeat_stop";
+    navigator.sendBeacon(url);
   });
 }
 


### PR DESCRIPTION
## Summary
Consolidates and supersedes the overlapping cursor draft PRs #251, #269, #270, #274, #275, #276 and #279 into one reviewed, conflict-free change. All of the underlying bugs were verified present on current main.

### SSRF / cached image fetch (supersedes #269, #270, #279, part of #251)
- Browser-mode `fetch_cached_image` did a raw `state.http_client.get(url)` on any URL and returned bare base64 — an authenticated server-side fetch primitive against localhost/LAN/cloud-metadata, and a broken contract for the frontend (which expects `data:<mime>;base64,...`).
- Desktop + browser paths now validate against the existing CivitAI HTTPS host allowlist (`parse_civitai_image_url`) and fetch via the redirect-safe `fetch_civitai_image_bytes`; browser mode returns the same data-URL contract as desktop.

### LAN auth gaps (supersedes #274, #276, part of #251)
- `_thumbnail`, `_gallery`, `_temp_image` fail closed for anonymous remote LAN callers instead of falling through to the **admin/root gallery**.
- `_heartbeat_stop` requires auth; remote LAN users interrupt only their own prompts (localhost keeps legacy stop-all). The unload beacon now carries the auth token.
- `get_queue_snapshot` hides other users' prompt ids from regular users; `get_history`, `get_recovered_outputs`, `interrupt_generation` and `delete_queue_item` enforce prompt ownership.
- Moderators can no longer modify admin/moderator accounts or grant elevated roles.
- `upgrade_password_encryption` verifies the password before revealing hash-format state (no account/hash probing), and clears lockout counters on success.

### Session migration data loss (supersedes #275)
- A legacy flat `sessions.json` parsed as an *empty* v2 store (both fields `#[serde(default)]`) and was immediately saved back, wiping every remembered LAN session. Parsing is now shape-checked and legacy formats migrate through their explicit parsers.

### JXL gallery visibility (from #251/#274)
- Browser gallery listing, storage quota and expiry sweeps now include `.jxl` files; browser metadata reads use the format-aware reader.

## Validation
- `cargo fmt` + `cargo check` (desktop) and `cargo check --no-default-features --features server` — clean, pre-existing warnings only
- `cargo clippy` both feature sets — pre-existing warnings only
- `cargo test --features server --lib auth::` — 5 passed (incl. new migration + password-upgrade tests)
- `cargo test --features server --lib sidecar` — 3 passed (incl. new URL-policy regression test)
- `npm run build` — ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)