### PR TITLE
v1.4.18: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.18
+
+### Prompt Assistant (server / read-only config)
+- **Enhance/Compose works on deployments with a read-only config**: when `config.json` is mounted read-only (for example a Kubernetes ConfigMap), the app can never persist the model you pick in the UI, so `prompt_assistant_model_id` stays empty and Enhance failed with `prompt_assistant.no_model`. The server now falls back to whatever prompt-assistant model is already downloaded on disk, so no config write is required.
+
+---
+
 ## What's New in v1.4.17
 
 ### Prompt Assistant (server / multi-user)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.18
+
+### Prompt Assistant (server / read-only config)
+- **Enhance/Compose works on deployments with a read-only config**: when `config.json` is mounted read-only (for example a Kubernetes ConfigMap), the app can never persist the model you pick in the UI, so `prompt_assistant_model_id` stays empty and Enhance failed with `prompt_assistant.no_model`. The server now falls back to whatever prompt-assistant model is already downloaded on disk, so no config write is required.
+
+---
+
 ## What's New in v1.4.17
 
 ### Prompt Assistant (server / multi-user)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.17"
+version = "1.4.18"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.17"
+version = "1.4.18"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4416,7 +4416,20 @@ pub async fn run_prompt_assistant_headless(
             cfg.prompt_assistant_idle_timeout_secs,
         )
     };
-    let model_id = model_id.ok_or_else(|| "prompt_assistant.no_model".to_string())?;
+    // Fall back to whatever model is already on disk when config.json carries no
+    // explicit selection. This is the only path that works on read-only-config
+    // deployments (e.g. a Kubernetes ConfigMap mounted at config.json), where the
+    // UI's model pick can never be persisted back, leaving `prompt_assistant_model_id`
+    // perpetually None despite a model sitting in the data dir.
+    let model_id = match model_id {
+        Some(id) => id,
+        None => state
+            .prompt_assistant
+            .installed_models()
+            .into_iter()
+            .next()
+            .ok_or_else(|| "prompt_assistant.no_model".to_string())?,
+    };
     let hw = tokio::task::spawn_blocking(hardware::detect)
         .await
         .map_err(|e| e.to_string())?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v1.4.18

### Prompt Assistant (server / read-only config)
- **Enhance/Compose works on deployments with a read-only config**: when `config.json` is mounted read-only (for example a Kubernetes ConfigMap), the app can never persist the model picked in the UI, so `prompt_assistant_model_id` stays empty and Enhance failed with `prompt_assistant.no_model`. The server now falls back to whatever prompt-assistant model is already downloaded on disk, so no config write is required.

Verified with `cargo check`.