### PR TITLE
fix: live preview broken on desktop since 1.4.10 (#309)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1928,13 +1928,25 @@
         if (data.prompt_id && progress.activePromptId && data.prompt_id !== progress.activePromptId) return;
 
         if (data.temp_filename) {
-          // SSE/browser path: fetch image from temp endpoint
+          // The worker WebSocket delivers preview frames as temp-file
+          // references (not inline base64). On desktop there is no HTTP server,
+          // so a fetch to /internal-api would resolve to the SPA shell and
+          // produce a broken <img>. Read the temp file via invoke() instead,
+          // mirroring the output_image handler. See issue #309.
           try {
-            const resp = await fetch(`/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}`, {
-              headers: authHeaders(),
-            });
-            if (!resp.ok) return;
-            const blob = await resp.blob();
+            let blob: Blob;
+            if (isTauri) {
+              const rawBytes = await readTempImage(data.temp_filename);
+              const mime = data.format === "png" ? "image/png" : "image/jpeg";
+              blob = new Blob([new Uint8Array(rawBytes)], { type: mime });
+            } else {
+              // SSE/browser path: fetch image from temp endpoint
+              const resp = await fetch(`/internal-api/_temp_image/${encodeURIComponent(data.temp_filename)}`, {
+                headers: authHeaders(),
+              });
+              if (!resp.ok) return;
+              blob = await resp.blob();
+            }
             // The prompt may have completed while the fetch was in flight
             // (common on remote browser mode with inpaint chains). Setting
             // previewImage now would overwrite the finalized output in the


### PR DESCRIPTION
## Summary

Fixes #309 — the live preview panel showed a broken-image glyph on desktop for every generation since 1.4.10. The final/output image was unaffected.

## Root cause

At 1.4.10 (commit 0132806, #271) desktop generation switched to `connect_websocket_for_worker_inner`, which emits preview frames as `{ temp_filename }` references rather than inline base64. The frontend `comfyui:preview` handler had no `isTauri` branch and unconditionally fetched `/internal-api/_temp_image/...`. On desktop there is no HTTP server, so that fetch resolved against the SPA shell, returned the index.html body with status 200 (resp.ok true), and the resulting "image" blob was HTML, rendering a broken `<img>`. The `comfyui:output_image` handler already had the `isTauri` + `readTempImage()` branch, which is why the final image survived.

## Fix

Added the `isTauri` branch to the preview handler, mirroring the proven output_image pattern: on desktop, read the temp file via `readTempImage()` and build a blob with the correct MIME (png vs jpeg); browser/SSE mode keeps the existing temp-endpoint fetch.

Frontend-only change. `npm run build` passes.