### PR TITLE
chore: zh interrogate title, Claude Code skills sync, lockfile catch-up

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -32,6 +32,7 @@ Invoke by name or slash-style request (`/push`, `/release`, etc.):
 
 | Target | Format | Notes |
 |--------|--------|-------|
+| [`.claude/skills/`](../.claude/skills/) | `SKILL.md` | Direct copy (Claude Code project skills) |
 | [`.cursor/skills/`](../.cursor/skills/) | `SKILL.md` | Direct copy |
 | [`.cursor/rules/`](../.cursor/rules/) | `.mdc` | Cursor frontmatter (`alwaysApply`, `globs`) |
 | [`.roo/commands/`](../.roo/commands/) | `.md` | Roo slash commands + `argument-hint` |

--- a/.claude/skills/add-generation-param/SKILL.md
+++ b/.claude/skills/add-generation-param/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: add-generation-param
+description: >-
+  Adds a generation parameter across MooshieUI's Svelte store, TypeScript types,
+  Rust GenerationParams, and workflow templates. Use for new UI settings, ComfyUI
+  inputs, or /add-generation-param.
+---
+
+# Add Generation Parameter (MooshieUI)
+
+**6 touchpoints**, in order. New workflow-only params still need Rust + TS types if exposed in UI.
+
+## Gather from user
+
+1. Name (TS `camelCase`, Rust/iface `snake_case`)
+2. Type + default
+3. Templates: txt2img | img2img | inpainting | upscale | all
+4. ComfyUI node + input field name
+
+## 1. `src/lib/types/index.ts`
+
+```typescript
+export interface GenerationParams {
+  new_param: SomeType;
+}
+```
+
+## 2–4. `src/lib/stores/generation.svelte.ts`
+
+```typescript
+newParam = $state<SomeType>(defaultValue);
+
+// loadSettings()
+if (saved.newParam !== undefined) this.newParam = saved.newParam;
+
+// saveSettings()
+newParam: this.newParam,
+
+// toParams()
+new_param: this.newParam,
+```
+
+Use `!== undefined` for bool/number defaults that can be `0` or `false`.
+
+## 5. `src-tauri/src/comfyui/types.rs`
+
+```rust
+pub new_param: Type,
+// or
+pub new_param: Option<Type>,
+```
+
+## 6. `src-tauri/src/templates/{mode}.rs`
+
+```rust
+"node_input": params.new_param,
+```
+
+## Verify
+
+```powershell
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+```
+- [ ] Interface snake_case field
+- [ ] Store $state + load/save + toParams()
+- [ ] Rust GenerationParams field
+- [ ] ≥1 template references param
+```
+
+If UI needs i18n: add keys to **all** files in `src/lib/locales/` (parity with `en.ts`).
+
+For new workflow **modes**, use **workflow-template-builder** skill after params exist.

--- a/.claude/skills/add-tauri-command/SKILL.md
+++ b/.claude/skills/add-tauri-command/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: add-tauri-command
+description: >-
+  Adds a MooshieUI Tauri command end-to-end — Rust handler, lib.rs registration,
+  and TypeScript ipcInvoke wrapper. Use when adding a backend command, IPC endpoint,
+  or /add-tauri-command.
+---
+
+# Add Tauri Command (MooshieUI)
+
+Minimum **3 files**, in this order. Works in **desktop and browser mode** only if you use `ipcInvoke()` (never raw `invoke()`).
+
+## Gather from user
+
+1. Command name (Rust `snake_case`, TS `camelCase` function)
+2. Parameters (name + type each)
+3. Return type
+4. Module: `api` | `server` | `websocket` | `workflow` | `config` | new
+5. Needs `AppHandle`? (only for events / app paths)
+
+## 1. Rust — `src-tauri/src/commands/{module}.rs`
+
+```rust
+#[tauri::command]
+pub async fn my_command(
+    state: State<'_, AppState>,
+    my_param: String,
+) -> Result<ReturnType, AppError> {
+    let config = state.config.read().await;
+    // ...
+    drop(config);
+    Ok(result)
+}
+```
+
+- `Result<T, AppError>` only; no panic
+- `AppHandle` only if emitting events / spawning tasks
+- Drop `RwLock` before I/O `.await`
+- HTTP via `state.http_client`
+- New module → `pub mod x;` in `commands/mod.rs`
+
+## 2. Register — `src-tauri/src/lib.rs`
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    commands::api::my_command,
+])
+```
+
+## 3. TypeScript — `src/lib/utils/api.ts`
+
+```typescript
+export async function myCommand(myParam: string): Promise<ReturnType> {
+  return ipcInvoke("my_command", { myParam });
+}
+```
+
+- camelCase keys in payload; Rust receives snake_case
+- New shapes → `src/lib/types/index.ts` (serde field names, often snake_case)
+
+## Verify
+
+```powershell
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+```
+- [ ] #[tauri::command] + Result<_, AppError>
+- [ ] Listed in generate_handler!
+- [ ] api.ts uses ipcInvoke("my_command", ...)
+- [ ] Names aligned TS camelCase ↔ Rust snake_case
+```

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: cleanup
+description: >-
+  Runs branch hygiene and bot PR comment triage without cutting a release.
+  Use when the user says /cleanup, branch cleanup, stale branch cleanup,
+  or wants bot-comment triage across open/recent PRs.
+---
+
+# Cleanup (MooshieUI)
+
+Standalone maintenance path: **branch hygiene → PR/bot triage → targeted cleanup actions → summary**.
+
+This workflow does **not** bump versions, edit release notes/changelog, create release tags, or trigger release CI.
+
+## Windows git (required)
+
+Prefix git commands with:
+
+```text
+git -c core.hooksPath=/dev/null ...
+```
+
+Pre-commit hook is bash and hangs in PowerShell.
+
+## Workflow
+
+### 1. Branch inventory and stale detection
+
+```powershell
+git fetch --prune origin
+git branch -vv
+git branch -r
+gh pr list --state open --base main --json number,title,headRefName,updatedAt,isDraft
+gh api repos/Mooshieblob1/MooshieUI/branches?per_page=100 --jq '.[].name'
+```
+
+Identify:
+- stale local branches tracking deleted remotes
+- stale remote `release/v*` branches with merged/closed PRs
+- duplicate release branches for the same version
+- open PR branches with no recent activity and no merge intent
+
+### 2. Bot comment triage scope
+
+Review bot comments on:
+1) open PRs to `main`
+2) recently merged PRs (default: last 20, or since last tag)
+
+```powershell
+gh pr list --state open --base main --json number,title,headRefName
+gh pr list --state merged --base main --limit 20 --json number,title,mergedAt
+# Per PR N:
+gh pr view N --json reviews,comments,state,mergedAt
+gh api repos/Mooshieblob1/MooshieUI/pulls/N/comments
+gh api repos/Mooshieblob1/MooshieUI/pulls/N/reviews
+```
+
+Primary bots: `gemini-code-assist[bot]`, `copilot-pull-request-reviewer[bot]`, and actionable `github-actions[bot]` comments.
+
+Classify with `docs/BOT_REVIEW_TRIAGE.md`:
+- **Fix**: correctness/safety/consistency
+- **Skip**: stylistic nits, premature abstraction, factually wrong
+- **Defer**: valid but not maintenance-blocking
+
+### 3. Cleanup actions
+
+Apply only safe, explicit actions:
+- Delete stale local branches
+- Delete stale remote release branches (`release/v*`) that are merged/abandoned
+- Close superseded release PRs when appropriate
+- For bot **Fix** findings:
+  - open PR: push fix on that branch
+  - merged PR: create follow-up branch/PR (do not rewrite history)
+
+Avoid destructive/unsafe actions:
+- never force-push protected branches
+- never delete unmerged branches with active intent
+- never force-move or delete tags
+
+### 4. Re-check and report
+
+Re-run inventory commands after actions and provide:
+- branch/PR action table (what changed)
+- bot triage table (PR, comment, verdict, rationale)
+- unresolved follow-ups (if any)
+
+## Checklist
+
+```
+- [ ] Remote/local branches inventoried and pruned
+- [ ] Stale `release/v*` branches addressed
+- [ ] Open PRs reviewed for stale/conflicting branch state
+- [ ] Bot comments triaged on open + recent merged PRs
+- [ ] Fix/Skip/Defer outcomes documented
+- [ ] Safe cleanup actions completed and re-verified
+```
+
+## Mistakes to avoid
+
+1. Deleting active unmerged branches without confirmation
+2. Ignoring bot comments on non-release open PRs
+3. Treating all bot comments as mandatory fixes
+4. Force-updating tags/branches during cleanup

--- a/.claude/skills/pre-commit-check/SKILL.md
+++ b/.claude/skills/pre-commit-check/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: pre-commit-check
+description: >-
+  Validates MooshieUI uncommitted changes before commit or PR — build gates,
+  Rust fmt/clippy, conventions, i18n. Use before committing, or when push/release
+  skills invoke pre-commit validation.
+---
+
+# Pre-Commit Check (MooshieUI)
+
+Run **before** any commit in the push or release workflows. Execute steps in order; **stop on blocking failures**. Only audit **changed** files (unstaged + staged).
+
+## Setup
+
+```powershell
+cd "$(git rev-parse --show-toplevel)"
+git diff --name-only HEAD
+git diff --staged --name-only
+```
+
+Combine lists. Classify: `rust` (`src-tauri/**/*.rs`), `config`, `rust-deps`, `svelte`, `store`, `typescript`, `locale`, `python-nodes`, `frontend-deps`.
+
+If empty → report "Nothing to check" and stop.
+
+## Build gates [BLOCKING]
+
+| Step | When | Command |
+|------|------|---------|
+| Frontend | svelte / store / ts / package.json changed | `npm run build` — PASS if output ends with `✓ built in` |
+| Rust compile | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml` |
+| Rust fmt | any `.rs` changed | `cd src-tauri; cargo fmt --check` — only **blocking** if diffs overlap **your** changed lines |
+
+If a build gate fails → report full error and **STOP** (skip convention audit).
+
+## Lint [NON-BLOCKING]
+
+If `.rs` changed: `cd src-tauri; cargo clippy` — warn only on **new** issues in changed files.
+
+## Convention audit [NON-BLOCKING unless noted]
+
+Inspect only `+` lines in `git diff HEAD`. Full rule tables: [reference.md](reference.md).
+
+**Blocking convention errors:**
+- Svelte: `<style>` blocks; legacy `on:click` / `on:input`; unpinned `installPipPackage("pkg")` (must contain `==`)
+- Stores: imports from `svelte/store`
+- Utils: duplicate exports
+- Rust commands: `#[tauri::command]` must return `Result<T, AppError>`
+- Templates: new builders must return complete `WorkflowResult`
+- Locales: key parity and interpolation parity (see i18n below)
+
+## i18n [BLOCKING if locale files changed]
+
+- **Canonical:** `src/lib/locales/en.ts`
+- **Parity:** every other `src/lib/locales/*.ts` must have the same keys and matching `{placeholder}` names as `en.ts`
+- **Export:** each file ends with `export default <name>;` matching filename
+
+## Cross-file [NON-BLOCKING]
+
+If `commands/*.rs` or `lib.rs` changed: matching wrapper in `src/lib/utils/api.ts` using `ipcInvoke()` (not raw `invoke()`).
+
+## Report format
+
+```markdown
+## Pre-Commit Check Report
+
+### Files Changed
+- path (category)
+
+### Build Gates
+- [ ] Frontend build: PASS/FAIL
+- [ ] Rust compile: PASS/FAIL
+- [ ] Rust formatting: PASS/FAIL
+
+### Lint
+- [ ] Clippy: PASS/WARN
+
+### Convention / i18n
+- (list findings with file:line)
+
+### Summary
+✅ Ready to commit
+— or —
+❌ N blocking issue(s)
+⚠️ N warning(s)
+```
+
+## Rules
+
+- Diff-aware; ignore pre-existing issues in untouched lines
+- Do **not** auto-fix unless the parent workflow (push/release) is fixing blockers
+- Push/release: fix blocking issues, re-run this skill, then continue

