### PR TITLE
Fix stuck blurry previews, default Refine to OmniSR 2x, prompt overlay drift

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -91,6 +91,20 @@
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, FETCH_TIMEOUT_MS));
     await Promise.race([Promise.allSettled(fetches), timeout]);
   }
+  /** Fetch a `_temp_image` URL, retrying once after a short delay. A transient
+   *  failure here (e.g. a 401 while the LAN session token refreshes) would
+   *  otherwise drop the final output image and leave the blurry progress
+   *  preview stuck as the displayed result. */
+  async function fetchTempImageWithRetry(url: string): Promise<Response> {
+    try {
+      const resp = await fetch(url, { headers: authHeaders() });
+      if (resp.ok) return resp;
+    } catch {
+      // fall through to retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    return fetch(url, { headers: authHeaders() });
+  }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
   let sseReconnectHandler: (() => void) | null = null;
   let modelPreviewActionHandler: ((event: Event) => void) | null = null;
@@ -1322,6 +1336,36 @@
     }
   });
 
+  /** Recover output images from the server temp cache (browser mode) when the
+   *  output_image SSE event was dropped or its fetch failed. Without this the
+   *  blurry progress frame stays as the displayed result. The `_temp_image`
+   *  endpoint transcodes JXL to WebP, so the blobs are always displayable. */
+  async function recoverMissingOutputImages(
+    promptId: string,
+    images: Array<{ blob: Blob; url: string; tempFilename?: string; displayTempFilename?: string }>,
+  ): Promise<void> {
+    if (isTauri) return;
+    try {
+      const recovered = await recoverPromptOutputs(promptId);
+      for (const imgRef of recovered.images) {
+        const tempFn = imgRef.temp_filename?.trim();
+        if (!tempFn) continue;
+        progress.registerPromptOutput(promptId, tempFn);
+        try {
+          const resp = await fetch(
+            `/internal-api/_temp_image/${encodeURIComponent(tempFn)}`,
+            { headers: authHeaders() },
+          );
+          if (resp.ok) {
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            images.push({ blob, url, tempFilename: tempFn });
+          }
+        } catch { /* individual image fetch failed */ }
+      }
+    } catch { /* recovery command failed */ }
+  }
+
   /**
    * Finalize images received via WebSocket during generation.
    * MooshieSaveImage sends PNG bytes directly over WS — no disk round-trip.
@@ -1879,9 +1923,12 @@
             // (common on remote browser mode with inpaint chains). Setting
             // previewImage now would overwrite the finalized output in the
             // lightbox with a stale blurry preview frame — and nothing would
-            // ever clear it.
+            // ever clear it. The pendingPrompts check also covers the window
+            // between one queued prompt completing and the next starting,
+            // when activePromptId is briefly null.
             if (
               !progress.isGenerating ||
+              (data.prompt_id && !progress.pendingPrompts.some((p: any) => p.promptId === data.prompt_id)) ||
               (data.prompt_id && progress.activePromptId && data.prompt_id !== progress.activePromptId)
             ) {
               return;
@@ -1987,10 +2034,10 @@
                     ? `/internal-api/_temp_image/${encodeURIComponent(displayFilename)}`
                     : `/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}?format=webp`;
                   const [canonicalResp, displayResp] = await Promise.all([
-                    fetch(`/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}?raw=true`, {
-                      headers: authHeaders(),
-                    }),
-                    fetch(displayUrl, { headers: authHeaders() }),
+                    fetchTempImageWithRetry(
+                      `/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}?raw=true`,
+                    ),
+                    fetchTempImageWithRetry(displayUrl),
                   ]);
                   if (!canonicalResp.ok) {
                     console.error(
@@ -2012,9 +2059,8 @@
                     url = progress.displayImage ?? "";
                   }
                 } else {
-                  const resp = await fetch(
+                  const resp = await fetchTempImageWithRetry(
                     `/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}`,
-                    { headers: authHeaders() },
                   );
                   if (!resp.ok) {
                     console.error("[output_image] failed to fetch temp image:", resp.status);
@@ -2096,15 +2142,24 @@
             pendingOutputFetches.delete(promptId);
           }
 
-          const item = progress.completePrompt(promptId);
+          // Read the collected output images first so completePrompt knows
+          // whether a real final image is about to replace the preview frame.
+          const images = pendingOutputImages.get(promptId) ?? [];
+          const item = progress.completePrompt(promptId, images.length > 0);
           promptLastActivity.delete(promptId);
           if (item) {
-            const images = pendingOutputImages.get(promptId) ?? [];
             for (const img of images) {
               const tempFn = img.tempFilename?.trim();
               if (tempFn) progress.registerPromptOutput(promptId, tempFn);
             }
             pendingOutputImages.delete(promptId);
+
+            if (images.length === 0) {
+              // The output_image event was dropped or its fetch failed — try
+              // to recover from the server temp cache so the final image
+              // replaces the blurry progress frame.
+              await recoverMissingOutputImages(promptId, images);
+            }
 
             const skipGallery = shouldSuppressRegionalChainGallerySave(promptId);
             if (skipGallery) {
@@ -2225,10 +2280,10 @@
               await awaitFetchesWithTimeout(fetches);
               pendingOutputFetches.delete(p.promptId);
             }
-            const item = progress.completePrompt(p.promptId);
+            let images = pendingOutputImages.get(p.promptId) ?? [];
+            const item = progress.completePrompt(p.promptId, images.length > 0);
             promptLastActivity.delete(p.promptId);
             if (item) {
-              let images = pendingOutputImages.get(p.promptId) ?? [];
               for (const img of images) {
                 const tempFn = img.tempFilename?.trim();
                 if (tempFn) progress.registerPromptOutput(p.promptId, tempFn);
@@ -2239,24 +2294,7 @@
                 // SSE event was likely dropped during a reconnect — the image was
                 // saved to a temp file on the server and cached by the cleanup
                 // reactor.  Try to recover it before giving up.
-                try {
-                  const recovered = await recoverPromptOutputs(p.promptId);
-                  for (const imgRef of recovered.images) {
-                    const tempFn = imgRef.temp_filename?.trim();
-                    if (tempFn) progress.registerPromptOutput(p.promptId, tempFn);
-                    try {
-                      const resp = await fetch(
-                        `/internal-api/_temp_image/${encodeURIComponent(imgRef.temp_filename)}`,
-                        { headers: authHeaders() },
-                      );
-                      if (resp.ok) {
-                        const blob = await resp.blob();
-                        const url = URL.createObjectURL(blob);
-                        images.push({ blob, url, tempFilename: imgRef.temp_filename });
-                      }
-                    } catch { /* individual image fetch failed */ }
-                  }
-                } catch { /* recovery command failed */ }
+                await recoverMissingOutputImages(p.promptId, images);
               }
 
               if (images.length > 0) {

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -694,7 +694,7 @@
       {placeholder}
       {rows}
       class="w-full border border-neutral-700 rounded-lg px-3 py-2 text-sm leading-5 text-neutral-100 placeholder-neutral-500 resize-y focus:outline-none focus:border-indigo-500 transition-colors break-words {minHeight} {showBackdrop ? 'bg-transparent' : 'bg-neutral-800'}"
-      style="position: relative; z-index: 1; {resizeStyle}{showBackdrop ? 'caret-color: #e5e5e5;' : ''}"
+      style="position: relative; z-index: 1; scrollbar-gutter: stable; {resizeStyle}{showBackdrop ? 'caret-color: #e5e5e5;' : ''}"
       onkeydown={handleKeydown}
       oninput={handleInput}
       onclick={handleClick}

--- a/src/lib/components/generation/UpscaleSettings.svelte
+++ b/src/lib/components/generation/UpscaleSettings.svelte
@@ -8,57 +8,7 @@
   import InfoTip from "../ui/InfoTip.svelte";
   import EditableValue from "../ui/EditableValue.svelte";
   import { scrollCapture } from "../../utils/scrollCapture.js";
-
-  interface RecommendedModel {
-    label: string;
-    filename: string;
-    url: string;
-    description: string;
-  }
-
-  const HF_BASE = "https://huggingface.co/AshtakaOOf/safetensored-upscalers/resolve/main";
-
-  const recommendedModels: RecommendedModel[] = [
-    // SPAN — fast, sharp, excellent general-purpose upscaler
-    {
-      label: "SPAN 2x — Spanimation",
-      filename: "2x_ModernSpanimationV1.safetensors",
-      url: `${HF_BASE}/span/2x_ModernSpanimationV1.safetensors`,
-      description: "Fast 2x with clean lines and vivid colours. Great for anime and illustration.",
-    },
-    {
-      label: "SPAN 4x — NomosUni",
-      filename: "4xNomosUni_span_multijpg.safetensors",
-      url: `${HF_BASE}/span/4xNomosUni_span_multijpg.safetensors`,
-      description: "Fast 4x all-rounder. Handles photos, art, and JPEG artifacts well.",
-    },
-    // OmniSR — lightweight, reliable, good balance of speed and quality
-    {
-      label: "OmniSR 2x",
-      filename: "OmniSR_X2_DIV2K.safetensors",
-      url: `${HF_BASE}/omnisr/OmniSR_X2_DIV2K.safetensors`,
-      description: "Tiny model (~1.6 MB). Quick and artifact-free 2x upscale.",
-    },
-    {
-      label: "OmniSR 3x",
-      filename: "OmniSR_X3_DIV2K.safetensors",
-      url: `${HF_BASE}/omnisr/OmniSR_X3_DIV2K.safetensors`,
-      description: "Tiny model (~1.7 MB). Balanced 3x upscale when 2x isn't enough and 4x is too much.",
-    },
-    {
-      label: "OmniSR 4x",
-      filename: "OmniSR_X4_DIV2K.safetensors",
-      url: `${HF_BASE}/omnisr/OmniSR_X4_DIV2K.safetensors`,
-      description: "Tiny model (~1.7 MB). Quick 4x upscale with solid detail for its size.",
-    },
-    // DAT — slow but highest quality, best for final output
-    {
-      label: "DAT 4x — IllustrationJaNai",
-      filename: "4x_IllustrationJaNai_V1_DAT2_190k.safetensors",
-      url: `${HF_BASE}/dat/4x_IllustrationJaNai_V1_DAT2_190k.safetensors`,
-      description: "Slow but excellent quality. Best for illustrations and anime final prints (~140 MB).",
-    },
-  ];
+  import { recommendedUpscaleModels as recommendedModels } from "../../utils/upscalers.js";
 
   let downloading = $state<string | null>(null);
   let downloadError = $state<string | null>(null);

--- a/src/lib/components/progress/PreviewImage.svelte
+++ b/src/lib/components/progress/PreviewImage.svelte
@@ -2,9 +2,15 @@
   import { progress } from "../../stores/progress.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
+  import { models } from "../../stores/models.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
-  import { generate, uploadImageBytes } from "../../utils/api.js";
+  import { generate, uploadImageBytes, downloadModel } from "../../utils/api.js";
   import { loadOutputImageForGenerationInput, uploadImageUrlForGenerationInput } from "../../utils/galleryActions.js";
+  import {
+    DEFAULT_REFINE_UPSCALER,
+    DEFAULT_REFINE_UPSCALER_SCALE,
+    recommendedUpscaleModels,
+  } from "../../utils/upscalers.js";
   import type { GenerationParams } from "../../types/index.js";
 
   let currentTipIndex = $state(0);
@@ -97,6 +103,22 @@
     return () => stopAutoPlay();
   });
 
