### PR TITLE
fix(docker): copy anima-tags.json into the server build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN cd src-tauri && \
 
 # Now copy the real source and build
 COPY src-tauri/ src-tauri/
+# The prompt-assistant grounding corpus is include_str!'d from the frontend
+# asset tree (src/lib/assets/anima-tags.json), which lives outside src-tauri.
+COPY src/lib/assets/anima-tags.json src/lib/assets/anima-tags.json
 RUN touch src-tauri/src/lib.rs src-tauri/src/server_main.rs src-tauri/src/main.rs && \
     cd src-tauri && \
     cargo build --release --no-default-features --features server --bin mooshieui-server


### PR DESCRIPTION
The `docker-publish` job in the v1.4.13 release failed to compile the server binary:

```
error: couldn't read `src/prompt_assistant/../../../src/lib/assets/anima-tags.json`: No such file or directory
```

## Cause
The prompt-assistant grounding corpus is `include_str!`d from `src/lib/assets/anima-tags.json` ([grounding.rs:31](src-tauri/src/prompt_assistant/grounding.rs#L31)), which lives outside `src-tauri/`. The Dockerfile builder stage only `COPY src-tauri/`, so the file is missing at compile time. The `build-server` job (full checkout) and the desktop builds were unaffected. This gap was latent because `docker-publish` was skipped on the prior failed v1.4.12 run, so it never executed until v1.4.13.

## Fix
Copy `src/lib/assets/anima-tags.json` into the build stage before compiling. No app code or version change.

After merge, the v1.4.13 Docker image can be published by re-dispatching the release workflow with `tag=v1.4.13` from `main`.