### PR TITLE
v1.4.24: Audit hardening pass (18 fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## What's New in v1.4.24
+
+This release lands a large code-audit pass (18 reviewed fixes) that hardens the backend, generation pipeline, gallery, canvas, and setup flow. Most changes are correctness and reliability fixes that you should simply notice as fewer glitches.
+
+### Backend reliability
+- **Locks no longer held across I/O**: RwLock guards are dropped before blocking and async file or network work, so long-running operations no longer stall unrelated requests.
+- **Sturdier multi-GPU**: worker readiness checks were hardened and a stuck-worker watchdog now recovers a worker that stops responding instead of hanging the queue.
+- **Shared HTTP client**: requests reuse the single shared client instead of spinning up new ones, and a MIME-parsing panic path was removed.
+- **Browser and LAN-mode security gaps closed**: tightened the web-server surface used in browser/LAN mode.
+- **Read-only config locations**: saving settings where the config file is read-only (such as a mounted ConfigMap in hosted deployments) now skips quietly instead of erroring.
+
+### Browser / desktop parity
+- **IPC parity gaps closed**: several backend calls that worked on desktop but silently failed in browser mode now behave identically.
+- **Preference sync wired end to end**: server-side preference sync is fully plumbed so settings round-trip correctly in browser mode.
+- **Release-notes fetch hardened**: the browser-mode release-notes endpoint now checks the GitHub API response status before parsing, matching the desktop command.
+
+### Generation pipeline
+- **Correct inpainting and diffusion routing**: workflow parameters for inpainting and diffusion are routed to the right nodes.
+- **No more dropped parameters**: generation params that were being silently dropped are now plumbed through, and dead fields were removed.
+- **Prompt editing fixes**: corrected several prompt-editing utility bugs flagged in the audit.
+
+### Gallery and canvas
+- **Gallery index stays consistent**: the gallery SQLite index and image metadata are kept in sync.
+- **Canvas drawing fixes**: corrected canvas redraw, history reset, and removed dead mask stubs.
+- **Store save fixes**: fixed mutation and persistence bugs across LoRA, ModelHub, and Compare.
+- **Fewer redundant image fetches**: favourite-artist thumbnails and artist cards/lightbox now reuse the image cache instead of triggering an extra raw CDN fetch.
+
+### Setup and updates
+- **Hardened setup wizard**: more robust download and error handling during first-run setup.
+- **Notification and updater follow-through**: closed gaps in the notification and updater flows.
+
+### UI and localisation
+- **More complete translations**: added missing i18n keys and replaced remaining hardcoded UI strings; corrected the new layout-toggle strings for German and French.
+- **Layout override toggle**: removed dead mobile components and added an explicit toggle to switch between the mobile and desktop layouts.
+
+---
+
 ## What's New in v1.4.23
 
 ### Illustrious models

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+## What's New in v1.4.24
+
+This release lands a large code-audit pass (18 reviewed fixes) that hardens the backend, generation pipeline, gallery, canvas, and setup flow. Most changes are correctness and reliability fixes that you should simply notice as fewer glitches.
+
+### Backend reliability
+- **Locks no longer held across I/O**: RwLock guards are dropped before blocking and async file or network work, so long-running operations no longer stall unrelated requests.
+- **Sturdier multi-GPU**: worker readiness checks were hardened and a stuck-worker watchdog now recovers a worker that stops responding instead of hanging the queue.
+- **Shared HTTP client**: requests reuse the single shared client instead of spinning up new ones, and a MIME-parsing panic path was removed.
+- **Browser and LAN-mode security gaps closed**: tightened the web-server surface used in browser/LAN mode.
+- **Read-only config locations**: saving settings where the config file is read-only (such as a mounted ConfigMap in hosted deployments) now skips quietly instead of erroring.
+
+### Browser / desktop parity
+- **IPC parity gaps closed**: several backend calls that worked on desktop but silently failed in browser mode now behave identically.
+- **Preference sync wired end to end**: server-side preference sync is fully plumbed so settings round-trip correctly in browser mode.
+- **Release-notes fetch hardened**: the browser-mode release-notes endpoint now checks the GitHub API response status before parsing, matching the desktop command.
+
+### Generation pipeline
+- **Correct inpainting and diffusion routing**: workflow parameters for inpainting and diffusion are routed to the right nodes.
+- **No more dropped parameters**: generation params that were being silently dropped are now plumbed through, and dead fields were removed.
+- **Prompt editing fixes**: corrected several prompt-editing utility bugs flagged in the audit.
+
+### Gallery and canvas
+- **Gallery index stays consistent**: the gallery SQLite index and image metadata are kept in sync.
+- **Canvas drawing fixes**: corrected canvas redraw, history reset, and removed dead mask stubs.
+- **Store save fixes**: fixed mutation and persistence bugs across LoRA, ModelHub, and Compare.
+- **Fewer redundant image fetches**: favourite-artist thumbnails and artist cards/lightbox now reuse the image cache instead of triggering an extra raw CDN fetch.
+
+### Setup and updates
+- **Hardened setup wizard**: more robust download and error handling during first-run setup.
+- **Notification and updater follow-through**: closed gaps in the notification and updater flows.
+
+### UI and localisation
+- **More complete translations**: added missing i18n keys and replaced remaining hardcoded UI strings; corrected the new layout-toggle strings for German and French.
+- **Layout override toggle**: removed dead mobile components and added an explicit toggle to switch between the mobile and desktop layouts.
+
+---
+
 ## What's New in v1.4.23
 
 ### Illustrious models

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.23"
+version = "1.4.24"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.23"
+version = "1.4.24"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4029,6 +4029,9 @@ async fn dispatch_command(
                 .send()
                 .await
                 .map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("GitHub API returned {}", resp.status()));
+            }
             let releases: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
             // Map to the same { version, body, published_at } shape the desktop
             // command (commands::api::fetch_release_notes) returns, so the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -213,7 +213,7 @@ const de: Record<string, string> = {
 
   "settings.appearance.title": "Erscheinung",
   "settings.appearance.layout_title": "Layout",
