### PR TITLE
v1.4.14: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v1.4.14
+
+### Fixes and maintenance
+- **Prompt Assistant errors are now visible**: Enhance and Compose failures surface the real backend reason (model-load crash, missing shared library, health timeout) in the toast and console instead of a generic message, so failures are diagnosable from the UI alone, especially on headless server deployments.
+- **Fixed server-mode Enhance/Compose returning HTTP 500**: the Docker image now installs `libgomp1`, which the Prompt Assistant's CPU llama.cpp build requires; without it `llama-server` exited immediately on load and every enhance/compose request failed.
+- **Export Logs now works in browser/server mode**: it produces a downloadable diagnostic log (including the Prompt Assistant `llama-server` log) for remote users, instead of doing nothing.
+
+---
+
 ## What's New in v1.4.13
 
 ### Prompt Assistant (local LLM)

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,10 +70,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 # System packages
+# libgomp1 is required by the prompt-assistant llama.cpp CPU build (OpenMP); the
+# CUDA runtime base image does not ship it, so without it llama-server exits
+# immediately on load with "error while loading shared libraries: libgomp.so.1"
+# and every enhance/compose request 500s.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12 python3.12-venv python3-pip \
     git curl ca-certificates \
-    libxcb1 libglib2.0-0 libgl1 \
+    libxcb1 libglib2.0-0 libgl1 libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (fast Python package manager)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v1.4.14
+
+### Fixes and maintenance
+- **Prompt Assistant errors are now visible**: Enhance and Compose failures surface the real backend reason (model-load crash, missing shared library, health timeout) in the toast and console instead of a generic message, so failures are diagnosable from the UI alone, especially on headless server deployments.
+- **Fixed server-mode Enhance/Compose returning HTTP 500**: the Docker image now installs `libgomp1`, which the Prompt Assistant's CPU llama.cpp build requires; without it `llama-server` exited immediately on load and every enhance/compose request failed.
+- **Export Logs now works in browser/server mode**: it produces a downloadable diagnostic log (including the Prompt Assistant `llama-server` log) for remote users, instead of doing nothing.
+
+---
+
 ## What's New in v1.4.13
 
 ### Prompt Assistant (local LLM)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.13"
+version = "1.4.14"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.13"
+version = "1.4.14"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -4762,6 +4762,17 @@ pub async fn export_logs(
     destination: String,
     frontend_logs: Option<Vec<String>>,
 ) -> Result<(), AppError> {
+    let output = build_diagnostic_log(&state, frontend_logs).await;
+    std::fs::write(&destination, &output)?;
+    Ok(())
+}
+
+/// Build the full diagnostic log text (config, GPU, Python/ComfyUI versions,
+/// ComfyUI + llama-server logs, Rust/frontend ring buffers). Shared by the
+/// desktop `export_logs` command (which writes it to a file) and the
+/// browser/server-mode handler (which returns it for a client-side download).
+#[cfg(any(feature = "desktop", feature = "server"))]
+pub async fn build_diagnostic_log(state: &AppState, frontend_logs: Option<Vec<String>>) -> String {
     use std::fmt::Write;
 
     // Fold any newly-submitted frontend logs into the ring buffer so repeat
@@ -4910,6 +4921,22 @@ pub async fn export_logs(
         }
     }
 
+    // Prompt-assistant llama-server stderr log (model-load diagnostics such as
+    // missing shared libraries, unsupported architectures, health timeouts).
+    let _ = writeln!(output);
+    let _ = writeln!(output, "=== Prompt Assistant (llama-server) Log ===");
+    match state.prompt_assistant.server.read_server_log() {
+        Some(content) if !content.trim().is_empty() => {
+            let _ = write!(output, "{}", content);
+        }
+        Some(_) => {
+            let _ = writeln!(output, "(log file is empty)");
+        }
+        None => {
+            let _ = writeln!(output, "(no llama-server log yet)");
+        }
+    }
+
     // Rust-side log ring buffer (captured by log_buffer::RingLogger)
     let rust_lines = crate::log_buffer::snapshot_rust();
     if !rust_lines.is_empty() {
@@ -4934,9 +4961,7 @@ pub async fn export_logs(
         }
     }
 
