### PR TITLE
lock panel wheel scrolling to element under cursor at gesture start

### DIFF
--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -3,6 +3,7 @@
   import { compare } from "../../stores/compare.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
   import { scrollCapture } from "../../utils/scrollCapture.js";
+  import { wheelScrollLock } from "../../utils/wheelScrollLock.js";
   import PromptInputs from "./PromptInputs.svelte";
   import RegionalPromptModal from "./RegionalPromptModal.svelte";
   import ModelSelector from "./ModelSelector.svelte";
@@ -2061,6 +2062,7 @@
       {#if !leftCollapsed || mobileFriendly}
         <div
           bind:this={leftColumnRef}
+          use:wheelScrollLock
           class="{mobileFriendly
             ? 'fixed left-0 right-0 top-0 bg-neutral-950 flex flex-col overflow-hidden will-change-transform'
             : 'overflow-y-auto overflow-x-hidden px-3 pt-2 flex flex-col gap-2 shrink-0 border-r'} {draggingSection && pendingDrop?.side === 'left' ? 'border-indigo-500/50' : 'border-transparent'} {compare.enabled ? 'compare-cell-glow' : ''}"
@@ -2269,6 +2271,7 @@
     {#if (rightHasSections || controlsSide === "right" || draggingSection) && (!rightCollapsed || mobileFriendly)}
       <div
         bind:this={rightColumnRef}
+        use:wheelScrollLock
         class="{mobileFriendly
           ? 'fixed left-0 right-0 top-0 bg-neutral-950 flex flex-col overflow-hidden will-change-transform'
           : 'overflow-y-auto p-3 flex flex-col gap-2 shrink-0 border-l'} {draggingSection && pendingDrop?.side === 'right' ? 'border-indigo-500/50' : 'border-transparent'} {compare.enabled ? 'compare-cell-glow' : ''}"

--- a/src/lib/utils/wheelScrollLock.ts
+++ b/src/lib/utils/wheelScrollLock.ts
@@ -1,0 +1,68 @@
+/**
+ * Svelte action: lock wheel scrolling to whatever scrollable is under the
+ * cursor when the wheel gesture STARTS.
+ *
+ * Usage: <div use:wheelScrollLock> on a scrollable section that contains
+ * nested scrollables (prompt textareas, lists, etc.).
+ *
+ * - Gesture starts over a nested scrollable → only that element scrolls,
+ *   even when it hits its end (no scroll chaining to the section).
+ * - Gesture starts over anything else → only the section scrolls, even if
+ *   the cursor drifts over a nested scrollable mid-gesture.
+ * - A pause in wheel events ends the gesture; the next wheel event picks a
+ *   new target from the cursor position.
+ */
+
+const GESTURE_PAUSE_MS = 250;
+const LINE_HEIGHT_PX = 16;
+
+function isScrollableY(el: HTMLElement): boolean {
+  if (el.scrollHeight <= el.clientHeight + 1) return false;
+  const overflowY = getComputedStyle(el).overflowY;
+  return overflowY === "auto" || overflowY === "scroll";
+}
+
+export function wheelScrollLock(node: HTMLElement) {
+  let lockedTarget: HTMLElement | null = null;
+  let lastWheelAt = 0;
+
+  function findScrollTarget(start: EventTarget | null): HTMLElement | null {
+    let el = start instanceof Element ? start : null;
+    while (el && el !== node) {
+      if (el instanceof HTMLElement && isScrollableY(el)) return el;
+      el = el.parentElement;
+    }
+    return isScrollableY(node) ? node : null;
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (e.ctrlKey) return; // pinch-zoom / browser zoom gesture
+    if (e.deltaY === 0 || Math.abs(e.deltaX) > Math.abs(e.deltaY)) return;
+
+    const gestureStarting = e.timeStamp - lastWheelAt > GESTURE_PAUSE_MS;
+    lastWheelAt = e.timeStamp;
+    if (gestureStarting || !lockedTarget?.isConnected) {
+      lockedTarget = findScrollTarget(e.target);
+    }
+    if (!lockedTarget) return;
+
+    e.preventDefault();
+    const delta =
+      e.deltaMode === WheelEvent.DOM_DELTA_LINE
+        ? e.deltaY * LINE_HEIGHT_PX
+        : e.deltaMode === WheelEvent.DOM_DELTA_PAGE
+          ? e.deltaY * lockedTarget.clientHeight
+          : e.deltaY;
+    lockedTarget.scrollTop += delta;
+  }
+
+  // Non-passive: we call preventDefault to stop the browser's own scroll
+  // (and its hover-based target pick) once a gesture is locked.
+  node.addEventListener("wheel", onWheel, { passive: false });
+
+  return {
+    destroy() {
+      node.removeEventListener("wheel", onWheel);
+    },
+  };
+}


### PR DESCRIPTION
Wheel scrolling in the generation page side panels now locks to whatever scrollable is under the cursor when the gesture starts: starting over an overflowing nested scrollable (e.g. the prompt textarea) scrolls only it with no chaining to the panel; starting anywhere else scrolls the panel even if the cursor drifts over a nested scrollable mid-gesture. A 250ms pause ends the gesture and re-picks the target.

 src/lib/components/generation/GenerationPage.svelte |  3 +++
 src/lib/utils/wheelScrollLock.ts (new)              | 68 ++++++++++++++++++++