### PR TITLE
fix: harden multi-GPU worker readiness and stuck-worker watchdog (#356)

### DIFF
--- a/src-tauri/src/comfyui/gpu_manager.rs
+++ b/src-tauri/src/comfyui/gpu_manager.rs
@@ -49,6 +49,11 @@ pub struct GpuWorker {
     pub status: RwLock<WorkerStatus>,
     /// Whether this worker is currently reserved (executing a prompt).
     pub reserved: AtomicBool,
+    /// Timestamp (millis since epoch) of the last successful `try_reserve`.
+    /// Zero until the worker is reserved for the first time. The stuck-worker
+    /// watchdog measures reservation age from this, not `last_released`, so a
+    /// freshly-started worker on its first job is never force-released.
+    pub reserved_at: AtomicU64,
     /// Timestamp (millis since epoch) of last time this worker was released.
     pub last_released: AtomicU64,
     /// The child process handle.
@@ -75,6 +80,7 @@ impl GpuWorker {
                 WorkerStatus::Disabled
             }),
             reserved: AtomicBool::new(false),
+            reserved_at: AtomicU64::new(0),
             last_released: AtomicU64::new(0),
             process: Mutex::new(None),
             ws_handle: Mutex::new(None),
@@ -94,9 +100,18 @@ impl GpuWorker {
 
     /// Reserve this worker for a prompt. Returns false if already reserved.
     pub fn try_reserve(&self) -> bool {
-        self.reserved
+        let reserved = self
+            .reserved
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+            .is_ok();
+        if reserved {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            self.reserved_at.store(now, Ordering::Release);
+        }
+        reserved
     }
 
     /// Release this worker after prompt completion/error.

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -1433,6 +1433,45 @@ pub async fn wait_all_workers_ready(state: &AppState, timeout_secs: u64) {
             for i in 0..iterations {
                 tokio::time::sleep(Duration::from_millis(500)).await;
                 if comfyui_health_ok(&http_client, &url).await {
+                    // Health endpoint responding is not enough: verify the
+                    // required MooshieUI custom nodes are actually loaded before
+                    // marking the worker Idle, mirroring wait_for_worker_ready.
+                    // Otherwise a node-less worker gets handed generation jobs
+                    // and fails them.
+                    if let Err(e) =
+                        super::nodes::verify_required_mooshie_nodes(&http_client, &base_url).await
+                    {
+                        let mut status = w.status.write().await;
+                        *status = WorkerStatus::Error;
+                        log::error!(
+                            "Worker {} (GPU {}): MooshieUI nodes not loaded at {}: {}",
+                            worker_id,
+                            gpu_index,
+                            base_url,
+                            e
+                        );
+                        return Err(worker_id);
+                    }
+                    if let Err(e) =
+                        super::nodes::verify_required_controlnet_nodes(&http_client, &base_url)
+                            .await
+                    {
+                        log::warn!(
+                            "Worker {}: ControlNet custom nodes not loaded (optional): {}",
+                            worker_id,
+                            e
+                        );
+                    }
+                    if let Err(e) =
+                        super::nodes::verify_required_style_transfer_nodes(&http_client, &base_url)
+                            .await
+                    {
+                        log::warn!(
+                            "Worker {}: style transfer custom nodes not loaded (optional): {}",
+                            worker_id,
+                            e
+                        );
+                    }
                     let mut status = w.status.write().await;
                     *status = WorkerStatus::Idle;
                     log::info!(

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -494,17 +494,29 @@ pub fn spawn_stuck_worker_watchdog(state: Arc<AppState>) {
                         wmap.values().any(|&wid| wid == worker.id)
                     };
                     if !has_active_prompt {
-                        let last_released = worker
-                            .last_released
+                        // Measure reservation age from when the worker was
+                        // reserved, NOT from `last_released`. The old code used
+                        // `now_ms / 1000` (epoch seconds, ~1.7e9) whenever
+                        // `last_released == 0`, which is always > 600, so a
+                        // freshly-started worker running its very first job got
+                        // force-released the instant the watchdog observed it in
+                        // the brief window before the dispatcher records its
+                        // prompt in the worker map.
+                        let reserved_at = worker
+                            .reserved_at
                             .load(std::sync::atomic::Ordering::Acquire);
                         let now_ms = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_millis() as u64;
-                        let stuck_secs = if last_released == 0 {
-                            now_ms / 1000
+                        // reserved_at == 0 means the current reservation predates
+                        // this field (or we observed the tiny race between the
+                        // reserve CAS and the timestamp store) — treat as not-yet-
+                        // stuck rather than releasing an in-flight job.
+                        let stuck_secs = if reserved_at == 0 {
+                            0
                         } else {
-                            (now_ms.saturating_sub(last_released)) / 1000
+                            (now_ms.saturating_sub(reserved_at)) / 1000
                         };
                         if stuck_secs > max_stuck_secs {
                             log::warn!(


### PR DESCRIPTION
## Summary

Audit issue #356: multi-GPU and server-queue distribution correctness.

## Findings fixed

1. **Parallel worker startup skipped custom-node verification** (`comfyui/process.rs`, `wait_all_workers_ready`). The parallel readiness loop marked a worker `Idle` as soon as the ComfyUI health endpoint responded, unlike the single-worker `wait_for_worker_ready` which also verifies the MooshieUI custom nodes are loaded. A worker whose nodes failed to load was marked ready and handed generation jobs it could only fail. It now mirrors the single-worker path: required MooshieUI nodes must load (worker goes to `Error` otherwise), with optional ControlNet / style-transfer nodes logged as warnings.

2. **Stuck-worker watchdog could false-trigger** (`webserver.rs`, `spawn_stuck_worker_watchdog`). Reservation age was computed from `last_released`, falling back to `now_ms / 1000` (epoch seconds, ~1.7e9, always greater than the 600s threshold) whenever `last_released == 0`. A freshly started worker running its first job was force-released the instant the watchdog observed it in the brief window before the dispatcher records its prompt in the worker map. Added a `reserved_at` timestamp (set on each successful `try_reserve`) and based the stuck calculation on it; `reserved_at == 0` is treated as not-yet-stuck.

## Findings verified as already satisfied (no change needed)

3. **`do_submit_to_server_queue` and the worker map.** The worker-to-prompt mapping is the dispatcher caller's responsibility, not the internal submit helper's. Every `submit_prompt` caller (workflow.rs and the webserver generate paths) records `set_worker(prompt_id, worker_id)` regardless of whether the prompt took the reserve path (`do_submit`) or the server-queue path (`do_submit_to_server_queue`), so the worker map is populated in both cases in the current code.

4. **Image uploads route to the primary client.** All GPU workers are spawned from the same `config.comfyui_path` (they differ only by `--port` and `CUDA_VISIBLE_DEVICES`) and therefore share a single on-disk `input/` directory. An upload to the primary worker is visible on the shared filesystem to whichever worker later runs the job, so `LoadImage` resolves correctly. Routing uploads to the primary node is correct for this single-host architecture; no per-worker upload fan-out is needed.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `cargo fmt` applied

Closes #356
