### PR TITLE
v1.4.20: Artist gallery image variants + prompt-assistant 524 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v1.4.20
+
+### Artist Gallery
+- **Image variant support**: artist cards now show all available reference images for an artist. A flip button on each card cycles through variants, and a global variant selector in the toolbar lets you switch the entire gallery at once. The lightbox also gains a flip control for the active entry.
+
+### Prompt Assistant (hosted server)
+- **Fix 524 timeout on compose/enhance right after a generation**: on the hosted deployment, the diffusion model was staying resident in VRAM after a generation completed, forcing the LLM to load on CPU where it exceeds Cloudflare's 100-second proxy timeout. The server now unloads idle ComfyUI workers before starting the LLM so it can load on the GPU instead.
+
+---
+
 ## What's New in v1.4.19
 
 ### Brand and design refresh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v1.4.20
+
+### Artist Gallery
+- **Image variant support**: artist cards now show all available reference images for an artist. A flip button on each card cycles through variants, and a global variant selector in the toolbar lets you switch the entire gallery at once. The lightbox also gains a flip control for the active entry.
+
+### Prompt Assistant (hosted server)
+- **Fix 524 timeout on compose/enhance right after a generation**: on the hosted deployment, the diffusion model was staying resident in VRAM after a generation completed, forcing the LLM to load on CPU where it exceeds Cloudflare's 100-second proxy timeout. The server now unloads idle ComfyUI workers before starting the LLM so it can load on the GPU instead.
+
+---
+
 ## What's New in v1.4.19
 
 ### Brand and design refresh

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.19"
+version = "1.4.20"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -582,6 +582,86 @@ impl AppState {
         }
     }
 
+    /// Free idle ComfyUI workers' VRAM before loading the prompt-assistant LLM.
+    ///
+    /// The mirror image of `free_llm_vram_for_generation`. On a shared GPU
+    /// deployment a compose/enhance that lands right after a generation finds
+    /// ComfyUI's diffusion model still resident in VRAM, so the free-VRAM check
+    /// in `PromptAssistant::ensure_running` drops the LLM onto CPU. A 7B model on
+    /// CPU is slow enough to trip Cloudflare's 100s proxy timeout (a 524 on the
+    /// hosted instance). Unloading the models from workers that are not currently
+    /// executing reclaims the VRAM so the LLM loads on the GPU instead. Workers
+    /// that are reserved or running are skipped so an in-flight generation for
+    /// another user is never disrupted; ComfyUI transparently reloads its model
+    /// on the next generation.
+    #[cfg(any(feature = "desktop", feature = "server"))]
+    pub async fn free_comfyui_vram_for_llm(&self) {
+        use crate::comfyui::gpu_manager::{detect_free_vram_mb, WorkerStatus};
+
+        let before = tokio::task::spawn_blocking(detect_free_vram_mb)
+            .await
+            .ok()
+            .flatten();
+
+        let mut freed_any = false;
+        for worker in &self.gpu_manager.workers {
+            if worker.reserved.load(std::sync::atomic::Ordering::SeqCst) {
+                continue;
+            }
+            if *worker.status.read().await == WorkerStatus::Running {
+                continue;
+            }
+            log::info!(
+                "[prompt-assistant] freeing ComfyUI VRAM on worker {} before LLM load",
+                worker.id
+            );
+            let _ = self
+                .http_client
+                .post(format!("{}/free", worker.base_url))
+                .json(&serde_json::json!({
+                    "unload_models": true,
+                    "free_memory": true,
+                }))
+                .send()
+                .await;
+            freed_any = true;
+        }
+
+        if !freed_any {
+            return;
+        }
+
+        // ComfyUI's /free only *flags* the unload; the worker thread reclaims the
+        // VRAM a moment later. Wait until nvidia-smi reports the memory actually
+        // came back (or give up after a short cap) so the subsequent free-VRAM
+        // check in `ensure_running` sees the freed GPU and offloads to it instead
+        // of falling back to CPU. Only meaningful on NVIDIA, where free VRAM is
+        // observable; elsewhere `before` is None and we just settle briefly.
+        let Some(before_mb) = before else {
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            return;
+        };
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+            let now = tokio::task::spawn_blocking(detect_free_vram_mb)
+                .await
+                .ok()
+                .flatten();
+            if let Some(now_mb) = now {
+                if now_mb >= before_mb.saturating_add(1024) {
+                    log::info!(
+                        "[prompt-assistant] ComfyUI VRAM reclaimed: {before_mb} -> {now_mb} MB free"
+                    );
+                    return;
+                }
+            }
+        }
+        log::warn!(
+            "[prompt-assistant] ComfyUI VRAM not visibly reclaimed within timeout; \
+             LLM may load on CPU"
+        );
+    }
+
     pub async fn dispatch_webhook_event(
         &self,
         event: &str,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4433,6 +4433,11 @@ pub async fn run_prompt_assistant_headless(
     let hw = tokio::task::spawn_blocking(hardware::detect)
         .await
         .map_err(|e| e.to_string())?;
+    // Reclaim VRAM from idle ComfyUI workers so the LLM can load on the GPU.
+    // Without this, a compose/enhance right after a generation falls back to CPU
+    // (ComfyUI's model is still resident), and a 7B model on CPU overruns
+    // Cloudflare's 100s proxy timeout with a 524 on the hosted deployment.
+    state.free_comfyui_vram_for_llm().await;
     let noop = |_: &str, _: u64, _: u64, _: bool| {};
     let port = state
         .prompt_assistant

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -150,10 +150,14 @@
       : "";
     store.lightboxEntry = { tag: hit.tag, slug: hit.slug, imageId: hit.imageId, imageUrl, objectKey: "", postCount: hit.postCount, belowThreshold: hit.belowThreshold, b: hit.b, aliases: [], hasImage: hit.hasImage };
     store.lightboxIndex = index;
-    // Background: fetch full shard entry to patch in aliases once loaded
+    // Background: fetch full shard entry to patch in aliases (and v2 variants) once loaded
     store.client.getArtist(hit.slug).then((full) => {
       if (full && store.lightboxEntry?.slug === hit.slug) {
-        store.lightboxEntry = { ...full, imageUrl: proxiedCdnUrl(full.imageUrl) };
+        store.lightboxEntry = {
+          ...full,
+          imageUrl: proxiedCdnUrl(full.imageUrl),
+          images: full.images?.map((img) => ({ ...img, imageUrl: proxiedCdnUrl(img.imageUrl) })),
+        };
       }
     }).catch(() => {});
   }
@@ -189,9 +193,68 @@
     pageInputValue = "";
   }
 
