### PR TITLE
Fix stale preview overwriting final image in lightbox; copy toast hidden behind hover bar

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1875,6 +1875,17 @@
             });
             if (!resp.ok) return;
             const blob = await resp.blob();
+            // The prompt may have completed while the fetch was in flight
+            // (common on remote browser mode with inpaint chains). Setting
+            // previewImage now would overwrite the finalized output in the
+            // lightbox with a stale blurry preview frame — and nothing would
+            // ever clear it.
+            if (
+              !progress.isGenerating ||
+              (data.prompt_id && progress.activePromptId && data.prompt_id !== progress.activePromptId)
+            ) {
+              return;
+            }
             const url = URL.createObjectURL(blob);
             // Revoke the previous preview blob URL to avoid memory leaks
             if (progress.previewImage?.startsWith("blob:")) URL.revokeObjectURL(progress.previewImage);
@@ -3062,7 +3073,7 @@
 
 {#if generationDoneToast}
   {#key generationDoneToast.id}
-    <div class="fixed bottom-5 right-4 z-80 w-[min(22rem,calc(100vw-2rem))] md:right-5">
+    <div class="fixed bottom-5 right-4 z-10000 w-[min(22rem,calc(100vw-2rem))] md:right-5">
       <div
         class="generation-done-toast flex items-center gap-3 rounded-[var(--app-panel-radius)] border border-neutral-700 bg-neutral-900/95 p-2 shadow-2xl shadow-black/40 backdrop-blur-sm {generationDoneToast.leaving ? 'generation-done-toast-out' : 'generation-done-toast-in'}"
       >
@@ -3101,7 +3112,7 @@
 {#if gallery.toast}
   {@const type = gallery.toast.type}
   <div
-    class="fixed bottom-6 left-1/2 z-60 flex -translate-x-1/2 animate-fade-in items-center gap-2 rounded-[var(--app-panel-radius)] border px-4 py-2.5 text-sm shadow-2xl shadow-black/40 backdrop-blur-sm
+    class="fixed bottom-6 left-1/2 z-10000 flex -translate-x-1/2 animate-fade-in items-center gap-2 rounded-[var(--app-panel-radius)] border px-4 py-2.5 text-sm shadow-2xl shadow-black/40 backdrop-blur-sm
     {type === 'success' ? 'border-green-700/80 bg-green-950/95 text-green-100' : 
      type === 'error' ? 'border-red-700/80 bg-red-950/95 text-red-100' :
      'border-neutral-700 bg-neutral-900/95 text-neutral-100'}"


### PR DESCRIPTION
## Summary
Two browser-mode UI fixes:

**Lightbox stale-preview race.** The `comfyui:preview` handler checks `progress.isGenerating` and the prompt-id filters synchronously, then (browser mode) awaits a network fetch of the temp preview image. If the prompt completes while that fetch is in flight — common on remote browser mode with regional inpaint chains, whose final preview frames are blurry face-segment crops — the stale frame was written to `progress.previewImage` *after* `finalizeOutputImages` had set the real image, and since `displayImage` prefers `previewImage` and generation was over, the blurry frame replaced the final image in the lightbox permanently (until the next generation). The guards are now re-checked after the await.

**Copy toast hidden behind the session-image hover bar.** The hover action bar in the bottom panel renders at `z-9999` while the copy/save toast rendered at `z-60` (generation-done toast at `z-80`), so the bar covered the "Copied to clipboard" feedback whenever the hovered image sat low in the panel or the window was short. Toasts are transient top-level feedback and now render at `z-10000`.

## Validation
- `npm run build` — ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)