### PR TITLE
v1.4.23: M2 parameter correctness + artist gallery fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## What's New in v1.4.23
+
+### Illustrious models
+- **Stable output on non-turbo Illustrious checkpoints**: the default sampler is now `euler_ancestral_cfg_pp` at CFG 2.0 (previously `euler_cfg_pp` at CFG 5.0, which ran a CFG++ sampler far outside its intended low-CFG band and over-baked results). On older ComfyUI builds that lack the ancestral CFG++ sampler, it falls back gracefully to `euler_ancestral`.
+
+### CFG guidance
+- **Loud CFG 1 warning**: setting CFG to 1.0 now shows a prominent, non-blocking warning explaining that it disables prompt guidance and breaks CFG++ samplers entirely (only Turbo, distilled, and Lightning models tolerate it). Generation still proceeds.
+- **Corrected recommended CFG range for CFG++ samplers**: the recommended band is now 1.5 to 2.2 (target 1.8). The previous range treated the value that breaks these samplers as in-range.
+- **Sampler switch snaps to the right CFG**: switching to a CFG++ sampler from a high CFG now snaps to the recommended target (1.8) instead of a stale 1.4 that read as out-of-range.
+
+### Advanced Mode
+- **New opt-in Advanced Mode (Settings)**: when enabled, swapping checkpoints no longer overwrites your steps, CFG, sampler, scheduler, or dimensions, so power users keep their tuned parameters across model changes. Model family detection still runs so the generation pipeline stays correct. Enabling it shows a confirmation dialog; the first model selected on a fresh profile still gets sensible defaults.
+
+### Upscale
+- **Upscale CFG floor for CFG++ samplers**: the high-res upscale pass halves the base CFG, which would drop the new Illustrious default to CFG 1.0 and collapse the CFG++ sampler. The upscale CFG is now floored at 2.0 whenever a CFG++ sampler is in use.
+
+### Artist Gallery
+- **Favourite-artist thumbnails now render on the generation page**: the bottom-panel Artists tab still built `.webp` image URLs while the v2 dataset ships AVIF, so favourited artists showed blank previews (the same fix v1.4.22 applied to the gallery grid, missed here). The thumbnail URL now picks the correct extension from the index version.
+- **Removed the stray horizontal scrollbar in the artist lightbox**: clicking an artist card to view it larger showed an unwanted horizontal scrollbar. The prev/next arrow overlays sit just outside the content box and were being counted as horizontal overflow by the scroll container. Scrolling is now confined to an inner wrapper so the arrows no longer trigger it.
+
+---
+
 ## What's New in v1.4.22
 
 ### Artist Gallery

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+## What's New in v1.4.23
+
+### Illustrious models
+- **Stable output on non-turbo Illustrious checkpoints**: the default sampler is now `euler_ancestral_cfg_pp` at CFG 2.0 (previously `euler_cfg_pp` at CFG 5.0, which ran a CFG++ sampler far outside its intended low-CFG band and over-baked results). On older ComfyUI builds that lack the ancestral CFG++ sampler, it falls back gracefully to `euler_ancestral`.
+
+### CFG guidance
+- **Loud CFG 1 warning**: setting CFG to 1.0 now shows a prominent, non-blocking warning explaining that it disables prompt guidance and breaks CFG++ samplers entirely (only Turbo, distilled, and Lightning models tolerate it). Generation still proceeds.
+- **Corrected recommended CFG range for CFG++ samplers**: the recommended band is now 1.5 to 2.2 (target 1.8). The previous range treated the value that breaks these samplers as in-range.
+- **Sampler switch snaps to the right CFG**: switching to a CFG++ sampler from a high CFG now snaps to the recommended target (1.8) instead of a stale 1.4 that read as out-of-range.
+
+### Advanced Mode
+- **New opt-in Advanced Mode (Settings)**: when enabled, swapping checkpoints no longer overwrites your steps, CFG, sampler, scheduler, or dimensions, so power users keep their tuned parameters across model changes. Model family detection still runs so the generation pipeline stays correct. Enabling it shows a confirmation dialog; the first model selected on a fresh profile still gets sensible defaults.
+
+### Upscale
+- **Upscale CFG floor for CFG++ samplers**: the high-res upscale pass halves the base CFG, which would drop the new Illustrious default to CFG 1.0 and collapse the CFG++ sampler. The upscale CFG is now floored at 2.0 whenever a CFG++ sampler is in use.
+
+### Artist Gallery
+- **Favourite-artist thumbnails now render on the generation page**: the bottom-panel Artists tab still built `.webp` image URLs while the v2 dataset ships AVIF, so favourited artists showed blank previews (the same fix v1.4.22 applied to the gallery grid, missed here). The thumbnail URL now picks the correct extension from the index version.
+- **Removed the stray horizontal scrollbar in the artist lightbox**: clicking an artist card to view it larger showed an unwanted horizontal scrollbar. The prev/next arrow overlays sit just outside the content box and were being counted as horizontal overflow by the scroll container. Scrolling is now confined to an inner wrapper so the arrows no longer trigger it.
+
+---
+
 ## What's New in v1.4.22
 
 ### Artist Gallery