+  /** Make sure the default refine upscale model is installed, downloading it
+   *  on first use (~1.6 MB). Returns false if it can't be made available. */
+  async function ensureDefaultRefineUpscaler(): Promise<boolean> {
+    if (models.upscaleModels.includes(DEFAULT_REFINE_UPSCALER)) return true;
+    const rec = recommendedUpscaleModels.find((r) => r.filename === DEFAULT_REFINE_UPSCALER);
+    if (!rec) return false;
+    try {
+      await downloadModel(rec.url, "upscale_models", rec.filename);
+      await models.refresh();
+      return true;
+    } catch (e) {
+      console.warn("Default refine upscaler download failed; keeping current upscale settings:", e);
+      return false;
+    }
+  }
+
   async function upscaleImage() {
     // The Refine button takes the most-recent output and runs it back through
     // the upscale chain (MooshieUI's "refiner") at low denoise — analogous to
@@ -132,6 +154,17 @@
       // the upscale chain alone is the refiner pass.
       params.refine_only = true;
       params.upscale_enabled = true;
+      // Default the refiner to the OmniSR 2x model upscaler unless the user
+      // has explicitly chosen a model upscaler in the Upscale settings.
+      let appliedDefaultUpscaler = false;
+      if (generation.upscaleMethod !== "model" || !generation.upscaleModel) {
+        if (await ensureDefaultRefineUpscaler()) {
+          params.upscale_method = "model";
+          params.upscale_model = DEFAULT_REFINE_UPSCALER;
+          params.upscale_scale = DEFAULT_REFINE_UPSCALER_SCALE;
+          appliedDefaultUpscaler = true;
+        }
+      }
       // ControlNet on a refine pass would re-condition the existing image
       // against the original control input, which is rarely what the user
       // wants. Disable it for this pass.
@@ -145,6 +178,11 @@
       generation.mode = "img2img";
       generation.inputImage = uploadName;
       generation.upscaleEnabled = true;
+      if (appliedDefaultUpscaler) {
+        generation.upscaleMethod = "model";
+        generation.upscaleModel = DEFAULT_REFINE_UPSCALER;
+        generation.upscaleScale = DEFAULT_REFINE_UPSCALER_SCALE;
+      }
     } catch (e) {
       console.error("Refine failed:", e);
       gallery.showToast(`${locale.t("preview.refine_failed")}: ${e}`, "error");

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -296,8 +296,14 @@ class ProgressStore {
     }
   }
 
