### PR TITLE
v1.4.16: GPU-accelerated prompt assistant on server image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.16
+
+### Prompt Assistant (server / GPU)
+- **GPU-accelerated enhance/compose on the server image**: the Docker image now ships a CUDA-enabled `llama-server` and points the app at it, so prompt enhancement offloads to the GPU and finishes in seconds. The llama.cpp release only provides a CPU build for Linux, which made a 7B model take longer than Cloudflare's 100s proxy timeout and fail with a 524. The app can now use a pre-provisioned binary via the `MOOSHIEUI_LLAMA_BIN_DIR` environment variable. (Requires rebuilding the Docker image; the CUDA build needs the container to be run with GPU access.)
+
+---
+
 ## What's New in v1.4.15
 
 ### Fixes and maintenance

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,17 @@ RUN touch src-tauri/src/lib.rs src-tauri/src/server_main.rs src-tauri/src/main.r
     cargo build --release --no-default-features --features server --bin mooshieui-server
 
 # ---------------------------------------------------------------------------
+# Stage 2b: CUDA-enabled llama.cpp server (prompt assistant)
+# ---------------------------------------------------------------------------
+# The llama.cpp GitHub release assets only ship a CPU build for Linux, so the
+# app would otherwise run enhance/compose on CPU even though the host has GPUs.
+# A 7B model on CPU takes >100s and trips Cloudflare's 524 timeout. Pull the
+# official CUDA server image and copy its binary + ggml/llama shared libs; the
+# app is pointed at them via MOOSHIEUI_LLAMA_BIN_DIR so `-ngl` offloads to the
+# GPU and a generation finishes in seconds. Pin a digest for reproducibility.
+FROM ghcr.io/ggml-org/llama.cpp:server-cuda AS llama
+
+# ---------------------------------------------------------------------------
 # Stage 3: Runtime with CUDA + Python + ComfyUI
 # ---------------------------------------------------------------------------
 FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
@@ -67,17 +78,20 @@ ENV DEBIAN_FRONTEND=noninteractive \
     MOOSHIEUI_DATA_DIR=/data \
     COMFYUI_PATH=/opt/comfyui \
     NVIDIA_VISIBLE_DEVICES=all \
-    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    MOOSHIEUI_LLAMA_BIN_DIR=/app/llama \
+    LD_LIBRARY_PATH=/app/llama:${LD_LIBRARY_PATH}
 
 # System packages
-# libgomp1 is required by the prompt-assistant llama.cpp CPU build (OpenMP); the
+# libgomp1 is required by the prompt-assistant llama.cpp build (OpenMP); the
 # CUDA runtime base image does not ship it, so without it llama-server exits
 # immediately on load with "error while loading shared libraries: libgomp.so.1"
-# and every enhance/compose request 500s.
+# and every enhance/compose request 500s. libcurl4 is linked by the official
+# CUDA llama-server build (HF model fetch support) and is likewise absent.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12 python3.12-venv python3-pip \
     git curl ca-certificates \
-    libxcb1 libglib2.0-0 libgl1 libgomp1 \
+    libxcb1 libglib2.0-0 libgl1 libgomp1 libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (fast Python package manager)
@@ -130,6 +144,14 @@ COPY comfyui-nodes/nanosaur_support/ ${COMFYUI_PATH}/custom_nodes/nanosaur_suppo
 # Copy server binary, frontend, and entrypoint
 COPY --from=builder /build/src-tauri/target/release/mooshieui-server /app/mooshieui-server
 COPY --from=frontend /build/dist /app/dist
+
+# CUDA llama-server + its ggml/llama shared libs for the prompt assistant. The
+# official server-cuda image lays the binary and *.so out flat under /app, so
+# copying that directory gives both. MOOSHIEUI_LLAMA_BIN_DIR (set above) points
+# the app here, and LD_LIBRARY_PATH lets the binary find its libs. NOTE: this
+# build links libcuda.so.1 (the driver stub), so the container must be run with
+# GPU access (--gpus all); on a CPU-only host enhance/compose will fail to load.
+COPY --from=llama /app/ /app/llama/
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.16
+
+### Prompt Assistant (server / GPU)
+- **GPU-accelerated enhance/compose on the server image**: the Docker image now ships a CUDA-enabled `llama-server` and points the app at it, so prompt enhancement offloads to the GPU and finishes in seconds. The llama.cpp release only provides a CPU build for Linux, which made a 7B model take longer than Cloudflare's 100s proxy timeout and fail with a 524. The app can now use a pre-provisioned binary via the `MOOSHIEUI_LLAMA_BIN_DIR` environment variable. (Requires rebuilding the Docker image; the CUDA build needs the container to be run with GPU access.)
+
+---
+
 ## What's New in v1.4.15
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.15"
+version = "1.4.16"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.15"
+version = "1.4.16"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/prompt_assistant/mod.rs
+++ b/src-tauri/src/prompt_assistant/mod.rs
@@ -28,7 +28,16 @@ impl PromptAssistant {
         let root = config::app_data_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("prompt-assistant");
-        let server = Arc::new(LlamaServer::new(root.join("bin")));
+        // A deployment can supply its own llama-server (e.g. a CUDA build baked
+        // into the Docker image) via MOOSHIEUI_LLAMA_BIN_DIR. The release only
+        // ships a CPU build for Linux, so this is how the server image gets
+        // GPU-accelerated enhance/compose. When unset, fall back to the
+        // downloaded binary under the app data dir.
+        let (bin_dir, external) = match std::env::var("MOOSHIEUI_LLAMA_BIN_DIR") {
+            Ok(d) if !d.trim().is_empty() => (PathBuf::from(d), true),
+            _ => (root.join("bin"), false),
+        };
+        let server = Arc::new(LlamaServer::new(bin_dir, external));
         Self { root, server }
     }
 