--- a/.claude/skills/pre-commit-check/reference.md
+++ b/.claude/skills/pre-commit-check/reference.md
@@ -1,0 +1,67 @@
+# Pre-Commit Convention Reference
+
+Apply only to **changed** files; check `+` lines in `git diff HEAD`.
+
+## Svelte components (`src/lib/components/**/*.svelte`)
+
+| Rule | Severity |
+|------|----------|
+| No `<style>` blocks | ERROR |
+| No `on:click`, `on:input`, `on:change` (use `onclick`, etc.) | ERROR |
+| No direct `invoke()` from `@tauri-apps/api` | WARN |
+| Tailwind only; no inline `style=` except dynamic values | WARN |
+| `installPipPackage` args must include `==` | ERROR |
+
+## Stores (`src/lib/stores/**/*.svelte.ts`)
+
+| Rule | Severity |
+|------|----------|
+| No `svelte/store` imports | ERROR |
+| No `.push()` / `.splice()` on `$state` arrays (use spread) | WARN |
+| `generation.svelte.ts`: `saveSettings()` after mutations | WARN |
+
+## TypeScript utils (`src/lib/utils/**/*.ts`)
+
+| Rule | Severity |
+|------|----------|
+| No duplicate exports (inline + barrel) | ERROR |
+| No new `any` in changed lines | WARN |
+
+## Rust commands (`src-tauri/src/commands/**/*.rs`)
+
+| Rule | Severity |
+|------|----------|
+| `Result<T, AppError>` on commands | ERROR |
+| No new `.unwrap()` / `.expect()` | WARN |
+| Drop `RwLock` guards before `.await` on I/O | WARN |
+
+## Workflow templates (`src-tauri/src/templates/**/*.rs`)
+
+| Rule | Severity |
+|------|----------|
+| Complete `WorkflowResult` | ERROR |
+| Node IDs via `next_id.to_string()` | WARN |
+
+## Tauri config (`src-tauri/tauri.conf.json`)
+
+| Rule | Severity |
+|------|----------|
+| `csp` or `capabilities` changes | WARN — manual review |
+
+## Locales (`src/lib/locales/*.ts`)
+
+| Rule | Severity |
+|------|----------|
+| All files share keys with `en.ts` | ERROR |
+| `{var}` placeholders match `en.ts` per key | ERROR |
+| New keys: `/^[a-z][a-z0-9]*(\.[a-z][a-z0-9_]*)+$/` | WARN |
+| No empty string values | WARN |
+
+## Hardcoded UI strings (svelte / stores)
+
+New user-facing literals should use `locale.t()`. Ignore: class names, console logs, command names, paths, comparisons, comments, strings already inside `locale.t()`.
+
+## Accepted patterns
+
+- Component-local `listen()` in `onMount` for download/install progress is OK
+- `.unwrap_or()` / `.unwrap_or_default()` / `.unwrap_or_else()` are OK

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: push
+description: >-
+  Commits MooshieUI working-tree changes and lands them on main via a squash-merged
+  PR without version bump or release tag. Use when the user says /push, push to main,
+  chore PR, or wants docs/CI/fixes merged without a release.
+---
+
+# Push to Main (MooshieUI)
+
+Non-release path: **PR → GlassWorm CI → squash merge → sync main**. Run autonomously; do not pause for confirmation unless blocked.
+
+**Does not:** bump version, edit `RELEASE_NOTES.md` / `CHANGELOG.md`, create tags, or run full release build CI.
+
+## Inputs
+
+- **Commit message:** user-provided, or derive from `git diff` (imperative, ≤72 chars, e.g. `fix CI toolchain`)
+- **Branch:** `chore/<slug>` — lowercase, hyphens, ≤50 chars from message
+
+## Windows git (required)
+
+Pre-commit hook is bash and **hangs in PowerShell**. Prefix **every** git command:
+
+```text
+git -c core.hooksPath=/dev/null ...
+```
+
+## Workflow
+
+### 1. Pre-flight
+
+```powershell
+cd "$(git rev-parse --show-toplevel)"
+git diff --stat
+git diff --cached --stat
+```
+
+Clean tree → tell user and stop.
+
+If `package.json`, `src-tauri/Cargo.toml`, or `src-tauri/tauri.conf.json` show version-only bumps → warn user to use **release** skill instead.
+
+### 2. Pre-commit-check
+
+Follow the **pre-commit-check** skill. Fix blocking issues; re-run until ✅ Ready to commit.
+
+### 3. Branch, commit, push
+
+```powershell
+git checkout -b chore/<slug>
+git add -A
+git -c core.hooksPath=/dev/null commit -m "<message>"
+git -c core.hooksPath=/dev/null push -u origin chore/<slug>
+```
+
+### 4. Open PR
+
+```powershell
+gh pr create --base main --head chore/<slug> --title "<message>" --body "$(git diff --stat origin/main...HEAD)"
+```
+
+### 5. Wait for CI
+
+Poll until **GlassWorm Infection Audit** is `SUCCESS` (30s interval, 5 min timeout):
+
+```powershell
+gh pr checks --watch --interval 30
+```
+
+On failure: `gh pr checks` / run logs → fix → push → re-poll.
+
+### 6. Merge
+
+```powershell
+gh pr merge --squash --delete-branch
+```
+
+### 7. Sync local main
+
+```powershell
+git checkout main
+git fetch origin main
+git reset --hard origin/main
+```
+
+### 8. Cleanup
+
+Remote branch is deleted by `--delete-branch` if merge succeeded. If not:
+
+```powershell
+git -c core.hooksPath=/dev/null push origin --delete chore/<slug>
+```
+
+## Checklist
+
+```
+- [ ] Pre-commit-check passed
+- [ ] PR created chore/<slug> → main
+- [ ] GlassWorm SUCCESS
+- [ ] Squash merged
+- [ ] Local main reset to origin/main
+```
+
+## Mistakes to avoid
+
+1. Pushing directly to `main` (branch protection)
+2. Omitting `core.hooksPath=/dev/null` on Windows
+3. Including release version bumps — use **release** skill

