### PR TITLE
fix: plumb dropped generation params and remove dead fields (#355)

### DIFF
--- a/src-tauri/src/comfyui/mooshie_nodes.py
+++ b/src-tauri/src/comfyui/mooshie_nodes.py
@@ -48,6 +48,7 @@ class MooshieFaceDetailer:
                 "bbox_threshold": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.05}),
                 "bbox_padding": ("FLOAT", {"default": 1.5, "min": 1.0, "max": 4.0, "step": 0.1}),
                 "feather": ("INT", {"default": 20, "min": 0, "max": 100}),
+                "max_faces": ("INT", {"default": 0, "min": 0, "max": 100}),
             }
         }
 
@@ -73,6 +74,7 @@ class MooshieFaceDetailer:
         bbox_threshold,
         bbox_padding,
         feather,
+        max_faces=0,
     ):
         from ultralytics import YOLO
 
@@ -97,10 +99,13 @@ class MooshieFaceDetailer:
             if not detections or len(detections[0].boxes) == 0:
                 continue
 
-            for box in detections[0].boxes:
-                conf = box.conf[0].item()
-                if conf < bbox_threshold:
-                    continue
+            # Keep only boxes above threshold, then (when capped) refine the
+            # most-confident faces first so max_faces drops the weakest detections.
+            boxes = [box for box in detections[0].boxes if box.conf[0].item() >= bbox_threshold]
+            if max_faces > 0 and len(boxes) > max_faces:
+                boxes = sorted(boxes, key=lambda box: box.conf[0].item(), reverse=True)[:max_faces]
+
+            for box in boxes:
 
                 x1, y1, x2, y2 = box.xyxy[0].cpu().int().tolist()
 

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -178,9 +178,6 @@ pub struct GenerationParams {
     /// True when metadata or filename indicates a v-pred SDXL variant.
     #[serde(default)]
     pub is_vpred_model: bool,
-    /// Whether the model uses rectified flow scheduling (detected from filename or architecture)
-    #[serde(default)]
-    pub uses_rectified_flow: bool,
     /// Enable Smart Guidance (positive-biased) — patches model for all generation passes
     #[serde(default)]
     pub smart_guidance: bool,

--- a/src-tauri/src/commands/prompt_assistant.rs
+++ b/src-tauri/src/commands/prompt_assistant.rs
@@ -159,7 +159,7 @@ async fn run_generation(
         .unwrap_or_else(|| "natural_language".to_string());
     let tag_only = grounding::is_tag_only(&purpose, family);
     let candidates = grounding::retrieve_candidates(input, 40);
-    let system = grounding::system_prompt(tag_only, mode, &candidates);
+    let system = grounding::system_prompt(tag_only, mode, &candidates, opts.include_artists);
     let max_tokens = match opts.length.as_deref() {
         Some("short") => 96,
         Some("detailed") => 384,

--- a/src-tauri/src/prompt_assistant/grounding.rs
+++ b/src-tauri/src/prompt_assistant/grounding.rs
@@ -152,7 +152,14 @@ pub fn is_tag_only(purpose: &str, family: &str) -> bool {
 
 /// Build the system prompt, seeded with grounding candidates. `tag_only`
 /// selects between danbooru-tag and Anima natural-language conventions.
-pub fn system_prompt(tag_only: bool, mode: GenMode, candidates: &[String]) -> String {
+/// `include_artists` relaxes the default artist restriction when the user opts
+/// in, letting the assistant suggest well-known artists for style.
+pub fn system_prompt(
+    tag_only: bool,
+    mode: GenMode,
+    candidates: &[String],
+    include_artists: bool,
+) -> String {
     let cand = if candidates.is_empty() {
         String::new()
     } else {
@@ -181,8 +188,14 @@ matches it. Use concrete, well-known tags; do not invent subjects the descriptio
 mention."
             }
         };
+        let artist_rule = if include_artists {
+            " You may add one or more well-known danbooru artist tags that fit the requested \
+style; only use real artist names you are confident exist."
+        } else {
+            " Do not add artist tags."
+        };
         format!(
-            "You are a danbooru tag prompt writer for an anime image generator. {body} \
+            "You are a danbooru tag prompt writer for an anime image generator. {body}{artist_rule} \
 Output ONLY a comma-separated list of lowercase danbooru tags. \
 No sentences, no explanations, no quotes, no numbering. \
 Prefer concrete, well-known tags.{cand}"
@@ -202,6 +215,13 @@ made-up tag into a real one."
             }
             GenMode::Compose => "Write a prompt from the user's description.",
         };
+        let artist_rule = if include_artists {
+            "You may reference well-known artists as @name to match the requested style; \
+only use real artist names you are confident exist, and never emit a literal placeholder."
+        } else {
+            "Only reference an artist that appears in the user's input, written as @name; \
+never invent one or emit a literal placeholder."
+        };
         format!(
             "You are a prompt writer for the Anima anime image model. {body} \
 For every concept that has a known Gelbooru-style tag, use that tag; only fall back to \
@@ -209,8 +229,7 @@ natural language for ideas that have no matching tag. \
 Put all the tags first as a single comma-separated section, then finish with one \
 detailed, grammatically complete natural-language sentence describing the scene. \
 Keep everything on one line, comma-separated, tags before the sentence. \
-Only reference an artist that appears in the user's input, written as @name; \
-never invent one or emit a literal placeholder. \
+{artist_rule} \
 Do not repeat tags inside the sentence. \
 Do not add headings, labels like 'tags:', or em dashes. No explanations or quotes.{cand}"
         )
@@ -262,36 +281,115 @@ fn count_tag_set() -> &'static HashSet<&'static str> {
 /// dropping scene, pose, clothing, and background tags.
 const FACE_ATOMS: &[&str] = &[
     // hair
-    "hair", "bangs", "ahoge", "ponytail", "ponytails", "twintail", "twintails",
-    "braid", "braids", "sidelocks", "sidelock", "forelock", "bun", "bob", "hime",
-    "drill", "drills", "hairband", "hairclip", "hairpin", "hairpins", "scrunchie",
+    "hair",
+    "bangs",
+    "ahoge",
+    "ponytail",
+    "ponytails",
+    "twintail",
+    "twintails",
+    "braid",
+    "braids",
+    "sidelocks",
+    "sidelock",
+    "forelock",
+    "bun",
+    "bob",
+    "hime",
+    "drill",
+    "drills",
+    "hairband",
+    "hairclip",
+    "hairpin",
+    "hairpins",
+    "scrunchie",
     "fringe",
     // eyes
-    "eye", "eyes", "eyelashes", "eyebrow", "eyebrows", "eyeshadow", "eyeliner",
-    "eyepatch", "eyewear", "heterochromia", "pupils", "pupil", "sclera", "iris",
+    "eye",
+    "eyes",
+    "eyelashes",
+    "eyebrow",
+    "eyebrows",
+    "eyeshadow",
+    "eyeliner",
+    "eyepatch",
+    "eyewear",
+    "heterochromia",
+    "pupils",
+    "pupil",
+    "sclera",
+    "iris",
     // mouth
-    "mouth", "lips", "lip", "teeth", "fang", "fangs", "tongue", "saliva", "drool",
+    "mouth",
+    "lips",
+    "lip",
+    "teeth",
+    "fang",
+    "fangs",
+    "tongue",
+    "saliva",
+    "drool",
     "lipstick",
     // expression
-    "smile", "grin", "smirk", "frown", "pout", "scowl", "blush", "blushing",
-    "wink", "expression", "expressionless", "ahegao", "tears", "teary", "crying",
+    "smile",
+    "grin",
+    "smirk",
+    "frown",
+    "pout",
+    "scowl",
+    "blush",
+    "blushing",
+    "wink",
+    "expression",
+    "expressionless",
+    "ahegao",
+    "tears",
+    "teary",
+    "crying",
     // face features
-    "face", "facial", "nose", "cheek", "cheeks", "chin", "jaw", "forehead",
-    "freckles", "mole", "dimples", "makeup", "mascara",
+    "face",
+    "facial",
+    "nose",
+    "cheek",
+    "cheeks",
+    "chin",
+    "jaw",
+    "forehead",
+    "freckles",
+    "mole",
+    "dimples",
+    "makeup",
+    "mascara",
     // glasses / facial hair
-    "glasses", "sunglasses", "monocle", "beard", "mustache", "goatee", "stubble",
+    "glasses",
+    "sunglasses",
+    "monocle",
+    "beard",
+    "mustache",
+    "goatee",
+    "stubble",
     "sideburns",
     // ears / head ornaments visible in a face crop
-    "ears", "ear", "earrings", "horn", "horns", "antlers", "halo", "head",
-    "headband", "headphones", "headdress", "headgear",
+    "ears",
+    "ear",
+    "earrings",
+    "horn",
+    "horns",
+    "antlers",
+    "halo",
+    "head",
+    "headband",
+    "headphones",
+    "headdress",
+    "headgear",
 ];
 
 /// Danbooru emoticon/expression tags that carry no `_`-separated word a
 /// [`FACE_ATOMS`] check could catch, yet clearly describe a facial expression.
 const EMOTICON_FACE_TAGS: &[&str] = &[
-    ":d", ":3", ":o", ":p", ":q", ":t", ":i", ":<", ":>", ":/", ":|", ";)", ";d",
-    ";o", ";p", ";3", ";q", "xd", "x3", "d:", "o3o", "uwu", ">:)", ">:(", ">_<",
-    "@_@", "+_+", "^_^", "^o^", "0_0", "o_o", "._.", "=_=", "qwq", "tot",
+    ":d", ":3", ":o", ":p", ":q", ":t", ":i", ":<", ":>", ":/", ":|", ";)", ";d", ";o", ";p", ";3",
+    ";q", "xd", "x3", "d:", "o3o", "uwu", ">:)", ">:(", ">_<", "@_@", "+_+", "^_^", "^o^", "0_0",
+    "o_o", "._.", "=_=", "qwq", "tot",
 ];
 
 /// Extract the face/head-relevant subset of a comma-separated prompt, preserving

--- a/src-tauri/src/templates/facefix.rs
+++ b/src-tauri/src/templates/facefix.rs
@@ -70,7 +70,8 @@ pub fn append_facefix_chain(
                 "guide_size": params.facefix_guide_size,
                 "bbox_threshold": 0.5,
                 "bbox_padding": 1.5,
-                "feather": 20
+                "feather": 20,
+                "max_faces": params.facefix_max_faces
             }
         }),
     );

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4299,8 +4299,16 @@ async fn dispatch_command(
                 crate::prompt_assistant::grounding::GenMode::Compose
             };
             let length = args["opts"]["length"].as_str();
-            let result =
-                run_prompt_assistant_headless(&state, &input, &family, mode, length).await?;
+            let include_artists = args["opts"]["include_artists"].as_bool().unwrap_or(false);
+            let result = run_prompt_assistant_headless(
+                &state,
+                &input,
+                &family,
+                mode,
+                length,
+                include_artists,
+            )
+            .await?;
             Ok(serde_json::Value::String(result))
         }
         #[cfg(any(feature = "desktop", feature = "server"))]
@@ -4539,6 +4547,7 @@ pub async fn run_prompt_assistant_headless(
     family: &str,
     mode: crate::prompt_assistant::grounding::GenMode,
     length: Option<&str>,
+    include_artists: bool,
 ) -> Result<String, String> {
     use crate::prompt_assistant::{grounding, hardware};
     // No active-generation guard here: `prompt_queue` is shared across every user
@@ -4595,7 +4604,7 @@ pub async fn run_prompt_assistant_headless(
         .unwrap_or_else(|| "natural_language".to_string());
     let tag_only = grounding::is_tag_only(&purpose, family);
     let candidates = grounding::retrieve_candidates(input, 40);
-    let system = grounding::system_prompt(tag_only, mode, &candidates);
+    let system = grounding::system_prompt(tag_only, mode, &candidates, include_artists);
     // Mirror the desktop token budget so browser Enhance/Compose honors the
     // user's length pick instead of always generating at the medium default.
     let max_tokens = match length {

--- a/src/lib/components/generation/FaceFixSettings.svelte
+++ b/src/lib/components/generation/FaceFixSettings.svelte
@@ -19,7 +19,7 @@
 
   const recommendedModels: RecommendedModel[] = [
     {
-      labelKey: "generation.facefix.yolov8m",
+      labelKey: "generation.facefix.yolo11n",
       filename: "Anzhc Face seg 640 v4 y11n.pt",
       url: "https://huggingface.co/Anzhc/Anzhcs_YOLOs/resolve/0319daeae9ae40752c2fb3904069cb35cc61d2ec/Anzhc%20Face%20seg%20640%20v4%20y11n.pt",
       sha256: "1e77ad7bd349babd8a4a90478bfc965348642b63a8d95d3b43ee13db42fd0a64",

--- a/src/lib/config/controlnet-presets.ts
+++ b/src/lib/config/controlnet-presets.ts
@@ -16,7 +16,6 @@ export interface ControlNetPreset {
   label: string;
   description: string;
   preprocessor: string | null;
-  preprocessorParams?: Record<string, number>;
   defaults?: ControlNetDefaults;
   requiresMode?: "inpainting";
   models: {
@@ -41,7 +40,6 @@ export const CONTROLNET_PRESETS: ControlNetPreset[] = [
     label: "Canny Edge",
     description: "Detects edges — best for preserving structure and composition",
     preprocessor: "CannyEdgePreprocessor",
-    preprocessorParams: { low_threshold: 100, high_threshold: 200 },
     models: {
       sdxl: {
         filename: "diffusers_xl_canny_full.safetensors",

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -640,7 +640,7 @@ const de: Record<string, string> = {
   "generation.facefix.tip": "Erkennt Gesichter im erzeugten Bild und entrauscht jeden Gesichtsbereich erneut für bessere Details. Läuft nach der Erzeugung (nach dem Refiner, falls aktiviert).",
   "generation.facefix.detector": "Erkennungsmodell",
   "generation.facefix.detector_tip": "Das YOLO-Modell für die Gesichtserkennung. 'YOLO11n Face Seg' ist die empfohlene hochwertige Option, 'YOLOv8n' ist schneller und leichter. Modelle werden beim ersten Gebrauch automatisch heruntergeladen.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Empfohlen)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Empfohlen)",
   "generation.facefix.yolov8n": "YOLOv8n Gesicht (Leicht)",
   "generation.facefix.denoise": "Entrauschen",
   "generation.facefix.denoise_tip": "Wie stark die KI jedes erkannte Gesicht überarbeitet. Niedrig (0.2-0.4) bewahrt das Originalgesicht treu, hoch fügt Details hinzu, kann aber Gesichtszüge verändern.",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -780,7 +780,7 @@ const en: Record<string, string> = {
   "generation.facefix.tip": "Detects faces in the generated image and re-denoises each face region for better detail. Runs after generation (and after the refiner if enabled).",
   "generation.facefix.detector": "Detector Model",
   "generation.facefix.detector_tip": "The YOLO model used to detect faces. 'YOLO11n Face Seg' is the recommended high-quality option, 'YOLOv8n' is faster and lighter. Models are downloaded automatically on first use.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Recommended)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Recommended)",
   "generation.facefix.yolov8n": "YOLOv8n Face (Lightweight)",
   "generation.facefix.denoise": "Denoise",
   "generation.facefix.denoise_tip": "How much the AI re-draws each detected face. Lower values (0.2-0.4) preserve the original face closely, higher values add more detail but may change facial features.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -667,7 +667,7 @@ const es: Record<string, string> = {
   "generation.facefix.tip": "Detecta rostros en la imagen generada y redibuja cada región facial para mayor detalle. Se ejecuta después de la generación (y después del refiner si está activado).",
   "generation.facefix.detector": "Modelo detector",
   "generation.facefix.detector_tip": "El modelo YOLO usado para detectar rostros. 'YOLO11n Face Seg' es la opción recomendada de alta calidad, 'YOLOv8n' es más rápido y ligero. Los modelos se descargan automáticamente en el primer uso.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Recomendado)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Recomendado)",
   "generation.facefix.yolov8n": "YOLOv8n Rostro (Ligero)",
   "generation.facefix.denoise": "Eliminación de ruido",
   "generation.facefix.denoise_tip": "Cuánto redibuja la IA cada rostro detectado. Valores bajos (0.2-0.4) conservan el rostro original, valores altos añaden más detalle pero pueden cambiar rasgos faciales.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -642,7 +642,7 @@ const fr: Record<string, string> = {
   "generation.facefix.tip": "Détecte les visages dans l'image générée et redébruite chaque région faciale pour plus de détails. S'exécute après la génération (et après le refiner si activé).",
   "generation.facefix.detector": "Modèle de détection",
   "generation.facefix.detector_tip": "Le modèle YOLO utilisé pour détecter les visages. 'YOLO11n Face Seg' est l'option recommandée haute qualité, 'YOLOv8n' est plus rapide et léger. Les modèles sont téléchargés automatiquement à la première utilisation.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Recommandé)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Recommandé)",
   "generation.facefix.yolov8n": "YOLOv8n Visage (Léger)",
   "generation.facefix.denoise": "Débruitage",
   "generation.facefix.denoise_tip": "À quel point l'IA redessine chaque visage détecté. Valeurs basses (0.2-0.4) préservent le visage fidèlement, valeurs hautes ajoutent plus de détails mais peuvent modifier les traits du visage.",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -624,7 +624,7 @@ const it: Record<string, string> = {
   "generation.facefix.tip": "Rileva i visi nell'immagine generata e rielabora ogni regione del viso per migliori dettagli. Si esegue dopo la generazione (e dopo il refiner se abilitato).",
   "generation.facefix.detector": "Modello rilevatore",
   "generation.facefix.detector_tip": "Il modello YOLO usato per rilevare i visi. 'YOLO11n Face Seg' è l'opzione consigliata ad alta qualità, 'YOLOv8n' è più veloce e leggero. I modelli vengono scaricati automaticamente al primo utilizzo.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Consigliato)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Consigliato)",
   "generation.facefix.yolov8n": "YOLOv8n Viso (Leggero)",
   "generation.facefix.denoise": "Denoising",
   "generation.facefix.denoise_tip": "Quanto l'IA ridisegna ogni viso rilevato. Valori bassi (0.2-0.4) preservano il viso originale fedelmente, valori alti aggiungono più dettagli ma possono modificare i tratti del viso.",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -642,7 +642,7 @@ const ja: Record<string, string> = {
   "generation.facefix.tip": "生成画像の顔を検出し、各顔領域を再デノイズしてディテールを改善します。生成後（リファイナー有効時はリファイナー後）に実行されます。",
   "generation.facefix.detector": "検出モデル",
   "generation.facefix.detector_tip": "顔検出に使用するYOLOモデル。'YOLO11n Face Seg'は推奨の高品質オプション、'YOLOv8n'はより高速で軽量。モデルは初回使用時に自動ダウンロードされます。",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg（推奨）",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg（推奨）",
   "generation.facefix.yolov8n": "YOLOv8n 顔（軽量）",
   "generation.facefix.denoise": "デノイズ",
   "generation.facefix.denoise_tip": "検出された各顔をAIがどれだけ描き直すか。低い値（0.2-0.4）は元の顔を忠実に保持、高い値はディテールを追加するが顔の特徴が変わる可能性あり。",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -624,7 +624,7 @@ const ko: Record<string, string> = {
   "generation.facefix.tip": "생성 이미지에서 얼굴을 감지하고 각 얼굴 영역을 재디노이즈하여 디테일을 개선합니다. 생성 후(리파이너가 활성화된 경우 리파이너 후) 실행됩니다.",
   "generation.facefix.detector": "감지 모델",
   "generation.facefix.detector_tip": "얼굴 감지에 사용하는 YOLO 모델. 'YOLO11n Face Seg'는 권장 고품질 옵션, 'YOLOv8n'은 더 빠르고 가볍습니다. 모델은 처음 사용 시 자동 다운로드됩니다.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (권장)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (권장)",
   "generation.facefix.yolov8n": "YOLOv8n 얼굴 (경량)",
   "generation.facefix.denoise": "디노이즈",
   "generation.facefix.denoise_tip": "감지된 각 얼굴을 AI가 얼마나 다시 그리는지. 낮은 값(0.2-0.4)은 원래 얼굴을 충실히 보존, 높은 값은 디테일을 추가하지만 얼굴 특징이 변할 수 있습니다.",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -624,7 +624,7 @@ const pt: Record<string, string> = {
   "generation.facefix.tip": "Detecta rostos na imagem gerada e re-processa cada região facial para melhor detalhe. Executa após a geração (e após o refiner, se ativado).",
   "generation.facefix.detector": "Modelo Detector",
   "generation.facefix.detector_tip": "O modelo YOLO usado para detectar rostos. 'YOLO11n Face Seg' é a opção recomendada de alta qualidade, 'YOLOv8n' é mais rápido e leve. Modelos são baixados automaticamente no primeiro uso.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Recomendado)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Recomendado)",
   "generation.facefix.yolov8n": "YOLOv8n Face (Leve)",
   "generation.facefix.denoise": "Ruído",
   "generation.facefix.denoise_tip": "Quanto a IA redesenha cada rosto detectado. Valores baixos (0.2-0.4) preservam o rosto original fielmente, valores altos adicionam mais detalhes, mas podem alterar feições faciais.",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -624,7 +624,7 @@ const ru: Record<string, string> = {
   "generation.facefix.tip": "Обнаруживает лица на сгенерированном изображении и повторно обрабатывает каждую область лица для лучших деталей. Запускается после генерации (и после рифайнера, если включено).",
   "generation.facefix.detector": "Модель детектора",
   "generation.facefix.detector_tip": "Модель YOLO для обнаружения лиц. 'YOLO11n Face Seg' — рекомендуемый высококачественный вариант, 'YOLOv8n' быстрее и легче. Модели скачиваются автоматически при первом использовании.",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg (Рекомендуется)",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg (Рекомендуется)",
   "generation.facefix.yolov8n": "YOLOv8n Лицо (Лёгкая)",
   "generation.facefix.denoise": "Шумоподавление",
   "generation.facefix.denoise_tip": "Насколько сильно ИИ перерисовывает каждое обнаруженное лицо. Низкие значения (0.2-0.4) сохраняют оригинальное лицо, высокие добавляют больше деталей, но могут изменить черты лица.",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -624,7 +624,7 @@ const zhTw: Record<string, string> = {
   "generation.facefix.tip": "偵測生成影像中的臉部，並對每個臉部區域重新去雜訊以改善細節。在生成後執行（若啟用了精煉器，則在精煉後執行）。",
   "generation.facefix.detector": "偵測模型",
   "generation.facefix.detector_tip": "用於臉部偵測的 YOLO 模型。'YOLO11n Face Seg' 是建議的高品質選項，'YOLOv8n' 更快更輕量。模型會在首次使用時自動下載。",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg（建議）",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg（建議）",
   "generation.facefix.yolov8n": "YOLOv8n 臉部（輕量）",
   "generation.facefix.denoise": "去雜訊",
   "generation.facefix.denoise_tip": "AI 重繪每個偵測到的臉部的程度。低值（0.2-0.4）忠實保留原始臉部，高值增加細節但可能改變臉部特徵。",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -624,7 +624,7 @@ const zh: Record<string, string> = {
   "generation.facefix.tip": "检测生成图像中的面部，并对每个面部区域重新去噪以改善细节。在生成后运行（如果启用了精炼器，则在精炼后运行）。",
   "generation.facefix.detector": "检测模型",
   "generation.facefix.detector_tip": "用于面部检测的 YOLO 模型。'YOLO11n Face Seg' 是推荐的高质量选项，'YOLOv8n' 更快更轻量。模型会在首次使用时自动下载。",
-  "generation.facefix.yolov8m": "YOLO11n Face Seg（推荐）",
+  "generation.facefix.yolo11n": "YOLO11n Face Seg（推荐）",
   "generation.facefix.yolov8n": "YOLOv8n 面部（轻量）",
   "generation.facefix.denoise": "去噪",
   "generation.facefix.denoise_tip": "AI 重绘每个检测到的面部的程度。低值（0.2-0.4）忠实保留原始面部，高值添加细节但可能改变面部特征。",

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -1397,6 +1397,7 @@ class GenerationStore {
       height: this.height,
       batchSize: this.batchSize,
       denoise: this.denoise,
+      refineOnly: this.refineOnly,
       differentialDiffusion: this.differentialDiffusion,
       upscaleEnabled: this.upscaleEnabled,
       upscaleMethod: this.upscaleMethod,
@@ -1438,6 +1439,7 @@ class GenerationStore {
       styleTransferNormStrength: this.styleTransferNormStrength,
       styleTransferPmiAlpha: this.styleTransferPmiAlpha,
       styleTransferMegapixels: this.styleTransferMegapixels,
+      styleTransferBlocks: this.styleTransferBlocks,
       facefixEnabled: this.facefixEnabled,
       facefixDetector: this.facefixDetector,
       facefixDenoise: this.facefixDenoise,
@@ -1462,6 +1464,7 @@ class GenerationStore {
       autoSaveDirs: this.autoSaveDirs,
       regionalPrompts: this.regionalPrompts,
       regionalPromptStrategy: this.regionalPromptStrategy,
+      modelFamilyOverrides: this.modelFamilyOverrides,
     };
   }
 
@@ -1733,9 +1736,7 @@ class GenerationStore {
         creativity: s.creativity,
         threshold: s.threshold,
       })),
-      raw_positive_prompt: translateNaiWeightSyntax(positivePrompt),
       positive_regions: builtRegions,
-      raw_negative_prompt: translateNaiWeightSyntax(negativePrompt),
       checkpoint: this.checkpoint,
       vae: this.vae || null,
       loras: this.loras

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -79,10 +79,6 @@ export interface GenerationParams {
   negative_segments: PromptSegment[];
   detail_segments: DetailSegment[];
   positive_regions?: PositiveRegion[];
-  /** Raw prompt text with scheduling tags intact, for metadata embedding */
-  raw_positive_prompt: string;
-  /** Raw prompt text with scheduling tags intact, for metadata embedding */
-  raw_negative_prompt: string;
   checkpoint: string;
   vae: string | null;
   loras: LoraPayloadEntry[];
@@ -110,6 +106,10 @@ export interface GenerationParams {
   upscale_fast_refine?: boolean;
   upscale_soft_guidance: boolean;
   upscale_soft_guidance_multiplier: number;
+  /** Quality-prompt override for the upscale pass (family-specific). Null falls back to base conditioning. */
+  upscale_positive_prompt: string | null;
+  /** Negative quality-prompt override for the upscale pass. Null falls back to base conditioning. */
+  upscale_negative_prompt: string | null;
   /** Also save the base image before the upscale chain runs. */
   save_pre_upscale_image?: boolean;
   smart_guidance: boolean;
@@ -122,6 +122,17 @@ export interface GenerationParams {
   diffusion_model: string | null;
   clip_model: string | null;
   clip_type: string | null;
+  /** Auto face-refinement pass after the main sample. */
+  facefix_enabled: boolean;
+  /** YOLO/segmentation detector model filename, or null for the default. */
+  facefix_detector: string | null;
+  facefix_denoise: number;
+  facefix_steps: number;
+  facefix_guide_size: number;
+  /** Cap on faces refined per image; 0 means no limit. */
+  facefix_max_faces: number;
+  /** Reuse the positive prompt for each detected face instead of a generic prompt. */
+  facefix_auto_prompt: boolean;
   controlnet: ControlNetPayload | null;
   model_architecture: string;
   is_sdxl_like?: boolean;


### PR DESCRIPTION
## Summary

Audit issue #355: generation parameters that were collected in the store but dropped before reaching the backend, plus dead fields and a misleading config name.

## Findings fixed

1. **`collectPrefs()` dropped three settings** (`stores/generation.svelte.ts`). `refineOnly`, `styleTransferBlocks`, and `modelFamilyOverrides` were saved/loaded locally but omitted from `collectPrefs()`, so the server-side preference sync silently lost them (`collectPrefs`/`loadSettings` must stay symmetric). All three are now collected.

2. **`raw_positive_prompt` / `raw_negative_prompt` were dead** (`stores/generation.svelte.ts` + `types/index.ts`). The Rust `GenerationParams` no longer reads them (metadata embedding is built from `positive_prompt` plus re-appended `<segment:...>` tags, not `raw_*`). Removed from the `toParams()` payload and from the `GenerationParams` interface.

3. **Dead `uses_rectified_flow` field** (`comfyui/types.rs`). Deserialized into `GenerationParams` but never read anywhere. Removed.

4. **`facefix_max_faces` was ignored by the node** (`comfyui/mooshie_nodes.py` + `templates/facefix.rs`). The value was collected and sent, but `MooshieFaceDetailer` refined every detected face regardless. The node now takes a `max_faces` input: detections above threshold are sorted by confidence and capped to the top N when `max_faces > 0` (0 = no limit). The facefix template wires `params.facefix_max_faces` through.

5. **`GenerationParams` TS interface drifted from the wire payload** (`types/index.ts`). `toParams()` already sends `facefix_enabled`, `facefix_detector`, `facefix_denoise`, `facefix_steps`, `facefix_guide_size`, `facefix_max_faces`, `facefix_auto_prompt`, `upscale_positive_prompt`, and `upscale_negative_prompt`, but the interface declared none of them (esbuild does not type-check, so the drift was silent). Added.

6. **`include_artists` was collected but dropped** (`commands/prompt_assistant.rs`, `webserver.rs`, `prompt_assistant/grounding.rs`). The prompt assistant option never influenced the system prompt. It is now threaded into `grounding::system_prompt` for both the desktop command and the browser-mode headless path: with it on, the assistant may suggest well-known artists for style; with it off, the default artist restriction stays (Anima references only user-supplied artists; tag-only mode adds no artist tags).

7. **Misleading locale key** (`FaceFixSettings.svelte` + 11 locales). The detector is YOLO11n but the key was named `generation.facefix.yolov8m`. Renamed to `generation.facefix.yolo11n` everywhere (the display string was already correct).

8. **Dead `preprocessorParams`** (`config/controlnet-presets.ts`). Defined on the preset interface and set on the canny preset, but never consumed by the preprocessor wiring. Removed the field and its one usage.

## Deferred (with rationale)

- **Segment detailer borrows `facefix_steps` / `facefix_guide_size`** (`templates/segment_detail.rs`). Giving the segment detailer its own dedicated params is a new UI surface, which is feature work rather than a correctness fix. The shared values remain functional, so this is left as-is for a follow-up.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `npm run build` clean
- `cargo fmt` applied

Closes #355
