### PR TITLE
fix: close browser/LAN-mode security gaps (#352)

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -576,6 +576,18 @@ impl AuthState {
             .map(|a| a.role.clone())
     }
 
+    /// Usernames of every account whose role is in `roles`. Used to target
+    /// notifications at staff (admins/moderators) instead of broadcasting them
+    /// to all users.
+    pub fn usernames_with_roles(&self, roles: &[&str]) -> Vec<String> {
+        let db = self.db.read().unwrap();
+        db.accounts
+            .iter()
+            .filter(|a| roles.iter().any(|r| a.role.eq_ignore_ascii_case(r)))
+            .map(|a| a.username.clone())
+            .collect()
+    }
+
     /// Set the role of an account. Valid roles: "user", "moderator", "admin".
     pub fn set_account_role(&self, username: &str, role: &str) -> Result<(), String> {
         if role != "user" && role != "moderator" && role != "admin" {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -189,6 +189,38 @@ fn resolve_username_with_query_token(
     None
 }
 
+/// Authentication gate for the read-only external proxies (cdn/animadex).
+/// These serve `<img>`-style requests that cannot set an Authorization header,
+/// so a `?token=` query param is also accepted. Localhost / non-LAN callers are
+/// always allowed; remote LAN clients must present valid credentials.
+fn proxy_request_authed(
+    state: &WebState,
+    headers: &HeaderMap,
+    remote: &SocketAddr,
+    query: &str,
+) -> bool {
+    if !state.lan_enabled || is_localhost(remote) {
+        return true;
+    }
+    if resolve_role(state, headers, remote) != UserRole::Anonymous {
+        return true;
+    }
+    query_param(query, "token")
+        .and_then(|t| state.auth.validate_token(t))
+        .is_some()
+}
+
+/// Progress/log events emitted only by admin/moderator operations (setup,
+/// model downloads, package/backend installs). Regular LAN users must not
+/// receive these on their SSE stream.
+fn is_staff_only_event(event: &str) -> bool {
+    event.starts_with("setup:")
+        || event.starts_with("download:")
+        || event.starts_with("install:")
+        || event.starts_with("attention:")
+        || event == "custom_node:installed"
+}
+
 /// Gallery files we list, count against storage quotas, and expire — must stay
 /// in sync with the formats `save_to_gallery` can write (JXL included).
 fn is_gallery_image_filename(name: &str) -> bool {
@@ -1211,6 +1243,8 @@ async fn sse_handler(
     if role == UserRole::Anonymous {
         return unauthorized_response("Authentication required");
     }
+    // Only admins/moderators receive setup/download/install progress events.
+    let is_staff = matches!(role, UserRole::Admin | UserRole::Moderator);
 
     // Resolve the username for this SSE connection (None = admin)
     let sse_username = resolve_username(&state, &hdrs, &remote);
@@ -1257,6 +1291,10 @@ async fn sse_handler(
         let prompt_queue = prompt_queue.clone();
         match result {
             Ok(evt) => {
+                // Admin-only operation progress must not leak to regular users.
+                if !is_staff && is_staff_only_event(&evt.event) {
+                    return None;
+                }
                 // Resolve alias: translate ComfyUI's real prompt_id to our placeholder
                 let raw_prompt_id = evt
                     .payload
@@ -1318,7 +1356,16 @@ async fn sse_handler(
 }
 
 /// Heartbeat — browser pings this to keep the backend alive.
-async fn heartbeat_handler(AxumState(state): AxumState<SharedState>) -> StatusCode {
+/// Requires authentication so an unauthenticated LAN client cannot keep the
+/// embedded server awake against the idle watchdog.
+async fn heartbeat_handler(
+    AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> StatusCode {
+    if resolve_role(&state, &headers, &remote) == UserRole::Anonymous {
+        return StatusCode::UNAUTHORIZED;
+    }
     let mut hb = state.app.last_heartbeat.lock().await;
     *hb = std::time::Instant::now();
     StatusCode::OK
@@ -1686,9 +1733,14 @@ async fn gpu_stats_handler(
 /// Animadex API proxy — characters search/facets only.
 async fn animadex_proxy_handler(
     AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     Path(path): Path<String>,
     uri: axum::http::Uri,
 ) -> Response {
+    if !proxy_request_authed(&state, &headers, &remote, uri.query().unwrap_or("")) {
+        return unauthorized_response("Authentication required");
+    }
     let clean = path.trim_start_matches('/');
     if !clean.starts_with("api/characters/") {
         return StatusCode::BAD_REQUEST.into_response();
@@ -1730,9 +1782,14 @@ async fn animadex_proxy_handler(
 /// Only proxies from the hardcoded CDN origin; this is NOT an open proxy.
 async fn cdn_proxy_handler(
     AxumState(state): AxumState<SharedState>,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     Path(path): Path<String>,
     uri: axum::http::Uri,
 ) -> Response {
+    if !proxy_request_authed(&state, &headers, &remote, uri.query().unwrap_or("")) {
+        return unauthorized_response("Authentication required");
+    }
     let mut target_url = format!("https://cdn.mooshieblob.com/{}", path);
     if let Some(query) = uri.query() {
         target_url.push('?');
@@ -4142,6 +4199,14 @@ async fn dispatch_command(
                             .map_err(|e| format!("Invalid base64: {}", e))?
                     }
                     "interrogate_image_path" => {
+                        // Reading an arbitrary on-disk path is a desktop-only action.
+                        // Allowing it for remote LAN clients is an arbitrary file read.
+                        if !caller_is_local {
+                            return Err(
+                                "Reading arbitrary file paths is not available in browser mode."
+                                    .to_string(),
+                            );
+                        }
                         let path = args["path"].as_str().ok_or("Missing path")?.to_string();
                         std::fs::read(&path).map_err(|e| format!("Failed to read image: {}", e))?
                     }
@@ -4156,8 +4221,10 @@ async fn dispatch_command(
                         {
                             return Err("Invalid filename".to_string());
                         }
+                        // Resolve within the caller's own gallery directory so a LAN
+                        // user cannot read another user's (or the admin's) images.
                         let dir =
-                            crate::config::gallery_dir().ok_or("Cannot find gallery directory")?;
+                            user_gallery_dir(username).ok_or("Cannot find gallery directory")?;
                         let path = dir.join(&filename);
                         std::fs::read(&path).map_err(|e| e.to_string())?
                     }
@@ -4334,6 +4401,14 @@ async fn dispatch_command(
         }
 
         // --- Clipboard ---
+        // The clipboard physically belongs to the machine running the server, not
+        // the remote LAN client. Restrict every clipboard command to local callers
+        // so a LAN user can neither write to nor read the operator's clipboard.
+        "copy_image_to_clipboard" | "copy_bytes_to_clipboard" | "read_clipboard_image"
+            if !caller_is_local =>
+        {
+            Err("Clipboard access is only available on the local machine.".to_string())
+        }
         "copy_image_to_clipboard" => {
             let file_path = args["filePath"]
                 .as_str()
@@ -5493,11 +5568,12 @@ async fn storage_set_limit_handler(
         }
     };
 
-    // Moderators cannot change storage limits for admin accounts
+    // Moderators may only manage regular user accounts, consistent with the
+    // delete / reset-password / set-role / modelhub handlers.
     if role == UserRole::Moderator {
         if let Some(target_role) = state.auth.get_account_role(username) {
-            if target_role == "admin" {
-                return forbidden_response("Moderators cannot modify admin storage limits.");
+            if target_role == "admin" || target_role == "moderator" {
+                return forbidden_response("Moderators can only manage regular user accounts.");
             }
         }
     }
@@ -5738,18 +5814,27 @@ async fn model_requests_add_handler(
         &category,
     );
 
-    // Notify all mods/admins about the new request
-    let _ = state.app.notifications.create_i18n(
-        "global",
-        "notifications.model_request.new_title",
-        Some("notifications.model_request.new_body"),
-        Some(serde_json::json!({
-            "username": username,
-            "model_name": model_name,
-            "model_type": model_type,
-        })),
-        "info",
-    );
+    // Notify mods/admins about the new request. A "global" notification would
+    // leak the request (and requester's username) to every user, so target each
+    // staff account individually. The localhost super-admin reads notifications
+    // under the literal "admin" key, so include it explicitly.
+    let mut recipients = state.auth.usernames_with_roles(&["admin", "moderator"]);
+    if !recipients.iter().any(|u| u.eq_ignore_ascii_case("admin")) {
+        recipients.push("admin".to_string());
+    }
+    for recipient in recipients {
+        let _ = state.app.notifications.create_i18n(
+            &recipient,
+            "notifications.model_request.new_title",
+            Some("notifications.model_request.new_body"),
+            Some(serde_json::json!({
+                "username": username,
+                "model_name": model_name,
+                "model_type": model_type,
+            })),
+            "info",
+        );
+    }
 
     (
         StatusCode::OK,

--- a/src/lib/animadex/fetch.ts
+++ b/src/lib/animadex/fetch.ts
@@ -5,14 +5,20 @@
  * because animadex.net does not allow cross-origin fetches from the app origin.
  * Image URLs on blobs.animadex.net load via plain <img src> (no proxy needed).
  */
-import { ipcInvoke, isBrowserMode, isTauri } from "../utils/ipc.js";
+import { getAuthToken, ipcInvoke, isBrowserMode, isTauri } from "../utils/ipc.js";
 
 export const ANIMADEX_ORIGIN = "https://animadex.net/";
 
 export function proxiedAnimadexApiUrl(apiPath: string): string {
   const clean = apiPath.replace(/^\//, "");
   if (isBrowserMode) {
-    return `/internal-api/_animadex/${clean}`;
+    const url = `/internal-api/_animadex/${clean}`;
+    const token = getAuthToken();
+    if (token) {
+      const sep = url.includes("?") ? "&" : "?";
+      return `${url}${sep}token=${encodeURIComponent(token)}`;
+    }
+    return url;
   }
   return `${ANIMADEX_ORIGIN}${clean}`;
 }

--- a/src/lib/utils/cdnFetch.ts
+++ b/src/lib/utils/cdnFetch.ts
@@ -14,13 +14,21 @@
  * Plain `<img src>` loads can display CDN images, but cached image fetches and
  * JSON requests still need the proxy in browser/server mode.
  */
-import { ipcInvoke, isBrowserMode, isTauri } from "./ipc.js";
+import { getAuthToken, ipcInvoke, isBrowserMode, isTauri } from "./ipc.js";
 
 const CDN_PREFIX = "https://cdn.mooshieblob.com/";
 
+/** Append the auth token as a query param so `<img src>` loads pass LAN auth. */
+function withToken(url: string): string {
+  const token = getAuthToken();
+  if (!token) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
 export function proxiedCdnUrl(url: string): string {
   if (isBrowserMode && url.startsWith(CDN_PREFIX)) {
-    return `/internal-api/_cdn/${url.slice(CDN_PREFIX.length)}`;
+    return withToken(`/internal-api/_cdn/${url.slice(CDN_PREFIX.length)}`);
   }
   return url;
 }

--- a/src/lib/utils/ipc.ts
+++ b/src/lib/utils/ipc.ts
@@ -204,7 +204,7 @@ export function startHeartbeat() {
   if (!isBrowserMode || heartbeatInterval) return;
   heartbeatInterval = setInterval(async () => {
     try {
-      await fetch("/internal-api/_heartbeat", { method: "POST" });
+      await fetch("/internal-api/_heartbeat", { method: "POST", headers: authHeaders() });
     } catch {
       // Server unreachable — nothing we can do
     }
@@ -214,7 +214,7 @@ export function startHeartbeat() {
   document.addEventListener("visibilitychange", () => {
     // Send on both hide and show: when hiding, reset the timestamp so the
     // 120s watchdog clock starts fresh *before* browser throttling kicks in.
-    fetch("/internal-api/_heartbeat", { method: "POST" }).catch(() => {});
+    fetch("/internal-api/_heartbeat", { method: "POST", headers: authHeaders() }).catch(() => {});
   });
 
   // Send heartbeat before unload to give a final ping


### PR DESCRIPTION
Closes #352.

Hardens the embedded web server against unauthenticated and cross-user access when LAN mode is enabled. Each finding from the audit issue is addressed:

1. **Arbitrary file read** (`interrogate_image_path`): refused for remote callers. Reading an arbitrary on-disk path is a desktop-only action; it was an arbitrary file read over the LAN.
2. **Cross-user gallery read** (`interrogate_gallery_image`): now resolves within the caller's own gallery directory via `user_gallery_dir(username)`, so a LAN user cannot read another user's or the admin's images.
3. **Clipboard access** (`copy_image_to_clipboard`, `copy_bytes_to_clipboard`, `read_clipboard_image`): restricted to local callers. The clipboard belongs to the host machine, not the remote client.
4. **Open proxies** (`_cdn`, `_animadex`): now require authentication. Because these serve `<img>`-style requests that cannot set an `Authorization` header, a `?token=` query param is also accepted (validated against issued tokens).
5. **SSE event leakage**: setup/download/install/attention progress events and `custom_node:installed` are filtered so admin-only operation logs do not reach regular users.
6. **Notification leakage** (`model_requests_add`): a "global" notification leaked the request (and requester's username) to every user. Each admin/moderator account is now notified individually; the localhost super-admin "admin" key is included explicitly.
7. **Unauthenticated heartbeat**: `_heartbeat` now requires authentication so an unauthenticated LAN client cannot keep the server awake against the idle watchdog.
8. **Moderator privilege** (`storage_set_limit`): moderators may only manage regular user accounts, consistent with the delete / reset-password / set-role / modelhub handlers (previously only admin accounts were protected, leaving moderator-on-moderator changes open).

Frontend threads the auth token through the heartbeat, CDN, and animadex proxy requests (`authHeaders()` for the heartbeat POSTs, `?token=` for the proxy URLs used in `<img src>`) so legitimate browser-mode usage keeps working.

## Validation
- `cargo check` (default `desktop` features): clean
- `cargo check --no-default-features --features server`: clean
- `npm run build`: passes
- `cargo fmt`: clean

No test framework exists in this repo; validation is the build/check gates above.
