### PR TITLE
v1.4.17: prompt-assistant multi-user guard fix + face detailer auto-prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v1.4.17
+
+### Prompt Assistant (server / multi-user)
+- **Enhance/Compose no longer blocks when someone else is generating**: on shared server/browser-mode deployments the generation queue is global, so one person running a generation would make everyone else's prompt enhancement fail with `prompt_assistant.busy_generation`. The hard guard is removed; GPU contention is already handled by loading the LLM on CPU when the GPU is busy with a diffusion model.
+
+### Face Detailer
+- **Auto face prompt**: a new toggle conditions each detected face on a face-only subset of your prompt (hair, eyes, expression, named characters) instead of the full prompt, so scene, pose, and background tags don't bleed into the re-denoised face. Falls back to the full prompt when no face tags are present.
+
+---
+
 ## What's New in v1.4.16
 
 ### Prompt Assistant (server / GPU)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v1.4.17
+
+### Prompt Assistant (server / multi-user)
+- **Enhance/Compose no longer blocks when someone else is generating**: on shared server/browser-mode deployments the generation queue is global, so one person running a generation would make everyone else's prompt enhancement fail with `prompt_assistant.busy_generation`. The hard guard is removed; GPU contention is already handled by loading the LLM on CPU when the GPU is busy with a diffusion model.
+
+### Face Detailer
+- **Auto face prompt**: a new toggle conditions each detected face on a face-only subset of your prompt (hair, eyes, expression, named characters) instead of the full prompt, so scene, pose, and background tags don't bleed into the re-denoised face. Falls back to the full prompt when no face tags are present.
+
+---
+
 ## What's New in v1.4.16
 
 ### Prompt Assistant (server / GPU)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.16"