-    // Write to destination
-    std::fs::write(&destination, &output)?;
-    Ok(())
+    output
 }
 
 /// Append a batch of frontend console log lines to the in-memory diagnostics

--- a/src-tauri/src/prompt_assistant/server.rs
+++ b/src-tauri/src/prompt_assistant/server.rs
@@ -117,6 +117,13 @@ impl LlamaServer {
         self.bin_dir.join("llama-server.log")
     }
 
+    /// Full contents of the captured llama-server stderr log, if it exists.
+    /// Used by the diagnostics export so prompt-assistant load failures are
+    /// visible to remote/server-mode users who can't reach the host filesystem.
+    pub fn read_server_log(&self) -> Option<String> {
+        std::fs::read_to_string(self.log_path()).ok()
+    }
+
     /// Returns the child's exit status if it has already terminated.
     async fn child_exit_status(&self) -> Option<std::process::ExitStatus> {
         let mut guard = self.child.lock().await;

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -3925,25 +3925,21 @@ async fn dispatch_command(
             Ok(releases)
         }
         "export_logs" => {
-            let destination = args["destination"]
-                .as_str()
-                .ok_or("Missing destination")?
-                .to_string();
-            // Fold any frontend logs from the payload into the shared ring
-            // buffer before exporting so this handler matches the desktop
-            // command's behaviour.
-            if let Some(lines) = args.get("frontendLogs").and_then(|v| v.as_array()) {
-                let strings: Vec<String> = lines
-                    .iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect();
-                crate::log_buffer::push_frontend_lines(strings);
-            }
-            // Simplified: just write config info to the destination
-            let cfg = state.config.read().await;
-            let info = format!("MooshieUI Log Export\nConfig: {:?}", *cfg);
-            std::fs::write(&destination, info).map_err(|e| e.to_string())?;
-            Ok(serde_json::json!(null))
+            // In server/browser mode there is no meaningful host filesystem path
+            // for a remote browser, so build the full diagnostic log (same
+            // content as the desktop command, including the llama-server log) and
+            // return it as a string for the client to download.
+            let frontend_logs = args
+                .get("frontendLogs")
+                .and_then(|v| v.as_array())
+                .map(|lines| {
+                    lines
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<String>>()
+                });
+            let content = crate::commands::api::build_diagnostic_log(&state, frontend_logs).await;
+            Ok(serde_json::json!({ "content": content }))
         }
 
         "download_model" => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/PromptComposeModal.svelte
+++ b/src/lib/components/generation/PromptComposeModal.svelte
@@ -26,12 +26,20 @@
         error = locale.t("prompt_assistant.couldnt_compose");
       }
     } catch (e) {
+      console.error("Prompt compose failed:", e);
       const msg = String(e);
-      error = msg.includes("busy_generation")
-        ? locale.t("prompt_assistant.busy_generation")
-        : msg.includes("no_model")
-          ? locale.t("prompt_assistant.no_model")
+      if (msg.includes("busy_generation")) {
+        error = locale.t("prompt_assistant.busy_generation");
+      } else if (msg.includes("no_model")) {
+        error = locale.t("prompt_assistant.no_model");
+      } else {
+        // Surface the real backend reason instead of a generic message so
+        // server-side failures are diagnosable from the UI alone.
+        const detail = msg.replace(/^Error:\s*/, "").trim();
+        error = detail
+          ? `${locale.t("prompt_assistant.error_generic")}: ${detail}`
           : locale.t("prompt_assistant.error_generic");
+      }
     }
   }
 

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -89,6 +89,7 @@
         gallery.showToast(locale.t("prompt_assistant.couldnt_enhance"), "error");
       }
     } catch (e) {
+      console.error("Prompt enhance failed:", e);
       gallery.showToast(mapLlmError(String(e)), "error");
     }
   }