--- a/.claude/skills/quickrelease/SKILL.md
+++ b/.claude/skills/quickrelease/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: quickrelease
+description: >-
+  Cuts a MooshieUI semver release quickly, skipping bot reviews, pre-commit-checks,
+  and local build validation. Bumps versions, prepends release notes, commits, pushes,
+  creates/merges release PR, and tags the release. Use when the user says /quickrelease or wants a checkless release.
+---
+
+# Quick Release (MooshieUI)
+
+Fast-path release: **checkout main → version bump → changelog → push branch → PR → auto-merge → tag → CI**.
+
+This workflow skips all developer hygiene checks, linting, pre-commit hooks, and local build verification. Use it only when the changes are trivial and already verified.
+
+## Inputs
+
+| Field | Default if omitted |
+|-------|-------------------|
+| Version `X.Y.Z` | Read `package.json`, patch+1 (no `v` prefix in files) |
+| Summary | `git log` since last `v*` tag |
+
+## Windows git (required)
+
+```text
+git -c core.hooksPath=/dev/null ...
+```
+
+Pre-commit hook hangs in PowerShell without this.
+
+## Workflow
+
+### 1. Sync main branch
+
+Ensure you are on a fresh, updated `main` branch before bumping versions:
+
+```powershell
+git checkout main
+git pull origin main
+```
+
+### 2. Version bump (all three must match)
+
+Update version in:
+
+| File | Field |
+|------|-------|
+| `package.json` | `"version": "X.Y.Z"` |
+| `src-tauri/Cargo.toml` | `version = "X.Y.Z"` under `[package]` |
+| `src-tauri/tauri.conf.json` | `"version": "X.Y.Z"` |
+
+### 3. Changelog files
+
+Prepend to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`:
+
+```markdown
+## What's New in vX.Y.Z
+
+### Fixes and maintenance
+- Detail
+
+---
+
+## What's New in vPREVIOUS
+```
+
+`CHANGELOG.md`: new section goes directly under `# Changelog`.
+
+### 4. Create and push release branch
+
+```powershell
+git checkout -b release/vX.Y.Z
+git add -A
+git -c core.hooksPath=/dev/null commit -m "vX.Y.Z: Quick release"
+git -c core.hooksPath=/dev/null push -u origin release/vX.Y.Z
+```
+
+### 5. Create Pull Request
+
+```powershell
+gh pr create --base main --head release/vX.Y.Z --title "vX.Y.Z: Quick release" --body "<bullet list of changes>"
+```
+
+### 6. Merge PR
+
+If branch checks are green or can be bypassed:
+```powershell
+gh pr merge <PR_NUMBER> --squash --delete-branch
+```
+If branch policy blocks the merge due to pending checks or admin settings, add the `--admin` flag:
+```powershell
+gh pr merge <PR_NUMBER> --squash --delete-branch --admin
+```
+
+### 7. Sync main & Tag
+
+```powershell
+git checkout main
+git fetch origin main
+git reset --hard origin/main
+git tag vX.Y.Z
+git -c core.hooksPath=/dev/null push origin vX.Y.Z
+```
+
+This triggers the **Build & Release** workflow on GitHub Actions.
+
+### 8. Cleanup
+
+```powershell
+git fetch --prune origin
+```
+
+Prune any stale local branches.
+
+## Checklist
+
+```
+- [ ] Stale release/* branches cleaned up
+- [ ] Three version files match X.Y.Z
+- [ ] RELEASE_NOTES.md + CHANGELOG.md updated
+- [ ] Release PR merged to main
+- [ ] Tag vX.Y.Z pushed
+- [ ] Release workflow running on GitHub
+```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: release
+description: >-
+  Cuts a MooshieUI semver release — bumps three version files, updates changelog
+  and release notes, validates build, opens release PR, merges, tags, and triggers
+  Build & Release CI. Use when the user says /release, cut a release, ship vX.Y.Z,
+  or version bump.
+---
+
+# Release (MooshieUI)
+
+Full release path: **repo hygiene → pre-commit → version bump → changelog → build validation → PR → GlassWorm → bot triage (all relevant PRs) → merge → tag → CI**.
+
+## Inputs
+
+| Field | Default if omitted |
+|-------|-------------------|
+| Version `X.Y.Z` | Read `package.json`, patch+1 (no `v` prefix in files) |
+| Summary | `git log` since last `v*` tag |
+
+## Windows git (required)
+
+```text
+git -c core.hooksPath=/dev/null ...
+```
+
+Pre-commit hook hangs in PowerShell without this.
+
+## Workflow
+
+### 1. Repo hygiene — branches and open PRs [BLOCKING before new release branch]
+
+Refresh remotes, inventory branches/PRs, and resolve conflicts **before** creating `release/vX.Y.Z`.
+
+```powershell
+git fetch --prune origin
+git branch -vv
+git branch -r
+gh pr list --state open --base main --json number,title,headRefName,updatedAt,isDraft
+gh api repos/Mooshieblob1/MooshieUI/branches?per_page=100 --jq '.[].name'
+```
+
+**Release / stale branch handling**
+
+| Situation | Action |
+|-----------|--------|
+| Remote `release/vX.Y.Z` already exists for **this** release | If PR is merged or abandoned: delete remote branch. If PR is still open and current: check out and continue on it (do not create a duplicate). |
+| Remote `release/v*` for an **older** version, PR merged | Delete remote branch: `git -c core.hooksPath=/dev/null push origin --delete release/vOLD` |
+| Remote `release/v*` with **closed** PR and no further work | Delete remote branch |
+| Local tracking branches for deleted remotes | `git fetch --prune` then delete stale locals |
+| Open PR targeting `main` that is superseded by this release | Close with a short comment, or merge first if it must ship in this release |
+| Open PR with failing **GlassWorm** or blocking CI | Fix on that branch/PR or close before cutting the release |
+
+**Do not** force-push `main` or protected tags. Do not delete branches that still have unmerged work the user intends to ship.
+
+Report a short table: branch/PR, status, action taken.
+
+### 2. Bot review sweep — open PRs and recent merges
+
+Before version bump, triage bot feedback on PRs that could block or duplicate this release.
+
+**Bots to read** (non-exhaustive): `gemini-code-assist[bot]`, `copilot-pull-request-reviewer[bot]`, `github-actions[bot]` (only when comment contains a concrete fix).
+
+```powershell
+# Open PRs targeting main
+gh pr list --state open --base main --json number,title,headRefName
+
+# Per PR (replace N):
+gh pr view N --json reviews,comments,state,mergedAt
+gh api repos/Mooshieblob1/MooshieUI/pulls/N/comments
+gh api repos/Mooshieblob1/MooshieUI/pulls/N/reviews
+```
+
+Also check **recently merged** PRs since the last `v*` tag (bots sometimes comment late or on squash-merge commits):
+
+```powershell
+$lastTag = git describe --tags --abbrev=0
+gh pr list --state merged --base main --limit 20 --json number,title,mergedAt
+```
+
+Classify every bot comment using [docs/BOT_REVIEW_TRIAGE.md](../../../docs/BOT_REVIEW_TRIAGE.md):
+
+| Verdict | Action |
+|---------|--------|
+| **Fix** | Correctness, safety, MIME mismatches, consistency — fix on that PR's branch if still open, or on `main`/release branch if merged and release-blocking |
+| **Skip** | Premature abstraction, nits, factually wrong bot claims — note rationale in release PR body or user summary |
+| **Defer** | Valid but not release-blocking — document for follow-up; do not block tag |
+
+**Release-blocking** bot findings on open PRs must be resolved (fix or explicit skip with verification) before creating the release PR. If a fix belongs on another open PR, land it there first or cherry-pick into the release branch.
+
+### 3. Pre-commit-check
+
+Run **pre-commit-check** on current tree. Fix blockers; re-run until ✅.
+
+### 4. Version bump (all three must match)
+
+| File | Field |
+|------|-------|
+| `package.json` | `"version": "X.Y.Z"` |
+| `src-tauri/Cargo.toml` | `version = "X.Y.Z"` under `[package]` |
+| `src-tauri/tauri.conf.json` | `"version": "X.Y.Z"` |
+
+Verify:
+
+```powershell
+Select-String -Pattern '"X.Y.Z"|version = "X.Y.Z"' package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json
+```
+
+### 5. Changelog files
+
+Prepend to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`:
+
+```markdown
+## What's New in vX.Y.Z
+
+### Group title
+- Detail
+
+---
+
+## What's New in vPREVIOUS
+```
+
+`CHANGELOG.md`: new section goes directly under `# Changelog`.
+
+### 6. Build validation [BLOCKING]
+
+```powershell
+cargo check --manifest-path src-tauri/Cargo.toml
+npm run build
+```
+
+### 7. Release branch and PR
+
+Confirm step 1: no conflicting `release/vX.Y.Z` on remote (unless intentionally continuing that PR).
+
+```powershell
+git checkout main
+git pull origin main
+git checkout -b release/vX.Y.Z
+git add -A
+git -c core.hooksPath=/dev/null commit -m "vX.Y.Z: Short summary"
+git -c core.hooksPath=/dev/null push -u origin release/vX.Y.Z
+gh pr create --base main --head release/vX.Y.Z --title "vX.Y.Z: Short summary" --body "<bullet list of changes; note any bot triage from steps 1-2>"
+```
+
+### 8. CI
+
+```powershell
+gh pr checks <PR_NUMBER> --watch --interval 30
+```
+
+Wait for **GlassWorm Infection Audit** SUCCESS (5 min timeout).
+
+### 9. Bot review triage — release PR (and late comments)
+
+Wait ~60s after CI green. Re-fetch **all** bot threads on the release PR:
+
+```powershell
+gh pr view <PR_NUMBER> --json reviews,comments,state
+gh api repos/Mooshieblob1/MooshieUI/pulls/<PR_NUMBER>/comments
+gh api repos/Mooshieblob1/MooshieUI/pulls/<PR_NUMBER>/reviews
+```
+
+Repeat classification (Fix / Skip / Defer). Present a summary table: bot, file, verdict, one-line rationale.
+
+Apply fixes only for **Fix**; then:
+
+```powershell
+git add -A
+git -c core.hooksPath=/dev/null commit -m "address bot review feedback"
+git -c core.hooksPath=/dev/null push
+gh pr checks <PR_NUMBER> --watch --interval 30
+```
+
+If bots post **after** a green run (common on squash-merge), re-poll comments once more before merge. Do not merge with unaddressed **Fix** items on the release PR.
+
+### 10. Merge and sync main
+
+```powershell
+gh pr merge <PR_NUMBER> --squash --delete-branch
+git checkout main
+git fetch origin main
+git reset --hard origin/main
+```
+
+### 11. Post-merge bot pass (before tag)
+
+On the merged release PR, fetch comments again in case bots reviewed the squash commit:
+
+```powershell
+gh pr view <PR_NUMBER> --json comments,reviews,mergedAt
+gh api repos/Mooshieblob1/MooshieUI/pulls/<PR_NUMBER>/comments
+```
+
+- **Fix** on `main`: commit directly on `main` only if policy allows; otherwise open a tiny follow-up PR. For release workflow, prefer a fast follow-up commit on `main` before tagging when the fix is trivial and release-blocking.
+- If a **Fix** requires re-tagging content, complete the fix, then tag (never move/delete an existing tag).
+
+### 12. Tag (after merge only)
+
+Tags are protected — no force/delete. Tag must point at merged `main`:
+
+```powershell
+git tag vX.Y.Z
+git -c core.hooksPath=/dev/null push origin vX.Y.Z
+```
+
+`v*` tag triggers **Build & Release** ([`.github/workflows/release.yml`](../../../.github/workflows/release.yml)).
+
+### 13. Verify CI
+
+```powershell
+gh run list --workflow=release.yml --limit 3
+```
+
+Tell user: https://github.com/Mooshieblob1/MooshieUI/actions
+
+### 14. Fallback
+
+If tag push fails or workflow does not start:
+
+```powershell
+gh workflow run release.yml -f tag=vX.Y.Z
+```
+
+### 15. Cleanup
+
+```powershell
+git fetch --prune origin
+git -c core.hooksPath=/dev/null push origin --delete release/vX.Y.Z
+```
+
+Confirm no duplicate `release/v*` branches remain for this version. Prune stale local branches.
+
+## About UI
+
+No manual About edit — version from `__APP_VERSION__`; release notes from GitHub Releases API at runtime.
+
+## Checklist
+
+```
+- [ ] Stale/existing branches and open PRs reviewed; release/* cleaned up or continued intentionally
+- [ ] Bot comments triaged on open PRs + recent merges (Fix/Skip/Defer documented)
+- [ ] Pre-commit-check passed
+- [ ] Three version files match X.Y.Z
+- [ ] RELEASE_NOTES.md + CHANGELOG.md updated
+- [ ] cargo check + npm run build passed
+- [ ] Release PR merged to main
+- [ ] Post-merge bot pass completed (no unaddressed Fix items)
+- [ ] Tag vX.Y.Z pushed
+- [ ] Release workflow running
+- [ ] Remote release/vX.Y.Z branch deleted
+```
+
+## Mistakes to avoid
+
+1. Missing one of the three version files
+2. Skipping `cargo check` (stale `Cargo.lock` breaks CI)
+3. Tag before PR merge
+4. `git` without `core.hooksPath=/dev/null` on Windows
+5. Force-updating tags — use `workflow_dispatch` instead
+6. Creating a second `release/vX.Y.Z` while an open PR already exists for the same version
+7. Merging the release PR while another open PR has release-blocking bot **Fix** items still unresolved
+8. Ignoring late bot comments posted after CI goes green