+version = "1.4.17"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.16"
+version = "1.4.17"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -200,6 +200,11 @@ pub struct GenerationParams {
     pub facefix_guide_size: u32,
     #[serde(default = "default_facefix_max_faces")]
     pub facefix_max_faces: u32,
+    /// When set, condition the face detailer on a face-only subset of the prompt
+    /// (auto-extracted) instead of the full prompt, so scene/pose/background tags
+    /// don't bleed into the re-denoised face region.
+    #[serde(default)]
+    pub facefix_auto_prompt: bool,
     /// Output image bit depth — "8bit" (default) or "16bit"
     #[serde(default = "default_output_bit_depth")]
     pub output_bit_depth: String,

--- a/src-tauri/src/commands/prompt_assistant.rs
+++ b/src-tauri/src/commands/prompt_assistant.rs
@@ -107,13 +107,12 @@ async fn run_generation(
     mode: GenMode,
     opts: &PromptAssistantOpts,
 ) -> Result<String, AppError> {
-    // Generation guard: do not contend with an active ComfyUI generation.
-    if !state.prompt_queue.is_empty() {
-        return Err(AppError::LlmError(
-            "prompt_assistant.busy_generation".into(),
-        ));
-    }
-
+    // No active-generation guard: contention with an in-flight ComfyUI generation
+    // is handled by the free-VRAM check in `ensure_running` (it loads the LLM on
+    // CPU when the GPU is busy rather than evicting the diffusion model), so there
+    // is no need to hard-block enhance/compose while a generation is queued. In
+    // server mode `prompt_queue` is shared across users, where blocking meant one
+    // person's generation locked the feature for everyone.
     let (model_id, idle_secs) = {
         let cfg = state.config.read().await;
         (

--- a/src-tauri/src/prompt_assistant/grounding.rs
+++ b/src-tauri/src/prompt_assistant/grounding.rs
@@ -21,6 +21,9 @@ pub struct Corpus {
     pub tags: HashMap<String, i64>,
     /// Canonical artist names (underscored form, category 1).
     pub artists: HashSet<String>,
+    /// Canonical character names (underscored form, category 4) — tracked
+    /// separately so the face-detailer auto-prompt can preserve named faces.
+    pub characters: HashSet<String>,
     /// alias (underscored) → canonical name, for snapping near-misses.
     pub alias_to_canonical: HashMap<String, String>,
 }
@@ -35,6 +38,7 @@ pub fn corpus() -> &'static Corpus {
         let raw: Vec<RawTag> = serde_json::from_str(ANIMA_TAGS_JSON).unwrap_or_default();
         let mut tags = HashMap::new();
         let mut artists = HashSet::new();
+        let mut characters = HashSet::new();
         let mut alias_to_canonical = HashMap::new();
         for t in raw {
             let canon = normalize(&t.n);
@@ -44,6 +48,9 @@ pub fn corpus() -> &'static Corpus {
                 }
                 // general, copyright, character — all valid danbooru tags
                 0 | 3 | 4 => {
+                    if t.c == 4 {
+                        characters.insert(canon.clone());
+                    }
                     tags.insert(canon.clone(), t.p);
                 }
                 _ => {} // meta (5), unknown (-1), etc.
@@ -55,6 +62,7 @@ pub fn corpus() -> &'static Corpus {
         Corpus {
             tags,
             artists,
+            characters,
             alias_to_canonical,
         }
     })
@@ -246,6 +254,67 @@ const COUNT_TAGS: &[&str] = &[
 fn count_tag_set() -> &'static HashSet<&'static str> {
     static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
     SET.get_or_init(|| COUNT_TAGS.iter().copied().collect())
+}
+
+/// Single-word atoms (danbooru canonical form, split on `_`) that mark a tag as
+/// describing the face or head. Used by the optional face-detailer auto-prompt to
+/// reduce a full prompt down to just what should condition a cropped face region,
+/// dropping scene, pose, clothing, and background tags.
+const FACE_ATOMS: &[&str] = &[
+    // hair
+    "hair", "bangs", "ahoge", "ponytail", "ponytails", "twintail", "twintails",
+    "braid", "braids", "sidelocks", "sidelock", "forelock", "bun", "bob", "hime",
+    "drill", "drills", "hairband", "hairclip", "hairpin", "hairpins", "scrunchie",
+    "fringe",
+    // eyes
+    "eye", "eyes", "eyelashes", "eyebrow", "eyebrows", "eyeshadow", "eyeliner",
+    "eyepatch", "eyewear", "heterochromia", "pupils", "pupil", "sclera", "iris",
+    // mouth
+    "mouth", "lips", "lip", "teeth", "fang", "fangs", "tongue", "saliva", "drool",
+    "lipstick",
+    // expression
+    "smile", "grin", "smirk", "frown", "pout", "scowl", "blush", "blushing",
+    "wink", "expression", "expressionless", "ahegao", "tears", "teary", "crying",
+    // face features
+    "face", "facial", "nose", "cheek", "cheeks", "chin", "jaw", "forehead",
+    "freckles", "mole", "dimples", "makeup", "mascara",
+    // glasses / facial hair
+    "glasses", "sunglasses", "monocle", "beard", "mustache", "goatee", "stubble",
+    "sideburns",
+    // ears / head ornaments visible in a face crop
+    "ears", "ear", "earrings", "horn", "horns", "antlers", "halo", "head",
+    "headband", "headphones", "headdress", "headgear",
+];
+
+/// Extract the face/head-relevant subset of a comma-separated prompt, preserving
+/// each kept item's original display text and order. Count tags (1girl/1boy),
+/// named characters, and any tag whose canonical form ends in `_hair`/`_eyes` or
+/// contains a [`FACE_ATOMS`] atom are kept; scene, pose, clothing, and background
+/// tags are dropped. Returns an empty string when nothing face-relevant is found,
+/// so the caller can fall back to conditioning on the full prompt.
+pub fn extract_face_tags(prompt: &str) -> String {
+    let c = corpus();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut kept: Vec<String> = Vec::new();
+    for raw in prompt.split(',') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        let canon = normalize(item);
+        if canon.is_empty() {
+            continue;
+        }
+        let is_face = canon.ends_with("_hair")
+            || canon.ends_with("_eyes")
+            || count_tag_set().contains(canon.as_str())
+            || c.characters.contains(&canon)
+            || canon.split('_').any(|atom| FACE_ATOMS.contains(&atom));
+        if is_face && seen.insert(canon) {
+            kept.push(item.to_string());
+        }
+    }
+    kept.join(", ")
 }
 
 /// Danbooru hair/eye colours, used to detect the colour-attribute families. A

--- a/src-tauri/src/prompt_assistant/grounding.rs
+++ b/src-tauri/src/prompt_assistant/grounding.rs
@@ -286,6 +286,14 @@ const FACE_ATOMS: &[&str] = &[
     "headband", "headphones", "headdress", "headgear",
 ];
 
+/// Danbooru emoticon/expression tags that carry no `_`-separated word a
+/// [`FACE_ATOMS`] check could catch, yet clearly describe a facial expression.
+const EMOTICON_FACE_TAGS: &[&str] = &[
+    ":d", ":3", ":o", ":p", ":q", ":t", ":i", ":<", ":>", ":/", ":|", ";)", ";d",
+    ";o", ";p", ";3", ";q", "xd", "x3", "d:", "o3o", "uwu", ">:)", ">:(", ">_<",
+    "@_@", "+_+", "^_^", "^o^", "0_0", "o_o", "._.", "=_=", "qwq", "tot",
+];
+
 /// Extract the face/head-relevant subset of a comma-separated prompt, preserving
 /// each kept item's original display text and order. Count tags (1girl/1boy),
 /// named characters, and any tag whose canonical form ends in `_hair`/`_eyes` or
@@ -301,7 +309,22 @@ pub fn extract_face_tags(prompt: &str) -> String {
         if item.is_empty() {
             continue;
         }
-        let canon = normalize(item);
+        // Match on a copy with ComfyUI/SD attention-weight syntax stripped
+        // (`(blue hair:1.1)`, `(((smiling)))`) but keep the original `item` — weights
+        // and all — in the output so the user's conditioning strength is preserved.
+        // Only unwrap when the item starts with a bracket, so a tag that merely carries
+        // a parenthesised qualifier (`hatsune miku (vocaloid)`) and emoticon tags
+        // (`:3`, `:d`) are left intact.
+        let mut clean = item;
+        if clean.starts_with('(') || clean.starts_with('[') {
+            clean = clean.trim_matches(|ch| matches!(ch, '(' | ')' | '[' | ']'));
+            if let Some(idx) = clean.rfind(':') {
+                if idx > 0 && clean[idx + 1..].trim().parse::<f32>().is_ok() {
+                    clean = clean[..idx].trim_end();
+                }
+            }
+        }
+        let canon = normalize(clean);
         if canon.is_empty() {
             continue;
         }
@@ -309,6 +332,7 @@ pub fn extract_face_tags(prompt: &str) -> String {
             || canon.ends_with("_eyes")
             || count_tag_set().contains(canon.as_str())
             || c.characters.contains(&canon)
+            || EMOTICON_FACE_TAGS.contains(&canon.as_str())
             || canon.split('_').any(|atom| FACE_ATOMS.contains(&atom));
         if is_face && seen.insert(canon) {
             kept.push(item.to_string());

--- a/src-tauri/src/templates/facefix.rs
+++ b/src-tauri/src/templates/facefix.rs
@@ -22,6 +22,33 @@ pub fn append_facefix_chain(
         .as_deref()
         .unwrap_or("Anzhc Face seg 640 v4 y11n.pt");
 
+    // Optionally condition the detailer on a face-only subset of the prompt so
+    // scene/pose/background tags don't bleed into the re-denoised face. Falls back
+    // to the full positive conditioning when the prompt has no face-relevant tags.
+    let positive_source = if params.facefix_auto_prompt {
+        let face_prompt =
+            crate::prompt_assistant::grounding::extract_face_tags(&params.positive_prompt);
+        if face_prompt.trim().is_empty() {
+            (result.positive_source.0.clone(), result.positive_source.1)
+        } else {
+            let encode_id = next_id.to_string();
+            workflow.insert(
+                encode_id.clone(),
+                json!({
+                    "class_type": "CLIPTextEncode",
+                    "inputs": {
+                        "clip": [result.clip_source.0.clone(), result.clip_source.1],
+                        "text": face_prompt
+                    }
+                }),
+            );
+            *next_id += 1;
+            (encode_id, 0)
+        }
+    } else {
+        (result.positive_source.0.clone(), result.positive_source.1)
+    };
+
     let detailer_id = next_id.to_string();
     workflow.insert(
         detailer_id.clone(),
@@ -31,7 +58,7 @@ pub fn append_facefix_chain(
                 "image": [current_image.0, current_image.1],
                 "model": [result.model_source.0.clone(), result.model_source.1],
                 "vae": [result.vae_source.0.clone(), result.vae_source.1],
-                "positive": [result.positive_source.0.clone(), result.positive_source.1],
+                "positive": [positive_source.0, positive_source.1],
                 "negative": [result.negative_source.0.clone(), result.negative_source.1],
                 "detector_model": detector_model,
                 "seed": seed + 2,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4404,9 +4404,11 @@ pub async fn run_prompt_assistant_headless(
     mode: crate::prompt_assistant::grounding::GenMode,
 ) -> Result<String, String> {
     use crate::prompt_assistant::{grounding, hardware};
-    if !state.prompt_queue.is_empty() {
-        return Err("prompt_assistant.busy_generation".to_string());
-    }
+    // No active-generation guard here: `prompt_queue` is shared across every user
+    // of a server/browser-mode instance, so blocking on it meant one person
+    // generating locked Enhance/Compose for everyone. Contention is instead handled
+    // by the free-VRAM check in `ensure_running`, which loads the LLM on CPU when a
+    // GPU is already busy with ComfyUI's model rather than evicting it.
     let (model_id, idle_secs) = {
         let cfg = state.config.read().await;
         (

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/FaceFixSettings.svelte
+++ b/src/lib/components/generation/FaceFixSettings.svelte
@@ -219,5 +219,24 @@
         class="w-full accent-indigo-500"
       />
     </div>
+
+    <!-- Auto face prompt -->
+    <div class="flex items-center justify-between">
+      <label class="text-xs text-neutral-400">{locale.t('generation.facefix.auto_prompt')}<InfoTip text={locale.t('generation.facefix.auto_prompt_tip')} /></label>
+      <button
+        class="relative w-10 h-5 rounded-full transition-colors {generation.facefixAutoPrompt
+          ? 'bg-indigo-600'
+          : 'bg-neutral-700'}"
+        onclick={() => (generation.facefixAutoPrompt = !generation.facefixAutoPrompt)}
+        role="switch"
+        aria-checked={generation.facefixAutoPrompt}
+      >
+        <span
+          class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform {generation.facefixAutoPrompt
+            ? 'translate-x-5'
+            : ''}"
+        ></span>
+      </button>
+    </div>
   {/if}
 </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -644,6 +644,8 @@ const de: Record<string, string> = {
   "generation.facefix.downloading": "{model} wird heruntergeladen...",
   "generation.facefix.download_failed": "Download fehlgeschlagen: {error}",
   "generation.facefix.select_model": "Modell wählen...",
+  "generation.facefix.auto_prompt": "Automatischer Gesichtsprompt",
+  "generation.facefix.auto_prompt_tip": "Konditioniert jedes erkannte Gesicht auf eine reine Gesichts-Teilmenge deines Prompts (Haare, Augen, Ausdruck, benannte Charaktere) statt auf den vollen Prompt, damit Szenen-, Posen- und Hintergrund-Tags nicht in das neu entrauschte Gesicht überlaufen. Fällt auf den vollen Prompt zurück, wenn keine Gesichts-Tags gefunden werden.",
   "generation.segment.downloading_detector": "Segment-Detektormodell wird heruntergeladen...",
   "generation.segment.detector_unavailable": "Segment-Detektor '{name}' ist nicht verfügbar — dieses Segment wird übersprungen.",
   "generation.segment.title": "Segment-Verfeinerung",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -784,6 +784,8 @@ const en: Record<string, string> = {
   "generation.facefix.downloading": "Downloading {model}...",
   "generation.facefix.download_failed": "Download failed: {error}",
   "generation.facefix.select_model": "Select model...",
+  "generation.facefix.auto_prompt": "Auto Face Prompt",
+  "generation.facefix.auto_prompt_tip": "Conditions each detected face on a face-only subset of your prompt (hair, eyes, expression, named characters) instead of the full prompt, so scene, pose, and background tags don't bleed into the re-denoised face. Falls back to the full prompt if no face tags are found.",
   "generation.segment.downloading_detector": "Downloading segment detector model...",
   "generation.segment.detector_unavailable": "Segment detector '{name}' is not available — that segment will be skipped.",
   "generation.segment.title": "Segment Refinement",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -671,6 +671,8 @@ const es: Record<string, string> = {
   "generation.facefix.downloading": "Descargando {model}...",
   "generation.facefix.download_failed": "Descarga fallida: {error}",
   "generation.facefix.select_model": "Seleccionar modelo...",
+  "generation.facefix.auto_prompt": "Prompt facial automático",
+  "generation.facefix.auto_prompt_tip": "Condiciona cada rostro detectado con un subconjunto del prompt centrado en la cara (cabello, ojos, expresión, personajes con nombre) en lugar del prompt completo, para que las etiquetas de escena, pose y fondo no se filtren en el rostro reprocesado. Vuelve al prompt completo si no se encuentran etiquetas faciales.",
   "generation.segment.downloading_detector": "Descargando modelo detector de segmentos...",
   "generation.segment.detector_unavailable": "El detector de segmentos '{name}' no está disponible — ese segmento se omitirá.",
   "generation.segment.title": "Refinamiento de segmentos",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -646,6 +646,8 @@ const fr: Record<string, string> = {
   "generation.facefix.downloading": "Téléchargement de {model}...",
   "generation.facefix.download_failed": "Échec du téléchargement : {error}",
   "generation.facefix.select_model": "Sélectionner un modèle...",
+  "generation.facefix.auto_prompt": "Invite de visage auto",
+  "generation.facefix.auto_prompt_tip": "Conditionne chaque visage détecté sur un sous-ensemble de votre invite limité au visage (cheveux, yeux, expression, personnages nommés) plutôt que sur l'invite complète, afin que les balises de scène, de pose et d'arrière-plan ne débordent pas sur le visage redébruité. Revient à l'invite complète si aucune balise de visage n'est trouvée.",
   "generation.segment.downloading_detector": "Téléchargement du modèle de détection de segment...",
   "generation.segment.detector_unavailable": "Le détecteur de segment '{name}' n'est pas disponible — ce segment sera ignoré.",
   "generation.segment.title": "Raffinement de segments",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -628,6 +628,8 @@ const it: Record<string, string> = {
   "generation.facefix.downloading": "Download {model}...",
   "generation.facefix.download_failed": "Download fallito: {error}",
   "generation.facefix.select_model": "Seleziona modello...",
+  "generation.facefix.auto_prompt": "Prompt viso automatico",
+  "generation.facefix.auto_prompt_tip": "Condiziona ogni volto rilevato su un sottoinsieme del prompt limitato al viso (capelli, occhi, espressione, personaggi con nome) invece del prompt completo, così che i tag di scena, posa e sfondo non si riversino sul volto rielaborato. Torna al prompt completo se non vengono trovati tag del viso.",
   "generation.segment.downloading_detector": "Download del modello rilevatore di segmenti...",
   "generation.segment.detector_unavailable": "Il rilevatore di segmenti '{name}' non è disponibile — quel segmento verrà saltato.",
   "generation.segment.title": "Rifinitura segmenti",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -646,6 +646,8 @@ const ja: Record<string, string> = {
   "generation.facefix.downloading": "{model}をダウンロード中...",
   "generation.facefix.download_failed": "ダウンロード失敗：{error}",
   "generation.facefix.select_model": "モデルを選択...",
+  "generation.facefix.auto_prompt": "自動フェイスプロンプト",
+  "generation.facefix.auto_prompt_tip": "検出された各顔を、プロンプト全体ではなく顔に関する部分（髪、目、表情、キャラクター名）だけで条件付けし、シーン・ポーズ・背景のタグが再ノイズ除去された顔に混ざらないようにします。顔のタグが見つからない場合はプロンプト全体にフォールバックします。",
   "generation.segment.downloading_detector": "セグメント検出モデルをダウンロード中...",
   "generation.segment.detector_unavailable": "セグメント検出器「{name}」が利用できないため、そのセグメントはスキップされます。",
   "generation.segment.title": "セグメント精細化",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -628,6 +628,8 @@ const ko: Record<string, string> = {
   "generation.facefix.downloading": "{model} 다운로드 중...",
   "generation.facefix.download_failed": "다운로드 실패: {error}",
   "generation.facefix.select_model": "모델 선택...",
+  "generation.facefix.auto_prompt": "자동 얼굴 프롬프트",
+  "generation.facefix.auto_prompt_tip": "감지된 각 얼굴을 전체 프롬프트 대신 얼굴 관련 부분(머리카락, 눈, 표정, 명명된 캐릭터)으로만 조건화하여, 장면·포즈·배경 태그가 다시 디노이즈된 얼굴에 섞이지 않도록 합니다. 얼굴 태그가 없으면 전체 프롬프트로 대체합니다.",
   "generation.segment.downloading_detector": "세그먼트 감지 모델 다운로드 중...",
   "generation.segment.detector_unavailable": "세그먼트 감지기 '{name}'를 사용할 수 없어 해당 세그먼트를 건너뜁니다.",
   "generation.segment.title": "세그먼트 정밀화",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -628,6 +628,8 @@ const pt: Record<string, string> = {
   "generation.facefix.downloading": "Baixando {model}...",
   "generation.facefix.download_failed": "Download falhou: {error}",
   "generation.facefix.select_model": "Selecionar modelo...",
+  "generation.facefix.auto_prompt": "Prompt de rosto automático",
+  "generation.facefix.auto_prompt_tip": "Condiciona cada rosto detectado em um subconjunto do prompt focado no rosto (cabelo, olhos, expressão, personagens nomeados) em vez do prompt completo, para que tags de cena, pose e fundo não vazem para o rosto reprocessado. Volta ao prompt completo se nenhuma tag de rosto for encontrada.",
   "generation.segment.downloading_detector": "Baixando modelo detector de segmentos...",
   "generation.segment.detector_unavailable": "O detector de segmentos '{name}' não está disponível — esse segmento será ignorado.",
   "generation.segment.title": "Refinamento de segmentos",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -628,6 +628,8 @@ const ru: Record<string, string> = {
   "generation.facefix.downloading": "Скачивание {model}...",
   "generation.facefix.download_failed": "Скачивание не удалось: {error}",
   "generation.facefix.select_model": "Выбрать модель...",
+  "generation.facefix.auto_prompt": "Авто-промпт лица",
+  "generation.facefix.auto_prompt_tip": "Обуславливает каждое обнаруженное лицо подмножеством промпта, относящимся только к лицу (волосы, глаза, выражение, именованные персонажи), вместо полного промпта, чтобы теги сцены, позы и фона не просачивались в повторно очищенное от шума лицо. Возвращается к полному промпту, если теги лица не найдены.",
   "generation.segment.downloading_detector": "Загрузка модели детектора сегментов...",
   "generation.segment.detector_unavailable": "Детектор сегментов '{name}' недоступен — этот сегмент будет пропущен.",
   "generation.segment.title": "Доработка сегментов",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -628,6 +628,8 @@ const zhTw: Record<string, string> = {
   "generation.facefix.downloading": "正在下載 {model}...",
   "generation.facefix.download_failed": "下載失敗：{error}",
   "generation.facefix.select_model": "選擇模型...",
+  "generation.facefix.auto_prompt": "自動臉部提示詞",
+  "generation.facefix.auto_prompt_tip": "讓每個偵測到的臉部僅根據提示詞中與臉部相關的部分（頭髮、眼睛、表情、指定角色）進行條件化，而非整個提示詞，以避免場景、姿勢和背景標籤滲入重新去噪的臉部。若未找到臉部標籤，則回退到完整提示詞。",
   "generation.segment.downloading_detector": "正在下載分割偵測模型...",
   "generation.segment.detector_unavailable": "分割偵測器 '{name}' 無法使用——將跳過該分割。",
   "generation.segment.title": "分割細化",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -628,6 +628,8 @@ const zh: Record<string, string> = {
   "generation.facefix.downloading": "正在下载 {model}...",
   "generation.facefix.download_failed": "下载失败：{error}",
   "generation.facefix.select_model": "选择模型...",
+  "generation.facefix.auto_prompt": "自动面部提示词",
+  "generation.facefix.auto_prompt_tip": "让每个检测到的面部仅基于提示词中与面部相关的部分（头发、眼睛、表情、指定角色）进行条件化，而非整个提示词，从而避免场景、姿势和背景标签渗入重新去噪的面部。若未找到面部标签，则回退到完整提示词。",
   "generation.segment.downloading_detector": "正在下载分割检测模型...",
   "generation.segment.detector_unavailable": "分割检测器 '{name}' 不可用——将跳过该分割。",
   "generation.segment.title": "分割细化",

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -340,6 +340,7 @@ class GenerationStore {
   facefixSteps = $state(20);
   facefixGuideSize = $state(512);
   facefixMaxFaces = $state(8);
+  facefixAutoPrompt = $state(false);
   outputBitDepth = $state<"8bit" | "16bit">("8bit");
   outputFormat = $state<"png" | "jxl">("png");
   metadataMode = $state<"text_chunk" | "stealth" | "both">("both");
@@ -1184,6 +1185,7 @@ class GenerationStore {
         if (saved.facefixSteps !== undefined) this.facefixSteps = saved.facefixSteps;
         if (saved.facefixGuideSize !== undefined) this.facefixGuideSize = saved.facefixGuideSize;
         if (saved.facefixMaxFaces !== undefined) this.facefixMaxFaces = saved.facefixMaxFaces;
+        if (saved.facefixAutoPrompt !== undefined) this.facefixAutoPrompt = saved.facefixAutoPrompt;
         if (saved.modeToggles !== undefined) {
           this.modeToggles = normalizeModeToggles(saved.modeToggles);
         } else {
@@ -1326,6 +1328,7 @@ class GenerationStore {
         facefixSteps: this.facefixSteps,
         facefixGuideSize: this.facefixGuideSize,
         facefixMaxFaces: this.facefixMaxFaces,
+        facefixAutoPrompt: this.facefixAutoPrompt,
         outputBitDepth: this.outputBitDepth,
         outputFormat: this.outputFormat,
         metadataMode: this.metadataMode,
@@ -1418,6 +1421,7 @@ class GenerationStore {
       facefixSteps: this.facefixSteps,
       facefixGuideSize: this.facefixGuideSize,
       facefixMaxFaces: this.facefixMaxFaces,
+      facefixAutoPrompt: this.facefixAutoPrompt,
       outputBitDepth: this.outputBitDepth,
       outputFormat: this.outputFormat,
       metadataMode: this.metadataMode,
@@ -1758,6 +1762,7 @@ class GenerationStore {
       facefix_steps: this.facefixSteps,
       facefix_guide_size: this.facefixGuideSize,
       facefix_max_faces: this.facefixMaxFaces,
+      facefix_auto_prompt: this.facefixAutoPrompt,
       model_architecture: this.modelFamily,
       is_sdxl_like: this.isSdxlLike,
       is_vpred_model: signalsIndicateVPred(this.modelFamilySignals()),


### PR DESCRIPTION
## Prompt Assistant (server / multi-user)
- Remove the shared-state generation guard so Enhance/Compose no longer fails with `prompt_assistant.busy_generation` when another user is generating on a server/browser-mode instance. The generation queue is global across users, so the guard blocked everyone whenever anyone generated. GPU contention is already handled by the free-VRAM check in `ensure_running` (loads the LLM on CPU when the GPU is busy with a diffusion model).

## Face Detailer
- Add an optional "auto face prompt" toggle. When on, each detected face is conditioned on a face-only subset of the prompt (`extract_face_tags`: hair, eyes, expression, named characters, count tags) via a dedicated `CLIPTextEncode`, instead of the full prompt, so scene/pose/background tags don't bleed into the re-denoised face. Falls back to the full prompt when no face tags are found.
- Touchpoints: `GenerationParams.facefix_auto_prompt`, generation store + `toParams()`, `FaceFixSettings.svelte` toggle, i18n keys in all 11 locales, corpus now tracks category-4 character tags.

## Validation
- `cargo check` and `npm run build` both green.