### PR TITLE
fix: correct inpainting/diffusion workflow parameter routing (#354)

### DIFF
--- a/src-tauri/src/templates/inpainting.rs
+++ b/src-tauri/src/templates/inpainting.rs
@@ -81,6 +81,28 @@ pub fn build(params: &GenerationParams, seed: i64) -> WorkflowResult {
     );
     next_id += 1;
 
+    // Optionally grow (dilate) the mask so the inpaint blends past the hard
+    // mask edge. The user-configured `grow_mask_by` was previously read into
+    // GenerationParams but never wired into the graph. Skipped when 0/None.
+    let mask_source = if params.grow_mask_by.unwrap_or(0) > 0 {
+        let grow_id = next_id.to_string();
+        workflow.insert(
+            grow_id.clone(),
+            json!({
+                "class_type": "GrowMask",
+                "inputs": {
+                    "mask": [load_mask_id, 0],
+                    "expand": params.grow_mask_by.unwrap_or(0),
+                    "tapered_corners": true
+                }
+            }),
+        );
+        next_id += 1;
+        grow_id
+    } else {
+        load_mask_id
+    };
+
     // Encode source image to latent space.
     let encode_id = next_id.to_string();
     workflow.insert(
@@ -103,7 +125,7 @@ pub fn build(params: &GenerationParams, seed: i64) -> WorkflowResult {
             "class_type": "SetLatentNoiseMask",
             "inputs": {
                 "samples": [encode_id, 0],
-                "mask": [load_mask_id, 0]
+                "mask": [mask_source, 0]
             }
         }),
     );
