### PR TITLE
v1.4.21: Point artist gallery at v2 multi-variant dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.21
+
+### Artist Gallery
+- **Point the gallery at the new multi-variant dataset**: 1.4.20 added the image-variant flip controls but the app was still loading the previous single-image index, so the second image never appeared. The manifest now points at the v2 release (`20260425_anima_all_artists`), so artists with two reference images expose the flip toggle as intended.
+
+---
+
 ## What's New in v1.4.20
 
 ### Artist Gallery

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.21
+
+### Artist Gallery
+- **Point the gallery at the new multi-variant dataset**: 1.4.20 added the image-variant flip controls but the app was still loading the previous single-image index, so the second image never appeared. The manifest now points at the v2 release (`20260425_anima_all_artists`), so artists with two reference images expose the flip toggle as intended.
+
+---
+
 ## What's New in v1.4.20
 
 ### Artist Gallery

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.20"
+version = "1.4.21"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.20",
+  "version": "1.4.21",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/README.md
+++ b/src/lib/artist-gallery/README.md
@@ -16,7 +16,7 @@ Designed to drop, unchanged, into:
   import { ArtistGalleryPage } from "$lib/artist-gallery";
 
   const manifestUrl =
-    "https://cdn.mooshieblob.com/20260325_anima_all_artists/indices/manifest.json";
+    "https://cdn.mooshieblob.com/20260425_anima_all_artists/indices/manifest.json";
 
   function insertTagIntoPrompt(tag: string) {
     // Integrator wires this up; omit the prop if you don't want the button.

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -9,7 +9,7 @@ class ConnectionStore {
   serverUrl = $state("http://127.0.0.1:8188");
   /** Manifest URL for the Anima artist gallery. Proxied in browser mode to avoid CORS. */
   artistGalleryManifestUrl = $state(
-    `${CDN_BASE}/20260325_anima_all_artists/indices/manifest.json`,
+    `${CDN_BASE}/20260425_anima_all_artists/indices/manifest.json`,
   );
 }
 


### PR DESCRIPTION
1.4.20 shipped the image-variant flip controls but the app still loaded the previous single-image index (`20260325_anima_all_artists`), so the second image never appeared. Swaps the manifest URL to the v2 release (`20260425_anima_all_artists`, version 2, 42197 artists) so multi-variant artists expose the flip toggle as intended.