### PR TITLE
fix: store mutation and save bugs across LoRA, ModelHub, and Compare

### DIFF
--- a/src/lib/components/generation/LoraGallery.svelte
+++ b/src/lib/components/generation/LoraGallery.svelte
@@ -360,7 +360,6 @@
 
   async function invalidateLoraCache(filename: string) {
     delete cache[filename];
-    fetchedSet.delete(filename);
     cache = { ...cache };
     await fetchLoraInfo(filename);
   }
@@ -458,6 +457,7 @@
     const current = generation.positivePrompt.trim();
     if (current.includes(word)) return;
     generation.positivePrompt = current ? `${current}, ${word}` : word;
+    generation.saveSettings();
   }
 
   function formatCount(n: number | undefined): string {

--- a/src/lib/components/modelhub/ModelHubPage.svelte
+++ b/src/lib/components/modelhub/ModelHubPage.svelte
@@ -312,6 +312,7 @@
     if (type === "Upscaler") return "upscale_models";
     if (type === "VAE") return "vae";
     if (type === "Controlnet") return "controlnet";
+    if (type === "TextualInversion") return "embeddings";
     return null;
   }
 

--- a/src/lib/components/settings/ModelRequestsPanel.svelte
+++ b/src/lib/components/settings/ModelRequestsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { modelRequests, type ModelRequest } from "../../stores/modelRequests.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
+  import { downloadModel } from "../../utils/api.js";
   import { onMount } from "svelte";
 
   let { userRole = "user" }: { userRole?: string } = $props();
@@ -23,7 +24,17 @@
   }
 
   async function handleApprove(req: ModelRequest) {
-    await modelRequests.approveRequest(req.id);
+    const approved = await modelRequests.approveRequest(req.id);
+    if (approved) {
+      // The button is "Approve & Download" — approving only flips the request
+      // status, so actually kick off the (server-side) download of the file now.
+      // A download failure is surfaced but does not undo the approval.
+      try {
+        await downloadModel(approved.file_url, approved.category, approved.file_name);
+      } catch (e) {
+        modelRequests.showToast(String(e), "error");
+      }
+    }
     await modelRequests.fetchRequests(statusFilter || undefined);
   }
 

--- a/src/lib/stores/compare.svelte.ts
+++ b/src/lib/stores/compare.svelte.ts
@@ -127,6 +127,10 @@ class CompareStore {
     generation.height = snap.height;
     generation.denoise = snap.denoise;
     generation.batchSize = snap.batchSize;
+    // Loading a compare cell into the live generation state must persist, or a
+    // reload reverts to whatever was last saved. selectCell/removeColumn/removeRow
+    // all funnel through here, so saving once here covers every cell switch.
+    generation.saveSettings();
   }
 
   saveActiveCell() {

--- a/src/lib/stores/modelRequests.svelte.ts
+++ b/src/lib/stores/modelRequests.svelte.ts
@@ -105,9 +105,9 @@ class ModelRequestsStore {
       if (!resp.ok) {
         throw new Error(data.error ?? locale.t("model_requests.error.approve"));
       }
-      // Update local state
-      const idx = this.requests.findIndex((r) => r.id === requestId);
-      if (idx !== -1) this.requests[idx] = data.request;
+      // Update local state (spread reassignment — in-place index mutation does
+      // not trigger Svelte 5 rune reactivity).
+      this.requests = this.requests.map((r) => (r.id === requestId ? data.request : r));
       this.showToast(locale.t("model_requests.approved"), "success");
       return data.request as ModelRequest;
     } catch (e) {
@@ -128,9 +128,9 @@ class ModelRequestsStore {
       if (!resp.ok) {
         throw new Error(data.error ?? locale.t("model_requests.error.deny"));
       }
-      // Update local state
-      const idx = this.requests.findIndex((r) => r.id === requestId);
-      if (idx !== -1) this.requests[idx] = data.request;
+      // Update local state (spread reassignment — in-place index mutation does
+      // not trigger Svelte 5 rune reactivity).
+      this.requests = this.requests.map((r) => (r.id === requestId ? data.request : r));
       this.showToast(locale.t("model_requests.denied"), "info");
       return data.request as ModelRequest;
     } catch (e) {


### PR DESCRIPTION
Fixes the audit findings tracked in #362. All six are mutations that skipped an explicit `saveSettings()` or mutated state in place (the project requires spread reassignment plus an explicit save for rune reactivity and persistence).

## Changes

- **LoraGallery (high):** removed the undeclared `fetchedSet.delete(filename)` call in `invalidateLoraCache`, which threw a `ReferenceError` at runtime. The working `refetchLora` sibling never referenced a `fetchedSet`.
- **LoraGallery:** `addTriggerWord` now calls `generation.saveSettings()` so the appended trigger word survives a reload.
- **ModelHubPage:** `mapCivitaiTypeToCategory` maps the CivitAI `TextualInversion` type to the `embeddings` category, so embeddings can actually be installed/requested instead of failing with `cannot_install`. The backend already supports the `embeddings` category and the filter dropdown already uses it.
- **ModelRequestsPanel:** "Approve & Download" now actually downloads the file after approval. Previously the approve call only flipped the request status server-side and no download was ever triggered.
- **compare:** `applyToGeneration` now persists the loaded cell via `generation.saveSettings()`, covering `selectCell`, `removeColumn`, and `removeRow` (all funnel through it).
- **modelRequests:** `approveRequest` and `denyRequest` update the local list with a spread reassignment instead of an in-place index write that skipped Svelte rune reactivity.

## Validation

- `npm run build` passes (only pre-existing chunk-size / dynamic-import warnings).

Closes #362