### PR TITLE
fix: persist ComfyUI GPU kernel caches across restarts (#329)

### DIFF
--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -637,6 +637,44 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
     cmd.env("PYTHONUTF8", "1");
     cmd.env("PYTHONIOENCODING", "utf-8");
 
+    // Persist GPU kernel / compile caches across app restarts.
+    //
+    // On newer GPUs the first generation after each launch can spend many minutes
+    // compiling and autotuning kernels. This is most severe on AMD RDNA4
+    // (gfx120x) with bleeding-edge ROCm, where MIOpen has no prebuilt kernel db
+    // and does an exhaustive search, but it also affects the torch.compile /
+    // Triton path on CUDA. Those caches default to per-process or /tmp locations,
+    // so the compile cost is re-paid on every restart. Point them at a stable
+    // directory under the app data dir (the parent of the ComfyUI install) so the
+    // cost is paid once. Any value the user already set in the environment wins.
+    {
+        let cache_base = std::path::Path::new(&config.comfyui_path)
+            .parent()
+            .map(|p| p.join("kernel-cache"))
+            .unwrap_or_else(|| std::env::temp_dir().join("mooshieui-kernel-cache"));
+        // (env var, subdir). MIOpen vars are no-ops off ROCm; the inductor/Triton
+        // vars are harmless on platforms that don't use them.
+        let caches: [(&str, &str); 4] = [
+            ("TORCHINDUCTOR_CACHE_DIR", "torchinductor"),
+            ("TRITON_CACHE_DIR", "triton"),
+            ("MIOPEN_USER_DB_PATH", "miopen"),
+            ("MIOPEN_CUSTOM_CACHE_DIR", "miopen"),
+        ];
+        for (var, subdir) in caches {
+            if std::env::var_os(var).is_some() {
+                continue; // respect an explicit user override
+            }
+            let dir = cache_base.join(subdir);
+            match std::fs::create_dir_all(&dir) {
+                Ok(()) => {
+                    cmd.env(var, &dir);
+                }
+                Err(e) => log::warn!("Could not create kernel cache dir {:?}: {}", dir, e),
+            }
+        }
+        log::info!("Persistent kernel cache dir: {}", cache_base.display());
+    }
+
     // When running inside an AppImage, the bundled LD_LIBRARY_PATH and LD_PRELOAD
     // can interfere with Python/PyTorch. Clear them for the child process so it
     // uses the system's native libraries (CUDA, ROCm, etc.).
@@ -1152,6 +1190,35 @@ pub async fn start_worker_process(
 
     // Pin to specific GPU
     cmd.env("CUDA_VISIBLE_DEVICES", worker.gpu_index.to_string());
+
+    // Persist GPU kernel / compile caches across restarts (see the single-process
+    // spawn path for the rationale). Namespaced per GPU so concurrent workers
+    // don't contend on the same MIOpen db.
+    {
+        let cache_base = std::path::Path::new(&config.comfyui_path)
+            .parent()
+            .map(|p| p.join("kernel-cache"))
+            .unwrap_or_else(|| std::env::temp_dir().join("mooshieui-kernel-cache"))
+            .join(format!("gpu{}", worker.gpu_index));
+        let caches: [(&str, &str); 4] = [
+            ("TORCHINDUCTOR_CACHE_DIR", "torchinductor"),
+            ("TRITON_CACHE_DIR", "triton"),
+            ("MIOPEN_USER_DB_PATH", "miopen"),
+            ("MIOPEN_CUSTOM_CACHE_DIR", "miopen"),
+        ];
+        for (var, subdir) in caches {
+            if std::env::var_os(var).is_some() {
+                continue; // respect an explicit user override
+            }
+            let dir = cache_base.join(subdir);
+            match std::fs::create_dir_all(&dir) {
+                Ok(()) => {
+                    cmd.env(var, &dir);
+                }
+                Err(e) => log::warn!("Could not create kernel cache dir {:?}: {}", dir, e),
+            }
+        }
+    }
 
     // AppImage cleanup on Linux
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
Fixes the recurring multi-minute first-generation hang reported in #329 on AMD RDNA4 (RX 9070 XT / gfx1201, ROCm 7.13).

## Problem
On brand-new GPU architectures the first sampler run after each launch spends many minutes compiling and autotuning GPU kernels (MIOpen with no prebuilt kernel db, plus the torch.compile / Triton path). Those caches default to per-process or /tmp locations, so the compile cost is re-paid on every app restart. Verified from the issue logs: two prompts completed at 00:20:39 and 00:21:21, then subsequent gens ran at ~30s, with the slowdown returning after restart.

## Fix
Point the kernel/compile caches at a stable directory under the app data dir (parent of the ComfyUI install) when spawning the managed ComfyUI, so compiled kernels survive a restart:
- TORCHINDUCTOR_CACHE_DIR, TRITON_CACHE_DIR, MIOPEN_USER_DB_PATH, MIOPEN_CUSTOM_CACHE_DIR
- Applied to both the single-process spawn and the per-GPU worker spawn (worker caches namespaced per GPU to avoid MIOpen db contention).
- Respects any value the user already set in the environment.
- MIOpen vars are no-ops off ROCm; inductor/Triton vars are harmless where unused, so this also shortens torch.compile first-run cost on CUDA.
- Non-fatal: a cache dir that cannot be created logs a warning and spawn continues.

## Validation
- cargo check: clean
- cargo clippy: no new warnings
- cargo fmt: clean for changed file