@@ -120,7 +121,14 @@
   function mapLlmError(msg: string): string {
     if (msg.includes("busy_generation")) return locale.t("prompt_assistant.busy_generation");
     if (msg.includes("no_model")) return locale.t("prompt_assistant.no_model");
-    return locale.t("prompt_assistant.error_generic");
+    // Surface the real backend reason (llama-server crash tail, missing shared
+    // library, health timeout, etc.) instead of a generic message — the detailed
+    // string is what makes a failed enhance diagnosable, especially on headless
+    // server deployments where the only signal the user sees is this toast.
+    const detail = msg.replace(/^Error:\s*/, "").trim();
+    return detail
+      ? `${locale.t("prompt_assistant.error_generic")}: ${detail}`
+      : locale.t("prompt_assistant.error_generic");
   }
 
   function onSetupInstalled() {

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AppConfig, QueueInfo } from "../../types/index.js";
-  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, getGalleryPath, setGalleryPath, setStorageLimit, installAttentionBackend, checkAttentionBackend, clearAllQueues, getQueue, getGpuStats } from "../../utils/api.js";
+  import { getConfig, updateConfig, stopComfyui, startComfyui, fetchReleaseNotes, importImageDirectory, exportLogs, exportLogsContent, getGalleryPath, setGalleryPath, setStorageLimit, installAttentionBackend, checkAttentionBackend, clearAllQueues, getQueue, getGpuStats } from "../../utils/api.js";
   import type { ReleaseNote, ImportResult, AttentionBackendStatus } from "../../utils/api.js";
   import { connection } from "../../stores/connection.svelte.js";
   import { autocomplete } from "../../stores/autocomplete.svelte.js";
@@ -665,21 +665,43 @@
   let galleryPathMessage = $state<string | null>(null);
 
   async function handleExportLogs() {
-    let destination: string | null = null;
     if (isTauri) {
       const { save: saveDialog } = await import("@tauri-apps/plugin-dialog");
-      destination = await saveDialog({
+      const destination = await saveDialog({
         title: locale.t('settings.about.save_dialog_title'),
         defaultPath: "mooshieui-diagnostics.log",
         filters: [{ name: locale.t("settings.about.log_files_filter"), extensions: ["log", "txt"] }],
       });
+      if (!destination) return;
+      exportingLogs = true;
+      logExportDone = false;
+      logExportError = null;
+      try {
+        await exportLogs(destination);
+        logExportDone = true;
+        setTimeout(() => (logExportDone = false), 4000);
+      } catch (e) {
+        logExportError = String(e);
+      } finally {
+        exportingLogs = false;
+      }
+      return;
     }
-    if (!destination) return;
+    // Browser/server mode: fetch the diagnostic text and download it client-side.
     exportingLogs = true;
     logExportDone = false;
     logExportError = null;
     try {
-      await exportLogs(destination);
+      const content = await exportLogsContent();
+      const blob = new Blob([content], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "mooshieui-diagnostics.log";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
       logExportDone = true;
       setTimeout(() => (logExportDone = false), 4000);
     } catch (e) {

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -825,6 +825,16 @@ export async function exportLogs(destination: string): Promise<void> {
   });
 }
 
+// Browser/server mode: the backend has no meaningful local path to write to for
+// a remote browser, so it returns the diagnostic text and the caller triggers a
+// client-side download.
+export async function exportLogsContent(): Promise<string> {
+  const res = await ipcInvoke<{ content: string }>("export_logs", {
+    frontendLogs: getLogSnapshot(),
+  });
+  return res.content;
+}
+
 export async function getGpuStats(): Promise<GpuStats[]> {
   if (isTauri) {
     return ipcInvoke("get_gpu_stats");


### PR DESCRIPTION
Fast-path release with Prompt Assistant diagnostics fixes.

### Fixes and maintenance
- **Prompt Assistant errors are now visible**: Enhance and Compose failures surface the real backend reason (model-load crash, missing shared library, health timeout) in the toast and console instead of a generic message, so failures are diagnosable from the UI alone, especially on headless server deployments.
- **Fixed server-mode Enhance/Compose returning HTTP 500**: the Docker image now installs `libgomp1`, which the Prompt Assistant CPU llama.cpp build requires; without it `llama-server` exited immediately on load and every enhance/compose request failed.
- **Export Logs now works in browser/server mode**: it produces a downloadable diagnostic log (including the Prompt Assistant `llama-server` log) for remote users, instead of doing nothing.