### PR TITLE
v1.4.10: refine-only upscale, segment prompts, model detection, bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## What's New in v1.4.10
+
+### New Features
+- **Refine-only upscale**: send an existing image directly into the upscale/refine chain without re-running it through img2img first. Available as a checkbox in the Upscale settings panel when in img2img mode; the gallery "Upscale" action now enables it automatically.
+- **Segment prompt syntax**: SwarmUI-style `<segment:subject>` tags in the positive prompt trigger automatic detect-crop-refine-composite loops, applying per-region prompts to a masked area of the image without manual inpainting.
+
+### Improved Model Detection
+- **Richer base-model resolution**: model architecture is now resolved via a layered pipeline — safetensors header metadata, StabilityMatrix/Forge sidecar files, filename heuristics, and CivitAI hash lookup — with the result cached. Anima/Yume detection uses explicit markers to avoid false positives on Animation/Animagine models.
+
+### Bug Fixes
+- Fixed stuck blurry previews that could persist after generation completed; default refine upscaler changed to OmniSR 2x; corrected prompt overlay drift in the canvas.
+- Fixed stale preview images overwriting final output in the lightbox when a fetch was in-flight on completion.
+- Fixed img2img drag-drop in desktop mode; gallery favourites import from external formats; thumbnail assignment on fast generations.
+- Fixed LAN mode auth gaps: SSRF via cached image proxy, session migration data loss on re-login.
+- Fixed lock ordering inversion in LAN queue filter that could deadlock under concurrent prompt submissions.
+- Fixed CivitAI and sidecar-JSON error propagation in model spec reading: offline or rate-limited CivitAI no longer fails the whole model info panel; a corrupted sidecar no longer blocks the fallback chain.
+- Updated CSP to include Windows `http://{scheme}.localhost` forms for custom URI schemes and new allowed origins for connect-src.
+
+---
+
 ## What's New in v1.4.9
 
 ### Fixes and maintenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Project skills live in `.claude/skills/` (synced from canonical `.agents/skills/
 - **`error-logs/`**: drop large logs/stack traces here (git-ignored, excluded from context ingestion); read on demand by filename.
 - **Ring buffer log capture**: Rust `src-tauri/src/log_buffer.rs` (2000 lines) + frontend `src/lib/utils/log-buffer.ts` (1000) → `exportLogs()`. Console alone misses Rust output.
 - **Browser server lifecycle**: binds `127.0.0.1`, 120s idle heartbeat watchdog shuts it down unless LAN mode is enabled.
-- **CSP is null** in `src-tauri/tauri.conf.json`.
+- **CSP is enforced in production builds only** (`src-tauri/tauri.conf.json`; no `devCsp`, so `npm run tauri dev` never exercises it — CSP regressions only appear in release/`--debug` bundles). Any new remote `<img>`/`fetch` origin or custom URI scheme must be added to the CSP. Windows custom protocols resolve to `http://{scheme}.localhost` (Tauri v2 default), macOS/Linux to `{scheme}://` — img-src must list both forms.
 - **keep_alive config**: when true, the ComfyUI child process survives app close.
 - `comfyui-nodes/` is Python nodes installed into ComfyUI at setup — not app build output. `src-tauri/src/comfyui/` is the Rust ComfyUI client, not ComfyUI source.
 - **Agent config (canonical)**: `.agents/README.md` — skills in `.agents/skills/`, rules in `.agents/rules/` (mode-specific detail: architect, frontend, rust, debug, ask). `AGENTS.md` is the cross-agent entry point; deeper conventions in `.github/instructions/mooshieui.instructions.md`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+## What's New in v1.4.10
