### PR TITLE
fix: correct prompt editing utilities flagged in audit (#361)

### DIFF
--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -179,8 +179,10 @@
       return;
     }
 
-    // Skip if the fragment looks like a weight expression
-    if (/^\(.*:\d/.test(searchFragment)) {
+    // Skip only while typing an in-progress weight expression like `(tag:1.2`.
+    // Anchoring to the caret (no closing paren, ending at the number) means a
+    // completed `(tag:1.2)` followed by a fresh tag still autocompletes.
+    if (/^\([^)]*:\d[\d.]*$/.test(searchFragment)) {
       showSuggestions = false;
       suggestions = [];
       return;

--- a/src/lib/components/generation/ScheduleBuilder.svelte
+++ b/src/lib/components/generation/ScheduleBuilder.svelte
@@ -10,7 +10,7 @@
   let swapPivot = $state(0.5);
   let swapBefore = $state("");
   let swapAfter = $state("");
-  let swapSeparator = $state<"||" | "|" | ",">("||");
+  let swapSeparatorOverride = $state<"||" | "|" | "," | null>(null);
 
   // Schedule (MooshieUI) inputs
   let schedText = $state("");
@@ -27,23 +27,23 @@
   }
 
   /**
-   * Pick the least-intrusive separator for SwarmUI fromto — if either side
-   * already contains `,` we prefer `|`; if either already contains `|` we
-   * prefer `||`. User can override via the dropdown.
+   * Auto-pick a SwarmUI fromto separator that round-trips. The parser
+   * (`splitSwarmContent`) splits on the highest-priority separator present
+   * (`||` > `|` > `,`), so the separator must outrank anything already inside
+   * either side or the block parses back into the wrong two parts. Sides that
+   * themselves contain `||` cannot be represented at all; `||` is the least-bad
+   * fallback there. The user can override this via the dropdown.
    */
-  const autoSeparator = $derived.by(() => {
+  const autoSeparator = $derived.by<"||" | "|" | ",">(() => {
     const combined = `${swapBefore} ${swapAfter}`;
-    if (combined.includes("||")) return ",";
-    if (combined.includes("|")) return "||";
+    if (combined.includes("|")) return "||"; // covers both `|` and `||`
+    if (combined.includes(",")) return "|";
     return "||";
   });
 
-  // Keep dropdown in sync with auto-pick as the user types, but only if they
-  // haven't manually changed it recently. Simpler: always drive from auto, allow
-  // override via dropdown.
-  $effect(() => {
-    swapSeparator = autoSeparator;
-  });
+  // Follow the auto-pick as the user types, but once they manually change the
+  // dropdown keep their choice instead of stomping it on every keystroke.
+  const swapSeparator = $derived<"||" | "|" | ",">(swapSeparatorOverride ?? autoSeparator);
 
   const output = $derived.by(() => {
     if (mode === "fromto") {
@@ -176,7 +176,8 @@
         <label class="flex items-center gap-1 text-[11px] text-neutral-400">
           {locale.t("schedule.sep")}
           <select
-            bind:value={swapSeparator}
+            value={swapSeparator}
+            onchange={(e) => (swapSeparatorOverride = e.currentTarget.value as "||" | "|" | ",")}
             class="rounded border border-neutral-700 bg-neutral-800 px-1.5 py-1 text-[11px] text-neutral-200 focus:border-indigo-500 focus:outline-none"
           >
             <option value="||">||</option>

--- a/src/lib/stores/artistInsert.svelte.ts
+++ b/src/lib/stores/artistInsert.svelte.ts
@@ -31,6 +31,18 @@ function artistTagsMatch(a: string, b: string): boolean {
   return normalizeArtistTag(a).toLowerCase() === normalizeArtistTag(b).toLowerCase();
 }
 
+/**
+ * Split a prompt into individual tags. Tags are separated by commas *or*
+ * newlines, so detecting/removing artist tags must honour both, otherwise a
+ * tag on its own line escapes duplicate detection and toggle-off.
+ */
+function splitPromptTags(prompt: string): string[] {
+  return prompt
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 class ArtistInsertStore {
   pending = $state<ArtistInsertPending | null>(null);
 
@@ -50,10 +62,7 @@ class ArtistInsertStore {
     // round-trip correctly through the scheduler/highlight parser.
     const withAt = normalizeArtistTag(tag);
     const existing = generation.positivePrompt.trim();
-    const existingArtistTags = existing
-      .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s.startsWith("@"));
+    const existingArtistTags = splitPromptTags(existing).filter((s) => s.startsWith("@"));
     if (existingArtistTags.some((t) => artistTagsMatch(t, withAt))) {
       this.remove(withAt);
       return;
@@ -69,7 +78,7 @@ class ArtistInsertStore {
     const target = normalizeArtistTag(withAt);
     const existing = generation.positivePrompt.trim();
     if (!existing) return;
-    const tags = existing.split(",").map((s) => s.trim()).filter(Boolean);
+    const tags = splitPromptTags(existing);
     const filtered = tags.filter(
       (t) => !(t.startsWith("@") && artistTagsMatch(t, target)),
     );
@@ -86,9 +95,7 @@ class ArtistInsertStore {
     const existing = generation.positivePrompt.trim();
     let newPrompt: string;
     if (mode === "replace") {
-      const stripped = existing
-        .split(",")
-        .map((s) => s.trim())
+      const stripped = splitPromptTags(existing)
         .filter((s) => !s.startsWith("@"))
         .join(", ");
       newPrompt = stripped ? `${cleaned}, ${stripped}` : cleaned;

--- a/src/lib/stores/characterInsert.svelte.ts
+++ b/src/lib/stores/characterInsert.svelte.ts
@@ -44,12 +44,10 @@ class CharacterInsertStore {
   apply(level: CharacterTagLevel, mode: CharacterInsertMode): void {
     const p = this.pending;
     if (!p) return;
-    const resolvedLevel = level ?? p.tagLevel;
-    if (!resolvedLevel) return;
     generation.positivePrompt = applyCharacterInsert(
       generation.positivePrompt,
       p.character,
-      resolvedLevel,
+      level,
       mode,
     );
     generation.saveSettings();

--- a/src/lib/utils/promptInertRanges.ts
+++ b/src/lib/utils/promptInertRanges.ts
@@ -117,7 +117,11 @@ export function findPromptInertRangeContaining(
 ): PromptTextRange | null {
   const list = ranges ?? getPromptInertRanges(raw);
   for (const range of list) {
-    if (position > range.start && position <= range.end) {
+    // Half-open `[start, end)`, matching isInsidePromptInertRange. A caret at
+    // `end` sits just past the block (the start of the next tag) and a caret at
+    // `start` sits at the block's first character, so the old `> start && <= end`
+    // both swallowed the tag after the block and dropped the block's leading edge.
+    if (position >= range.start && position < range.end) {
       return range;
     }
   }


### PR DESCRIPTION
Fixes the seven correctness findings in the prompt editing utilities audit.

## Inert ranges (promptInertRanges.ts)
`findPromptInertRangeContaining` now uses half-open `[start, end)` caret
semantics, matching its sibling `isInsidePromptInertRange`. The old
`> start && <= end` predicate had two off-by-ones:
- caret at the block end was treated as inside, so autocomplete on the tag right
  after a scheduling block was suppressed (end-inclusive off-by-one)
- caret at the block start was treated as outside, dropping the block's leading
  edge into the previous tag (strict-start edge case)

## Schedule builder (ScheduleBuilder.svelte)
- The auto separator now round-trips. The parser (`splitSwarmContent`) always
  splits fromto content on the highest priority separator present (`||` > `|` >
  `,`), so the inserted separator must outrank anything already inside either
  side. The old logic returned `,` when a side contained `||`, which the parser
  then split on the `||` instead, yielding the wrong two parts.
- Removed the `$effect` that re-synced the separator dropdown from the auto pick
  on every keystroke, which stomped any manual selection. A manual choice now
  sticks via an override while the auto pick still drives the default.

## Autocomplete (PromptTextarea.svelte)
The weight-expression guard is anchored to the caret (`^\([^)]*:\d[\d.]*$`), so
it only suppresses autocomplete while a weight is still being typed (`(tag:1.2`).
A completed `(tag:1.2)` followed by a fresh tag now autocompletes again.

## Character insert (characterInsert.svelte.ts)
`apply()` dropped the dead `level ?? p.tagLevel` fallback that implied an
undefined level, contradicting its non-optional `CharacterTagLevel` parameter.
Both call sites already pass a defined level.

## Artist insert (artistInsert.svelte.ts)
Prompt tokenisation now splits on commas and newlines via a shared helper, so an
artist tag placed on its own line is detected as a duplicate and can be toggled
off, instead of escaping the comma-only split.

## Validation
`npm run build` passes (no new warnings).