-  /** Called when a prompt completes — removes it from the queue and returns its metadata. */
-  completePrompt(promptId: string): QueuedPrompt | undefined {
+  /** Called when a prompt completes — removes it from the queue and returns its metadata.
+   *
+   * `hasFinalImage` should be true when the caller is about to set the real
+   * output via `setLastOutputForMode` (finalizeOutputImages). The last preview
+   * frame is then discarded instead of being promoted to lastOutputImage —
+   * promoting it first risks the blurry progress frame sticking around if the
+   * final image swap fails. */
+  completePrompt(promptId: string, hasFinalImage = false): QueuedPrompt | undefined {
     const item = this.pendingPrompts.find((p) => p.promptId === promptId);
 
     if (item) {
@@ -319,7 +325,7 @@ class ProgressStore {
       this.generationStartTime = null;
       this._stopElapsedTimer();
 
-      if (this.previewImage && item) {
+      if (this.previewImage && item && !hasFinalImage) {
         this.setLastOutputForMode(item.mode, this.previewImage);
       }
       this.previewImage = null;

--- a/src/lib/utils/upscalers.ts
+++ b/src/lib/utils/upscalers.ts
@@ -1,0 +1,58 @@
+/** Curated upscale models offered in Upscale settings (auto-downloaded on
+ *  first selection). Shared with the preview Refine button, which defaults to
+ *  OmniSR 2x when the user hasn't picked a model upscaler. */
+
+export interface RecommendedUpscaleModel {
+  label: string;
+  filename: string;
+  url: string;
+  description: string;
+}
+
+const HF_BASE = "https://huggingface.co/AshtakaOOf/safetensored-upscalers/resolve/main";
+
+/** Default model upscaler used by the preview Refine button. */
+export const DEFAULT_REFINE_UPSCALER = "OmniSR_X2_DIV2K.safetensors";
+export const DEFAULT_REFINE_UPSCALER_SCALE = 2;
+
+export const recommendedUpscaleModels: RecommendedUpscaleModel[] = [
+  // SPAN — fast, sharp, excellent general-purpose upscaler
+  {
+    label: "SPAN 2x — Spanimation",
+    filename: "2x_ModernSpanimationV1.safetensors",
+    url: `${HF_BASE}/span/2x_ModernSpanimationV1.safetensors`,
+    description: "Fast 2x with clean lines and vivid colours. Great for anime and illustration.",
+  },
+  {
+    label: "SPAN 4x — NomosUni",
+    filename: "4xNomosUni_span_multijpg.safetensors",
+    url: `${HF_BASE}/span/4xNomosUni_span_multijpg.safetensors`,
+    description: "Fast 4x all-rounder. Handles photos, art, and JPEG artifacts well.",
+  },
+  // OmniSR — lightweight, reliable, good balance of speed and quality
+  {
+    label: "OmniSR 2x",
+    filename: "OmniSR_X2_DIV2K.safetensors",
+    url: `${HF_BASE}/omnisr/OmniSR_X2_DIV2K.safetensors`,
+    description: "Tiny model (~1.6 MB). Quick and artifact-free 2x upscale.",
+  },
+  {
+    label: "OmniSR 3x",
+    filename: "OmniSR_X3_DIV2K.safetensors",
+    url: `${HF_BASE}/omnisr/OmniSR_X3_DIV2K.safetensors`,
+    description: "Tiny model (~1.7 MB). Balanced 3x upscale when 2x isn't enough and 4x is too much.",
+  },
+  {
+    label: "OmniSR 4x",
+    filename: "OmniSR_X4_DIV2K.safetensors",
+    url: `${HF_BASE}/omnisr/OmniSR_X4_DIV2K.safetensors`,
+    description: "Tiny model (~1.7 MB). Quick 4x upscale with solid detail for its size.",
+  },
+  // DAT — slow but highest quality, best for final output
+  {
+    label: "DAT 4x — IllustrationJaNai",
+    filename: "4x_IllustrationJaNai_V1_DAT2_190k.safetensors",
+    url: `${HF_BASE}/dat/4x_IllustrationJaNai_V1_DAT2_190k.safetensors`,
+    description: "Slow but excellent quality. Best for illustrations and anime final prints (~140 MB).",
+  },
+];


### PR DESCRIPTION
## Summary

**Stuck blurry previews** (remaining holes after #282):
- `completePrompt()` no longer promotes the last blurry progress frame to `lastOutputImage` when a real final image is about to replace it — if the final-image fetch failed, the blurry frame stuck permanently
- `comfyui:preview` guard also rejects frames for prompts no longer in `pendingPrompts`, closing the queue race where `activePromptId` is briefly null between one prompt completing and the next starting
- `_temp_image` final-image fetches retry once after 1.5s (transient 401s during LAN session refresh were dropping the final image)
- temp-cache output recovery (previously reconciler-only) now also runs in the normal completion path, extracted as `recoverMissingOutputImages`

**Refine button default:** uses Model (Upscaler) OmniSR 2x — auto-downloads the ~1.6 MB model on first use — unless a model upscaler is already selected in Upscale settings. Recommended upscaler list extracted to shared `utils/upscalers.ts`.

**Prompt tag-highlight misalignment:** `scrollbar-gutter: stable` on the prompt textarea reserves the scrollbar track permanently, so text wrap width never changes when the scrollbar appears and the highlight/clickable overlays stay aligned.

```
 src/App.svelte                                     | 96 +++++++++++++++-------
 .../components/generation/PromptTextarea.svelte    |  2 +-
 .../components/generation/UpscaleSettings.svelte   | 52 +-----------
 src/lib/components/progress/PreviewImage.svelte    | 40 ++++++++-
 src/lib/stores/progress.svelte.ts                  | 12 ++-
 src/lib/utils/upscalers.ts                         | 58 +++++++++++++
 6 files changed, 175 insertions(+), 85 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)