@@ -162,7 +184,15 @@ pub fn build(params: &GenerationParams, seed: i64) -> WorkflowResult {
         workflow,
         next_id,
         image_output: (decode_id, 0),
-        model_source,
+        // Expose the model the KSampler is actually wired to (the
+        // DifferentialDiffusion node when enabled), not the raw checkpoint.
+        // The post-build injectors (vpred/zsnr, cascade, smart-guidance, ...)
+        // chain new model patches onto `model_source` and rewire the sampler
+        // to them. Returning the raw model here let those injectors re-point
+        // the sampler past the DifferentialDiffusion node, silently dropping
+        // it — which is exactly the v-pred/Anima inpaint case where it is
+        // auto-enabled. Anchoring on the wired model keeps it in the chain.
+        model_source: sampler_model_source,
         clip_source,
         positive_source: pos_source,
         negative_source: neg_source,

--- a/src-tauri/src/templates/upscale.rs
+++ b/src-tauri/src/templates/upscale.rs
@@ -143,11 +143,12 @@ pub fn append_upscale_chain(
     };
 
     // For tiled upscales, use quality-only prompts to reduce tile seam artifacts.
-    let (pos_source, neg_source) = if use_tiling {
-        if let (Some(ref pos_text), Some(ref neg_text)) = (
-            &params.upscale_positive_prompt,
-            &params.upscale_negative_prompt,
-        ) {
+    // Each override is applied independently: a positive-only or negative-only
+    // override is honoured on its own. The old paired `if let` required BOTH the
+    // positive AND negative override to be set, so supplying just one silently
+    // discarded it and fell back to the original generation conditioning.
+    let pos_source = if use_tiling {
+        if let Some(ref pos_text) = params.upscale_positive_prompt {
             let up_pos_id = next_id.to_string();
             workflow.insert(
                 up_pos_id.clone(),
@@ -160,7 +161,16 @@ pub fn append_upscale_chain(
                 }),
             );
             *next_id += 1;
+            (up_pos_id, 0u32)
+        } else {
+            (result.positive_source.0.clone(), result.positive_source.1)
+        }
+    } else {
+        (result.positive_source.0.clone(), result.positive_source.1)
+    };
 
+    let neg_source = if use_tiling {
+        if let Some(ref neg_text) = params.upscale_negative_prompt {
             let up_neg_id = next_id.to_string();
             workflow.insert(
                 up_neg_id.clone(),
@@ -173,28 +183,24 @@ pub fn append_upscale_chain(
                 }),
             );
             *next_id += 1;
-
-            ((up_pos_id, 0u32), (up_neg_id, 0u32))
+            (up_neg_id, 0u32)
         } else {
-            (
-                (result.positive_source.0.clone(), result.positive_source.1),
-                (result.negative_source.0.clone(), result.negative_source.1),
-            )
+            (result.negative_source.0.clone(), result.negative_source.1)
         }
     } else {
-        (
-            (result.positive_source.0.clone(), result.positive_source.1),
-            (result.negative_source.0.clone(), result.negative_source.1),
-        )
+        (result.negative_source.0.clone(), result.negative_source.1)
     };
 
     // Second KSampler pass at low denoise
     let sampler_id = next_id.to_string();
     let is_cfgpp_sampler = params.sampler_name.to_lowercase().contains("cfg_pp");
+    // Halve CFG for the low-denoise refine pass, but keep a floor so a low base
+    // CFG (or a Flux/distilled model at cfg 0-1) can't drive the upscale sampler
+    // to a near-zero CFG, which disables guidance and yields noise.
     let upscale_cfg = if is_cfgpp_sampler {
         (params.cfg / 2.0).max(2.0)
     } else {
-        params.cfg / 2.0
+        (params.cfg / 2.0).max(1.0)
     };
     workflow.insert(
         sampler_id.clone(),

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -483,6 +483,16 @@
 
       const params = generation.toParams();
 
+      // Anima models produce poor results below 1024 — clamp to 1024² area
+      // preserving aspect ratio. The single-image path does this on the store;
+      // the grid path builds params per cell, so mirror it here.
+      if (generation.isAnima && (params.width < 1024 || params.height < 1024)) {
+        const ratio = params.width / params.height;
+        const area = 1024 * 1024;
+        params.width = Math.round(Math.sqrt(area * ratio) / 8) * 8;
+        params.height = Math.round(Math.sqrt(area / ratio) / 8) * 8;
+      }
+
       // Use shared seed for random seeds so the grid is consistent
       if (params.seed < 0) {
         params.seed = sharedSeed;


### PR DESCRIPTION
## Summary

Audit issue #354: mask/diffusion parameters that are computed but never reach the ComfyUI graph, plus routing that differs from intent.

## Findings fixed

1. **`grow_mask_by` was never wired into the graph** (`templates/inpainting.rs`). The field is deserialized into `GenerationParams` but the mask flowed `LoadImageMask -> SetLatentNoiseMask` with nothing in between. A `GrowMask` node is now inserted between them when `grow_mask_by > 0`, so the configured dilation actually applies.

2. **DifferentialDiffusion node was bypassed** (`templates/inpainting.rs` + the injectors in `templates/mod.rs`). The inpainting template wires the KSampler's `model` input to a `DifferentialDiffusion` node, but returned the raw checkpoint as `WorkflowResult.model_source`. The post-build model-patch injectors (`inject_vpred_zsnr_sampling`, `inject_cascade_sampling`, `inject_smart_guidance`, ...) read `model_source`, chain a new patch onto it, and rewire the sampler to that patch. Because `model_source` pointed at the raw model rather than the wired DifferentialDiffusion node, the rewire re-pointed the sampler past DifferentialDiffusion and ComfyUI pruned it as unreferenced. This bit exactly the v-pred / Anima inpaint case, where DifferentialDiffusion is auto-enabled and v-pred injection always runs. Fixed by anchoring `model_source` on the model the sampler is actually wired to (the DifferentialDiffusion node when enabled), so downstream patches chain on top of it and it stays in the graph. DifferentialDiffusion with no noise mask is an identity op, so downstream non-masked samplers (upscale/facefix/segment-detail) are unaffected.

3. **Anima sub-1024 clamp was skipped in the grid path** (`GenerateButton.svelte`). The single-image path clamps Anima dimensions below 1024 to a 1024² area preserving aspect ratio; the compare-grid path built params per cell and skipped it. The clamp is now mirrored in the grid loop.

4. **Upscale CFG had no floor** (`templates/upscale.rs`). The refine pass halves CFG but only floored it (`.max(2.0)`) for `cfg_pp` samplers. A low base CFG, or a Flux/distilled model running at CFG 0-1, could drive the upscale sampler to a near-zero CFG, disabling guidance and producing noise. A `1.0` floor now applies to standard samplers as well.

5. **Upscale prompt overrides were both-or-neither** (`templates/upscale.rs`). The paired `if let (Some, Some)` required BOTH the positive and negative override to be set; supplying only one silently discarded it and fell back to the original conditioning. Each override is now honoured independently.

## Findings verified as already correct (no change needed)

- **Anima LLLite routing applied to non-LLLite checkpoints.** `inject_anima_lllite` only runs when ControlNet is enabled with a selected `controlnet_model` and image (the `cn.enabled && cn.controlnet_model.is_some() && cn.image.is_some()` guard in `build_workflow`). LLLite usage is driven by the selected ControlNet model, not the base checkpoint; the architecture check only selects the LLLite vs standard ControlNet path. This matches the intent of the recent #344 fix.

- **img2img sends empty `sampler_id`.** Only the refine-only path returns an empty `sampler_id`, which is intentional and documented: refine-only mode has no main KSampler, and the injector/ControlNet rewiring is keyed on `workflow.get_mut(&sampler_id)`, so a missing key is a safe no-op. The normal img2img path sets `sampler_id` correctly.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `npm run build` clean
- `cargo fmt` applied

Closes #354
