### PR TITLE
fix: route ControlNet to Anima LLLite for renamed Anima checkpoints

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -3718,11 +3718,27 @@ pub(crate) async fn read_modelspec_internal(
 
     // Merge the full ModelSpec display fields (title, author, description,
     // trigger phrase, ...) for the model info panel. Header-only read — no
-    // hashing. Runtime keys resolved above take precedence.
+    // hashing. Runtime keys resolved above take precedence. This also populates
+    // an inferred `architecture` (from tensor-key patterns) when the file has no
+    // declared modelspec.architecture.
     if let Ok(Some(display_meta)) = read_safetensors_modelspec(&path) {
         for (key, value) in display_meta {
             result.entry(key).or_insert(value);
         }
+    }
+
+    // Tensor-key architecture is ground truth for Wan2.1 / Anima checkpoints:
+    // they are DiT models, not classic UNets, so standard ControlNet cannot be
+    // applied to them — only the Anima LLLite path works. The soft filename and
+    // baseModel heuristics above miss Anima fine-tunes that were renamed without
+    // an `anima`/`yume` token (e.g. "PerfectDeliberate") and have no Wan
+    // baseModel sidecar/CivitAI tag. When the structural inference says Wan, it
+    // overrides the softer signals so ControlNet routes to Anima LLLite.
+    if result.get("family").map(String::as_str) != Some("anima")
+        && result.get("architecture").map(String::as_str) == Some("wan2.1")
+    {
+        result.insert("family".to_string(), "anima".to_string());
+        result.insert("is_sdxl_like".to_string(), "false".to_string());
     }
 
     if category == "diffusion_models" {


### PR DESCRIPTION
Fix ControlNet silently doing nothing on Anima-based checkpoints that were renamed without an `anima`/`yume` token (for example PerfectDeliberate).

## Root cause

ControlNet routing in `templates/mod.rs` branches on `model_architecture == "anima"`: Anima models go to the LLLite path (`inject_anima_lllite`), everything else to the standard ControlNet path. The architecture string is the frontend `modelFamily`, resolved by `read_modelspec_internal` in `commands/api.rs`.

Family resolution used only soft signals: the filename (`anima`/`yume` token), a `baseModel` sidecar, or a CivitAI hash lookup. The backend already infers the true architecture from the safetensors tensor keys (`infer_architecture_from_keys` detects Wan2.1 / Anima DiT blocks), but that result was stored only in a display-only `architecture` field and never consulted for `family`.

So an Anima fine-tune whose name lacks `anima`/`yume` and has no Wan baseModel tag resolved to a non-Anima family. ControlNet then took the standard path, which cannot apply LLLite weights to a Wan/COSMOS DiT model, so it silently did nothing. The base Anima model works only because its filename trips the token check.

## Fix

After family resolution, when the structural tensor-key inference reports Wan2.1 but the family is not already `anima`, override it to `anima`. Tensor keys are ground truth (it is the file that actually gets sampled), so ControlNet now routes to Anima LLLite regardless of naming or CivitAI tags.

## Validation

- cargo check: clean
- cargo clippy: no new warnings
- cargo test --lib: all pass except a pre-existing unrelated JXL codec roundtrip test
- npm run build: clean