--- a/.claude/skills/workflow-template-builder/SKILL.md
+++ b/.claude/skills/workflow-template-builder/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: workflow-template-builder
+description: >-
+  Builds or modifies ComfyUI workflow JSON templates in MooshieUI's Rust backend
+  (src-tauri/src/templates). Use for new generation modes, template nodes, LoRA chains,
+  upscale append chains, or ComfyUI workflow wiring.
+---
+
+# Workflow Template Builder (MooshieUI)
+
+Specialist workflow for `src-tauri/src/templates/`. Each template builds `serde_json::Map<String, Value>` for the ComfyUI API.
+
+## Before coding
+
+1. Read `src-tauri/src/templates/mod.rs`
+2. Read `txt2img.rs` (reference pattern)
+3. If new params needed → **add-generation-param** skill first
+
+## Rules
+
+1. Return **`WorkflowResult`** with all fields set
+2. Node IDs: `next_id.to_string()` after each node (`"1"`, `"2"`, …)
+3. Use `json!{}` for nodes
+4. Connections: `[node_id, port]` arrays from `(String, u32)` tuples
+5. Register: `pub mod x;` + `build_workflow()` match arm in `mod.rs`
+6. `SaveImage` is appended in `mod.rs`, not per-template
+
+## WorkflowResult
+
+```rust
+pub struct WorkflowResult {
+    pub workflow: Map<String, Value>,
+    pub next_id: u32,
+    pub image_output: (String, u32),
+    pub model_source: (String, u32),
+    pub positive_id: String,
+    pub negative_id: String,
+    pub vae_source: (String, u32),
+}
+```
+
+## Pipeline order (summary)
+
+| Mode | Flow |
+|------|------|
+| txt2img | Checkpoint → LoRAs → VAE? → CLIP×2 → EmptyLatent → KSampler → VAEDecode |
+| img2img | … → LoadImage → VAEEncode → KSampler (denoise < 1) → VAEDecode |
+| inpainting | … → LoadImage + Mask → VAEEncodeForInpaint → KSampler → VAEDecode |
+| upscale append | IMAGE → upscale → VAEEncodeTiled → KSampler → VAEDecodeTiled |
+
+## New template checklist
+
+```
+- [ ] src-tauri/src/templates/new_mode.rs
+- [ ] pub fn build(params: &GenerationParams, seed: i64) -> WorkflowResult
+- [ ] mod.rs: pub mod + build_workflow match
+- [ ] cargo check --manifest-path src-tauri/Cargo.toml
+```
+
+## Reference
+
+ComfyUI node tables, connection syntax, append-chain pattern: [reference.md](reference.md)

