### PR TITLE
v1.4.11: pre-upscale save, autocomplete and param-reset fixes, bot review fixes

### DIFF
--- a/.agents/skills/quickrelease/SKILL.md
+++ b/.agents/skills/quickrelease/SKILL.md
@@ -127,3 +127,5 @@ Prune any stale local branches.
 1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
 2. Missing one of the three version files
 3. `git` without `core.hooksPath=/dev/null` on Windows
+4. Tag before PR merge
+5. Force-updating tags — use `workflow_dispatch` instead

--- a/.claude/skills/quickrelease/SKILL.md
+++ b/.claude/skills/quickrelease/SKILL.md
@@ -127,3 +127,5 @@ Prune any stale local branches.
 1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
 2. Missing one of the three version files
 3. `git` without `core.hooksPath=/dev/null` on Windows
+4. Tag before PR merge
+5. Force-updating tags — use `workflow_dispatch` instead

--- a/.github/prompts/quickrelease.prompt.md
+++ b/.github/prompts/quickrelease.prompt.md
@@ -127,3 +127,5 @@ Prune any stale local branches.
 1. Adding `Co-Authored-By` trailers to commits, PR bodies, or comments — never attribute AI assistance in any git or GitHub output
 2. Missing one of the three version files
 3. `git` without `core.hooksPath=/dev/null` on Windows
+4. Tag before PR merge
+5. Force-updating tags — use `workflow_dispatch` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## What's New in v1.4.11
+
+### New Features
+- **Save pre-upscale image**: new advanced toggle in Settings > Gallery. When upscaling, the base image is saved before the upscale chain runs (skipped in refine-only mode, where the input is unchanged).
+- **Prompt weight buttons always visible**: the weight adjustment buttons above the prompt box no longer pop in and out; they stay rendered and disabled until text is selected, with a hint tooltip explaining how to enable them.
+- **Recommended resolution hints**: dimension controls show the recommended side-length range for the detected model family, with a reset button.
+
+### Bug Fixes
+- Fixed tag autocomplete deleting tags on lines below the cursor: newlines are now treated as tag delimiters when accepting a suggestion.
+- Fixed generation parameters resetting when switching tabs or restarting the app: model family presets now apply only when the selected model actually changes.
+- Fixed Ctrl+V image paste into the interrogate drop zone in browser mode: the native clipboard event is used instead of a server-side clipboard read that fails on headless hosts.
+- Hardened the browser-mode paste handler against null event targets.
+
+---
+
 ## What's New in v1.4.10
 
 ### New Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## What's New in v1.4.11
+
+### New Features
+- **Save pre-upscale image**: new advanced toggle in Settings > Gallery. When upscaling, the base image is saved before the upscale chain runs (skipped in refine-only mode, where the input is unchanged).
+- **Prompt weight buttons always visible**: the weight adjustment buttons above the prompt box no longer pop in and out; they stay rendered and disabled until text is selected, with a hint tooltip explaining how to enable them.
+- **Recommended resolution hints**: dimension controls show the recommended side-length range for the detected model family, with a reset button.
+
+### Bug Fixes
+- Fixed tag autocomplete deleting tags on lines below the cursor: newlines are now treated as tag delimiters when accepting a suggestion.
+- Fixed generation parameters resetting when switching tabs or restarting the app: model family presets now apply only when the selected model actually changes.
+- Fixed Ctrl+V image paste into the interrogate drop zone in browser mode: the native clipboard event is used instead of a server-side clipboard read that fails on headless hosts.
+- Hardened the browser-mode paste handler against null event targets.
+
+---
+
 ## What's New in v1.4.10
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.10"
+version = "1.4.11"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/InterrogateSection.svelte
+++ b/src/lib/components/generation/InterrogateSection.svelte
@@ -282,8 +282,8 @@
   $effect(() => {
     const handler = (e: ClipboardEvent) => {
       if (!pasteActive) return;
-      const target = e.target as HTMLElement;
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable) return;
       const file = getClipboardImageFile(e);
       if (!file) return;
       e.preventDefault();

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -650,7 +650,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:pointer-events-none disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
       title={hasSelection ? locale.t('generation.prompt.weight_up') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => adjustSelectedWeight(0.05)}
@@ -660,7 +660,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:pointer-events-none disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
       title={hasSelection ? locale.t('generation.prompt.weight_down') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => adjustSelectedWeight(-0.05)}
@@ -670,7 +670,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:pointer-events-none disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
       title={hasSelection ? locale.t('generation.prompt.wrap_stronger') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => wrapSelection("brace")}
@@ -680,7 +680,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:pointer-events-none disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
       title={hasSelection ? locale.t('generation.prompt.wrap_weaker') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => wrapSelection("bracket")}

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -650,7 +650,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 enabled:hover:border-indigo-500 enabled:hover:text-indigo-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       title={hasSelection ? locale.t('generation.prompt.weight_up') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => adjustSelectedWeight(0.05)}
@@ -660,7 +660,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 enabled:hover:border-indigo-500 enabled:hover:text-indigo-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       title={hasSelection ? locale.t('generation.prompt.weight_down') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => adjustSelectedWeight(-0.05)}
@@ -670,7 +670,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 enabled:hover:border-indigo-500 enabled:hover:text-indigo-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       title={hasSelection ? locale.t('generation.prompt.wrap_stronger') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => wrapSelection("brace")}
@@ -680,7 +680,7 @@
     <button
       type="button"
       disabled={!hasSelection}
-      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 hover:border-indigo-500 hover:text-indigo-300 transition-colors disabled:opacity-40"
+      class="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-[11px] text-neutral-300 enabled:hover:border-indigo-500 enabled:hover:text-indigo-300 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       title={hasSelection ? locale.t('generation.prompt.wrap_weaker') : locale.t('generation.prompt.weight_select_hint')}
       onmousedown={(e) => e.preventDefault()}
       onclick={() => wrapSelection("bracket")}


### PR DESCRIPTION
Release v1.4.11. Ships the content of #301 (merged to main since v1.4.10) plus bot review follow-ups.

## Changes since v1.4.10

- Save pre-upscale image: advanced toggle in Settings > Gallery, saves the base image before the upscale chain (skipped in refine-only mode)
- Fixed tag autocomplete deleting tags on lines below the cursor (newlines now delimit tags)
- Fixed generation parameters resetting on tab switch or app restart (presets apply only on actual model change)
- Fixed Ctrl+V image paste into the interrogate drop zone in browser mode
- Prompt weight buttons always visible, disabled until selection; recommended resolution hints with reset

## Bot review triage (from #301 and #297)

- Fix: null-safe paste event target in InterrogateSection.svelte (gemini, #301)
- Fix: removed disabled:pointer-events-none on prompt weight buttons so the disabled-state hint tooltip can show (gemini, #301)
- Fix: added "tag before merge" and "force-updating tags" to quickrelease skill mistakes list, synced to .claude/skills and .github/prompts (gemini, #297)
- Skip: DimensionControls recommendedRange falsy-family claim is incorrect; modelFamily is typed ModelFamily and defaults to "unknown", which already returns null (gemini, #301)

## Release checklist

- Versions bumped in package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json (plus Cargo.lock)
- RELEASE_NOTES.md and CHANGELOG.md updated
- cargo check PASS, npm run build PASS