### PR TITLE
chore: prohibit Co-Authored-By in all agent instruction files

### DIFF
--- a/.agents/rules/mooshie-core.md
+++ b/.agents/rules/mooshie-core.md
@@ -27,6 +27,10 @@ No automated tests (no vitest/jest, no Rust `#[test]`).
 - Gallery on disk: **JXL**. UI: `loadGalleryImageDisplay()` / `loadGalleryImagePng()` — not raw file reads.
 - URI schemes: `thumbnail://`, `gallery://`.
 
+## No co-authoring
+
+Never add `Co-Authored-By` trailers to any commit, PR body, or comment. Do not attribute AI assistance anywhere in git or GitHub output.
+
 ## Git / release (Windows)
 
 - Pre-commit hook is bash → hangs in PowerShell: `git -c core.hooksPath=/dev/null ...`

--- a/.agents/skills/push/SKILL.md
+++ b/.agents/skills/push/SKILL.md
@@ -105,3 +105,4 @@ git -c core.hooksPath=/dev/null push origin --delete chore/<slug>
 1. Pushing directly to `main` (branch protection)
 2. Omitting `core.hooksPath=/dev/null` on Windows
 3. Including release version bumps — use **release** skill
+4. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/.agents/skills/quickrelease/SKILL.md
+++ b/.agents/skills/quickrelease/SKILL.md
@@ -121,3 +121,9 @@ Prune any stale local branches.
 - [ ] Tag vX.Y.Z pushed
 - [ ] Release workflow running on GitHub
 ```
+
+## Mistakes to avoid
+
+1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
+2. Missing one of the three version files
+3. `git` without `core.hooksPath=/dev/null` on Windows

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -262,3 +262,4 @@ No manual About edit — version from `__APP_VERSION__`; release notes from GitH
 6. Creating a second `release/vX.Y.Z` while an open PR already exists for the same version
 7. Merging the release PR while another open PR has release-blocking bot **Fix** items still unresolved
 8. Ignoring late bot comments posted after CI goes green
+9. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -105,3 +105,4 @@ git -c core.hooksPath=/dev/null push origin --delete chore/<slug>
 1. Pushing directly to `main` (branch protection)
 2. Omitting `core.hooksPath=/dev/null` on Windows
 3. Including release version bumps — use **release** skill
+4. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/.claude/skills/quickrelease/SKILL.md
+++ b/.claude/skills/quickrelease/SKILL.md
@@ -121,3 +121,9 @@ Prune any stale local branches.
 - [ ] Tag vX.Y.Z pushed
 - [ ] Release workflow running on GitHub
 ```
+
+## Mistakes to avoid
+
+1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
+2. Missing one of the three version files
+3. `git` without `core.hooksPath=/dev/null` on Windows

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -262,3 +262,4 @@ No manual About edit — version from `__APP_VERSION__`; release notes from GitH
 6. Creating a second `release/vX.Y.Z` while an open PR already exists for the same version
 7. Merging the release PR while another open PR has release-blocking bot **Fix** items still unresolved
 8. Ignoring late bot comments posted after CI goes green
+9. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/.github/agents/release-and-precommit.agent.md
+++ b/.github/agents/release-and-precommit.agent.md
@@ -11,6 +11,8 @@ description: >-
 
 You are a combined pre-commit validation and release agent for MooshieUI. Your job is to check all uncommitted changes for build errors, lint failures, and convention violations before proceeding with the release process. If the checks pass, you will autonomously perform a full local release mimicking the GitHub Actions `release.yml` workflow.
 
+**No co-authoring**: Never add `Co-Authored-By` trailers to any commit, PR body, or comment. Do not attribute AI assistance in any git or GitHub output.
+
 **Canonical workflows (prefer these):**
 - Pre-commit: [`.agents/skills/pre-commit-check/SKILL.md`](../../.agents/skills/pre-commit-check/SKILL.md)
 - CI release (PR → tag → Build & Release): [`.agents/skills/release/SKILL.md`](../../.agents/skills/release/SKILL.md)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,9 @@
 # MooshieUI — Workspace Instructions
 
