### PR TITLE
fix: reuse a shared http client and stop unwrapping mime_str (#353)

### DIFF
--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -424,7 +424,7 @@ impl AppState {
         let part = multipart::Part::bytes(file_bytes)
             .file_name(file_name)
             .mime_str("image/png")
-            .unwrap();
+            .map_err(|e| AppError::Other(format!("Failed to set upload MIME type: {}", e)))?;
 
         let form = multipart::Form::new()
             .part("image", part)
@@ -452,7 +452,7 @@ impl AppState {
         let part = multipart::Part::bytes(bytes)
             .file_name(filename)
             .mime_str("image/png")
-            .unwrap();
+            .map_err(|e| AppError::Other(format!("Failed to set upload MIME type: {}", e)))?;
 
         let form = multipart::Form::new()
             .part("image", part)

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -2482,10 +2482,9 @@ pub(crate) async fn fetch_civitai_image_bytes(
     state: &AppState,
     url: &str,
 ) -> Result<Vec<u8>, AppError> {
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|e| AppError::Other(format!("Failed to build image fetch client: {}", e)))?;
+    // Reuse the shared no-redirect client so redirects stay manual (the token is
+    // gated per-host below) while still benefiting from connection pooling.
+    let client = &state.http_client_no_redirect;
     // The initial URL must be a CivitAI host so this command can't be turned into
     // a generic server-side fetch primitive (it is reachable through browser-mode
     // LAN auth and carries the user's CivitAI token).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -474,6 +474,12 @@ pub struct AppState {
     pub ws_handle: Mutex<Option<JoinHandle<()>>>,
     pub client_id: String,
     pub http_client: reqwest::Client,
+    /// Shared client that does NOT follow redirects. Used where redirects must
+    /// be handled manually for security (e.g. CivitAI image fetches gate the
+    /// user's API token on a per-host basis, so the token can never be carried
+    /// across a redirect to the CDN). Reuses one client to keep connection
+    /// pooling instead of building a fresh client per call.
+    pub http_client_no_redirect: reqwest::Client,
     #[cfg(any(feature = "desktop", feature = "server"))]
     pub interrogator: Arc<RwLock<InterrogatorState>>,
     #[cfg(any(feature = "desktop", feature = "server"))]
@@ -534,6 +540,10 @@ impl AppState {
     pub fn new(config: AppConfig) -> Self {
         let (event_tx, _) = broadcast::channel(1024);
         let http_client = reqwest::Client::new();
+        let http_client_no_redirect = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let gpu_manager = GpuManager::new(&config, http_client.clone());
         Self {
             config: RwLock::new(config),
@@ -541,6 +551,7 @@ impl AppState {
             ws_handle: Mutex::new(None),
             client_id: uuid::Uuid::new_v4().to_string(),
             http_client,
+            http_client_no_redirect,
             #[cfg(any(feature = "desktop", feature = "server"))]
             interrogator: Arc::new(RwLock::new(InterrogatorState::new())),
             #[cfg(any(feature = "desktop", feature = "server"))]


### PR DESCRIPTION
## Summary

Audit issue #353: CLAUDE.md requires reusing `state.http_client` so connection pooling and shared config aren't defeated by per-call clients.

## Findings fixed

1. **`fetch_civitai_image_bytes` built a fresh reqwest client per call** (commands/api.rs). It deliberately disables auto-redirect so the CivitAI token can be gated per-host (the token must never follow a redirect to the CDN), which is why it couldn't just use the auto-redirecting `state.http_client`. Added a shared `http_client_no_redirect` to `AppState` (built once with `redirect::Policy::none()`) and switched the function to it. This preserves the manual redirect/token-gating behaviour while restoring connection pooling.
2. **`.mime_str("image/png").unwrap()` could panic** in the two ComfyUI upload helpers (comfyui/client.rs). Both functions already return `Result<_, AppError>`, so the unwraps are now `?`-propagated via `map_err`.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `cargo fmt` applied

Closes #353