+  // ---------------------------------------------------------------------------
+  // Image variant toggle (index v2+; inert on single-variant v1 data)
+  // ---------------------------------------------------------------------------
+  let globalVariant = $derived(store.globalVariant);
+
+  /** Variant count for a hit; defaults to 1 on v1 data. */
+  function variantCountOf(hit: ArtistSearchHit): number {
+    return Math.max(1, hit.variantCount ?? hit.images?.length ?? 1);
+  }
+
+  /** True when ANY entry in the dataset exposes >= 2 variants. */
+  const hasVariants = $derived.by(() => allEntries.some((e) => variantCountOf(e) >= 2));
+  /** Largest variant count across the dataset (drives the toolbar toggle). */
+  const maxVariants = $derived.by(() =>
+    allEntries.reduce((m, e) => Math.max(m, variantCountOf(e)), 1),
+  );
+
+  function setGlobalVariant(value: number) {
+    store.setGlobalVariant(value);
+  }
+
+  function flipCard(hit: ArtistSearchHit, e: MouseEvent) {
+    e.stopPropagation();
+    const count = variantCountOf(hit);
+    if (count < 2) return;
+    const current = Math.min(store.resolveVariant(hit.slug), count);
+    const next = (current % count) + 1;
+    store.setVariant(hit.slug, next);
+  }
+
+  function imageIdForVariant(hit: ArtistSearchHit, variant: number): string {
+    const img = hit.images?.[variant - 1];
+    return img?.imageId || hit.imageId;
+  }
+
   function thumbUrl(hit: ArtistSearchHit): string {
-    if (!store.manifest || !hit.hasImage || !hit.imageId) return "";
-    return `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.webp`;
+    if (!store.manifest || !hit.hasImage) return "";
+    const count = variantCountOf(hit);
+    const variant = Math.min(store.resolveVariant(hit.slug), count);
+    const imageId = imageIdForVariant(hit, variant);
+    if (!imageId) return "";
+    return `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${imageId}.webp`;
+  }
+
+  // Variant state for the open lightbox entry (kept in sync with its grid card).
+  const activeVariantCount = $derived.by(() => {
+    if (!active) return 1;
+    const hit = gridEntries.find((h) => h.slug === active.slug);
+    return Math.max(1, hit ? variantCountOf(hit) : active.images?.length ?? 1);
+  });
+  const activeVariant = $derived(
+    active ? Math.min(store.resolveVariant(active.slug), activeVariantCount) : 1,
+  );
+  const activeCanFlip = $derived(activeVariantCount >= 2);
+
+  function flipActiveVariant() {
+    if (!active) return;
+    const count = activeVariantCount;
+    if (count < 2) return;
+    const current = Math.min(store.resolveVariant(active.slug), count);
+    const next = (current % count) + 1;
+    store.setVariant(active.slug, next);
   }
 
   function displayTag(tag: string): string {
@@ -566,6 +629,22 @@
           />
         </div>
 
+        {#if hasVariants}
+          <div class="flex items-center gap-0.5 rounded-lg border border-neutral-800 bg-neutral-900/50 p-1">
+            <span class="px-1.5 text-xs text-neutral-500">{locale.t('artist_gallery.variant_label')}</span>
+            {#each Array(maxVariants) as _, idx}
+              {@const n = idx + 1}
+              <button
+                type="button"
+                class="rounded px-2 py-0.5 text-xs transition-colors {globalVariant === n ? 'bg-indigo-600 text-white' : 'text-neutral-400 hover:text-neutral-200'}"
+                onclick={() => setGlobalVariant(n)}
+              >
+                {locale.t('artist_gallery.variant_n', { n })}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
         <button
           type="button"
           class="rounded-lg border px-2 py-1 text-xs transition-colors {showOnlyFavourites ? 'border-red-500 bg-red-950/50 text-red-300' : 'border-neutral-800 bg-neutral-900/50 text-neutral-400 hover:text-neutral-200'}"
@@ -730,6 +809,17 @@
               >
                 {locale.t('artist_gallery.copy_btn')}
               </button>
+              {#if variantCountOf(hit) >= 2}
+                <button
+                  type="button"
+                  class="absolute bottom-1 left-1 rounded border border-neutral-700 bg-neutral-900/90 px-1.5 py-0.5 text-[10px] text-neutral-200 opacity-0 transition-opacity group-hover:opacity-100 hover:border-indigo-500"
+                  onclick={(e) => flipCard(hit, e)}
+                  aria-label={locale.t('artist_gallery.flip_variant_aria')}
+                  title={locale.t('artist_gallery.flip_variant_aria')}
+                >
+                  ⇄ {Math.min(store.resolveVariant(hit.slug), variantCountOf(hit))}
+                </button>
+              {/if}
               {#if copiedSlug === hit.slug}
                 <div class="absolute inset-0 flex items-center justify-center bg-neutral-900/80">
                   <span class="rounded bg-emerald-600 px-2 py-1 text-xs font-semibold text-white">{locale.t('artist_gallery.copied')}</span>
@@ -874,6 +964,9 @@
     ontogglezoom={() => store.lightboxZoomed = !store.lightboxZoomed}
     onprev={activeIndex > 0 ? () => navigateTo(activeIndex - 1) : undefined}
     onnext={activeIndex >= 0 && activeIndex < gridEntries.length - 1 ? () => navigateTo(activeIndex + 1) : undefined}
+    variant={activeVariant}
+    canFlip={activeCanFlip}
+    onflip={flipActiveVariant}
   />
 {/if}
 

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -14,9 +14,15 @@
     /** Zoom state is owned by the parent so it survives modal close/reopen. */
     zoomed: boolean;
     ontogglezoom: () => void;
+    /** Currently displayed variant (1-based). Index v2+; defaults to the primary. */
+    variant?: number;
+    /** Show the in-modal flip button (only when the artist has >= 2 variants). */
+    canFlip?: boolean;
+    /** Flip the active artist's variant. Routed through the same override path as the grid. */
+    onflip?: () => void;
   }
 
-  let { entry, onclose, oninsertTag, onprev, onnext, zoomed, ontogglezoom }: Props = $props();
+  let { entry, onclose, oninsertTag, onprev, onnext, zoomed, ontogglezoom, variant = 1, canFlip = false, onflip }: Props = $props();
 
   /** Index v2+: variants with confirmed images. Falls back to the v1 primary when absent. */
   const visibleImages = $derived(
@@ -26,6 +32,40 @@
         ? [{ variantId: "p1", imageId: entry.imageId, imageUrl: entry.imageUrl, objectKey: entry.objectKey, hasImage: true }]
         : []
   );
+
+  /** Clamp the requested variant into the available range (1-based). */
+  const clampedVariant = $derived(
+    Math.min(Math.max(1, variant), Math.max(1, visibleImages.length)),
+  );
+  /** The single image shown for the current variant. */
+  const currentImage = $derived(visibleImages[clampedVariant - 1] ?? visibleImages[0]);
+  /** Total variants for flip math; falls back to 2 while the shard entry loads. */
+  const variantTotal = $derived(Math.max(visibleImages.length, canFlip ? 2 : 1));
+  /** Variant the flip button switches to (wraps around). */
+  const nextVariant = $derived(variantTotal >= 2 ? (clampedVariant % variantTotal) + 1 : clampedVariant);
+
+  /**
+   * 3D rotate animation, played only when the same artist's variant changes —
+   * NOT when navigating prev/next to a different artist (slug changes).
+   */
+  function flipImage(node: HTMLElement, params: { slug: string; variant: number }) {
+    let prev = params;
+    return {
+      update(next: { slug: string; variant: number }) {
+        if (next.slug === prev.slug && next.variant !== prev.variant) {
+          node.animate(
+            [
+              { transform: "perspective(1000px) rotateY(0deg)" },
+              { transform: "perspective(1000px) rotateY(90deg)", offset: 0.5 },
+              { transform: "perspective(1000px) rotateY(0deg)" },
+            ],
+            { duration: 400, easing: "ease-in-out" },
+          );
+        }
+        prev = next;
+      },
+    };
+  }
 
   function toggleZoom() { ontogglezoom(); }
 
@@ -86,18 +126,17 @@
         →
       </button>
     {/if}
-    {#if visibleImages.length > 0}
-      <div class="flex flex-wrap items-start justify-center gap-3">
-        {#each visibleImages as img (img.variantId)}
-          <img
-            use:cachedSrc={img.imageUrl}
-            src={img.imageUrl}
-            alt="{entry.tag} {img.variantId}"
-            class="max-h-[80vh] max-w-[92vw] w-auto rounded-lg border border-neutral-800 object-contain shadow-2xl"
-            style="zoom: {zoomed ? 1.5 : 1}; transition: zoom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); cursor: {zoomed ? 'zoom-out' : 'zoom-in'};"
-            onclick={toggleZoom}
-          />
-        {/each}
+    {#if currentImage}
+      <div class="flex items-start justify-center">
+        <img
+          use:cachedSrc={currentImage.imageUrl}
+          use:flipImage={{ slug: entry.slug, variant: clampedVariant }}
+          src={currentImage.imageUrl}
+          alt="{entry.tag} {currentImage.variantId}"
+          class="max-h-[80vh] max-w-[92vw] w-auto rounded-lg border border-neutral-800 object-contain shadow-2xl"
+          style="zoom: {zoomed ? 1.5 : 1}; transition: zoom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); cursor: {zoomed ? 'zoom-out' : 'zoom-in'};"
+          onclick={toggleZoom}
+        />
       </div>
     {:else}
       <div
@@ -127,6 +166,15 @@
         </div>
       </div>
       <div class="flex shrink-0 gap-2">
+        {#if canFlip && onflip}
+          <button
+            type="button"
+            class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-indigo-500 hover:bg-neutral-700"
+            onclick={onflip}
+          >
+            {locale.t('artist_gallery.lightbox.flip', { n: nextVariant })}
+          </button>
+        {/if}
         <button
           type="button"
           class="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 transition-colors hover:border-indigo-500 hover:bg-neutral-700"

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -60,11 +60,98 @@ export class ArtistGalleryStore {
   /** Last known scroll position of the gallery scroll container. */
   scrollTop = $state(0);
 
+  // --- Image variant toggle (index v2+; inert on single-variant v1 data) -----
+  /** Globally selected variant (1-based). Persisted across sessions. */
+  globalVariant = $state(1);
+  /**
+   * Per-card variant overrides. An entry is stored ONLY while it differs from
+   * `globalVariant` — a card flipped back to the global value drops its
+   * override so it re-syncs on the next global toggle.
+   */
+  variantOverrides = $state<Record<string, number>>({});
+
   /** Guard so rapid typing doesn't race older search results into state. */
   private searchSeq = 0;
 
+  private static readonly GLOBAL_VARIANT_KEY = "artist-gallery-global-variant";
+  private static readonly VARIANT_OVERRIDES_KEY = "artist-gallery-variant-overrides";
+
   constructor(manifestUrl: string) {
     this.client = createArtistGalleryClient({ manifestUrl, fetchImpl: cdnFetch });
+    this.loadVariants();
+  }
+
+  private loadVariants(): void {
+    try {
+      const g = localStorage.getItem(ArtistGalleryStore.GLOBAL_VARIANT_KEY);
+      if (g !== null) {
+        const n = parseInt(g, 10);
+        if (Number.isFinite(n) && n >= 1) this.globalVariant = n;
+      }
+      const o = localStorage.getItem(ArtistGalleryStore.VARIANT_OVERRIDES_KEY);
+      if (o) {
+        const parsed = JSON.parse(o);
+        if (parsed && typeof parsed === "object") {
+          const clean: Record<string, number> = {};
+          for (const [slug, v] of Object.entries(parsed)) {
+            if (typeof v === "number" && Number.isFinite(v) && v >= 1) clean[slug] = v;
+          }
+          this.variantOverrides = clean;
+        }
+      }
+    } catch {
+      /* localStorage unavailable; defaults are fine */
+    }
+  }
+
+  private persistVariants(): void {
+    try {
+      localStorage.setItem(ArtistGalleryStore.GLOBAL_VARIANT_KEY, String(this.globalVariant));
+      localStorage.setItem(
+        ArtistGalleryStore.VARIANT_OVERRIDES_KEY,
+        JSON.stringify(this.variantOverrides),
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Variant a card should display (1-based): its override if any, else global. */
+  resolveVariant(slug: string): number {
+    return this.variantOverrides[slug] ?? this.globalVariant;
+  }
+
+  /**
+   * Set a single card's variant. The override is stored ONLY while it differs
+   * from the global value; setting it equal to the global removes the override
+   * so the card re-syncs to the global on the next toggle.
+   */
+  setVariant(slug: string, value: number): void {
+    if (value === this.globalVariant) {
+      if (slug in this.variantOverrides) {
+        const next = { ...this.variantOverrides };
+        delete next[slug];
+        this.variantOverrides = next;
+      }
+    } else if (this.variantOverrides[slug] !== value) {
+      this.variantOverrides = { ...this.variantOverrides, [slug]: value };
+    }
+    this.persistVariants();
+  }
+
+  /**
+   * Set the global variant. Every override equal to the new global is absorbed
+   * (deleted) so those cards flip with the global; overrides that still differ
+   * are kept so those cards stay put. Symmetric in both directions.
+   */
+  setGlobalVariant(value: number): void {
+    this.globalVariant = value;
+    const next: Record<string, number> = {};
+    for (const [slug, v] of Object.entries(this.variantOverrides)) {
+      if (v !== value) next[slug] = v;
+    }
+    this.variantOverrides = next;
+    this.persistVariants();
   }
 
   async init(): Promise<void> {

--- a/src/lib/artist-gallery/types.ts
+++ b/src/lib/artist-gallery/types.ts
@@ -73,6 +73,12 @@ export interface ArtistSearchHit {
   hasImage: boolean;
   /** Number of image variants available; present in index v2+. */
   variantCount?: number;
+  /**
+   * Per-variant images; present in index v2+. Lets grid cards resolve a
+   * non-primary variant's thumbnail without a shard fetch. Absent in v1 —
+   * always fall back to `imageId`.
+   */
+  images?: ArtistImage[];
 }
 
 export interface SearchOptions {

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -2158,5 +2158,13 @@ const de: Record<string, string> = {
   "prompt_assistant.busy_generation": "Beschäftigt mit Generierung — nach Abschluss erneut versuchen.",
   "prompt_assistant.no_model": "Kein Prompt-Assistent-Modell installiert.",
   "prompt_assistant.error_generic": "Fehler beim Prompt-Assistenten, erneut versuchen.",
+  "artist_gallery.variant_label": "Variante",
+
+  "artist_gallery.variant_n": "Bild {n}",
+
+  "artist_gallery.flip_variant_aria": "Bildvariante wechseln",
+
+  "artist_gallery.lightbox.flip": "⇄ Bild {n}",
+
 };
 export default de;

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1549,6 +1549,9 @@ const en: Record<string, string> = {
   "artist_gallery.cat_uncategorised": "Uncategorised",
   "artist_gallery.cat_new": "＋ New category…",
   "artist_gallery.card_title": "{tag} · Right-click to copy tag",
+  "artist_gallery.variant_label": "Variant",
+  "artist_gallery.variant_n": "Image {n}",
+  "artist_gallery.flip_variant_aria": "Flip image variant",
 
   // Gen params modal
   "artist_gallery.gen_params.title": "Preview Generation Parameters",
@@ -1578,6 +1581,7 @@ const en: Record<string, string> = {
   "artist_gallery.lightbox.copy_tag": "Copy tag",
   "artist_gallery.lightbox.insert": "Insert into prompt",
   "artist_gallery.lightbox.close": "Close",
+  "artist_gallery.lightbox.flip": "⇄ Image {n}",
 
   // Favourites Manager
   "artist_gallery.fav_manager.aria": "Manage favourite categories",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -2184,5 +2184,13 @@ const es: Record<string, string> = {
   "prompt_assistant.busy_generation": "Ocupado generando — inténtalo de nuevo cuando termine.",
   "prompt_assistant.no_model": "No hay modelo de asistente de prompt instalado.",
   "prompt_assistant.error_generic": "Error del asistente de prompt, inténtalo de nuevo.",
+  "artist_gallery.variant_label": "Variante",
+
+  "artist_gallery.variant_n": "Imagen {n}",
+
+  "artist_gallery.flip_variant_aria": "Cambiar variante de imagen",
+
+  "artist_gallery.lightbox.flip": "⇄ Imagen {n}",
+
 };
 export default es;

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -2181,5 +2181,13 @@ const fr: Record<string, string> = {
   "prompt_assistant.busy_generation": "Génération en cours — réessayez une fois terminé.",
   "prompt_assistant.no_model": "Aucun modèle d'assistant de prompt installé.",
   "prompt_assistant.error_generic": "Erreur de l'assistant de prompt, réessayez.",
+  "artist_gallery.variant_label": "Variante",
+
+  "artist_gallery.variant_n": "Image {n}",
+
+  "artist_gallery.flip_variant_aria": "Changer de variante d'image",
+
+  "artist_gallery.lightbox.flip": "⇄ Image {n}",
+
 };
 export default fr;

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -2155,5 +2155,13 @@ const it: Record<string, string> = {
   "prompt_assistant.busy_generation": "Generazione in corso — riprova al termine.",
   "prompt_assistant.no_model": "Nessun modello assistente prompt installato.",
   "prompt_assistant.error_generic": "Errore assistente prompt, riprova.",
+  "artist_gallery.variant_label": "Variante",
+
+  "artist_gallery.variant_n": "Immagine {n}",
+
+  "artist_gallery.flip_variant_aria": "Cambia variante immagine",
+
+  "artist_gallery.lightbox.flip": "⇄ Immagine {n}",
+
 };
 export default it;

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -2180,5 +2180,13 @@ const ja: Record<string, string> = {
   "prompt_assistant.busy_generation": "生成中です — 完了後にもう一度お試しください。",
   "prompt_assistant.no_model": "プロンプトアシスタントモデルがインストールされていません。",
   "prompt_assistant.error_generic": "プロンプトアシスタントエラー、もう一度お試しください。",
+  "artist_gallery.variant_label": "バリエーション",
+
+  "artist_gallery.variant_n": "画像{n}",
+
+  "artist_gallery.flip_variant_aria": "画像バリエーションを切り替え",
+
+  "artist_gallery.lightbox.flip": "⇄ 画像{n}",
+
 };
 export default ja;

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -2155,5 +2155,13 @@ const ko: Record<string, string> = {
   "prompt_assistant.busy_generation": "생성 중입니다 — 완료 후 다시 시도하세요.",
   "prompt_assistant.no_model": "프롬프트 어시스턴트 모델이 설치되지 않았습니다.",
   "prompt_assistant.error_generic": "프롬프트 어시스턴트 오류, 다시 시도하세요.",
+  "artist_gallery.variant_label": "변형",
+
+  "artist_gallery.variant_n": "이미지 {n}",
+
+  "artist_gallery.flip_variant_aria": "이미지 변형 전환",
+
+  "artist_gallery.lightbox.flip": "⇄ 이미지 {n}",
+
 };
 export default ko;

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -2156,5 +2156,13 @@ const pt: Record<string, string> = {
   "prompt_assistant.busy_generation": "Gerando — tente novamente após concluir.",
   "prompt_assistant.no_model": "Nenhum modelo de assistente de prompt instalado.",
   "prompt_assistant.error_generic": "Erro do assistente de prompt, tente novamente.",
+  "artist_gallery.variant_label": "Variante",
+
+  "artist_gallery.variant_n": "Imagem {n}",
+
+  "artist_gallery.flip_variant_aria": "Alternar variante de imagem",
+
+  "artist_gallery.lightbox.flip": "⇄ Imagem {n}",
+
 };
 export default pt;

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -2155,5 +2155,13 @@ const ru: Record<string, string> = {
   "prompt_assistant.busy_generation": "Идёт генерация — попробуйте после завершения.",
   "prompt_assistant.no_model": "Модель ассистента промптов не установлена.",
   "prompt_assistant.error_generic": "Ошибка ассистента промптов, попробуйте ещё раз.",
+  "artist_gallery.variant_label": "Вариант",
+
+  "artist_gallery.variant_n": "Изображение {n}",
+
+  "artist_gallery.flip_variant_aria": "Сменить вариант изображения",
+
+  "artist_gallery.lightbox.flip": "⇄ Изображение {n}",
+
 };
 export default ru;

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -2155,5 +2155,13 @@ const zhTw: Record<string, string> = {
   "prompt_assistant.busy_generation": "正在生成中 — 請等待完成後再試。",
   "prompt_assistant.no_model": "未安裝提示詞助手模型。",
   "prompt_assistant.error_generic": "提示詞助手錯誤，請重試。",
+  "artist_gallery.variant_label": "變體",
+
+  "artist_gallery.variant_n": "圖片 {n}",
+
+  "artist_gallery.flip_variant_aria": "切換圖片變體",
+
+  "artist_gallery.lightbox.flip": "⇄ 圖片 {n}",
+
 };
 export default zhTw;

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -2156,5 +2156,13 @@ const zh: Record<string, string> = {
   "prompt_assistant.busy_generation": "正在生成中 — 请等待完成后重试。",
   "prompt_assistant.no_model": "未安装提示词助手模型。",
   "prompt_assistant.error_generic": "提示词助手错误，请重试。",
+  "artist_gallery.variant_label": "变体",
+
+  "artist_gallery.variant_n": "图片 {n}",
+
+  "artist_gallery.flip_variant_aria": "切换图片变体",
+
+  "artist_gallery.lightbox.flip": "⇄ 图片 {n}",
+
 };
 export default zh;


### PR DESCRIPTION
- Artist gallery image variant support: flip button on cards cycles through all reference images, global variant toolbar selector, lightbox flip control
- Fix 524 timeout on compose/enhance after generation on hosted deployment: unload idle ComfyUI workers before LLM startup so it loads on GPU instead of CPU