### PR TITLE
fix: keep gallery SQLite index and metadata consistent (#357)

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1277,7 +1277,19 @@ pub(crate) async fn load_gallery_image_png_from_dir(
             let mut buf = std::io::Cursor::new(Vec::new());
             img.write_to(&mut buf, image::ImageFormat::Png)
                 .map_err(|e| format!("PNG encode failed: {}", e))?;
-            Ok(buf.into_inner())
+            let png = buf.into_inner();
+            // The JXL may carry embedded generation metadata; the freshly encoded
+            // PNG does not. Re-embed it as a standard PNG text chunk so the
+            // exported file stays portable and metadata-complete.
+            match crate::metadata::read_image_metadata(&bytes) {
+                Ok(Some(meta)) => Ok(crate::metadata::embed_png_metadata(
+                    &png,
+                    &meta,
+                    crate::metadata::MetadataMode::TextChunk,
+                )
+                .unwrap_or(png)),
+                _ => Ok(png),
+            }
         })
         .await
         .map_err(|e| AppError::Other(format!("Task panicked: {}", e)))?
@@ -1594,6 +1606,7 @@ pub async fn rename_gallery_image(
     }
 
     std::fs::rename(&old_path, &new_path)?;
+    crate::gallery_index::rename(&old_path, &new_path);
     Ok(new_filename)
 }
 

--- a/src-tauri/src/gallery_index.rs
+++ b/src-tauri/src/gallery_index.rs
@@ -252,6 +252,27 @@ pub fn upsert(
     }
 }
 
