### PR TITLE
fix: restore LoRA previews broken by CivitAI CDN redirect allowlist

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2448,10 +2448,11 @@ fn parse_civitai_image_id(image_ref: &str) -> Result<u64, AppError> {
 }
 
 fn is_allowed_civitai_image_host(host: &str) -> bool {
-    matches!(
-        host.to_ascii_lowercase().as_str(),
-        "civitai.com" | "www.civitai.com" | "image.civitai.com" | "cdn.civitai.com"
-    )
+    // Accept civitai.com and any of its subdomains (image.civitai.com,
+    // cdn.civitai.com, and any future image host CivitAI introduces). The
+    // trailing-dot match keeps look-alikes like "civitai.com.evil.test" out.
+    let host = host.to_ascii_lowercase();
+    host == "civitai.com" || host.ends_with(".civitai.com")
 }
 
 pub(crate) fn parse_civitai_image_url(url: &str) -> Result<reqwest::Url, AppError> {
@@ -2479,15 +2480,27 @@ pub(crate) async fn fetch_civitai_image_bytes(
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| AppError::Other(format!("Failed to build image fetch client: {}", e)))?;
+    // The initial URL must be a CivitAI host so this command can't be turned into
+    // a generic server-side fetch primitive (it is reachable through browser-mode
+    // LAN auth and carries the user's CivitAI token).
     let mut current = parse_civitai_image_url(url)?;
     let civitai_api_key = state.config.read().await.civitai_api_key.clone();
 
     for _ in 0..5 {
+        // CivitAI redirects image requests to its CDN, which is not on a
+        // civitai.com host. Only attach the user's token while we are still on a
+        // CivitAI host so it can never leak to the CDN or any other origin.
+        let on_civitai_host = current
+            .host_str()
+            .map(is_allowed_civitai_image_host)
+            .unwrap_or(false);
         let mut req = client
             .get(current.clone())
             .header("User-Agent", "MooshieUI/0.5.7");
-        if let Some(key) = civitai_api_key.as_ref().filter(|v| !v.trim().is_empty()) {
-            req = req.bearer_auth(key);
+        if on_civitai_host {
+            if let Some(key) = civitai_api_key.as_ref().filter(|v| !v.trim().is_empty()) {
+                req = req.bearer_auth(key);
+            }
         }
 
         let resp = req
@@ -2504,7 +2517,14 @@ pub(crate) async fn fetch_civitai_image_bytes(
             current = current
                 .join(location)
                 .map_err(|e| AppError::Other(format!("Image fetch redirect invalid: {}", e)))?;
-            parse_civitai_image_url(current.as_str())?;
+            // Follow the redirect to CivitAI's CDN, but keep it HTTPS-only so a
+            // redirect can never reach an internal http service. The token is
+            // gated on the host check above, not on the target being CivitAI.
+            if current.scheme() != "https" {
+                return Err(AppError::Other(
+                    "CivitAI image redirect must use HTTPS".into(),
+                ));
+            }
             continue;
         }
         if !resp.status().is_success() {
@@ -2532,6 +2552,8 @@ mod sidecar_thumbnail_tests {
         assert!(parse_civitai_image_url("https://image.civitai.com/example.jpeg").is_ok());
         assert!(parse_civitai_image_url("https://cdn.civitai.com/example.png").is_ok());
         assert!(parse_civitai_image_url("https://civitai.com/images/123").is_ok());
+        // Any civitai.com subdomain is accepted so new image hosts keep working.
+        assert!(parse_civitai_image_url("https://imagecache.civitai.com/example.jpeg").is_ok());
     }
 
     #[test]

--- a/src/lib/components/generation/LoraGallery.svelte
+++ b/src/lib/components/generation/LoraGallery.svelte
@@ -476,8 +476,10 @@
     try {
       const dataUrl = await fetchCachedImage(url);
       resolvedImages = { ...resolvedImages, [url]: dataUrl };
-    } catch {
-      // Leave unresolved — the fallback placeholder will show.
+    } catch (e) {
+      // Leave unresolved — the fallback placeholder will show. Log so a broken
+      // preview fetch is diagnosable instead of silently blank.
+      console.warn(`LoraGallery: failed to load preview ${url}`, e);
     } finally {
       resolvingImages.delete(url);
     }


### PR DESCRIPTION
## Problem

LoRA preview thumbnails stopped loading for CivitAI-sourced images starting in v1.4.10/1.4.11 (issue #310). Locally-stored sidecar previews (rendered as `data:` URIs) kept working, which is why a couple of previews still showed.

## Root cause

`bd41a95` (the browser cached-image SSRF fix) changed `fetch_cached_image` from `state.http_client` (which follows redirects to any host) to a `reqwest::redirect::Policy::none()` client that re-validates **every redirect hop** against a 4-host CivitAI allowlist. CivitAI serves `image.civitai.com` requests via a 30x redirect to its CDN (a non-`civitai.com` host), so the new client rejected the redirect with "Only CivitAI image URLs can be used" and the frontend silently fell back to a blank placeholder.

The frontend rendering path (`getDisplayImages` / `resolveImage` / `fetchCachedImage`) is unchanged across the regression window, confirming the break is entirely in the backend fetch.

## Fix

- `fetch_civitai_image_bytes` now follows redirects off `civitai.com` (e.g. to the CDN) while only attaching the user's CivitAI token when the **current** host is a CivitAI host, so the token never leaks to the CDN or any other origin. Redirect hops are kept HTTPS-only so a redirect cannot reach an internal http service.
- The initial URL still must be a CivitAI host, so the command cannot be used as a generic server-side fetch primitive. SSRF protection is preserved.
- Broadened the CivitAI host allowlist to any `*.civitai.com` subdomain (look-alikes like `civitai.com.evil.test` are still rejected).
- `LoraGallery.svelte` now logs preview fetch failures instead of swallowing them silently, so future breakage is diagnosable.

## Validation

- `cargo check` + `cargo fmt` pass
- `npm run build` passes
- `cargo test sidecar_thumbnail_tests` passes (3/3)