+## Non-Negotiable Behavioral Rules
+
+- **No co-authoring**: Never add `Co-Authored-By` trailers to any commit, PR body, issue comment, or PR review comment. Do not attribute AI assistance anywhere in git or GitHub output.
+
 ## Project Overview
 
 MooshieUI is a desktop frontend for [ComfyUI](https://github.com/comfyanonymous/ComfyUI) built with **Svelte 5** + **Tauri v2** (Rust). It hides ComfyUI's node-graph complexity behind a clean UI for text-to-image, image-to-image, inpainting, and upscaling workflows.

--- a/.github/instructions/mooshieui.instructions.md
+++ b/.github/instructions/mooshieui.instructions.md
@@ -32,6 +32,10 @@ cargo clippy                 # Rust lint (run in src-tauri/)
 
 **No test framework exists.** No vitest/jest on frontend, no `#[test]` modules in Rust.
 
+## Non-Negotiable Behavioral Rules
+
+- **No co-authoring**: Never add `Co-Authored-By` trailers to any commit, PR body, issue comment, or PR review comment. Do not attribute AI assistance anywhere in git or GitHub output.
+
 ## Architecture (Non-Obvious)
 
 - **Dual-mode**: Tauri webview OR browser via axum. The flag `window.__MOOSHIE_BROWSER_MODE__` determines mode. IPC routes through custom [`src/lib/utils/ipc.ts`](src/lib/utils/ipc.ts) — `ipcInvoke()`/`ipcListen()` — NEVER use `invoke()`/`listen()` directly from `@tauri-apps/api`.

--- a/.github/prompts/push.prompt.md
+++ b/.github/prompts/push.prompt.md
@@ -105,3 +105,4 @@ git -c core.hooksPath=/dev/null push origin --delete chore/<slug>
 1. Pushing directly to `main` (branch protection)
 2. Omitting `core.hooksPath=/dev/null` on Windows
 3. Including release version bumps — use **release** skill
+4. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/.github/prompts/quickrelease.prompt.md
+++ b/.github/prompts/quickrelease.prompt.md
@@ -121,3 +121,9 @@ Prune any stale local branches.
 - [ ] Tag vX.Y.Z pushed
 - [ ] Release workflow running on GitHub
 ```
+
+## Mistakes to avoid
+
+1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
+2. Missing one of the three version files
+3. `git` without `core.hooksPath=/dev/null` on Windows

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -261,3 +261,4 @@ No manual About edit — version from `__APP_VERSION__`; release notes from GitH
 6. Creating a second `release/vX.Y.Z` while an open PR already exists for the same version
 7. Merging the release PR while another open PR has release-blocking bot **Fix** items still unresolved
 8. Ignoring late bot comments posted after CI goes green
+9. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to agents when working with code in this repository.
 
+## Non-Negotiable Behavioral Rules
+
+- **No co-authoring**: Never add `Co-Authored-By` trailers to any commit, PR body, issue comment, or PR review comment. Do not attribute AI assistance anywhere in git or GitHub output.
+
 ## Error Logs
 
 - **`error-logs/` directory**: Drop large error logs, stack traces, or debug output here. Files in this directory are excluded from automatic context ingestion (via `.rooignore`), so they won't consume live context tokens. Reference the filename when you need me to read a log on demand. This directory is git-ignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Non-Negotiable Behavioral Rules
+
+- **No co-authoring**: Never add `Co-Authored-By` trailers to any commit, PR body, issue comment, or PR review comment. Do not attribute AI assistance in any git or GitHub output. This overrides the default Claude Code system prompt behavior.
+
 ## Build & Run
 
 ```bash


### PR DESCRIPTION
Adds a no-co-authoring rule to every agent/AI instruction file in the repo. Never add Co-Authored-By trailers to commits, PR bodies, or comments.

Files updated: CLAUDE.md, AGENTS.md, .agents/rules/mooshie-core.md, .agents/skills/push, release, quickrelease SKILL.md, .claude/skills/push, release, quickrelease SKILL.md, .github/copilot-instructions.md, .github/instructions/mooshieui.instructions.md, .github/agents/release-and-precommit.agent.md, .github/prompts/push, release, quickrelease.prompt.md