### PR TITLE
fix: misc low-severity audit cleanup (#364)

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -793,14 +793,15 @@ fn hash_password(password: &str) -> String {
         .to_string()
 }
 
-/// Verify a password against a stored hash.
-/// Supports both Argon2id (PHC string) and legacy SHA-256 (64 hex chars).
+/// Hash a session token (SHA-256) for storage/lookup in the session table.
 fn hash_session_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     format!("{:x}", hasher.finalize())
 }
 
+/// Verify a password against a stored hash.
+/// Supports both Argon2id (PHC string) and legacy SHA-256 (64 hex chars).
 fn verify_password(password: &str, stored_hash: &str) -> bool {
     if is_legacy_sha256(stored_hash) {
         // Legacy path: constant-time SHA-256 comparison (upgraded to Argon2id on login).

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -431,6 +431,19 @@ pub fn save_config(config: &AppConfig) -> Result<(), String> {
     let dir = app_data_dir().ok_or("Failed to determine app data directory")?;
     std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create data dir: {}", e))?;
     let json = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
-    std::fs::write(dir.join("config.json"), json).map_err(|e| e.to_string())?;
+    if let Err(e) = std::fs::write(dir.join("config.json"), json) {
+        // On hosted deployments the config is a read-only mount (e.g. a Kubernetes
+        // ConfigMap), so persistence cannot succeed. Downgrade those cases to a
+        // warning instead of surfacing a hard error for every settings change;
+        // the in-memory config still reflects the user's choice for this session.
+        if matches!(
+            e.kind(),
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+        ) {
+            eprintln!("Skipping config save (read-only config location): {}", e);
+            return Ok(());
+        }
+        return Err(e.to_string());
+    }
     Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: thumbnail: gallery: http://asset.localhost https://asset.localhost http://thumbnail.localhost https://thumbnail.localhost http://gallery.localhost https://gallery.localhost https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://blobs.animadex.net; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://image.civitai.com https://cdn.civitai.com https://animadex.net https://thetacursed.github.io https://raw.githubusercontent.com; font-src 'self' data:; media-src 'self' blob: data:"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: thumbnail: gallery: http://asset.localhost https://asset.localhost http://thumbnail.localhost https://thumbnail.localhost http://gallery.localhost https://gallery.localhost https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://blobs.animadex.net; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://animadex.net https://thetacursed.github.io https://raw.githubusercontent.com; font-src 'self' data:; media-src 'self' blob: data:"
     }
   },
   "bundle": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1630,6 +1630,7 @@
     rows: number,
     cols: number,
     cellLabels: string[],
+    mode: "txt2img" | "img2img" | "inpainting",
   ) {
     try {
       const loadImg = (src: string) => new Promise<HTMLImageElement>((resolve, reject) => {
@@ -1733,7 +1734,7 @@
         subfolder: "",
         type: "output",
         prompt_id: gridPromptId,
-        generation_mode: "txt2img",
+        generation_mode: mode,
         is_upscaled: false,
         url: gridUrl,
         file_size_bytes: gridBlob.size,
@@ -2222,7 +2223,7 @@
             if (images.length > 0 && compare.isGridPrompt(promptId)) {
               const gridResult = compare.addGridResult(promptId, images[0]!);
               if (gridResult) {
-                stitchGrid(gridResult.images, gridResult.rows, gridResult.cols, gridResult.cellLabels);
+                stitchGrid(gridResult.images, gridResult.rows, gridResult.cols, gridResult.cellLabels, item.mode);
               }
             }
           }

--- a/src/lib/artist-gallery/components/ArtistCard.svelte
+++ b/src/lib/artist-gallery/components/ArtistCard.svelte
@@ -26,7 +26,6 @@
     {#if entry.hasImage && entry.imageUrl}
       <img
         use:cachedSrc={entry.imageUrl}
-        src={entry.imageUrl}
         alt={entry.tag}
         loading="lazy"
         decoding="async"

--- a/src/lib/artist-gallery/components/ArtistLightbox.svelte
+++ b/src/lib/artist-gallery/components/ArtistLightbox.svelte
@@ -134,7 +134,6 @@
         <img
           use:cachedSrc={currentImage.imageUrl}
           use:flipImage={{ slug: entry.slug, variant: clampedVariant }}
-          src={currentImage.imageUrl}
           alt="{entry.tag} {currentImage.variantId}"
           class="max-h-[80vh] max-w-[92vw] w-auto rounded-lg border border-neutral-800 object-contain shadow-2xl"
           style="zoom: {zoomed ? 1.5 : 1}; transition: zoom 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); cursor: {zoomed ? 'zoom-out' : 'zoom-in'};"

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -9,6 +9,7 @@
   import { compare } from "../../stores/compare.svelte.js";
   import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
   import { createArtistGalleryStore } from "../../artist-gallery/store.svelte.js";
+  import { cachedSrc } from "../../artist-gallery/imageCache.js";
   import { artistInsert } from "../../stores/artistInsert.svelte.js";
   import type { ArtistSearchHit } from "../../artist-gallery/types.js";
   import LoraGallery from "./LoraGallery.svelte";
@@ -635,7 +636,7 @@
                 >
                   <div class="relative aspect-3/4 w-full overflow-hidden rounded-t-lg bg-neutral-800">
                     {#if thumb}
-                      <img src={thumb} alt={hit.tag} loading="lazy" decoding="async" class="h-full w-full object-cover" />
+                      <img use:cachedSrc={thumb} alt={hit.tag} loading="lazy" decoding="async" class="h-full w-full object-cover" />
                     {:else}
                       <div class="flex h-full w-full items-center justify-center text-[10px] text-neutral-500">{locale.t("gallery.no_preview")}</div>
                     {/if}

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -212,7 +212,10 @@ class ProgressStore {
 
   /** Called when a progress event arrives — detects pass transitions */
   updateProgress(step: number, max: number, node: string | null) {
-    if (node && node !== this._lastProgressNode) {
+    // Only a multi-step node is a sampling pass; single-step nodes (VAE decode,
+    // upscale model, etc.) report progress too but must not advance the pass
+    // counter, or `samplingPass` would reach the upscale threshold prematurely.
+    if (node && node !== this._lastProgressNode && max > 1) {
       this._lastProgressNode = node;
       this.samplingPass += 1;
     }


### PR DESCRIPTION
Closes #364. Clears the miscellaneous low-severity audit grab bag.

## Findings addressed
- **samplingPass over-counts** (`progress.svelte.ts`): the pass counter advanced on any node change, so a VAE-decode or upscale-model node could push it to the upscale threshold and mislabel an early step as "Upscaling". It now advances only on multi-step (sampling) nodes.
- **stitchGrid hardcoded txt2img** (`App.svelte`): the stitched grid image now records the actual generation mode the cells were produced with.
- **save_config errors on read-only config** (`config.rs`): on hosted deployments the config is a read-only mount (e.g. a Kubernetes ConfigMap), so every settings change returned an error. Read-only/permission-denied writes are now downgraded to a logged warning; the in-memory config still reflects the choice for the session.
- **BottomPanel artist thumbnail coupled to the CDN** (`BottomPanel.svelte`): favourite thumbnails now resolve through `cachedSrc`, matching the gallery cards.
- **Redundant raw CDN src** (`ArtistCard.svelte`, `ArtistLightbox.svelte`): dropped the static `src=` that fired an extra raw-CDN fetch before `cachedSrc` swapped in the cached blob URL.
- **Redundant CSP entries** (`tauri.conf.json`): removed `image.civitai.com` and `cdn.civitai.com` from connect-src (already covered by the `*.civitai.com` wildcard).
- **Misplaced doc comment** (`auth.rs`): the password-verification doc now sits on `verify_password` instead of `hash_session_token`.

## Skipped
- **animadex.net missing from img-src**: not needed. Character images (`img_url`/`thumb_url`) only ever resolve to `blobs.animadex.net`, which is already allowlisted. Verified against the live API response.

## Validation
- `npm run build` passes.
- `cargo check --manifest-path src-tauri/Cargo.toml` passes.