--- a/.claude/skills/workflow-template-builder/reference.md
+++ b/.claude/skills/workflow-template-builder/reference.md
@@ -1,0 +1,56 @@
+# ComfyUI Node Reference (MooshieUI templates)
+
+## Model loading
+
+| class_type | Inputs | Outputs |
+|------------|--------|---------|
+| CheckpointLoaderSimple | ckpt_name | 0 MODEL, 1 CLIP, 2 VAE |
+| LoraLoader | model, clip, lora_name, strength_model, strength_clip | 0 MODEL, 1 CLIP |
+| VAELoader | vae_name | 0 VAE |
+| UpscaleModelLoader | model_name | 0 UPSCALE_MODEL |
+
+## Text / latent / sample / decode
+
+| class_type | Notes |
+|------------|--------|
+| CLIPTextEncode | clip, text → CONDITIONING |
+| EmptyLatentImage | width, height, batch_size |
+| VAEEncode / VAEEncodeForInpaint / VAEEncodeTiled | pixels + vae (+ mask for inpaint) |
+| KSampler | model, ±, latent, seed, steps, cfg, sampler_name, scheduler, denoise |
+| VAEDecode / VAEDecodeTiled | samples, vae |
+
+## Images
+
+| class_type | Notes |
+|------------|--------|
+| LoadImage / LoadImageMask | |
+| SaveImage | terminal (usually via mod.rs) |
+| ImageUpscaleWithModel / ImageScaleBy | |
+
+## Advanced
+
+| class_type | Notes |
+|------------|--------|
+| ApplyTiledDiffusion | model, method, tile_* |
+| CLIPSetLastLayer | clip, stop_at_clip_layer |
+| ControlNetLoader / ControlNetApplyAdvanced | |
+
+## Connection syntax
+
+```rust
+"model": [model_source.0, model_source.1],
+"steps": params.steps,
+"text": params.positive_prompt,
+```
+
+## Append chain
+
+```rust
+pub fn append_my_chain(
+    result: &mut WorkflowResult,
+    params: &GenerationParams,
+    seed: i64,
+) -> (String, u32) { /* ... */ }
+```
+
+LoRA chaining: thread `model_source` / `clip_source` through sequential `LoraLoader` nodes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+npm install                  # Frontend dependencies
+npm run tauri dev            # Full dev (Tauri + Vite hot-reload on port 1420, strict)
+npm run tauri build          # Production binary
+npm run build                # Frontend-only build (used as a pre-commit gate)
+cargo check --manifest-path src-tauri/Cargo.toml   # Rust compile check
+cargo fmt && cargo clippy    # Rust format/lint (run in src-tauri/)
+```
+
+**No test framework exists** — no vitest/jest on the frontend, no `#[test]` modules in Rust. Validation is `npm run build` + `cargo check` (see the `pre-commit-check` skill).
+
+## Skills
+
+Project skills live in `.claude/skills/` (synced from canonical `.agents/skills/` — edit there first, then re-sync):
+
+| Skill | Purpose |
+|-------|---------|
+| `push` | Land changes on main via squash-merged PR, no release |
+| `release` | Full release: version bump, changelog, PR, bot triage, tag, CI |
+| `quickrelease` | Release without local checks/bot triage (trivial, pre-verified changes only) |
+| `cleanup` | Branch hygiene + bot PR comment triage |
+| `pre-commit-check` | Pre-commit/pre-PR validation (build gates, conventions, i18n) |
+| `add-tauri-command` | New Tauri command: Rust handler + lib.rs registration + TS wrapper |
+| `add-generation-param` | New generation setting across store/types/Rust/templates (6 touchpoints) |
+| `workflow-template-builder` | ComfyUI workflow JSON templates in `src-tauri/src/templates/` |
+
+## Critical Architecture (Non-Obvious)
+
+- **Dual-mode app**: Runs as a Tauri desktop app AND as a browser web app served by an embedded axum server (`src-tauri/src/webserver.rs`, shared `Arc<AppState>`). `window.__MOOSHIE_BROWSER_MODE__` flags browser mode, where IPC becomes REST POST + SSE.
+- **Custom IPC abstraction** (`src/lib/utils/ipc.ts`): ALL backend calls go through `ipcInvoke()`/`ipcListen()` — never raw `invoke()`/`listen()` from `@tauri-apps/api` (works on desktop, breaks silently in browser mode). Typed wrappers live in `src/lib/utils/api.ts`.
+- **JXL storage**: Gallery images are stored as JPEG XL on disk. Display via `loadGalleryImageDisplay()` (JXL→WebP), PNG export via `loadGalleryImagePng()` — never read gallery files directly. Custom URI schemes: `thumbnail://`, `gallery://`. Gallery metadata comes from SQLite, not directory scans.
+- **Svelte 5 runes, no `svelte/store`**: Stores are class singletons with `$state` in `*.svelte.ts` files (extension required for rune compilation). Inside stores use `get` accessors for computed values (not `$derived`); `$derived` is for component-local computeds. Read shared state directly from store singletons instead of passing props. Reassign arrays with spread (no `.push()`); call `saveSettings()` explicitly after mutations; guard persisted fields with `!== undefined`. Stores must not import each other — cross-store logic lives in `App.svelte`.
+- **Rust commands**: `#[tauri::command]` must return `Result<T, AppError>` (never raw string errors), use `State<'_, AppState>` (re-exported), register in `lib.rs` `generate_handler![]`. Drop `RwLock` guards before `.await` on I/O. HTTP via shared `state.http_client` — never create new clients. Event names: `"comfyui:{type}"` / `"setup:{type}"`.
+- **`toParams()`** in the generation store maps camelCase → snake_case for Rust manually — mismatches break silently.
+- **i18n**: only `locale.t('key')`, no hardcoded user strings. Every key and `{placeholder}` added to `src/lib/locales/en.ts` must exist in **all** other locale files (missing keys fall back to English with no error).
+- **UI**: Tailwind only, no `<style>` blocks in `.svelte`; `onclick` not legacy `on:click`; dark neutral palette with accents via `--theme-accent-*` in `app.css`.
+
+## Release Process Gotchas
+
+- **Version must match exactly in 3 files**: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`.
+- **Pre-commit hook is bash** (GlassWorm scan in `.githooks/pre-commit`) and hangs in PowerShell — on Windows, prefix every git command with `git -c core.hooksPath=/dev/null`.
+- **Branch protection on `main`** — land via PR; CI gate is the "GlassWorm Infection Audit" check.
+- **Tags are protected** (no delete/force-update). If a tag push fails to trigger the release workflow, use `gh workflow run release.yml -f tag=vX.Y.Z`.
+- Prepend release notes to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`. The About UI needs no manual edit (`__APP_VERSION__` + GitHub Releases API).
+- Bot PR comment triage rules: `docs/BOT_REVIEW_TRIAGE.md` (Fix / Skip / Defer).
+
+## Other Non-Obvious Items
+
+- **`error-logs/`**: drop large logs/stack traces here (git-ignored, excluded from context ingestion); read on demand by filename.
+- **Ring buffer log capture**: Rust `src-tauri/src/log_buffer.rs` (2000 lines) + frontend `src/lib/utils/log-buffer.ts` (1000) → `exportLogs()`. Console alone misses Rust output.
+- **Browser server lifecycle**: binds `127.0.0.1`, 120s idle heartbeat watchdog shuts it down unless LAN mode is enabled.
+- **CSP is null** in `src-tauri/tauri.conf.json`.
+- **keep_alive config**: when true, the ComfyUI child process survives app close.
+- `comfyui-nodes/` is Python nodes installed into ComfyUI at setup — not app build output. `src-tauri/src/comfyui/` is the Rust ComfyUI client, not ComfyUI source.
+- **Agent config (canonical)**: `.agents/README.md` — skills in `.agents/skills/`, rules in `.agents/rules/` (mode-specific detail: architect, frontend, rust, debug, ask). `AGENTS.md` is the cross-agent entry point; deeper conventions in `.github/instructions/mooshieui.instructions.md`.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.8"
+version = "1.4.9"
 dependencies = [
  "argon2",
  "axum",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -695,7 +695,7 @@ const zhTw: Record<string, string> = {
   "generation.panel.expand_bottom": "展開底部面板",
   "generation.panel.collapse_bottom": "摺疊底部面板",
 
-  "generation.interrogate.title": "影像分析",
+  "generation.interrogate.title": "AI圖片標註",
   "generation.interrogate.tip": "分析影像以擷取標籤（角色、藝術家、通用）。拖放影像、瀏覽檔案或從剪貼簿貼上。標籤可直接套用到提示詞。",
   "generation.interrogate.browse_or_drop": "瀏覽或拖放",
   "generation.interrogate.paste": "Ctrl+V 貼上",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -695,7 +695,7 @@ const zh: Record<string, string> = {
   "generation.panel.expand_bottom": "展开底部面板",
   "generation.panel.collapse_bottom": "折叠底部面板",
 
-  "generation.interrogate.title": "图像分析",
+  "generation.interrogate.title": "AI图片标注",
   "generation.interrogate.tip": "分析图像以提取标签（角色、艺术家、通用）。拖放图像、浏览文件或从剪贴板粘贴。标签可直接应用到提示词。",
   "generation.interrogate.browse_or_drop": "浏览或拖放",
   "generation.interrogate.paste": "Ctrl+V 粘贴",


### PR DESCRIPTION
- zh/zh-tw: rename the Interrogate Image modal title to AI图片标注 / AI圖片標註 (ja already uses 解析 correctly — no criminal-interrogation terms found)
- Add `.claude/skills/` (Claude Code project skills synced from `.agents/skills/`) plus `CLAUDE.md`, and document the new sync target in `.agents/README.md`
- `Cargo.lock`: catch up to the v1.4.9 version bump

`npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)