### PR TITLE
fix: wire up server-side preference sync end to end (#348)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod setup;
 pub mod state;
 pub mod temp_images;
 pub mod templates;
+pub mod user_prefs;
 pub mod webserver;
 
 use std::sync::Arc;

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -543,6 +543,11 @@ pub async fn start_server(
         )
         .route("/internal-api/_auth/logout", post(auth_logout_handler))
         .route("/internal-api/_auth/lan_info", get(auth_lan_info_handler))
+        // Per-user preference sync (cross-device prefs in browser/LAN mode)
+        .route(
+            "/internal-api/_user/prefs",
+            get(user_prefs_get_handler).put(user_prefs_put_handler),
+        )
         // Storage management
         .route("/internal-api/_storage/info", get(storage_info_handler))
         .route(
@@ -5331,6 +5336,53 @@ fn dir_usage_bytes(dir: &std::path::Path) -> u64 {
                 .sum()
         })
         .unwrap_or(0)
+}
+
+/// The username key used for localhost / single-admin sessions, where
+/// `resolve_username` returns `None`. Matches the convention documented in
+/// `user_prefs.rs`.
+const ADMIN_PREFS_KEY: &str = "_admin";
+
+/// GET /internal-api/_user/prefs — fetch the current user's saved preferences.
+/// Returns 204 when the user has no saved prefs yet.
+async fn user_prefs_get_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    if resolve_role(&state, &headers, &remote) == UserRole::Anonymous {
+        return forbidden_response("Authentication required.");
+    }
+    let username =
+        resolve_username(&state, &headers, &remote).unwrap_or_else(|| ADMIN_PREFS_KEY.to_string());
+    match crate::user_prefs::load(&username).await {
+        Some(prefs) => (StatusCode::OK, Json(prefs)).into_response(),
+        None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+/// PUT /internal-api/_user/prefs — replace the current user's saved preferences.
+/// The `updated_at` timestamp is set server-side, ignoring any client value.
+async fn user_prefs_put_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(mut prefs): Json<crate::user_prefs::UserPrefs>,
+) -> Response {
+    if resolve_role(&state, &headers, &remote) == UserRole::Anonymous {
+        return forbidden_response("Authentication required.");
+    }
+    let username =
+        resolve_username(&state, &headers, &remote).unwrap_or_else(|| ADMIN_PREFS_KEY.to_string());
+    prefs.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    match crate::user_prefs::save(&username, &prefs).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
 }
 
 /// GET /internal-api/_storage/info — returns current user's storage usage,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,7 @@
   import { canvas } from "./lib/stores/canvas.svelte.js";
   import { accessibility } from "./lib/stores/accessibility.svelte.js";
   import { locale } from "./lib/stores/locale.svelte.js";
+  import { prefsSync } from "./lib/stores/prefsSync.svelte.js";
   import type { GenerationParams, OutputImage, InterrogationResult } from "./lib/types/index.js";
   import UpdateNotification from "./lib/components/updater/UpdateNotification.svelte";
   import DownloadBanner from "./lib/components/downloads/DownloadBanner.svelte";
@@ -1837,6 +1838,13 @@
 
     // Load persisted settings
     await Promise.all([generation.loadSettings(), autocomplete.loadSettings(), locale.loadSettings()]);
+
+    // Browser/LAN mode: pull the server-side preference snapshot (or seed it
+    // from current local state) once local settings have loaded and the auth
+    // token is available. No-op in Tauri desktop mode.
+    if (isBrowserMode) {
+      void prefsSync.loadAndApply();
+    }
 
     // Prompt assistant: detect hardware + pre-select recommended model at launch.
     promptAssistant.init();

--- a/src/lib/stores/prefsSync.svelte.ts
+++ b/src/lib/stores/prefsSync.svelte.ts
@@ -28,6 +28,7 @@ import { autocomplete } from "./autocomplete.svelte.js";
 class PrefsSyncStore {
   private _syncTimer: ReturnType<typeof setTimeout> | null = null;
   private _syncing = false;
+  private _pending = false;
 
   constructor() {
     registerSyncHandler(() => this.scheduleSync());
@@ -111,12 +112,23 @@ class PrefsSyncStore {
   }
 
   private async _doSync(): Promise<void> {
-    if (this._syncing) return;
+    // If a push is already in flight, mark that another is needed rather than
+    // dropping it — changes made mid-flight would otherwise never reach the
+    // server until the next unrelated save.
+    if (this._syncing) {
+      this._pending = true;
+      return;
+    }
     this._syncing = true;
     try {
       await pushServerPrefs(this.collectAll());
     } finally {
       this._syncing = false;
+    }
+    if (this._pending) {
+      this._pending = false;
+      // Re-run once to flush the state that changed during the last push.
+      this._doSync().catch(() => {});
     }
   }
 }


### PR DESCRIPTION
Closes #348.

The server-side preference sync subsystem was fully built but disconnected on both ends, so it was dead code:

- The `prefsSync` singleton was never imported anywhere, so `registerSyncHandler` never ran and every store's `triggerSync()` was a permanent no-op. `loadAndApply()` was never called.
- The `user_prefs` storage layer existed but had no module declaration, no routes, and no handlers.

This wires the whole path end to end (the chosen direction over deleting the subsystem, since cross-device prefs are useful for the hosted multi-user browser deployment).

## Backend

- Declare the `user_prefs` module in `lib.rs`.
- Add `GET`/`PUT` `/internal-api/_user/prefs` routes and handlers. Both reject anonymous callers, resolve the per-user prefs key (localhost/admin maps to `_admin`, matching the convention in `user_prefs.rs`), and load/save via `user_prefs`. `PUT` stamps `updated_at` server-side and returns 204; `GET` returns 204 when no snapshot exists yet.

## Frontend

- Import `prefsSync` in `App.svelte` and call `loadAndApply()` once on browser-mode startup, after local settings load and the auth token is available (no-op on desktop).
- Fix `_doSync` dropping an in-flight sync: a save that lands mid-push now marks a pending flush and re-runs once the push completes, instead of being silently discarded until the next unrelated save.

## Notes

- `prefsSync` imports several stores as the central sync hub. That cross-store coupling is pre-existing and is in scope for the store cross-import audit (#350); this PR wires the existing design rather than restructuring it.

## Validation

- `cargo check` (desktop) and `cargo check --no-default-features --features server` both pass.
- `npm run build` passes.