+
+### New Features
+- **Refine-only upscale**: send an existing image directly into the upscale/refine chain without re-running it through img2img first. Available as a checkbox in the Upscale settings panel when in img2img mode; the gallery "Upscale" action now enables it automatically.
+- **Segment prompt syntax**: SwarmUI-style `<segment:subject>` tags in the positive prompt trigger automatic detect-crop-refine-composite loops, applying per-region prompts to a masked area of the image without manual inpainting.
+
+### Improved Model Detection
+- **Richer base-model resolution**: model architecture is now resolved via a layered pipeline — safetensors header metadata, StabilityMatrix/Forge sidecar files, filename heuristics, and CivitAI hash lookup — with the result cached. Anima/Yume detection uses explicit markers to avoid false positives on Animation/Animagine models.
+
+### Bug Fixes
+- Fixed stuck blurry previews that could persist after generation completed; default refine upscaler changed to OmniSR 2x; corrected prompt overlay drift in the canvas.
+- Fixed stale preview images overwriting final output in the lightbox when a fetch was in-flight on completion.
+- Fixed img2img drag-drop in desktop mode; gallery favourites import from external formats; thumbnail assignment on fast generations.
+- Fixed LAN mode auth gaps: SSRF via cached image proxy, session migration data loss on re-login.
+- Fixed lock ordering inversion in LAN queue filter that could deadlock under concurrent prompt submissions.
+- Fixed CivitAI and sidecar-JSON error propagation in model spec reading: offline or rate-limited CivitAI no longer fails the whole model info panel; a corrupted sidecar no longer blocks the fallback chain.
+- Updated CSP to include Windows `http://{scheme}.localhost` forms for custom URI schemes and new allowed origins for connect-src.
+
+---
+
 ## What's New in v1.4.9
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.9"
+version = "1.4.10"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -3622,14 +3622,18 @@ pub(crate) async fn read_modelspec_internal(
         .map(str::to_string)
     {
         result.insert("base_model".to_string(), base_model);
-    } else if let Some(base_model) = read_forge_metadata(&path)?
+    } else if let Some(base_model) = read_forge_metadata(&path)
+        .ok()
+        .flatten()
         .as_ref()
         .and_then(|v| v.get("baseModel"))
         .and_then(|v| v.as_str())
         .map(str::to_string)
     {
         result.insert("base_model".to_string(), base_model);
-    } else if let Some(base_model) = read_stability_matrix_metadata(&path)?
+    } else if let Some(base_model) = read_stability_matrix_metadata(&path)
+        .ok()
+        .flatten()
         .as_ref()
         .and_then(|v| v.get("baseModel"))
         .and_then(|v| v.as_str())
@@ -3653,7 +3657,11 @@ pub(crate) async fn read_modelspec_internal(
             .map_err(|e| AppError::Other(format!("Hash task failed: {}", e)))??;
         let autov2 = autov2_hash(&hash);
         result.insert("hash".to_string(), autov2.clone());
-        if let Some(base_model) = lookup_civitai_base_model_by_hash(state, &autov2).await? {
+        if let Some(base_model) = lookup_civitai_base_model_by_hash(state, &autov2)
+            .await
+            .ok()
+            .flatten()
+        {
             result.insert("base_model".to_string(), base_model);
         }
     }

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2214,9 +2214,7 @@ async fn dispatch_command(
             let tracked: Vec<String> = {
                 let q = state.prompt_queue.queue.read().unwrap();
                 q.iter()
-                    .filter(|(pid, _)| {
-                        is_privileged || state.prompt_queue.is_owned_by(pid, &caller)
-                    })
+                    .filter(|(_, owner)| is_privileged || *owner == caller)
                     .map(|(pid, _)| pid.clone())
                     .collect()
             };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: https://asset.localhost https://thumbnail.localhost https://gallery.localhost; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://image.civitai.com https://cdn.civitai.com https://animadex.net; font-src 'self' data:; media-src 'self' blob: data:"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: thumbnail: gallery: http://asset.localhost https://asset.localhost http://thumbnail.localhost https://thumbnail.localhost http://gallery.localhost https://gallery.localhost https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://blobs.animadex.net; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://image.civitai.com https://cdn.civitai.com https://animadex.net https://thetacursed.github.io https://raw.githubusercontent.com; font-src 'self' data:; media-src 'self' blob: data:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Changes since v1.4.9

### New Features
- **Refine-only upscale** (#295): send an existing image directly into the upscale/refine chain without re-running img2img first; gallery Upscale action enables it automatically
- **Segment prompt syntax** (#292): SwarmUI-style `<segment:subject>` tags trigger detect-crop-refine-composite loops for per-region prompting

### Improved Model Detection (#290)
- Layered resolution: safetensors header -> StabilityMatrix/Forge sidecar -> filename heuristics -> CivitAI hash lookup
- Anima/Yume detection uses explicit markers; no more false positives on Animation/Animagine

### Bug Fixes
- Fix stuck blurry previews; default refine upscaler to OmniSR 2x; prompt overlay drift (#285)
- Fix stale preview overwriting final image in lightbox (#282)
- Fix img2img drag-drop, gallery favourites import, thumbnail assignment (#280)
- Fix LAN auth gaps: SSRF via cached image proxy, session migration data loss (#281)

### Bot Review Fixes (pre-tag)
- **Fix lock ordering inversion** in LAN queue tracker (webserver.rs): holding queue lock while calling is_owned_by which acquires owners lock was a potential deadlock under concurrent submissions
- **Fix CivitAI/sidecar error propagation** (commands/api.rs): ? on network/file errors replaced with ok().flatten() so offline users and corrupted sidecars no longer fail the whole model info panel

### Infrastructure
- CSP updated: Windows http://{scheme}.localhost forms for custom URI schemes, new connect-src origins
- CLAUDE.md: document CSP enforcement details

## Bot Triage
- **Fixed**: lock inversion (#281 follow-up), CivitAI/sidecar error propagation (#290 follow-up)
- **Deferred**: segment tag stripping in raw_positive_prompt (#292), recoverMissingOutputImages retry consistency (#285), Argon2 perf under write lock (#281)
- **Skipped**: getFilenameFromPath undefined claim -- function is defined locally in same file (bot wrong)