--- a/docs/superpowers/plans/2026-06-17-m2-parameter-correctness-control.md
+++ b/docs/superpowers/plans/2026-06-17-m2-parameter-correctness-control.md
@@ -1,0 +1,527 @@
+# M2 — Parameter Correctness & Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Illustrious generate stably at the correct low CFG, make CFG=1 impossible to footgun silently, add an opt-in Advanced Mode that stops auto-tuning generation params on checkpoint change, and stop the upscale pass from collapsing CFG++ samplers at low base CFG.
+
+**Architecture:** Four isolated changes. (1) The Illustrious non-turbo preset switches from `euler_cfg_pp` @ 5.0 to `euler_ancestral_cfg_pp` @ 2.0 with a graceful sampler fallback; (2) the sampler panel raises the cfg_pp recommended floor and adds a prominent CFG=1 warning box; (3) a new persisted `advancedMode` flag gates the param-writing half of `applyModelSpecificPreset()`; (4) the Rust upscale template floors CFG at 2.0 for CFG++ samplers. No new Tauri commands, no guidance-node changes.
+
+**Tech Stack:** Svelte 5 runes (class-singleton store in `*.svelte.ts`), TypeScript, Tauri/Rust template builders, flat-key i18n in `src/lib/locales/*.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-m2-parameter-correctness-control-design.md`
+
+**Project-specific constraints (apply to every task):**
+- **No test framework exists.** "Tests" are the build gates: `npm run build` (PASS = output ends with `✓ built in`) for frontend/TS/Svelte changes, and `cargo check --manifest-path src-tauri/Cargo.toml` for Rust changes. Plus the manual verification noted per task.
+- **Windows git:** prefix every git command with `git -c core.hooksPath=/dev/null` (the bash pre-commit hook hangs in PowerShell).
+- **No `Co-Authored-By` trailers** in any commit message.
+- **i18n parity is enforced:** every key added to `src/lib/locales/en.ts` must be added to all 10 other locale files (`de, es, fr, it, ja, ko, pt, ru, zh, zh-tw`). Locale files use a **flat** key structure (`"a.b.c": "value"`), not nested objects. English fallback text in the non-English files is acceptable per existing repo precedent.
+- **Svelte/Tailwind rules:** Tailwind classes only (no `<style>` blocks); `onclick`/`onchange` not legacy `on:click`; dark-neutral palette.
+
+---
+
+## Task 1: Fix the Illustrious non-turbo preset + sampler fallback
+
+**Files:**
+- Modify: `src/lib/stores/generation.svelte.ts` (the `ModelPreset` interface ~line 49; `applyResolvedPreset()` ~line 844; the `case "illustrious"` block ~lines 1069-1078)
+
+**Context:** `applyResolvedPreset()` already routes the preset sampler through `resolveAvailableOption(models.samplers, preset.samplerName, "euler")`, which falls back to the literal `"euler"` if the preferred sampler is absent from the backend's enumerated sampler list. For Illustrious we want the fallback to be `euler_ancestral` (preserve the ancestral character), so we add an optional per-preset fallback field. Only the `illustrious` case changes — the `sdxl`/`mugen`/`unknown`/default block keeps `euler_cfg_pp` @ 5.0, and Anima/Wan/Qwen keep `er_sde` @ 4.0.
+
+- [ ] **Step 1: Add an optional `samplerFallback` field to the `ModelPreset` interface**
+
+In `src/lib/stores/generation.svelte.ts`, the interface currently reads (lines 49-57):
+
+```ts
+interface ModelPreset {
+  steps: number;
+  cfg: number;
+  samplerName: string;
+  scheduler: string;
+  width: number;
+  height: number;
+  upscaleDenoise?: number;
+}
+```
+
+Add the field:
+
+```ts
+interface ModelPreset {
+  steps: number;
+  cfg: number;
+  samplerName: string;
+  scheduler: string;
+  width: number;
+  height: number;
+  upscaleDenoise?: number;
+  /** Sampler to use when `samplerName` is absent from the backend's enumerated list. Defaults to "euler". */
+  samplerFallback?: string;
+}
+```
+
+- [ ] **Step 2: Use `samplerFallback` in `applyResolvedPreset()`**
+
+The line is currently (line 844):
+
+```ts
+    this.samplerName = this.resolveAvailableOption(models.samplers, preset.samplerName, "euler");
+```
+
+Change it to:
+
+```ts
+    this.samplerName = this.resolveAvailableOption(models.samplers, preset.samplerName, preset.samplerFallback ?? "euler");
+```
+
+Leave the scheduler line (845) unchanged.
+
+- [ ] **Step 3: Update the `case "illustrious"` block**
+
+The block is currently (lines 1069-1078):
+
+```ts
+      case "illustrious":
+        preset = {
+          steps: this.hasTurboModelVariant ? 10 : 20,
+          cfg: this.hasTurboModelVariant ? 1.0 : 5.0,
+          samplerName: this.hasTurboModelVariant ? "euler" : "euler_cfg_pp",
+          scheduler: this.hasTurboModelVariant ? "normal" : "sgm_uniform",
+          width: 1024,
+          height: 1024,
+        };
+        break;
+```
+
+Replace it with:
+
+```ts
+      case "illustrious":
+        preset = {
+          steps: this.hasTurboModelVariant ? 10 : 20,
+          // euler_ancestral_cfg_pp is a CFG++ sampler tuned for low CFG (~1.5-2.2);
+          // CFG 2.0 keeps it inside its band. Falls back to plain euler_ancestral
+          // on older ComfyUI builds that lack the cfg_pp variant.
+          cfg: this.hasTurboModelVariant ? 1.0 : 2.0,
+          samplerName: this.hasTurboModelVariant ? "euler" : "euler_ancestral_cfg_pp",
+          samplerFallback: this.hasTurboModelVariant ? "euler" : "euler_ancestral",
+          scheduler: this.hasTurboModelVariant ? "normal" : "sgm_uniform",
+          width: 1024,
+          height: 1024,
+        };
+        break;
+```
+
+Do **not** touch the `case "sdxl": case "mugen": case "unknown": default:` block (lines 1094-1106) or any other case.
+
+- [ ] **Step 4: Verify the build passes**
+
+Run: `npm run build`
+Expected: output ends with `✓ built in` (no TS errors about `samplerFallback`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -c core.hooksPath=/dev/null add src/lib/stores/generation.svelte.ts
+git -c core.hooksPath=/dev/null commit -m "fix: correct Illustrious non-turbo preset to euler_ancestral_cfg_pp @ CFG 2.0"
+```
+
+**Manual verification (note for later, not a blocker):** Selecting a non-turbo Illustrious checkpoint should set sampler `euler_ancestral_cfg_pp` (or `euler_ancestral` on older backends) and CFG 2.0.
+
+---
+
+## Task 2: CFG=1 loud warning + fix the misleading cfg_pp range
+
+**Files:**
+- Modify: `src/lib/components/generation/SamplerSettings.svelte` (`recommendedCfgRange()` ~line 32-35; insert a warning box after the recommendations row ~line 245)
+- Modify: `src/lib/locales/en.ts` (add 2 keys after the existing `generation.sampler.*` block)
+- Modify: all 10 other locale files (`src/lib/locales/{de,es,fr,it,ja,ko,pt,ru,zh,zh-tw}.ts`) — add the same 2 keys
+
+**Context:** `recommendedCfgRange()` currently treats CFG 1.0 as in-range for cfg_pp samplers (`min: 1.0`), so the UI never warns at the exact value that breaks CFG++ samplers. We raise the floor and add a prominent, non-blocking warning box that only appears at `cfg <= 1.0`. The existing small amber recommendations row (lines 230-245) stays for the milder out-of-range case.
+
+- [ ] **Step 1: Raise the cfg_pp recommended floor**
+
+In `src/lib/components/generation/SamplerSettings.svelte`, the function is currently (lines 32-35):
+
+```ts
+  function recommendedCfgRange() {
+    if (isCfgPpSampler(generation.samplerName)) return { min: 1.0, max: 2.2, target: 1.4 };
+    return { min: 4.0, max: 8.0, target: 6.0 };
+  }
+```
+
+Change only the cfg_pp branch:
+
+```ts
+  function recommendedCfgRange() {
+    if (isCfgPpSampler(generation.samplerName)) return { min: 1.5, max: 2.2, target: 1.8 };
+    return { min: 4.0, max: 8.0, target: 6.0 };
+  }
+```
+
+- [ ] **Step 2: Add the i18n keys to `en.ts`**
+
+In `src/lib/locales/en.ts`, find the `generation.sampler.juice_hint` line (currently line 589). Immediately after it, add:
+
+```ts
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
+```
+
+- [ ] **Step 3: Add the same 2 keys to all 10 other locale files**
+
+For each of `src/lib/locales/de.ts`, `es.ts`, `fr.ts`, `it.ts`, `ja.ts`, `ko.ts`, `pt.ts`, `ru.ts`, `zh.ts`, `zh-tw.ts`: locate the `"generation.sampler.juice_hint":` line in that file and add the same two lines immediately after it (the English text above is acceptable as the value in every file — do not invent translations):
+
+```ts
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
+```
+
+Note: these keys have **no `{placeholder}`** interpolation, so there is nothing to keep in sync beyond the key names themselves.
+
+- [ ] **Step 4: Add the prominent warning box after the recommendations row**
+
+In `SamplerSettings.svelte`, the recommendations row closes at line 245 with `</div>`, immediately followed by the `<!-- Seed + Batch Size -->` comment at line 247. Insert the warning box between them (after line 245, before line 247):
+
+```svelte
+  {#if generation.cfg <= 1.0}
+    <div class="flex items-start gap-2 rounded-lg border border-amber-600/60 bg-amber-950/30 px-3 py-2 mt-1">
+      <svg class="w-4 h-4 mt-0.5 shrink-0 text-amber-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+      <div>
+        <p class="text-xs font-semibold text-amber-200">{locale.t('generation.sampler.cfg1_warning_title')}</p>
+        <p class="text-[10px] text-amber-300/80 mt-0.5">{locale.t('generation.sampler.cfg1_warning_body')}</p>
+      </div>
+    </div>
+  {/if}
+```
+
+This is non-blocking (display only). `locale` is already imported in this component (used throughout).
+
+- [ ] **Step 5: Verify the build passes**
+
+Run: `npm run build`
+Expected: output ends with `✓ built in`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -c core.hooksPath=/dev/null add src/lib/components/generation/SamplerSettings.svelte src/lib/locales
+git -c core.hooksPath=/dev/null commit -m "feat: prominent CFG=1 warning and corrected cfg_pp recommended range"
+```
+
+**Manual verification (note for later):** Drag CFG to 1.0 → the prominent amber warning box appears; the cfg_pp recommended-range text reads `1.5-2.2`; generation still proceeds.
+
+---
+
+## Task 3: Add the `advancedMode` flag and gate `applyModelSpecificPreset()`
+
+**Files:**
+- Modify: `src/lib/stores/generation.svelte.ts` (declare flag ~line 359; gate inside `applyModelSpecificPreset()` ~line 868; load guard ~line 1219; two save objects ~line 1346 and ~line 1438)
+
+**Context:** `advancedMode` is a persisted app-level preference (mirror the `manualSaveMode` wiring exactly — declaration, one load guard, two save objects). When on, `applyModelSpecificPreset()` still runs family detection and updates `modelPresetAppliedKey` (so template behavior stays correct), but skips writing the user-facing params (`steps`, `cfg`, `samplerName`, `scheduler`, `width`, `height`) — which all happen inside `applyResolvedPreset()`. A first-ever application is exempt so fresh users still get sane defaults. Family/architecture metadata is set in `applyModelMetadata()` (a separate method), so skipping the preset application here does not affect family detection.
+
+- [ ] **Step 1: Declare the flag**
+
+In `src/lib/stores/generation.svelte.ts`, after the `autoSaveDirs` declaration (line 361):
+
+```ts
+  autoSaveDirs = $state<string[]>([]);
+```
+
+add:
+
+```ts
+  /** When true, swapping checkpoints no longer auto-applies per-model generation
+   *  presets (steps/cfg/sampler/scheduler/dimensions) — power users keep their tuning.
+   *  The first preset of a fresh profile is still applied so defaults aren't nonsense. */
+  advancedMode = $state(false);
+```
+
+- [ ] **Step 2: Gate the preset application**
+
+In `applyModelSpecificPreset()`, the idempotency guard is currently (lines 867-868):
+
+```ts
+    if (presetKey === this.modelPresetAppliedKey) return;
+    this.modelPresetAppliedKey = presetKey;
+```
+
+Replace with:
+
+```ts
+    if (presetKey === this.modelPresetAppliedKey) return;
+    const isFirstPresetApplication = !this.modelPresetAppliedKey;
+    this.modelPresetAppliedKey = presetKey;
+
+    // Advanced Mode: once a preset has been applied at least once, preserve the
+    // user's generation params across checkpoint swaps. Family/architecture
+    // metadata is set in applyModelMetadata(), so templates still behave correctly.
+    if (this.advancedMode && !isFirstPresetApplication) return;
+```
+
+- [ ] **Step 3: Restore the flag in `loadSettings()`**
+
+Find the `manualSaveMode` load guard (line 1219):
+
+```ts
+        if (saved.manualSaveMode !== undefined) this.manualSaveMode = saved.manualSaveMode;
+```
+
+Add immediately after it:
+
+```ts
+        if (saved.advancedMode !== undefined) this.advancedMode = saved.advancedMode;
+```
+
+- [ ] **Step 4: Persist the flag in both save objects**
+
+First save object — find (line 1346):
+
+```ts
+        manualSaveMode: this.manualSaveMode,
+```
+
+Add immediately after:
+
+```ts
+        advancedMode: this.advancedMode,
+```
+
+Second save object — find (line 1438, note the shallower indentation here):
+
+```ts
+      manualSaveMode: this.manualSaveMode,
+```
+
+Add immediately after:
+
+```ts
+      advancedMode: this.advancedMode,
+```
+
+- [ ] **Step 5: Verify the build passes**
+
+Run: `npm run build`
+Expected: output ends with `✓ built in`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -c core.hooksPath=/dev/null add src/lib/stores/generation.svelte.ts
+git -c core.hooksPath=/dev/null commit -m "feat: add advancedMode flag gating per-model preset auto-apply"
+```
+
+**Manual verification deferred to Task 4** (needs the toggle UI to set the flag).
+
+---
+
+## Task 4: Advanced Mode toggle UI + confirmation modal
+
+**Files:**
+- Modify: `src/lib/components/settings/SettingsPage.svelte` (add a `showAdvancedModeWarning` state var in the `<script>`; add the toggle inside the `quality` section ~line 2567; add the confirmation modal near the `showQualityTagsWarning` modal ~line 4175)
+- Modify: `src/lib/locales/en.ts` (add 6 keys after the `settings.quality_warning.*` block)
+- Modify: all 10 other locale files — add the same 6 keys
+
+**Context:** Mirror the existing `autoQualityTags` confirmation pattern: the checkbox reflects the store value; enabling it pops a confirmation modal (the box doesn't flip until confirmed); disabling is silent. The toggle lives in the `quality` settings section (its keyword list already includes "illustrious pony" model concepts). The `showQualityTagsWarning` modal at lines 4149-4175 is the exact template to copy.
+
+- [ ] **Step 1: Add the modal state variable**
+
+In the `<script>` of `src/lib/components/settings/SettingsPage.svelte`, find the existing `showQualityTagsWarning` declaration (search for `showQualityTagsWarning`) and add a sibling declaration next to it:
+
+```ts
+  let showAdvancedModeWarning = $state(false);
+```
+
+(Match the existing declaration style in that file — if `showQualityTagsWarning` uses `let showQualityTagsWarning = $state(false);`, mirror it exactly.)
+
+- [ ] **Step 2: Add the toggle inside the quality section**
+
+In the quality section, the auto-quality-tags toggle block ends at line 2567 with `</div>`, immediately before `{#if generation.autoQualityTags}` at line 2569. Insert the Advanced Mode toggle between them (after line 2567, before line 2569):
+
+```svelte
+          <div class="flex items-start gap-3">
+            <input
+              type="checkbox"
+              id="advanced-mode"
+              checked={generation.advancedMode}
+              onchange={(e) => {
+                const target = e.target as HTMLInputElement;
+                if (target.checked) {
+                  // Revert visually — let the confirmation popup decide.
+                  target.checked = false;
+                  showAdvancedModeWarning = true;
+                } else {
+                  generation.advancedMode = false;
+                  generation.saveSettings();
+                }
+              }}
+              class="w-4 h-4 mt-0.5 accent-indigo-500 rounded"
+            />
+            <div>
+              <label for="advanced-mode" class="text-sm text-neutral-200">{locale.t('settings.advanced_mode.label')}</label>
+              <p class="text-[10px] text-neutral-500 mt-0.5">{locale.t('settings.advanced_mode.desc')}</p>
+            </div>
+          </div>
+```
+
+- [ ] **Step 3: Add the confirmation modal**
+
+After the `showQualityTagsWarning` modal's closing `{/if}` (line 4175), add:
+
+```svelte
+{#if showAdvancedModeWarning}
+<div class="fixed inset-0 bg-black/70 z-50 flex items-center justify-center" role="dialog">
+  <div class="bg-neutral-900 border border-neutral-700 rounded-xl p-6 max-w-md mx-4 shadow-2xl">
+    <h3 class="text-sm font-semibold text-neutral-100 mb-3">{locale.t('settings.advanced_mode.warning_title')}</h3>
+    <p class="text-xs text-neutral-400 mb-4">{locale.t('settings.advanced_mode.warning_body')}</p>
+    <div class="flex gap-3 justify-end">
+      <button
+        onclick={() => { showAdvancedModeWarning = false; }}
+        class="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 text-neutral-400 rounded-lg text-xs transition-colors cursor-pointer"
+      >
+        {locale.t('settings.advanced_mode.cancel')}
+      </button>
+      <button
+        onclick={() => {
+          generation.advancedMode = true;
+          generation.saveSettings();
+          showAdvancedModeWarning = false;
+        }}
+        class="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-medium transition-colors cursor-pointer"
+      >
+        {locale.t('settings.advanced_mode.enable')}
+      </button>
+    </div>
+  </div>
+</div>
+{/if}
+```
+
+- [ ] **Step 4: Add the 5 i18n keys to `en.ts`**
+
+In `src/lib/locales/en.ts`, find the `settings.quality_warning.disable` line (line 454). Immediately after it, add:
+
+```ts
+  "settings.advanced_mode.label": "Advanced mode (lock generation parameters)",
+  "settings.advanced_mode.desc": "When on, switching checkpoints no longer auto-adjusts steps, CFG, sampler, scheduler, or dimensions. Your manual settings are preserved.",
+  "settings.advanced_mode.warning_title": "Enable advanced mode?",
+  "settings.advanced_mode.warning_body": "Steps, CFG, sampler, scheduler, and dimensions will stop auto-tuning when you change models. Recommended defaults will no longer be applied, so make sure your settings suit each model you load.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
+```
+
+- [ ] **Step 5: Add the same 6 keys to all 10 other locale files**
+
+For each of `de.ts, es.ts, fr.ts, it.ts, ja.ts, ko.ts, pt.ts, ru.ts, zh.ts, zh-tw.ts`: find the `"settings.quality_warning.disable":` line and add the same six lines from Step 4 immediately after it (English text acceptable as the value). None of these keys use `{placeholder}` interpolation.
+
+- [ ] **Step 6: Verify the build passes**
+
+Run: `npm run build`
+Expected: output ends with `✓ built in`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -c core.hooksPath=/dev/null add src/lib/components/settings/SettingsPage.svelte src/lib/locales
+git -c core.hooksPath=/dev/null commit -m "feat: Advanced Mode toggle with confirmation dialog in settings"
+```
+
+**Manual verification (note for later):** Enable Advanced Mode (confirm the dialog) → set a custom CFG/sampler/steps/dimensions → swap checkpoints → those params are preserved. Disable Advanced Mode → swapping checkpoints auto-applies per-model presets again. A brand-new profile with no prior preset still gets defaults on first model select.
+
+---
+
+## Task 5: Upscale CFG floor for CFG++ samplers (Rust)
+
+**Files:**
+- Modify: `src-tauri/src/templates/upscale.rs` (the second-pass KSampler ~lines 191-210)
+
+**Context:** The upscale pass halves the base CFG (`params.cfg / 2.0`) and inherits the base sampler. With the new Illustrious default (CFG 2.0 + a CFG++ sampler), this would produce CFG 1.0 on `euler_ancestral_cfg_pp` — the exact collapse this milestone fixes. Floor the upscale CFG at 2.0 when the sampler is a CFG++ variant. The detection idiom (`sampler_name.to_lowercase().contains("cfg_pp")`) mirrors `inpainting.rs:113`. Compute the values *before* the `json!` block, since `params.sampler_name` is moved into the workflow at line 205.
+
+- [ ] **Step 1: Compute the floored CFG before the KSampler insert**
+
+In `src-tauri/src/templates/upscale.rs`, the second KSampler pass begins at line 191. The block is currently:
+
+```rust
+    // Second KSampler pass at low denoise
+    let sampler_id = next_id.to_string();
+    workflow.insert(
+        sampler_id.clone(),
+        json!({
+            "class_type": "KSampler",
+            "inputs": {
+                "model": [model_after_soft.0, model_after_soft.1],
+                "positive": [pos_source.0, pos_source.1],
+                "negative": [neg_source.0, neg_source.1],
+                "latent_image": [latent_source.0.clone(), latent_source.1],
+                "seed": seed + 1,
+                "steps": params.upscale_steps,
+                "cfg": params.cfg / 2.0,
+                "sampler_name": params.sampler_name,
+                "scheduler": params.scheduler,
+                "denoise": params.upscale_denoise
+            }
+        }),
+    );
+```
+
+Change it to:
+
+```rust
+    // Second KSampler pass at low denoise
+    let sampler_id = next_id.to_string();
+    // CFG++ samplers collapse to unconditional output at CFG=1. Halving a low base
+    // CFG (e.g. Illustrious 2.0) would land there, so floor the upscale CFG at 2.0
+    // for CFG++ variants; other samplers keep the plain half-CFG behaviour.
+    let is_cfgpp_sampler = params.sampler_name.to_lowercase().contains("cfg_pp");
+    let upscale_cfg = if is_cfgpp_sampler {
+        (params.cfg / 2.0).max(2.0)
+    } else {
+        params.cfg / 2.0
+    };
+    workflow.insert(
+        sampler_id.clone(),
+        json!({
+            "class_type": "KSampler",
+            "inputs": {
+                "model": [model_after_soft.0, model_after_soft.1],
+                "positive": [pos_source.0, pos_source.1],
+                "negative": [neg_source.0, neg_source.1],
+                "latent_image": [latent_source.0.clone(), latent_source.1],
+                "seed": seed + 1,
+                "steps": params.upscale_steps,
+                "cfg": upscale_cfg,
+                "sampler_name": params.sampler_name,
+                "scheduler": params.scheduler,
+                "denoise": params.upscale_denoise
+            }
+        }),
+    );
+```
+
+- [ ] **Step 2: Verify Rust compiles**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+Expected: finishes with no errors (a benign unused-warning is not expected since both `is_cfgpp_sampler` and `upscale_cfg` are used).
+
+- [ ] **Step 3: Verify Rust formatting on the changed lines**
+
+Run: `cd src-tauri && cargo fmt --check`
+Expected: no diffs that overlap the lines you changed. If `cargo fmt` reports your new lines, run `cargo fmt` and re-stage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -c core.hooksPath=/dev/null add src-tauri/src/templates/upscale.rs
+git -c core.hooksPath=/dev/null commit -m "fix: floor upscale CFG at 2.0 for CFG++ samplers"
+```
+
+**Manual verification (note for later):** Generate with the new Illustrious default and enable upscale → the upscale pass runs at CFG 2.0 (not 1.0) and produces a clean result.
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `npm run build` → ends with `✓ built in`
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` → no errors
+- [ ] Run the `pre-commit-check` skill once over the full changeset to confirm i18n key parity across all 11 locale files and Svelte/store conventions.
+- [ ] Spot-check each "Done when" from the spec (the per-task manual-verification notes above).
+
+This milestone is independently releasable as a stability/correctness release.

--- a/docs/superpowers/specs/2026-06-17-m2-parameter-correctness-control-design.md
+++ b/docs/superpowers/specs/2026-06-17-m2-parameter-correctness-control-design.md
@@ -1,0 +1,97 @@
+# M2 — Parameter Correctness & Control
+
+**Date:** 2026-06-17
+**Status:** Approved (design)
+**Topic:** Fix the Illustrious CFG=1 instability, correct Illustrious defaults, add a loud CFG=1 warning, and add an opt-in Advanced Mode that stops auto-resetting generation params on checkpoint change.
+
+## Purpose
+
+Everyone using Illustrious (a major model family) currently gets either broken output at CFG=1 or a bad-habit default that runs a CFG++ sampler far outside its band. This milestone makes Illustrious generate stably at the correct low CFG, makes CFG=1 impossible to footgun silently, and gives power users a way to stop the app from auto-tuning params when they swap checkpoints.
+
+This is milestone M2 of the user-feedback roadmap (`docs/superpowers/specs/2026-06-17-feedback-milestones-roadmap-design.md`). It is independently releasable.
+
+## Root-cause findings (from codebase investigation)
+
+These reshape the milestone and are baked into the design below:
+
+- **The guidance nodes are NOT the cause.** `MooshieSmartGuidance` is an opt-in toggle, off by default (`generation.svelte.ts:303` `smartGuidance = $state(false)`), injected only when `params.smart_guidance == true` (`src-tauri/src/templates/mod.rs:334`). `MooshieSoftGuidance` runs only in the optional upscale pass (`src-tauri/src/templates/upscale.rs:127`). Both are numerically stable at CFG=1 (no divide-by-`(cfg-1)`; std is clamped to `1e-8`). Neither is auto-attached for Illustrious.
+- **The cause is `euler_cfg_pp` at CFG=1.** The main generation path is stock ComfyUI `KSampler` passing `cfg` verbatim (`src-tauri/src/templates/txt2img.rs:133`). CFG++ samplers steer with a `(cfg − 1) · (cond − uncond)` term; at CFG=1 that term is zero, leaving pure unconditional stepping, so the prompt has no influence and output is garbage.
+- **The current Illustrious default is internally inconsistent.** The non-turbo preset pairs `euler_cfg_pp` with CFG 5.0 (`generation.svelte.ts:1069-1078`), but CFG++ samplers are designed for ~1–2.2 (`SamplerSettings.svelte:33`). Running a CFG++ sampler at 5.0 over-bakes output. The roadmap's "recommend 1.8–2.2" fix is about aligning CFG to the sampler.
+- **The existing CFG warning is weak and misleading.** It is a tiny amber text label + "Fix" button, and its recommended floor for cfg_pp is `1.0` (`SamplerSettings.svelte:32-43`) — so the UI currently treats the exact value that breaks as "in range".
+- **No Advanced/lock-params concept exists.** The only guard is the `modelPresetAppliedKey` idempotency check in `applyModelSpecificPreset()` (`generation.svelte.ts:867`), which still re-applies on every *new* model.
+- **The sampler list is dynamic.** Available samplers are enumerated from the ComfyUI backend into `models.samplers` (`src/lib/stores/models.svelte.ts:40,108`). `euler_ancestral_cfg_pp` is standard in modern ComfyUI but may be absent on older builds — the preset must fall back gracefully.
+
+## Design
+
+### Part 1 — Fix the Illustrious non-turbo preset
+
+In `applyModelSpecificPreset()` (`src/lib/stores/generation.svelte.ts`), change only the `case "illustrious"` non-turbo branch (currently lines 1069-1078):
+
+| Field | Today | New |
+|-------|-------|-----|
+| samplerName | `euler_cfg_pp` | `euler_ancestral_cfg_pp` |
+| cfg | `5.0` | `2.0` |
+| scheduler | `sgm_uniform` | `sgm_uniform` (unchanged) |
+| steps | `20` | `20` (unchanged) |
+| width × height | 1024 × 1024 | 1024 × 1024 (unchanged) |
+
+- Turbo Illustrious (`euler` @ CFG 1.0, scheduler `normal`, 10 steps) is **untouched**.
+- **Isolation:** only the `illustrious` case changes. The `sdxl`/`mugen`/`unknown`/default block keeps `euler_cfg_pp` @ 5.0; Anima/Wan/Qwen keep `er_sde` @ 4.0; every other family is unchanged.
+- **Sampler-availability fallback:** if the chosen sampler is not present in `models.samplers`, fall back to `euler_ancestral` (a universally-present stock sampler) so the preset never sets an invalid `sampler_name` on older ComfyUI builds. This fallback is applied to the value the preset assigns to `this.samplerName`, not to the literal in the switch.
+
+### Part 2 — CFG=1 loud warning + fix the misleading range
+
+Two changes in `src/lib/components/generation/SamplerSettings.svelte`:
+
+1. **Raise the cfg_pp recommended floor.** In `recommendedCfgRange()` (line 33), change the cfg_pp branch from `{ min: 1.0, max: 2.2, target: 1.4 }` to `{ min: 1.5, max: 2.2, target: 1.8 }`. The standard-sampler branch (`{ min: 4.0, max: 8.0, target: 6.0 }`) is unchanged. This makes CFG=1 read as out-of-range for CFG++ samplers and aligns the "Fix" target with the new Illustrious default.
+2. **Add a prominent warning box** that renders when `generation.cfg <= 1.0`. It is visually distinct from the existing small amber "recommended range" row: an alert box with a warning icon and a bold heading, using the dark-neutral palette with an amber/red accent border (Tailwind only, no `<style>` block). Copy explains: *CFG=1 disables prompt guidance — it only produces good results on Turbo / distilled / Lightning models, and it breaks CFG++ samplers entirely.* The box is **non-blocking**: generation still proceeds.
+
+The existing small amber recommended-range row and "Fix" button (lines 230-245) remain for the milder out-of-range case.
+
+**i18n:** new keys for the warning heading and body added to `src/lib/locales/en.ts` and to all 11 other locale files with matching `{placeholder}` names (English fallback text for non-English locales is acceptable per existing repo precedent). Keys to add (illustrative names): `generation.sampler.cfg1_warning_title`, `generation.sampler.cfg1_warning_body`.
+
+### Part 3 — Advanced Mode toggle
+
+- **New persisted flag:** `advancedMode = $state(false)` declared on `GenerationStore`, included in the `saveSettings()` `ipcStore.set(...)` object, and restored in `loadSettings()` with the `if (saved.advancedMode !== undefined) this.advancedMode = saved.advancedMode;` guard (the standard boolean-settings pattern; restores `false` correctly).
+- **Gate inside `applyModelSpecificPreset()`:** when `advancedMode` is on, the method still runs family detection and sets `modelPresetAppliedKey` plus all metadata the templates depend on (`modelFamily`, `modelIsSdxlLike`, `modelTurboVariant`, 16-channel-latent / vpred flags) — but it **skips writing** the user-facing generation params: `steps`, `cfg`, `samplerName`, `scheduler`, `width`, `height`. Swapping checkpoints therefore preserves all generation params.
+- **First-selection exception:** if no preset has ever been applied this session/profile (`modelPresetAppliedKey` is empty/initial at entry), apply the preset once even in Advanced Mode, so a fresh user is not left with nonsense defaults. Every subsequent swap preserves.
+- **UI:** a labeled toggle in the Settings page (generation settings section). Enabling it shows a confirmation dialog explaining params will no longer auto-tune per model; confirming sets the flag and calls `saveSettings()`. Disabling is silent (sets flag, saves). Re-enabling does not retroactively re-apply a preset.
+
+### Part 4 — Upscale CFG floor for CFG++ samplers
+
+The upscale pass halves CFG (`cfg: params.cfg / 2.0`, `src-tauri/src/templates/upscale.rs:204`) and inherits the base sampler. With the new Illustrious default (CFG 2.0 + a CFG++ sampler), the upscale KSampler would run at CFG 1.0 with `euler_ancestral_cfg_pp` — the exact collapse this milestone fixes.
+
+Fix: when the sampler name contains `cfg_pp`, clamp the upscale CFG to a floor of `2.0` — i.e. `max(params.cfg / 2.0, 2.0)` for CFG++ samplers; non-CFG++ samplers keep the existing `params.cfg / 2.0`. The inpainting template already detects cfg_pp samplers (`src-tauri/src/templates/inpainting.rs:113` `is_cfgpp_sampler`), so the detection idiom exists in the codebase to mirror.
+
+## Components & touchpoints
+
+| File | Change |
+|------|--------|
+| `src/lib/stores/generation.svelte.ts` | Illustrious preset (Part 1); sampler-availability fallback; `advancedMode` flag + save/load (Part 3); gate in `applyModelSpecificPreset()` (Part 3) |
+| `src/lib/components/generation/SamplerSettings.svelte` | cfg_pp recommended range (Part 2.1); prominent CFG=1 warning box (Part 2.2) |
+| Settings page (`src/lib/components/.../SettingsPage` or equivalent) | Advanced Mode toggle + confirmation dialog (Part 3) |
+| `src/lib/locales/en.ts` + 11 other locales | new warning i18n keys with placeholder parity (Part 2) |
+| `src-tauri/src/templates/upscale.rs` | CFG floor for cfg_pp samplers (Part 4) |
+
+No new Tauri commands. No changes to the guidance Python nodes.
+
+## Validation
+
+No test framework exists. Validation is `npm run build` + `cargo check --manifest-path src-tauri/Cargo.toml`, plus manual verification of each "Done when":
+
+- Selecting a non-turbo Illustrious checkpoint sets sampler `euler_ancestral_cfg_pp` (or `euler_ancestral` fallback) and CFG 2.0, and generates clean output.
+- Dragging CFG to 1.0 shows the prominent warning box; cfg_pp recommended range reads `1.5-2.2`; generation still works.
+- With Advanced Mode on, set custom CFG/sampler/steps/dimensions, swap checkpoints, and confirm those params are preserved (family-dependent template behavior still correct).
+- With Advanced Mode off, swapping checkpoints still auto-applies per-model presets as before.
+- Enabling upscale with the new Illustrious default does not produce a broken upscale pass (upscale CFG floored at 2.0 for cfg_pp).
+
+## Out of scope / parked
+
+- Changing any other model family's defaults.
+- Reworking or removing the guidance nodes (exonerated by investigation).
+- A general per-parameter "lock" UI beyond the single Advanced Mode flag.
+- Surfacing Advanced Mode in the sampler panel (decided: Settings page only for this milestone).
+
+## Delivery model
+
+Single spec → writing-plans → implementation cycle, executed via subagent-driven-development. Independently releasable as a stability/correctness release.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.19"
+version = "1.4.23"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.22"
+version = "1.4.23"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/templates/upscale.rs
+++ b/src-tauri/src/templates/upscale.rs
@@ -190,6 +190,12 @@ pub fn append_upscale_chain(
 
     // Second KSampler pass at low denoise
     let sampler_id = next_id.to_string();
+    let is_cfgpp_sampler = params.sampler_name.to_lowercase().contains("cfg_pp");
+    let upscale_cfg = if is_cfgpp_sampler {
+        (params.cfg / 2.0).max(2.0)
+    } else {
+        params.cfg / 2.0
+    };
     workflow.insert(
         sampler_id.clone(),
         json!({
@@ -201,7 +207,7 @@ pub fn append_upscale_chain(
                 "latent_image": [latent_source.0.clone(), latent_source.1],
                 "seed": seed + 1,
                 "steps": params.upscale_steps,
-                "cfg": params.cfg / 2.0,
+                "cfg": upscale_cfg,
                 "sampler_name": params.sampler_name,
                 "scheduler": params.scheduler,
                 "denoise": params.upscale_denoise

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -104,8 +104,10 @@
     onclick={onclose}
   ></button>
 
-  <div class="relative z-10 flex max-h-[92vh] overflow-y-auto flex-col items-center gap-3 p-4">
-    <!-- Prev / Next arrow overlays -->
+  <div class="relative z-10 flex max-h-[92vh] flex-col items-center">
+    <!-- Prev / Next arrow overlays. Kept on this non-scrolling positioned
+         parent so their negative offsets never add to the scroll container's
+         horizontal overflow (which would surface a stray horizontal scrollbar). -->
     {#if onprev}
       <button
         type="button"
@@ -126,6 +128,7 @@
         →
       </button>
     {/if}
+    <div class="flex w-full max-h-[92vh] flex-col items-center gap-3 overflow-y-auto p-4">
     {#if currentImage}
       <div class="flex items-start justify-center">
         <img
@@ -199,6 +202,7 @@
           {locale.t('artist_gallery.lightbox.close')}
         </button>
       </div>
+    </div>
     </div>
   </div>
 </div>

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -238,7 +238,10 @@
   function artistThumbUrl(hit: ArtistSearchHit): string {
     const m = artistStore?.manifest;
     if (!m || !hit.hasImage || !hit.imageId) return "";
-    return `${m.imageBaseUrl}/${m.releasePrefix}/images/${hit.imageId}.webp`;
+    // Match the gallery page's imgExt(): index v2+ stores AVIF, v1 stored WebP.
+    // Hardcoding .webp here 404s against the v2 multi-variant dataset.
+    const ext = (m.version ?? 1) >= 2 ? "avif" : "webp";
+    return `${m.imageBaseUrl}/${m.releasePrefix}/images/${hit.imageId}.${ext}`;
   }
 
   function applyArtistTag(hit: ArtistSearchHit) {

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -246,7 +246,7 @@
 
   {#if generation.cfg <= 1.0}
     <div class="flex items-start gap-2 rounded-lg border border-amber-600/60 bg-amber-950/30 px-3 py-2 mt-1">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mt-0.5 shrink-0 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="w-4 h-4 mt-0.5 shrink-0 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
         <path d="M12 9v4" />
         <path d="M12 17h.01" />

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -30,7 +30,7 @@
   }
 
   function recommendedCfgRange() {
-    if (isCfgPpSampler(generation.samplerName)) return { min: 1.0, max: 2.2, target: 1.4 };
+    if (isCfgPpSampler(generation.samplerName)) return { min: 1.5, max: 2.2, target: 1.8 };
     return { min: 4.0, max: 8.0, target: 6.0 };
   }
 
@@ -243,6 +243,20 @@
       </button>
     {/if}
   </div>
+
+  {#if generation.cfg <= 1.0}
+    <div class="flex items-start gap-2 rounded-lg border border-amber-600/60 bg-amber-950/30 px-3 py-2 mt-1">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 mt-0.5 shrink-0 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </svg>
+      <div>
+        <p class="text-xs font-semibold text-amber-200">{locale.t('generation.sampler.cfg1_warning_title')}</p>
+        <p class="text-[10px] text-amber-300/80 mt-0.5">{locale.t('generation.sampler.cfg1_warning_body')}</p>
+      </div>
+    </div>
+  {/if}
 
   <!-- Seed + Batch Size -->
   <div class="grid grid-cols-2 gap-2">

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -57,7 +57,7 @@
 
   function onSamplerChange() {
     if (isCfgPpSampler(generation.samplerName) && generation.cfg > 5) {
-      generation.cfg = 1.4;
+      generation.cfg = recommendedCfgRange().target;
     }
   }
 

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -82,6 +82,7 @@
   let tagUrlInput = $state("");
   let tagFileLoading = $state(false);
   let showQualityTagsWarning = $state(false);
+  let showAdvancedModeWarning = $state(false);
   let showCustomQualityTags = $state(false);
 
   // Attention backend state
@@ -2566,6 +2567,30 @@
             </div>
           </div>
 
+          <div class="flex items-start gap-3">
+            <input
+              type="checkbox"
+              id="advanced-mode"
+              checked={generation.advancedMode}
+              onchange={(e) => {
+                const target = e.target as HTMLInputElement;
+                if (target.checked) {
+                  // Revert — confirm via popup before enabling
+                  target.checked = false;
+                  showAdvancedModeWarning = true;
+                } else {
+                  generation.advancedMode = false;
+                  generation.saveSettings();
+                }
+              }}
+              class="w-4 h-4 mt-0.5 accent-indigo-500 rounded"
+            />
+            <div>
+              <label for="advanced-mode" class="text-sm text-neutral-200">{locale.t('settings.advanced_mode.label')}</label>
+              <p class="text-[10px] text-neutral-500 mt-0.5">{locale.t('settings.advanced_mode.desc')}</p>
+            </div>
+          </div>
+
           {#if generation.autoQualityTags}
           <div class="flex items-start gap-3">
             <input
@@ -4168,6 +4193,33 @@
         class="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 text-neutral-400 rounded-lg text-xs transition-colors cursor-pointer"
       >
         {locale.t('settings.quality_warning.disable')}
+      </button>
+    </div>
+  </div>
+</div>
+{/if}
+
+{#if showAdvancedModeWarning}
+<div class="fixed inset-0 bg-black/70 z-50 flex items-center justify-center" role="dialog">
+  <div class="bg-neutral-900 border border-neutral-700 rounded-xl p-6 max-w-md mx-4 shadow-2xl">
+    <h3 class="text-sm font-semibold text-neutral-100 mb-3">{locale.t('settings.advanced_mode.warning_title')}</h3>
+    <p class="text-xs text-neutral-400 mb-4">{locale.t('settings.advanced_mode.warning_body')}</p>
+    <div class="flex gap-3 justify-end">
+      <button
+        onclick={() => { showAdvancedModeWarning = false; }}
+        class="px-4 py-2 bg-neutral-800 hover:bg-neutral-700 text-neutral-400 rounded-lg text-xs transition-colors cursor-pointer"
+      >
+        {locale.t('settings.advanced_mode.cancel')}
+      </button>
+      <button
+        onclick={() => {
+          generation.advancedMode = true;
+          generation.saveSettings();
+          showAdvancedModeWarning = false;
+        }}
+        class="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg text-xs font-medium transition-colors cursor-pointer"
+      >
+        {locale.t('settings.advanced_mode.enable')}
       </button>
     </div>
   </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -445,6 +445,12 @@ const de: Record<string, string> = {
   "settings.quality_warning.body2": "Nur deaktivieren, wenn Sie vollständige manuelle Kontrolle über Ihre Prompts wünschen.",
   "settings.quality_warning.keep": "Aktiviert lassen",
   "settings.quality_warning.disable": "Trotzdem deaktivieren",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generierung ─────────────────────────────────────────
   "generation.mode.txt2img": "Text zu Bild",

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -534,6 +534,8 @@ const de: Record<string, string> = {
   "generation.sampler.sih_hint": "Keine öffentlichen SIH-Modellkarteneinstellungen. Projekt-Standardwerte: 20 Schritte, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Empfohlene Juice-Einstellungen",
   "generation.sampler.juice_hint": "Projekt-Standardwerte für Juice: 20 Schritte, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Empfohlene Nanosaur-Einstellungen",
   "generation.sampler.nanosaur_hint": "40 Schritte, CFG 7, euler Sampler, simple Scheduler. 896×1152 Standardauflösung.",
   "generation.sampler.fix": "Korrigieren",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -452,6 +452,12 @@ const en: Record<string, string> = {
   "settings.quality_warning.body2": "Only disable this if you know what you're doing and want full manual control over your prompts.",
   "settings.quality_warning.keep": "Keep enabled",
   "settings.quality_warning.disable": "Disable anyway",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generation ──────────────────────────────────────────
   "generation.mode.txt2img": "Text to Image",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -587,6 +587,8 @@ const en: Record<string, string> = {
   "generation.sampler.sih_hint": "No public SIH model-card settings found; using project defaults: 20 steps, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Juice Recommended Settings",
   "generation.sampler.juice_hint": "Project defaults for Juice: 20 steps, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.fix": "Fix",
 
   // Model

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -426,6 +426,12 @@ const es: Record<string, string> = {
   "settings.quality_warning.body2": "Solo desactiva esto si sabes lo que haces y quieres control manual completo sobre tus prompts.",
   "settings.quality_warning.keep": "Mantener activado",
   "settings.quality_warning.disable": "Desactivar de todos modos",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generación ──────────────────────────────────────────
   "generation.notification.image_ready_body": "Tu generación completada está lista para ver.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -556,6 +556,8 @@ const es: Record<string, string> = {
   "generation.sampler.sih_hint": "No se encontraron ajustes públicos del modelo SIH; usando valores predeterminados: 20 pasos, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Ajustes recomendados para Juice",
   "generation.sampler.juice_hint": "Valores predeterminados del proyecto para Juice: 20 pasos, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Ajustes recomendados para Nanosaur",
   "generation.sampler.nanosaur_hint": "40 pasos, CFG 7, muestreador euler, programador simple. Resolución predeterminada 896×1152.",
   "generation.sampler.fix": "Corregir",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -438,6 +438,12 @@ const fr: Record<string, string> = {
   "settings.quality_warning.body2": "Ne désactivez ceci que si vous savez ce que vous faites et souhaitez un contrôle entièrement manuel de vos prompts.",
   "settings.quality_warning.keep": "Garder activé",
   "settings.quality_warning.disable": "Désactiver quand même",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Génération ──────────────────────────────────────────
   "generation.mode.txt2img": "Texte vers image",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -531,6 +531,8 @@ const fr: Record<string, string> = {
   "generation.sampler.sih_hint": "Aucun paramètre public SIH trouvé ; utilisation des défauts du projet : 20 étapes, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Paramètres recommandés Juice",
   "generation.sampler.juice_hint": "Valeurs par défaut du projet pour Juice : 20 étapes, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Paramètres recommandés Nanosaur",
   "generation.sampler.nanosaur_hint": "40 étapes, CFG 7, échantillonneur euler, planificateur simple. Résolution par défaut 896×1152.",
   "generation.sampler.fix": "Corriger",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -429,6 +429,12 @@ const it: Record<string, string> = {
   "settings.quality_warning.body2": "Disabilita solo se sai cosa fai e vuoi il pieno controllo manuale sui tuoi prompt.",
   "settings.quality_warning.keep": "Mantieni abilitato",
   "settings.quality_warning.disable": "Disabilita comunque",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generazione ─────────────────────────────────────────
   "generation.mode.txt2img": "Testo a immagine",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -518,6 +518,8 @@ const it: Record<string, string> = {
   "generation.sampler.sih_hint": "Nessuna impostazione pubblica per il modello SIH; predefiniti del progetto: 20 passi, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Impostazioni consigliate Juice",
   "generation.sampler.juice_hint": "Predefiniti del progetto per Juice: 20 passi, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Impostazioni consigliate Nanosaur",
   "generation.sampler.nanosaur_hint": "40 passi, CFG 7, sampler euler, scheduler simple. Risoluzione predefinita 896×1152.",
   "generation.sampler.fix": "Correggi",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -531,6 +531,8 @@ const ja: Record<string, string> = {
   "generation.sampler.sih_hint": "公開SIHモデルカード設定なし。プロジェクトデフォルト使用：20ステップ、CFG 1.4、euler_cfg_pp、sgm_uniform。",
   "generation.sampler.juice_recommended": "Juice推奨設定",
   "generation.sampler.juice_hint": "Juice向けプロジェクトデフォルト：20ステップ、CFG 1.4、euler_cfg_pp、sgm_uniform。",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Nanosaur推奨設定",
   "generation.sampler.nanosaur_hint": "40ステップ、CFG 7、eulerサンプラー、simpleスケジューラー。デフォルト解像度896×1152。",
   "generation.sampler.fix": "修正",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -438,6 +438,12 @@ const ja: Record<string, string> = {
   "settings.quality_warning.body2": "プロンプトを完全に手動制御したい場合にのみ無効にしてください。",
   "settings.quality_warning.keep": "有効のまま",
   "settings.quality_warning.disable": "無効にする",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── 生成 ────────────────────────────────────────────────
   "generation.mode.txt2img": "テキストから画像",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -518,6 +518,8 @@ const ko: Record<string, string> = {
   "generation.sampler.sih_hint": "공개 SIH 모델 카드 설정 없음. 프로젝트 기본값 사용: 20단계, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Juice 권장 설정",
   "generation.sampler.juice_hint": "Juice 프로젝트 기본값: 20단계, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Nanosaur 권장 설정",
   "generation.sampler.nanosaur_hint": "40단계, CFG 7, euler 샘플러, simple 스케줄러. 기본 해상도 896×1152.",
   "generation.sampler.fix": "수정",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -429,6 +429,12 @@ const ko: Record<string, string> = {
   "settings.quality_warning.body2": "프롬프트를 완전히 수동으로 제어하려는 경우에만 비활성화하세요.",
   "settings.quality_warning.keep": "활성 유지",
   "settings.quality_warning.disable": "그래도 비활성화",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── 생성 ────────────────────────────────────────────────
   "generation.mode.txt2img": "텍스트에서 이미지",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -429,6 +429,12 @@ const pt: Record<string, string> = {
   "settings.quality_warning.body2": "Só desative se souber o que está fazendo e quiser controle manual total sobre seus prompts.",
   "settings.quality_warning.keep": "Manter ativado",
   "settings.quality_warning.disable": "Desativar mesmo assim",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Geração ─────────────────────────────────────────────
   "generation.mode.txt2img": "Texto para Imagem",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -518,6 +518,8 @@ const pt: Record<string, string> = {
   "generation.sampler.sih_hint": "Sem configurações públicas do modelo SIH; usando padrões do projeto: 20 passos, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Configurações Recomendadas para Juice",
   "generation.sampler.juice_hint": "Padrões do projeto para Juice: 20 passos, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Configurações Recomendadas para Nanosaur",
   "generation.sampler.nanosaur_hint": "40 passos, CFG 7, sampler euler, scheduler simple. Resolução padrão 896×1152.",
   "generation.sampler.fix": "Corrigir",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -518,6 +518,8 @@ const ru: Record<string, string> = {
   "generation.sampler.sih_hint": "Публичных настроек модели SIH не найдено; используются стандартные проекта: 20 шагов, CFG 1.4, euler_cfg_pp, sgm_uniform.",
   "generation.sampler.juice_recommended": "Рекомендуемые настройки Juice",
   "generation.sampler.juice_hint": "Стандартные значения проекта для Juice: 20 шагов, CFG 1.4, euler_cfg_pp, sgm_uniform.",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Рекомендуемые настройки Nanosaur",
   "generation.sampler.nanosaur_hint": "40 шагов, CFG 7, сэмплер euler, планировщик simple. Разрешение по умолчанию 896×1152.",
   "generation.sampler.fix": "Исправить",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -429,6 +429,12 @@ const ru: Record<string, string> = {
   "settings.quality_warning.body2": "Отключайте только если знаете, что делаете, и хотите полного ручного контроля над промптами.",
   "settings.quality_warning.keep": "Оставить включённым",
   "settings.quality_warning.disable": "Всё равно отключить",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── Генерация ───────────────────────────────────────────
   "generation.mode.txt2img": "Текст в изображение",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -518,6 +518,8 @@ const zhTw: Record<string, string> = {
   "generation.sampler.sih_hint": "無公開 SIH 模型卡設定。使用專案預設值：20 步，CFG 1.4，euler_cfg_pp，sgm_uniform。",
   "generation.sampler.juice_recommended": "Juice 建議設定",
   "generation.sampler.juice_hint": "Juice 專案預設值：20 步，CFG 1.4，euler_cfg_pp，sgm_uniform。",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Nanosaur 建議設定",
   "generation.sampler.nanosaur_hint": "40 步，CFG 7，euler 取樣器，simple 排程器。預設解析度 896×1152。",
   "generation.sampler.fix": "修復",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -429,6 +429,12 @@ const zhTw: Record<string, string> = {
   "settings.quality_warning.body2": "僅在您想完全手動控制提示時才停用。",
   "settings.quality_warning.keep": "保持啟用",
   "settings.quality_warning.disable": "仍然停用",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── 生成 ────────────────────────────────────────────────
   "generation.mode.txt2img": "文字生圖",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -518,6 +518,8 @@ const zh: Record<string, string> = {
   "generation.sampler.sih_hint": "无公开 SIH 模型卡设置。使用项目默认值：20 步，CFG 1.4，euler_cfg_pp，sgm_uniform。",
   "generation.sampler.juice_recommended": "Juice 推荐设置",
   "generation.sampler.juice_hint": "Juice 项目默认值：20 步，CFG 1.4，euler_cfg_pp，sgm_uniform。",
+  "generation.sampler.cfg1_warning_title": "CFG 1 disables prompt guidance",
+  "generation.sampler.cfg1_warning_body": "At CFG 1 the model ignores your prompt's guidance. This only produces good results on Turbo, distilled, or Lightning models, and it breaks CFG++ samplers (like euler_cfg_pp / euler_ancestral_cfg_pp) entirely. Raise CFG to the recommended range unless you know your model needs CFG 1.",
   "generation.sampler.nanosaur_recommended": "Nanosaur 推荐设置",
   "generation.sampler.nanosaur_hint": "40 步，CFG 7，euler 采样器，simple 调度器。默认分辨率 896×1152。",
   "generation.sampler.fix": "修复",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -429,6 +429,12 @@ const zh: Record<string, string> = {
   "settings.quality_warning.body2": "仅在您想完全手动控制提示时才禁用。",
   "settings.quality_warning.keep": "保持启用",
   "settings.quality_warning.disable": "仍然禁用",
+  "settings.advanced_mode.label": "Advanced Mode",
+  "settings.advanced_mode.desc": "Stop auto-applying recommended steps, CFG, sampler, scheduler, and dimensions when you switch checkpoints. Your current settings are kept on every model swap.",
+  "settings.advanced_mode.warning_title": "Enable Advanced Mode?",
+  "settings.advanced_mode.warning_body": "With Advanced Mode on, switching checkpoints will no longer auto-tune steps, CFG, sampler, scheduler, or dimensions for the selected model. You'll set these yourself. Model family detection still works.",
+  "settings.advanced_mode.enable": "Enable",
+  "settings.advanced_mode.cancel": "Cancel",
 
   // ── 生成 ────────────────────────────────────────────────
   "generation.mode.txt2img": "文生图",

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -363,7 +363,8 @@ class GenerationStore {
   autoSaveDirs = $state<string[]>([]);
   /** When true, swapping checkpoints no longer auto-applies per-model generation params
    *  (steps/cfg/sampler/scheduler/dimensions). Family/metadata detection still runs.
-   *  The first preset application in a session is exempt so fresh users still get sane defaults. */
+   *  The first-ever preset application (while `modelPresetAppliedKey` is still unset) is
+   *  exempt so a fresh profile still gets sane defaults; every later swap preserves. */
   advancedMode = $state(false);
   regionalPrompts = $state<RegionalPromptSelection[]>([]);
   /** SDXL/Illustrious: conditioning areas vs sequential inpaint. Anima always uses inpaint chain. */
@@ -873,8 +874,9 @@ class GenerationStore {
     if (presetKey === this.modelPresetAppliedKey) return;
     const isFirstPresetApplication = !this.modelPresetAppliedKey;
     this.modelPresetAppliedKey = presetKey;
-    // Advanced Mode: after the first application, preserve the user's generation
-    // params on checkpoint swaps. Family/metadata detection already ran above.
+    // Advanced Mode: after the first-ever application, preserve the user's generation
+    // params on checkpoint swaps. Family/metadata detection runs separately in
+    // applyModelMetadata(); only the param writes below are skipped.
     if (this.advancedMode && !isFirstPresetApplication) return;
 
     let preset: ModelPreset;

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -54,6 +54,8 @@ interface ModelPreset {
   width: number;
   height: number;
   upscaleDenoise?: number;
+  /** Sampler to use when `samplerName` is absent from the backend's enumerated list. Defaults to "euler". */
+  samplerFallback?: string;
 }
 
 function isModelFamily(value: unknown): value is ModelFamily {
@@ -841,7 +843,7 @@ class GenerationStore {
   private applyResolvedPreset(preset: ModelPreset) {
     this.steps = preset.steps;
     this.cfg = preset.cfg;
-    this.samplerName = this.resolveAvailableOption(models.samplers, preset.samplerName, "euler");
+    this.samplerName = this.resolveAvailableOption(models.samplers, preset.samplerName, preset.samplerFallback ?? "euler");
     this.scheduler = this.resolveAvailableOption(models.schedulers, preset.scheduler, "normal");
     this.width = preset.width;
     this.height = preset.height;
@@ -1069,8 +1071,12 @@ class GenerationStore {
       case "illustrious":
         preset = {
           steps: this.hasTurboModelVariant ? 10 : 20,
-          cfg: this.hasTurboModelVariant ? 1.0 : 5.0,
-          samplerName: this.hasTurboModelVariant ? "euler" : "euler_cfg_pp",
+          // euler_ancestral_cfg_pp is a CFG++ sampler tuned for low CFG (~1.5-2.2);
+          // CFG 2.0 keeps it inside its band. Falls back to plain euler_ancestral
+          // on older ComfyUI builds that lack the cfg_pp variant.
+          cfg: this.hasTurboModelVariant ? 1.0 : 2.0,
+          samplerName: this.hasTurboModelVariant ? "euler" : "euler_ancestral_cfg_pp",
+          samplerFallback: this.hasTurboModelVariant ? "euler" : "euler_ancestral",
           scheduler: this.hasTurboModelVariant ? "normal" : "sgm_uniform",
           width: 1024,
           height: 1024,

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -873,11 +873,15 @@ class GenerationStore {
     ].join("|");
     if (presetKey === this.modelPresetAppliedKey) return;
     const isFirstPresetApplication = !this.modelPresetAppliedKey;
-    this.modelPresetAppliedKey = presetKey;
     // Advanced Mode: after the first-ever application, preserve the user's generation
     // params on checkpoint swaps. Family/metadata detection runs separately in
     // applyModelMetadata(); only the param writes below are skipped.
+    // Record the key only once the preset is actually applied (below) — recording
+    // it here would let the idempotency guard suppress the preset forever if the
+    // user later disables Advanced Mode on the same model.
     if (this.advancedMode && !isFirstPresetApplication) return;
+
+    this.modelPresetAppliedKey = presetKey;
 
     let preset: ModelPreset;
     switch (this.modelFamily) {

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -361,6 +361,10 @@ class GenerationStore {
   manualSaveMode = $state(false);
   /** Directories to auto-save images to when manualSaveMode is enabled. */
   autoSaveDirs = $state<string[]>([]);
+  /** When true, swapping checkpoints no longer auto-applies per-model generation params
+   *  (steps/cfg/sampler/scheduler/dimensions). Family/metadata detection still runs.
+   *  The first preset application in a session is exempt so fresh users still get sane defaults. */
+  advancedMode = $state(false);
   regionalPrompts = $state<RegionalPromptSelection[]>([]);
   /** SDXL/Illustrious: conditioning areas vs sequential inpaint. Anima always uses inpaint chain. */
   regionalPromptStrategy = $state<RegionalPromptStrategy>("conditioning");
@@ -867,7 +871,11 @@ class GenerationStore {
       this.modelTurboVariant,
     ].join("|");
     if (presetKey === this.modelPresetAppliedKey) return;
+    const isFirstPresetApplication = !this.modelPresetAppliedKey;
     this.modelPresetAppliedKey = presetKey;
+    // Advanced Mode: after the first application, preserve the user's generation
+    // params on checkpoint swaps. Family/metadata detection already ran above.
+    if (this.advancedMode && !isFirstPresetApplication) return;
 
     let preset: ModelPreset;
     switch (this.modelFamily) {
@@ -1223,6 +1231,7 @@ class GenerationStore {
           ) as Record<string, ModelFamily>;
         }
         if (saved.manualSaveMode !== undefined) this.manualSaveMode = saved.manualSaveMode;
+        if (saved.advancedMode !== undefined) this.advancedMode = saved.advancedMode;
         if (Array.isArray(saved.autoSaveDirs)) this.autoSaveDirs = saved.autoSaveDirs;
         if (saved.regionalPromptStrategy === "conditioning" || saved.regionalPromptStrategy === "inpaint_chain") {
           this.regionalPromptStrategy = saved.regionalPromptStrategy;
@@ -1350,6 +1359,7 @@ class GenerationStore {
         customNanosaurNegativeQuality: this.customNanosaurNegativeQuality,
         modelFamilyOverrides: this.modelFamilyOverrides,
         manualSaveMode: this.manualSaveMode,
+        advancedMode: this.advancedMode,
         autoSaveDirs: this.autoSaveDirs,
         regionalPrompts: this.regionalPrompts,
         regionalPromptStrategy: this.regionalPromptStrategy,
@@ -1442,6 +1452,7 @@ class GenerationStore {
       customNanosaurPositiveQuality: this.customNanosaurPositiveQuality,
       customNanosaurNegativeQuality: this.customNanosaurNegativeQuality,
       manualSaveMode: this.manualSaveMode,
+      advancedMode: this.advancedMode,
       autoSaveDirs: this.autoSaveDirs,
       regionalPrompts: this.regionalPrompts,
       regionalPromptStrategy: this.regionalPromptStrategy,


### PR DESCRIPTION
## What''s New in v1.4.23

### Models (Illustrious)
- Corrected the Illustrious non-turbo preset to `euler_ancestral_cfg_pp` at CFG 2.0, with a safe fallback.

### CFG guidance
- Loud, prominent warning when CFG is set to 1 (collapses CFG++ samplers).
- Corrected the recommended range for `*_cfg_pp` samplers.

### Advanced Mode
- New Advanced Mode flag gates per-model preset auto-apply, with a settings toggle and confirmation dialog.

### Upscale
- Upscale CFG is now floored at 2.0 whenever a CFG++ sampler is in use (the high-res pass halves base CFG, which would otherwise drop to 1.0 and collapse the sampler).

### Artist Gallery
- Favourite-artist thumbnails now render on the generation page (the bottom-panel Artists tab still built `.webp` URLs while the v2 dataset ships AVIF).
- Removed the stray horizontal scrollbar in the artist lightbox (prev/next arrow overlays were counted as horizontal overflow; scrolling is now confined to an inner wrapper).

## Validation
- `cargo check` and `npm run build` both pass.
- No test framework; validation is build gates per project policy.

## Bot triage
- Open PRs are all dependabot bumps and two drafts, none superseded by this release.