### PR TITLE
fix: drop RwLock guards before blocking and async I/O (#351)

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2315,11 +2315,14 @@ pub async fn find_model_by_hash(
         return Err(AppError::Other("Invalid model category".into()));
     }
 
-    let config = state.config.read().await;
-    if config.comfyui_path.is_empty() {
+    let comfyui_path = {
+        let config = state.config.read().await;
+        config.comfyui_path.clone()
+    };
+    if comfyui_path.is_empty() {
         return Ok(None);
     }
-    let models_dir = std::path::Path::new(&config.comfyui_path)
+    let models_dir = std::path::Path::new(&comfyui_path)
         .join("models")
         .join(&category);
 
@@ -2374,11 +2377,14 @@ pub async fn hash_model_file(
         return Err(AppError::Other("Invalid model filename".into()));
     }
 
-    let config = state.config.read().await;
-    if config.comfyui_path.is_empty() {
+    let comfyui_path = {
+        let config = state.config.read().await;
+        config.comfyui_path.clone()
+    };
+    if comfyui_path.is_empty() {
         return Err(AppError::Other("ComfyUI path not configured".into()));
     }
-    let path = std::path::Path::new(&config.comfyui_path)
+    let path = std::path::Path::new(&comfyui_path)
         .join("models")
         .join(&category)
         .join(&filename);

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -53,9 +53,13 @@ pub async fn set_gallery_path(
     let trimmed = path.trim().to_string();
 
     let resolved = if trimmed.is_empty() {
-        // Reset to default
-        let mut cfg = state.config.write().await;
-        cfg.gallery_path = None;
+        // Reset to default. Snapshot under the guard, then write to disk after
+        // dropping it so the blocking save doesn't hold the config write lock.
+        let cfg = {
+            let mut cfg = state.config.write().await;
+            cfg.gallery_path = None;
+            cfg.clone()
+        };
         save_config(&cfg).map_err(AppError::Other)?;
         let dir = crate::config::app_data_dir()
             .ok_or_else(|| AppError::Other("Cannot find app data directory".into()))?
@@ -73,8 +77,11 @@ pub async fn set_gallery_path(
             .map_err(|e| AppError::Other(format!("Directory is not writable: {}", e)))?;
         let _ = std::fs::remove_file(&test_file);
 
-        let mut cfg = state.config.write().await;
-        cfg.gallery_path = Some(trimmed.clone());
+        let cfg = {
+            let mut cfg = state.config.write().await;
+            cfg.gallery_path = Some(trimmed.clone());
+            cfg.clone()
+        };
         save_config(&cfg).map_err(AppError::Other)?;
         trimmed
     };
@@ -91,13 +98,14 @@ pub async fn switch_to_browser_mode(
 ) -> Result<(), AppError> {
     log::info!("switch_to_browser_mode: called");
 
-    // Save browser_mode = true
-    let (mut port, lan_enabled) = {
+    // Save browser_mode = true. Snapshot under the guard, then write to disk
+    // after dropping it so the blocking save doesn't hold the config lock.
+    let (mut port, lan_enabled, cfg_snapshot) = {
         let mut cfg = state.config.write().await;
         cfg.browser_mode = true;
-        save_config(&cfg).map_err(AppError::Other)?;
-        (cfg.ui_server_port, cfg.lan_enabled)
+        (cfg.ui_server_port, cfg.lan_enabled, cfg.clone())
     };
+    save_config(&cfg_snapshot).map_err(AppError::Other)?;
     log::info!(
         "switch_to_browser_mode: config saved, port={}, lan={}",
         port,
@@ -130,8 +138,11 @@ pub async fn switch_to_browser_mode(
         let (actual_port, _handle) =
             webserver::start_server(state_for_server, port, lan_enabled).await;
         if actual_port != port {
-            let mut cfg = state.config.write().await;
-            cfg.ui_server_port = actual_port;
+            let cfg = {
+                let mut cfg = state.config.write().await;
+                cfg.ui_server_port = actual_port;
+                cfg.clone()
+            };
             save_config(&cfg).map_err(AppError::Other)?;
             log::info!(
                 "switch_to_browser_mode: persisted fallback ui_server_port={}",
@@ -159,8 +170,11 @@ pub async fn switch_to_browser_mode(
         Err(e) => {
             log::error!("switch_to_browser_mode: open::that failed: {}", e);
             {
-                let mut cfg = state.config.write().await;
-                cfg.browser_mode = false;
+                let cfg = {
+                    let mut cfg = state.config.write().await;
+                    cfg.browser_mode = false;
+                    cfg.clone()
+                };
                 save_config(&cfg).map_err(AppError::Other)?;
             }
             state

--- a/src-tauri/src/commands/interrogator.rs
+++ b/src-tauri/src/commands/interrogator.rs
@@ -13,28 +13,15 @@ async fn run_interrogation(
     state: &State<'_, Arc<AppState>>,
     image_bytes: Vec<u8>,
 ) -> Result<InterrogationResult, AppError> {
-    // Ensure model is downloaded
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_model_downloaded() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_model_downloaded(app, &state.http_client)
-                .await?;
-        }
+    // Resolve the model directory under a brief read lock, then run the
+    // (multi-second, network) downloads WITHOUT holding the guard across await.
+    let model_dir = { state.interrogator.read().await.model_dir() };
+    if !crate::interrogator::is_model_downloaded_at(&model_dir) {
+        crate::interrogator::ensure_model_downloaded_at(app, &state.http_client, &model_dir)
+            .await?;
     }
-
-    // Ensure ONNX Runtime shared library is downloaded
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_ort_library_present() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_ort_library(app, &state.http_client)
-                .await?;
-        }
+    if !crate::interrogator::is_ort_library_present_at(&model_dir) {
+        crate::interrogator::ensure_ort_library_at(app, &state.http_client, &model_dir).await?;
     }
 
     let (general_threshold, character_threshold) = {
@@ -67,27 +54,13 @@ async fn run_interrogation_from_image(
     state: &State<'_, Arc<AppState>>,
     img: image::DynamicImage,
 ) -> Result<InterrogationResult, AppError> {
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_model_downloaded() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_model_downloaded(app, &state.http_client)
-                .await?;
-        }
+    let model_dir = { state.interrogator.read().await.model_dir() };
+    if !crate::interrogator::is_model_downloaded_at(&model_dir) {
+        crate::interrogator::ensure_model_downloaded_at(app, &state.http_client, &model_dir)
+            .await?;
     }
-
-    // Ensure ONNX Runtime shared library is downloaded
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_ort_library_present() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_ort_library(app, &state.http_client)
-                .await?;
-        }
+    if !crate::interrogator::is_ort_library_present_at(&model_dir) {
+        crate::interrogator::ensure_ort_library_at(app, &state.http_client, &model_dir).await?;
     }
 
     let (general_threshold, character_threshold) = {

--- a/src-tauri/src/interrogator.rs
+++ b/src-tauri/src/interrogator.rs
@@ -72,105 +72,34 @@ impl InterrogatorState {
         }
     }
 
+    /// The directory holding the model/tags/ORT files. Callers clone this so
+    /// they can run downloads without holding the interrogator lock across I/O.
+    pub fn model_dir(&self) -> PathBuf {
+        self.model_dir.clone()
+    }
+
     fn model_path(&self) -> PathBuf {
-        self.model_dir.join(MODEL_FILENAME)
+        model_path_in(&self.model_dir)
     }
 
     fn tags_path(&self) -> PathBuf {
-        self.model_dir.join(TAGS_FILENAME)
+        tags_path_in(&self.model_dir)
     }
 
     pub fn is_model_downloaded(&self) -> bool {
-        self.model_path().exists() && self.tags_path().exists()
+        is_model_downloaded_at(&self.model_dir)
     }
 
     pub fn ort_library_path(&self) -> PathBuf {
-        self.model_dir.join(ORT_LIB_NAME)
+        ort_library_path_in(&self.model_dir)
     }
 
     pub fn is_ort_library_present(&self) -> bool {
-        self.ort_library_path().exists()
+        is_ort_library_present_at(&self.model_dir)
     }
 
     pub fn session_not_loaded(&self) -> bool {
         self.session.is_none()
-    }
-
-    /// Download model files from HuggingFace if not already present.
-    #[cfg(feature = "desktop")]
-    pub async fn ensure_model_downloaded(
-        &self,
-        app: &AppHandle,
-        client: &reqwest::Client,
-    ) -> Result<(), AppError> {
-        std::fs::create_dir_all(&self.model_dir)?;
-
-        if !self.model_path().exists() {
-            let url = format!("{}/{}", HF_BASE_URL, MODEL_FILENAME);
-            download_with_progress(app, client, &url, &self.model_path(), MODEL_FILENAME).await?;
-        }
-        if !self.tags_path().exists() {
-            let url = format!("{}/{}", HF_BASE_URL, TAGS_FILENAME);
-            download_with_progress(app, client, &url, &self.tags_path(), TAGS_FILENAME).await?;
-        }
-        Ok(())
-    }
-
-    /// Download the ONNX Runtime shared library if not already present.
-    #[cfg(feature = "desktop")]
-    pub async fn ensure_ort_library(
-        &self,
-        app: &AppHandle,
-        client: &reqwest::Client,
-    ) -> Result<(), AppError> {
-        if self.is_ort_library_present() {
-            return Ok(());
-        }
-
-        std::fs::create_dir_all(&self.model_dir)?;
-
-        let (url, archive_name) = ort_download_info();
-        let archive_path = self.model_dir.join(archive_name);
-
-        download_with_progress(app, client, &url, &archive_path, "ONNX Runtime").await?;
-        extract_ort_library(&archive_path, &self.ort_library_path())?;
-        std::fs::remove_file(&archive_path).ok();
-
-        Ok(())
-    }
-
-    /// Download model files without AppHandle (for browser mode).
-    pub async fn ensure_model_downloaded_headless(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<(), AppError> {
-        std::fs::create_dir_all(&self.model_dir)?;
-        if !self.model_path().exists() {
-            let url = format!("{}/{}", HF_BASE_URL, MODEL_FILENAME);
-            download_simple(client, &url, &self.model_path()).await?;
-        }
-        if !self.tags_path().exists() {
-            let url = format!("{}/{}", HF_BASE_URL, TAGS_FILENAME);
-            download_simple(client, &url, &self.tags_path()).await?;
-        }
-        Ok(())
-    }
-
-    /// Download ONNX Runtime without AppHandle (for browser mode).
-    pub async fn ensure_ort_library_headless(
-        &self,
-        client: &reqwest::Client,
-    ) -> Result<(), AppError> {
-        if self.is_ort_library_present() {
-            return Ok(());
-        }
-        std::fs::create_dir_all(&self.model_dir)?;
-        let (url, archive_name) = ort_download_info();
-        let archive_path = self.model_dir.join(archive_name);
-        download_simple(client, &url, &archive_path).await?;
-        extract_ort_library(&archive_path, &self.ort_library_path())?;
-        std::fs::remove_file(&archive_path).ok();
-        Ok(())
     }
 
     /// Load the ONNX session and tag list, caching for subsequent calls.
@@ -433,6 +362,108 @@ impl InterrogatorState {
             rating_tags,
         })
     }
+}
+
+// ---------------------------------------------------------------------------
+// Path-based download/status helpers.
+//
+// These operate on a plain `model_dir` path so callers can clone the directory
+// out from under the interrogator's RwLock and run the (multi-second, network)
+// downloads WITHOUT holding the guard across the await — per the project rule
+// that guards must be dropped before awaiting I/O.
+// ---------------------------------------------------------------------------
+
+fn model_path_in(model_dir: &std::path::Path) -> PathBuf {
+    model_dir.join(MODEL_FILENAME)
+}
+
+fn tags_path_in(model_dir: &std::path::Path) -> PathBuf {
+    model_dir.join(TAGS_FILENAME)
+}
+
+fn ort_library_path_in(model_dir: &std::path::Path) -> PathBuf {
+    model_dir.join(ORT_LIB_NAME)
+}
+
+pub fn is_model_downloaded_at(model_dir: &std::path::Path) -> bool {
+    model_path_in(model_dir).exists() && tags_path_in(model_dir).exists()
+}
+
+pub fn is_ort_library_present_at(model_dir: &std::path::Path) -> bool {
+    ort_library_path_in(model_dir).exists()
+}
+
+/// Download model files from HuggingFace if not already present.
+#[cfg(feature = "desktop")]
+pub async fn ensure_model_downloaded_at(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    model_dir: &std::path::Path,
+) -> Result<(), AppError> {
+    std::fs::create_dir_all(model_dir)?;
+    if !model_path_in(model_dir).exists() {
+        let url = format!("{}/{}", HF_BASE_URL, MODEL_FILENAME);
+        download_with_progress(app, client, &url, &model_path_in(model_dir), MODEL_FILENAME)
+            .await?;
+    }
+    if !tags_path_in(model_dir).exists() {
+        let url = format!("{}/{}", HF_BASE_URL, TAGS_FILENAME);
+        download_with_progress(app, client, &url, &tags_path_in(model_dir), TAGS_FILENAME).await?;
+    }
+    Ok(())
+}
+
+/// Download the ONNX Runtime shared library if not already present.
+#[cfg(feature = "desktop")]
+pub async fn ensure_ort_library_at(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    model_dir: &std::path::Path,
+) -> Result<(), AppError> {
+    if is_ort_library_present_at(model_dir) {
+        return Ok(());
+    }
+    std::fs::create_dir_all(model_dir)?;
+    let (url, archive_name) = ort_download_info();
+    let archive_path = model_dir.join(archive_name);
+    download_with_progress(app, client, &url, &archive_path, "ONNX Runtime").await?;
+    extract_ort_library(&archive_path, &ort_library_path_in(model_dir))?;
+    std::fs::remove_file(&archive_path).ok();
+    Ok(())
+}
+
+/// Download model files without AppHandle (for browser mode).
+pub async fn ensure_model_downloaded_headless_at(
+    client: &reqwest::Client,
+    model_dir: &std::path::Path,
+) -> Result<(), AppError> {
+    std::fs::create_dir_all(model_dir)?;
+    if !model_path_in(model_dir).exists() {
+        let url = format!("{}/{}", HF_BASE_URL, MODEL_FILENAME);
+        download_simple(client, &url, &model_path_in(model_dir)).await?;
+    }
+    if !tags_path_in(model_dir).exists() {
+        let url = format!("{}/{}", HF_BASE_URL, TAGS_FILENAME);
+        download_simple(client, &url, &tags_path_in(model_dir)).await?;
+    }
+    Ok(())
+}
+
+/// Download ONNX Runtime without AppHandle (for browser mode).
+pub async fn ensure_ort_library_headless_at(
+    client: &reqwest::Client,
+    model_dir: &std::path::Path,
+) -> Result<(), AppError> {
+    if is_ort_library_present_at(model_dir) {
+        return Ok(());
+    }
+    std::fs::create_dir_all(model_dir)?;
+    let (url, archive_name) = ort_download_info();
+    let archive_path = model_dir.join(archive_name);
+    download_simple(client, &url, &archive_path).await?;
+    extract_ort_library(&archive_path, &ort_library_path_in(model_dir))?;
+    std::fs::remove_file(&archive_path).ok();
+    Ok(())
 }
 
 /// Parse the selected_tags.csv file to extract tag names and categories.

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2014,11 +2014,15 @@ async fn dispatch_command(
             }
             #[cfg(feature = "desktop")]
             {
-                // Step 1: Save config
-                let mut cfg = state.config.write().await;
-                cfg.browser_mode = false;
+                // Step 1: Save config. Snapshot under the guard, then write to
+                // disk after dropping it so the blocking file write doesn't hold
+                // the config write lock.
+                let cfg = {
+                    let mut cfg = state.config.write().await;
+                    cfg.browser_mode = false;
+                    cfg.clone()
+                };
                 config::save_config(&cfg)?;
-                drop(cfg);
 
                 // Step 2: Disarm heartbeat watchdog
                 state
@@ -3974,8 +3978,11 @@ async fn dispatch_command(
             let path = args["path"].as_str().unwrap_or("").to_string();
             let trimmed = path.trim().to_string();
             let resolved = if trimmed.is_empty() {
-                let mut cfg = state.config.write().await;
-                cfg.gallery_path = None;
+                let cfg = {
+                    let mut cfg = state.config.write().await;
+                    cfg.gallery_path = None;
+                    cfg.clone()
+                };
                 config::save_config(&cfg)?;
                 let dir = config::app_data_dir()
                     .ok_or("Cannot find app data directory")?
@@ -3986,8 +3993,11 @@ async fn dispatch_command(
                 let p = std::path::Path::new(&trimmed);
                 std::fs::create_dir_all(p)
                     .map_err(|e| format!("Cannot create gallery directory: {}", e))?;
-                let mut cfg = state.config.write().await;
-                cfg.gallery_path = Some(trimmed.clone());
+                let cfg = {
+                    let mut cfg = state.config.write().await;
+                    cfg.gallery_path = Some(trimmed.clone());
+                    cfg.clone()
+                };
                 config::save_config(&cfg)?;
                 trimmed
             };
@@ -4464,30 +4474,18 @@ async fn run_interrogation_headless(
     state: &Arc<AppState>,
     image_bytes: Vec<u8>,
 ) -> Result<crate::interrogator::InterrogationResult, String> {
-    // Ensure model is downloaded
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_model_downloaded() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_model_downloaded_headless(&state.http_client)
-                .await
-                .map_err(|e| e.to_string())?;
-        }
+    // Resolve the model directory under a brief read lock, then run the
+    // (multi-second, network) downloads WITHOUT holding the guard across await.
+    let model_dir = { state.interrogator.read().await.model_dir() };
+    if !crate::interrogator::is_model_downloaded_at(&model_dir) {
+        crate::interrogator::ensure_model_downloaded_headless_at(&state.http_client, &model_dir)
+            .await
+            .map_err(|e| e.to_string())?;
     }
-
-    // Ensure ONNX Runtime shared library is downloaded
-    {
-        let interrogator = state.interrogator.read().await;
-        if !interrogator.is_ort_library_present() {
-            drop(interrogator);
-            let interrogator = state.interrogator.read().await;
-            interrogator
-                .ensure_ort_library_headless(&state.http_client)
-                .await
-                .map_err(|e| e.to_string())?;
-        }
+    if !crate::interrogator::is_ort_library_present_at(&model_dir) {
+        crate::interrogator::ensure_ort_library_headless_at(&state.http_client, &model_dir)
+            .await
+            .map_err(|e| e.to_string())?;
     }
 
     let (general_threshold, character_threshold) = {


### PR DESCRIPTION
## Summary

Audit issue #351: several command handlers held a `config` or `interrogator` `RwLock` guard across long-running, blocking, or awaited I/O. This serializes unrelated callers behind the guard and risks deadlocks (the CLAUDE.md rule "drop RwLock guards before .await on I/O", extended here to blocking sync I/O too).

## Findings fixed

1. **api.rs `find_model_by_hash`** held the config read guard across the GB-scale hashing loop. Now clones `comfyui_path` under a brief read lock and hashes without the guard.
2. **api.rs `hash_model_file`** same pattern.
3. **Interrogator downloads** held the interrogator read guard across multi-second HuggingFace/ONNX-runtime network downloads. Refactored the download/status helpers into path-based free functions (`is_model_downloaded_at`, `ensure_model_downloaded_at`, headless variants, etc.) so callers clone `model_dir` under a brief read lock and download without holding the guard. Updates the two desktop command callers (`commands/interrogator.rs`) and the headless webserver caller.
4. **Config writes** (`set_gallery_path`, `switch_to_browser_mode`, `switch_to_app_mode`) held the config write guard across the blocking `save_config` file write. Now snapshot the `AppConfig` inside the guarded block, drop the guard, then `save_config(&snapshot)`.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `npm run build` passes
- `cargo fmt` applied

Closes #351
