### PR TITLE
fix: notification and updater follow-through gaps

### DIFF
--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4030,7 +4030,29 @@ async fn dispatch_command(
                 .await
                 .map_err(|e| e.to_string())?;
             let releases: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
-            Ok(releases)
+            // Map to the same { version, body, published_at } shape the desktop
+            // command (commands::api::fetch_release_notes) returns, so the
+            // browser-mode client sees a defined `version` instead of raw GitHub
+            // release objects (which carry `tag_name`, not `version`).
+            let notes: Vec<serde_json::Value> = releases
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|r| {
+                            let tag = r.get("tag_name")?.as_str()?;
+                            Some(serde_json::json!({
+                                "version": tag,
+                                "body": r.get("body").and_then(|b| b.as_str()).unwrap_or(""),
+                                "published_at": r
+                                    .get("published_at")
+                                    .and_then(|p| p.as_str())
+                                    .unwrap_or(""),
+                            }))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(serde_json::json!(notes))
         }
         "export_logs" => {
             // In server/browser mode there is no meaningful host filesystem path

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1742,6 +1742,9 @@
 
       gallery.addImages([gridImage]);
       gallery.persistImages([gridImage], undefined, [gridBlob], generation.metadataMode);
+      // Mirror the single-image path (finalizeOutputImages) so a completed grid
+      // also surfaces a done toast / notification when off the generate page.
+      showGenerationDoneToast([gridImage]);
     } catch (e) {
       console.error("Grid stitching failed:", e);
     }

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -1037,6 +1037,9 @@
           updateState = "ready";
         }
       });
+      // Record the expected version so UpdateNotification can verify on the
+      // next launch that the update actually applied (mirrors the banner path).
+      if (updateVersion) localStorage.setItem("mooshieui_pending_update", updateVersion);
       updateState = "ready";
     } catch (e) {
       updateState = "error";


### PR DESCRIPTION
Resolves the notifications/updater follow-through audit findings (#363).

## fetch_release_notes shape in browser mode
The browser-mode REST handler (`webserver.rs`) returned the raw GitHub releases array, whose objects carry `tag_name` rather than `version`. The frontend `ReleaseNote` type expects `version`, so the About panel showed an undefined version. Now maps to the same `{version, body, published_at}` shape the desktop `fetch_release_notes` command already produces.

## Settings-panel update verification
`downloadAndInstallUpdate` in `SettingsPage.svelte` never set `mooshieui_pending_update`, so an update applied from the Settings panel was not verified on the next launch (only the `UpdateNotification` banner path stored it). It now records the expected version after a successful install, matching the banner.

## Grid completion notification
A completed grid generation added and persisted the stitched image but never raised a done toast / notification, unlike the single-image `finalizeOutputImages` path. `stitchGrid` now calls `showGenerationDoneToast` for the grid result too.

Validated with `npm run build` and `cargo check`.

Closes #363