--- a/src-tauri/src/prompt_assistant/server.rs
+++ b/src-tauri/src/prompt_assistant/server.rs
@@ -69,6 +69,12 @@ const SERVER_BIN: &str = "llama-server";
 /// Manages a single llama-server child process and its idle lifetime.
 pub struct LlamaServer {
     bin_dir: PathBuf,
+    /// When true, `bin_dir` holds a binary provisioned out-of-band (e.g. baked
+    /// into the Docker image) rather than one this struct downloads. The GitHub
+    /// release only ships a CPU build for Linux, so a GPU-accelerated server
+    /// deployment supplies its own CUDA `llama-server` and we must not clobber
+    /// it with the CPU download.
+    external_binary: bool,
     child: tokio::sync::Mutex<Option<Child>>,
     port: std::sync::atomic::AtomicU16,
     active_model: std::sync::Mutex<Option<String>>,
@@ -81,9 +87,10 @@ pub struct LlamaServer {
 }
 
 impl LlamaServer {
-    pub fn new(bin_dir: PathBuf) -> Self {
+    pub fn new(bin_dir: PathBuf, external_binary: bool) -> Self {
         Self {
             bin_dir,
+            external_binary,
             child: tokio::sync::Mutex::new(None),
             port: std::sync::atomic::AtomicU16::new(0),
             active_model: std::sync::Mutex::new(None),
@@ -157,6 +164,20 @@ impl LlamaServer {
         backend: Backend,
         progress: &(dyn Fn(&str, u64, u64, bool) + Sync),
     ) -> Result<(), AppError> {
+        // A pre-provisioned (e.g. CUDA) binary is used as-is; never download over
+        // it. The release download only offers a CPU build for Linux, which would
+        // silently undo GPU acceleration on a server deployment.
+        if self.external_binary {
+            return if self.is_binary_present() {
+                Ok(())
+            } else {
+                Err(AppError::LlmError(format!(
+                    "llama-server binary not found at {} (MOOSHIEUI_LLAMA_BIN_DIR is set but the \
+                     binary is missing)",
+                    self.server_path().display()
+                )))
+            };
+        }
         if self.is_binary_current() {
             return Ok(());
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
### Prompt Assistant (server / GPU)

Fixes enhance/compose failing with a Cloudflare **524** on the hosted deployment. Root cause: the llama.cpp GitHub release only ships a **CPU** build for Linux, so a 7B model ran on CPU and took longer than Cloudflare's 100s proxy timeout. The host has GPUs, but only **CUDA** is exposed (`NVIDIA_DRIVER_CAPABILITIES=compute,utility`, no Vulkan ICD), so a Vulkan build would silently fall back to CPU.

**Changes:**
- **Rust**: `LlamaServer` gains an `external_binary` mode; when `MOOSHIEUI_LLAMA_BIN_DIR` is set the app uses a pre-provisioned `llama-server` and skips the CPU-only release download. Desktop behaviour is unchanged (env unset, downloads as before).
- **Dockerfile**: multi-stage `COPY` of the official `ghcr.io/ggml-org/llama.cpp:server-cuda` binary + ggml/llama shared libs into `/app/llama`; sets `MOOSHIEUI_LLAMA_BIN_DIR` and `LD_LIBRARY_PATH`; adds `libcurl4`. The existing `-ngl 999` offload logic now actually runs on the GPU, so a generation finishes in seconds.

**Deploy note:** requires rebuilding the Docker image. The CUDA build links `libcuda.so.1`, so the container must run with GPU access (`--gpus all`, already the case on gpu.garden).

**Follow-up (not blocking):** the `:server-cuda` tag is unpinned; pin a digest for reproducibility. With 3 visible GPUs, llama.cpp splits layers across all by default; pinning `CUDA_VISIBLE_DEVICES` to the Quadro could be a tuning win.