+/// Update an image's path in the index after a rename. Best-effort: errors are
+/// logged. Preserves the existing row (and its metadata/created_at) rather than
+/// dropping and re-inserting.
+pub fn rename(old_path: &Path, new_path: &Path) {
+    let guard = conn().lock();
+    let Ok(guard) = guard else {
+        return;
+    };
+    let Some(ref c) = *guard else {
+        return;
+    };
+    let old_str = old_path.to_string_lossy().to_string();
+    let new_str = new_path.to_string_lossy().to_string();
+    if let Err(e) = c.execute(
+        "UPDATE images SET path = ?1 WHERE path = ?2",
+        params![new_str, old_str],
+    ) {
+        log::warn!("gallery_index: rename failed for {old_str} -> {new_str}: {e}");
+    }
+}
+
 /// Remove a gallery image from the index. Best-effort: errors are logged.
 pub fn remove(path: &Path) {
     let guard = conn().lock();

--- a/src-tauri/src/jxl.rs
+++ b/src-tauri/src/jxl.rs
@@ -117,8 +117,31 @@ fn iter_boxes(bytes: &[u8]) -> Vec<([u8; 4], std::ops::Range<usize>)> {
             // size=0 means box extends to end of file
             (pos + 8, bytes.len())
         } else if size == 1 {
-            // 64-bit size follows; rare for JXL metadata — treat as EOF.
-            break;
+            // size=1 means a 64-bit `largesize` follows the type field; the box
+            // (including its 16-byte header) spans `largesize` bytes from `pos`.
+            if pos + 16 > bytes.len() {
+                break;
+            }
+            let large = u64::from_be_bytes([
+                bytes[pos + 8],
+                bytes[pos + 9],
+                bytes[pos + 10],
+                bytes[pos + 11],
+                bytes[pos + 12],
+                bytes[pos + 13],
+                bytes[pos + 14],
+                bytes[pos + 15],
+            ]);
+            let Ok(large) = usize::try_from(large) else {
+                break;
+            };
+            let Some(box_end) = pos.checked_add(large) else {
+                break;
+            };
+            if large < 16 || box_end > bytes.len() {
+                break;
+            }
+            (pos + 16, box_end)
         } else {
             if pos + size > bytes.len() {
                 break;
@@ -353,6 +376,26 @@ mod tests {
         let decoded = decode_to_rgba8(&wrapped).expect("decode wrapped");
         assert_eq!(decoded.width, 2);
         assert_eq!(decoded.height, 2);
+    }
+
+    #[test]
+    fn iter_boxes_parses_64bit_extended_size() {
+        // A box with size==1 carries its real length in a trailing 64-bit
+        // `largesize` field; the payload then starts after the 16-byte header.
+        let payload = b"hello";
+        let total: u64 = 16 + payload.len() as u64;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&JXL_SIGNATURE_BOX);
+        bytes.extend_from_slice(&1u32.to_be_bytes()); // size = 1 (extended)
+        bytes.extend_from_slice(b"xml "); // type
+        bytes.extend_from_slice(&total.to_be_bytes()); // 64-bit largesize
+        bytes.extend_from_slice(payload);
+
+        let boxes = iter_boxes(&bytes);
+        assert_eq!(boxes.len(), 1, "should parse one extended-size box");
+        let (typ, range) = &boxes[0];
+        assert_eq!(typ, b"xml ");
+        assert_eq!(&bytes[range.clone()], payload);
     }
 
     #[test]

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -3074,6 +3074,7 @@ async fn dispatch_command(
             if path.exists() {
                 std::fs::remove_file(&path).map_err(|e| e.to_string())?;
             }
+            crate::gallery_index::remove(&path);
             Ok(serde_json::json!(null))
         }
         "rename_gallery_image" => {
@@ -3098,6 +3099,7 @@ async fn dispatch_command(
             let old_path = dir.join(&old);
             let new_path = dir.join(&new_name);
             std::fs::rename(&old_path, &new_path).map_err(|e| e.to_string())?;
+            crate::gallery_index::rename(&old_path, &new_path);
             Ok(serde_json::json!(new_name))
         }
         "import_image_directory" => {
@@ -5408,6 +5410,7 @@ fn save_to_gallery_in_dir(
     };
 
     std::fs::write(&path, &final_bytes).map_err(|e| e.to_string())?;
+    crate::gallery_index::upsert(&path, final_bytes.len() as u64, detected_format, metadata);
     Ok(gallery_filename)
 }
 

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -665,7 +665,12 @@ class GalleryStore {
    */
   async hydrateMetadataInBackground(): Promise<void> {
     if (this._metadataHydrationPromise) return this._metadataHydrationPromise;
-    this._metadataHydrationPromise = this._runMetadataHydration();
+    // Reset on completion so images added after this run can be hydrated by a
+    // later call. Without the reset the memoized promise stays resolved forever
+    // and newly inserted images never get their metadata.
+    this._metadataHydrationPromise = this._runMetadataHydration().finally(() => {
+      this._metadataHydrationPromise = null;
+    });
     return this._metadataHydrationPromise;
   }
 


### PR DESCRIPTION
## Summary

Audit issue #357: the gallery reads metadata from the SQLite index instead of scanning the directory, so any save/delete/rename path that skips the index drifts silently. A couple of export/parse paths also lost data.

## Findings fixed

1. **SQLite index not updated on rename (desktop)** (`commands/api.rs`). `rename_gallery_image` renamed the file but left a stale `path` row in the index. Added `gallery_index::rename(old, new)` (an in-place `UPDATE images SET path` so the row's metadata and `created_at` survive) and call it after the rename.

2. **SQLite index bypassed in browser path** (`webserver.rs`). The browser-mode handlers never touched the index. `save_to_gallery_in_dir` now upserts after writing, and the browser `delete_gallery_image` / `rename_gallery_image` handlers call `gallery_index::remove` / `gallery_index::rename`, mirroring the desktop handlers. (The index is a single global DB keyed by absolute path; per-user images live under `gallery_dir/users/{name}`, so their distinct paths stay coherent in the shared index.)

3. **JXL to PNG export dropped metadata** (`commands/api.rs`). `load_gallery_image_png_from_dir` decoded the JXL and re-encoded a bare PNG. It now reads the source metadata and re-embeds it as a standard PNG text chunk, so the exported file stays portable and metadata-complete.

4. **`_metadataHydrationPromise` never reset** (`gallery.svelte.ts`). The memoized hydration promise stayed resolved forever, so images added after the first run never had their metadata read. Reset it to null in a `.finally()` so a later call hydrates new images.

5. **`iter_boxes` 64-bit truncation** (`jxl.rs`). An ISO-BMFF box with `size==1` (64-bit extended size) was treated as end-of-file, cutting iteration short. Now parses the trailing 64-bit `largesize`, bounds-checks it, and continues. Added a unit test.

## Validation

- `cargo check` (default features) clean
- `cargo check --no-default-features --features server` clean (pre-existing warnings only)
- `npm run build` clean
- `cargo test --lib jxl::tests::` box-parsing tests pass (the new 64-bit test plus the existing xmp roundtrips). The pre-existing lossy `roundtrip_2x2_rgba8` pixel-tolerance test fails on `main` as well and is unrelated to this change.

Closes #357
