### PR TITLE
Fix uv pip install progress flag

### DIFF
--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -765,8 +765,6 @@ async fn uv_pip(
     let mut cmd = tokio::process::Command::new(uv);
     cmd.arg("pip")
         .arg("install")
-        .arg("--progress")
-        .arg("always")
         .arg("--python")
         .arg(&python_str)
         .args(args)
@@ -1075,8 +1073,6 @@ async fn step_install_deps(
     let mut cmd = tokio::process::Command::new(uv);
     cmd.arg("pip")
         .arg("install")
-        .arg("--progress")
-        .arg("always")
         .arg("--python")
         .arg(&python_str)
         .arg("-r")


### PR DESCRIPTION
## What?

Removed `--progress always` from the setup `uv pip install` commands.

## Why?

The bundled `uv 0.11.21` rejects `--progress` for `uv pip install`. During local setup, the PyTorch install failed before dependency resolution with:

`error: unexpected argument '--progress' found`

When `--progress` was removed but `always` remained, `uv` treated `always` as a package name and failed dependency resolution.

## How?

The setup install commands now call `uv pip install` without the unsupported progress flag pair. Existing setup progress messages and heartbeat logging remain unchanged.

## Testing?

Ran `git diff --check`.
Ran `npm ci`.
Ran `npm run build`.

Rust checks were not run because `cargo` is not available in the local shell.

## Screenshots (optional)

Not applicable.

## Anything Else?

None.