-  "settings.appearance.layout_desc": "Wahlen Sie zwischen dem touchoptimierten mobilen Layout und der vollstandigen Desktop-Oberflache.",
+  "settings.appearance.layout_desc": "Wählen Sie zwischen dem touchoptimierten mobilen Layout und der vollständigen Desktop-Oberfläche.",
   "settings.appearance.layout_use_desktop": "Zum Desktop-Layout wechseln",
   "settings.appearance.layout_use_mobile": "Zum mobilen Layout wechseln",
   "settings.appearance.theme": "Design",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -213,9 +213,9 @@ const fr: Record<string, string> = {
   // Apparence
   "settings.appearance.title": "Apparence",
   "settings.appearance.layout_title": "Mise en page",
-  "settings.appearance.layout_desc": "Choisissez entre la mise en page mobile optimisee pour le tactile et l'interface complete pour ordinateur.",
-  "settings.appearance.layout_use_desktop": "Passer a l'interface bureau",
-  "settings.appearance.layout_use_mobile": "Passer a l'interface mobile",
+  "settings.appearance.layout_desc": "Choisissez entre la mise en page mobile optimisée pour le tactile et l'interface complète pour ordinateur.",
+  "settings.appearance.layout_use_desktop": "Passer à l'interface bureau",
+  "settings.appearance.layout_use_mobile": "Passer à l'interface mobile",
   "settings.appearance.theme": "Thème",
   "settings.appearance.theme_dark": "Sombre",
   "settings.appearance.theme_light": "Clair",


### PR DESCRIPTION
Release v1.4.24. Bundles the 18 reviewed code-audit fixes (issues #347-#364, merged as #365-#382) plus three follow-up bot fixes applied on this branch.

## Backend reliability
- Drop RwLock guards before blocking and async I/O so long operations no longer stall unrelated requests
- Hardened multi-GPU worker readiness + stuck-worker watchdog
- Reuse the shared HTTP client; removed a MIME-parsing panic path
- Closed browser and LAN-mode security gaps
- Read-only config locations (hosted ConfigMap) now skip save quietly instead of erroring

## Browser / desktop parity
- Closed IPC parity gaps where calls worked on desktop but failed silently in browser mode
- Wired server-side preference sync end to end
- Browser-mode release-notes endpoint now checks GitHub API status before parsing (matches desktop command)

## Generation pipeline
- Correct inpainting and diffusion workflow parameter routing
- Plumbed through silently-dropped generation params; removed dead fields
- Fixed prompt-editing utilities

## Gallery and canvas
- Gallery SQLite index and metadata kept consistent
- Canvas redraw, history reset, dead mask stub fixes
- Store mutation/save fixes across LoRA, ModelHub, Compare
- Favourite-artist thumbnails and artist cards/lightbox reuse the image cache (no redundant raw CDN fetch)

## Setup and updates
- Hardened setup wizard download and error handling
- Closed notification and updater follow-through gaps

## UI and localisation
- Added missing i18n keys, replaced hardcoded UI strings
- Removed dead mobile components, added layout override toggle
- Corrected new layout-toggle strings for German and French

## Release housekeeping
- Version bumped to 1.4.24 in package.json, Cargo.toml, Cargo.lock, tauri.conf.json
- RELEASE_NOTES.md and CHANGELOG.md updated

### Bot triage from steps 1-2
- #380 de.ts/fr.ts diacritics: Fix (applied)
- #381 webserver.rs release-notes status check: Fix (applied)
- #382 config.rs PermissionDenied narrowing: Defer (already shipped narrowed to PermissionDenied | ReadOnlyFilesystem)

Validation: cargo check + npm run build pass; locale key parity 0 missing / 0 extra across all 10 non-en locales.
