### PR TITLE
docs: link standalone tiled diffusion node from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ npm run tauri build    # production build
 4. The workflow is submitted to ComfyUI's `/prompt` API.
 5. WebSocket streams progress and previews back to the UI in real time.
 
-MooshieUI also ships custom ComfyUI nodes (tiled diffusion, soft/smart guidance, an SDXL↔Flux2 VAE adapter, Nanosaur DiT support, and face fix) that are auto-installed into ComfyUI. Details live in [Models & the Model Hub](https://github.com/Mooshieblob1/MooshieUI/wiki/Models-and-the-Model-Hub).
+MooshieUI also ships custom ComfyUI nodes (tiled diffusion, soft/smart guidance, an SDXL↔Flux2 VAE adapter, Nanosaur DiT support, and face fix) that are auto-installed into ComfyUI. Details live in [Models & the Model Hub](https://github.com/Mooshieblob1/MooshieUI/wiki/Models-and-the-Model-Hub). The tiled diffusion node is also available as a standalone ComfyUI custom node: [ComfyUI-MooshieTiledDiffusion](https://github.com/Mooshieblob1/ComfyUI-MooshieTiledDiffusion).
 
 ---
 


### PR DESCRIPTION
Adds a pointer from the README custom-nodes line to the newly published standalone ComfyUI node ComfyUI-MooshieTiledDiffusion (closes #338 follow-up).