### PR TITLE
v1.4.25: Actionable generation errors and per-image generation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## What's New in v1.4.25
+
+This release makes generation failures explain themselves and adds a per-image generation-time readout.
+
+### Clearer error messages
+- **Actionable failure messages**: generation errors are now classified into specific, fixable causes instead of a generic "Generation failed". Covered cases include out-of-memory, an incompatible VAE, a checkpoint or model that is not in your list, a missing custom node, and component/shape mismatches.
+- **Desktop errors no longer go blank**: failures that previously surfaced no detail (the raw ComfyUI error carries no top-level message field) are now read from the underlying exception so you see what actually went wrong.
+- **Longer dwell on actionable errors**: messages that tell you how to fix something stay on screen longer before dismissing.
+
+### Generation time
+- **Time per image**: the total generation time now shows in the top-left corner of the result preview.
+- **On hover in the session gallery**: hovering a session thumbnail shows that image's generation time in the top-left corner.
+
+---
+
 ## What's New in v1.4.24
 
 This release lands a large code-audit pass (18 reviewed fixes) that hardens the backend, generation pipeline, gallery, canvas, and setup flow. Most changes are correctness and reliability fixes that you should simply notice as fewer glitches.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## What's New in v1.4.25
+
+This release makes generation failures explain themselves and adds a per-image generation-time readout.
+
+### Clearer error messages
+- **Actionable failure messages**: generation errors are now classified into specific, fixable causes instead of a generic "Generation failed". Covered cases include out-of-memory, an incompatible VAE, a checkpoint or model that is not in your list, a missing custom node, and component/shape mismatches.
+- **Desktop errors no longer go blank**: failures that previously surfaced no detail (the raw ComfyUI error carries no top-level message field) are now read from the underlying exception so you see what actually went wrong.
+- **Longer dwell on actionable errors**: messages that tell you how to fix something stay on screen longer before dismissing.
+
+### Generation time
+- **Time per image**: the total generation time now shows in the top-left corner of the result preview.
+- **On hover in the session gallery**: hovering a session thumbnail shows that image's generation time in the top-left corner.
+
+---
+
 ## What's New in v1.4.24
 
 This release lands a large code-audit pass (18 reviewed fixes) that hardens the backend, generation pipeline, gallery, canvas, and setup flow. Most changes are correctness and reliability fixes that you should simply notice as fewer glitches.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.24",
+  "version": "1.4.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.24"
+version = "1.4.25"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.24"
+version = "1.4.25"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.24",
+  "version": "1.4.25",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,9 +56,9 @@
     type ModelPreviewActionDetail,
   } from "./lib/utils/modelPreviewImage.js";
   import {
-    isStyleTransferExecutionError,
     checkStyleTransferNodesReady,
   } from "./lib/utils/styleTransferNodes.js";
+  import { classifyGenerationError } from "./lib/utils/generationErrors.js";
   import {
     parseComfyServerError,
     type ComfyServerErrorPayload,
@@ -1400,6 +1400,7 @@
     wasUpscaled: boolean,
     params: GenerationParams | null,
     images: Array<{ blob: Blob; url: string; tempFilename?: string; displayTempFilename?: string }>,
+    generationTimeMs?: number,
   ) {
     if (images.length === 0) return;
 
@@ -1418,6 +1419,7 @@
         displayTempFilename: img.displayTempFilename,
         file_size_bytes: img.blob.size,
         generated_at_ms: Date.now(),
+        generationTimeMs,
       };
     });
 
@@ -2216,7 +2218,7 @@
               clearRegionalChainGallerySuppress(promptId);
               console.log("[regional] Skipping gallery save for chain intermediate:", promptId);
             } else {
-              finalizeOutputImages(promptId, item.mode, item.wasUpscaled, item.params, images);
+              finalizeOutputImages(promptId, item.mode, item.wasUpscaled, item.params, images, item.durationMs);
             }
 
             // Track grid batch completion — stitch when all cells are done
@@ -2237,31 +2239,21 @@
       ipcListen("comfyui:execution_error", (event: any) => {
         console.error("Execution error:", event.payload);
         const data = event.payload;
-        // Build a user-visible error message from the raw error string
-        const rawErr = String(data.error ?? "");
-        let toastMsg = locale.t("generation.toast.failed");
-        if (isStyleTransferExecutionError(rawErr)) {
-          toastMsg = locale.t("generation.style_transfer.execution_failed");
+        // Classify the failure into an actionable message. The raw ComfyUI
+        // desktop payload exposes exception_message/exception_type/node_type/
+        // traceback (no top-level `error`), so pass the whole payload, not just
+        // data.error, or most desktop errors fall through to the generic toast.
+        const classified = classifyGenerationError(data);
+        const toastMsg = locale.t(classified.messageKey, classified.params);
+        if (classified.clearStyleTransfer) {
           // Auto-clear style transfer state on failure so the user is not stuck unable to generate
           // normal images after enabling via a preview button (for example on a LoRA card). This addresses
           // reports of generation loading quickly with no final output.
           generation.styleTransferEnabled = false;
           generation.styleReferenceImage = null;
           generation.saveSettings();
-        } else if (rawErr.includes("value_not_in_list") || rawErr.includes("Value not in list") || rawErr.includes("prompt_outputs_failed_validation")) {
-          toastMsg = locale.t("generation.toast.failed_validation");
-        } else {
-          try {
-            const m = rawErr.match(/API error \(\d+\): ([\s\S]+)/);
-            if (m) {
-              const parsed = JSON.parse(m[1]);
-              if (parsed.error?.message) {
-                toastMsg = locale.t("generation.toast.failed_detail", { message: parsed.error.message });
-              }
-            }
-          } catch { /* ignore parse errors */ }
         }
-        gallery.showToast(toastMsg, "error");
+        gallery.showToast(toastMsg, "error", classified.durationMs ? { durationMs: classified.durationMs } : false);
         if (data.prompt_id) {
           pendingOutputImages.delete(data.prompt_id);
           pendingOutputFetches.delete(data.prompt_id);
@@ -2353,7 +2345,7 @@
                   clearRegionalChainGallerySuppress(p.promptId);
                   console.log("[regional] Skipping gallery save for chain intermediate:", p.promptId);
                 } else {
-                  finalizeOutputImages(p.promptId, item.mode, item.wasUpscaled, item.params, images);
+                  finalizeOutputImages(p.promptId, item.mode, item.wasUpscaled, item.params, images, item.durationMs);
                 }
               } else {
                 const failedStyleTransfer = item.params?.style_transfer_enabled;

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -6,6 +6,7 @@
   import { scrollCapture } from "../../utils/scrollCapture.js";
   import { models } from "../../stores/models.svelte.js";
   import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
+  import { formatGenerationTime } from "../../utils/localeFormat.js";
   import { compare } from "../../stores/compare.svelte.js";
   import { artistFavourites } from "../../artist-gallery/favourites.svelte.js";
   import { createArtistGalleryStore } from "../../artist-gallery/store.svelte.js";
@@ -484,6 +485,17 @@
                       class="w-full h-full object-cover"
                     />
                   </button>
+                  {#if hoveredImage === image && image.generationTimeMs != null}
+                    <div
+                      class="absolute top-1.5 left-1.5 flex items-center gap-1 bg-black/65 text-white text-[10px] font-medium px-1.5 py-0.5 rounded backdrop-blur-sm pointer-events-none"
+                      title={locale.t("generation.gen_time_label")}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
+                      </svg>
+                      {formatGenerationTime(image.generationTimeMs, locale.current)}
+                    </div>
+                  {/if}
                 </div>
               {/each}
               </div>

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -23,6 +23,7 @@
     clearAllRegionalChainGallerySuppress,
   } from "../../utils/regionalChainGallery.js";
   import { checkStyleTransferNodesReady } from "../../utils/styleTransferNodes.js";
+  import { classifyGenerationError } from "../../utils/generationErrors.js";
   import { parseSegmentDetailPrompt, yoloTargetFilename } from "../../utils/promptSegmentDetail.js";
 
   interface Props {
@@ -348,7 +349,14 @@
       if (runToken === submitRunToken) {
         console.error("Generation failed:", e);
         const message = e instanceof Error ? e.message : String(e);
-        errorMsg = locale.t("generation.error_failed_message", { message });
+        // Classify submission failures (stale model cache, incompatible VAE,
+        // OOM, missing node, etc.) into actionable guidance. Fall back to the
+        // raw message only when nothing matched.
+        const classified = classifyGenerationError(message);
+        errorMsg =
+          classified.messageKey === "generation.toast.failed"
+            ? locale.t("generation.error_failed_message", { message })
+            : locale.t(classified.messageKey, classified.params);
       }
     } finally {
       if (sequential) finishSubmitRun(runToken);

--- a/src/lib/components/progress/PreviewImage.svelte
+++ b/src/lib/components/progress/PreviewImage.svelte
@@ -6,6 +6,7 @@
   import { locale } from "../../stores/locale.svelte.js";
   import { generate, uploadImageBytes, downloadModel } from "../../utils/api.js";
   import { loadOutputImageForGenerationInput, uploadImageUrlForGenerationInput } from "../../utils/galleryActions.js";
+  import { formatGenerationTime } from "../../utils/localeFormat.js";
   import {
     DEFAULT_REFINE_UPSCALER,
     DEFAULT_REFINE_UPSCALER_SCALE,
@@ -214,6 +215,12 @@
     return progress.displayImage;
   });
 
+  /** Total generation time for the currently shown output, ms (badge). */
+  const activeGenerationTimeMs = $derived.by(() => {
+    if (progress.isGenerating || !progress.lastOutputImage) return null;
+    return getActiveSavedImage()?.generationTimeMs ?? null;
+  });
+
   function openPreviewLightbox() {
     if (Date.now() < suppressOpenUntil) return;
 
@@ -288,6 +295,17 @@
         class="w-full h-full object-contain"
       />
     </button>
+    {#if activeGenerationTimeMs != null}
+      <div
+        class="absolute top-3 left-3 flex items-center gap-1.5 bg-black/60 text-white text-xs font-medium px-2.5 py-1 rounded-lg shadow-lg backdrop-blur-sm pointer-events-none"
+        title={locale.t("generation.gen_time_label")}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
+        </svg>
+        {formatGenerationTime(activeGenerationTimeMs, locale.current)}
+      </div>
+    {/if}
     {#if !progress.isGenerating && progress.lastOutputImage}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -723,6 +723,7 @@ const de: Record<string, string> = {
   "generation.error_failed": "Generierung fehlgeschlagen",
   "generation.error_model_config": "Generierung fehlgeschlagen — ein Modell oder VAE ist möglicherweise nicht richtig konfiguriert. Prüfen Sie die Modelleinstellungen.",
   "generation.error_failed_message": "Generierung fehlgeschlagen: {message}",
+  "generation.gen_time_label": "Gesamte Generierungszeit",
   "generation.error_cancelled": "Generierung abgebrochen",
   "generation.downloading_facefix": "Face-Detailer-Modell wird heruntergeladen...",
 
@@ -1914,6 +1915,12 @@ const de: Record<string, string> = {
   "generation.toast.failed_validation": "Generierung fehlgeschlagen — ein Modell oder VAE ist möglicherweise falsch konfiguriert. Prüfen Sie die Modelleinstellungen.",
 
   "generation.toast.failed_detail": "Generierung fehlgeschlagen: {message}",
+  "generation.error.out_of_memory": "Kein GPU-Speicher mehr verfügbar. Versuche eine kleinere Bildgröße oder weniger Schritte, schließe andere GPU-Apps oder aktiviere den Low-VRAM-Modus. Eine niedrigere Auflösung hilft meist am meisten.",
+  "generation.error.vae_incompatible": "Der ausgewählte VAE ist mit diesem Checkpoint nicht kompatibel. Wähle einen passenden VAE oder stelle VAE auf Automatisch, um den im Checkpoint enthaltenen VAE zu verwenden.",
+  "generation.error.model_not_found": "'{model}' ist in ComfyUI nicht verfügbar. Wähle dein Modell erneut aus oder starte ComfyUI neu, falls du die Datei gerade hinzugefügt oder umbenannt hast.",
+  "generation.error.model_not_found_generic": "Ein ausgewähltes Modell ist in ComfyUI nicht verfügbar. Überprüfe deine Modell- und VAE-Einstellungen oder starte ComfyUI neu, falls du gerade eine Datei hinzugefügt oder umbenannt hast.",
+  "generation.error.missing_node": "Dieser Workflow benötigt einen Custom Node, der nicht installiert ist: {node}. Installiere ihn in ComfyUI und starte neu.",
+  "generation.error.component_mismatch": "Diese Modellkomponenten passen nicht zusammen. Stelle sicher, dass Checkpoint, VAE, LoRAs und CLIP alle zur selben Modellfamilie gehören (zum Beispiel alle SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -66,6 +66,12 @@ const en: Record<string, string> = {
   "generation.toast.failed": "Generation failed",
   "generation.toast.failed_validation": "Generation failed — a model or VAE may not be configured correctly. Check your model settings.",
   "generation.toast.failed_detail": "Generation failed: {message}",
+  "generation.error.out_of_memory": "Out of GPU memory. Try a smaller image size or fewer steps, close other GPU apps, or enable low-VRAM mode. Lowering the resolution usually helps most.",
+  "generation.error.vae_incompatible": "The selected VAE isn't compatible with this checkpoint. Pick a matching VAE, or set VAE to Automatic to use the checkpoint's built-in VAE.",
+  "generation.error.model_not_found": "'{model}' isn't available in ComfyUI. Re-select your model, or restart ComfyUI if you just added or renamed the file.",
+  "generation.error.model_not_found_generic": "A selected model isn't available in ComfyUI. Check your model and VAE settings, or restart ComfyUI if you just added or renamed a file.",
+  "generation.error.missing_node": "This workflow needs a custom node that isn't installed: {node}. Install it in ComfyUI and restart.",
+  "generation.error.component_mismatch": "These model components don't fit together. Make sure the checkpoint, VAE, LoRAs, and CLIP are all for the same model family (for example all SDXL).",
 
   // ── App Status ─────────────────────────────────────────
   "app.status.starting": "Starting...",
@@ -871,6 +877,7 @@ const en: Record<string, string> = {
   "generation.error_failed": "Generation failed",
   "generation.error_model_config": "Generation failed — a model or VAE may not be configured correctly. Check your model settings.",
   "generation.error_failed_message": "Generation failed: {message}",
+  "generation.gen_time_label": "Total generation time",
   "generation.error_lost_connection": "A generation was lost due to a connection issue — please try again.",
   "generation.error_cancelled": "Generation cancelled",
   "generation.downloading_facefix": "Downloading Face Detailer model...",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -756,6 +756,7 @@ const es: Record<string, string> = {
   "generation.error_failed": "La generación falló",
   "generation.error_model_config": "La generación falló — puede que un modelo o VAE no esté configurado correctamente. Revisa la configuración del modelo.",
   "generation.error_failed_message": "La generación falló: {message}",
+  "generation.gen_time_label": "Tiempo total de generación",
   "generation.error_lost_connection": "Se perdió una generación por un problema de conexión — inténtalo de nuevo.",
   "generation.error_cancelled": "Generación cancelada",
   "generation.downloading_facefix": "Descargando modelo Face Detailer...",
@@ -1946,6 +1947,12 @@ const es: Record<string, string> = {
   "generation.toast.failed_validation": "Generación fallida — un modelo o VAE puede estar mal configurado. Revise la configuración de modelos.",
 
   "generation.toast.failed_detail": "Generación fallida: {message}",
+  "generation.error.out_of_memory": "Sin memoria de GPU. Prueba con un tamaño de imagen menor o menos pasos, cierra otras apps que usen la GPU o activa el modo de poca VRAM. Bajar la resolución suele ayudar más.",
+  "generation.error.vae_incompatible": "El VAE seleccionado no es compatible con este checkpoint. Elige un VAE compatible o pon VAE en Automático para usar el VAE incluido en el checkpoint.",
+  "generation.error.model_not_found": "'{model}' no está disponible en ComfyUI. Vuelve a seleccionar tu modelo o reinicia ComfyUI si acabas de añadir o renombrar el archivo.",
+  "generation.error.model_not_found_generic": "Un modelo seleccionado no está disponible en ComfyUI. Revisa la configuración de modelo y VAE, o reinicia ComfyUI si acabas de añadir o renombrar un archivo.",
+  "generation.error.missing_node": "Este flujo de trabajo necesita un nodo personalizado que no está instalado: {node}. Instálalo en ComfyUI y reinicia.",
+  "generation.error.component_mismatch": "Estos componentes del modelo no encajan entre sí. Asegúrate de que el checkpoint, el VAE, los LoRA y el CLIP sean de la misma familia de modelos (por ejemplo, todos SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -728,6 +728,7 @@ const fr: Record<string, string> = {
   "generation.error_failed": "La génération a échoué",
   "generation.error_model_config": "La génération a échoué — un modèle ou VAE est peut-être mal configuré. Vérifiez les réglages du modèle.",
   "generation.error_failed_message": "La génération a échoué : {message}",
+  "generation.gen_time_label": "Temps de génération total",
   "generation.error_cancelled": "Génération annulée",
   "generation.downloading_facefix": "Téléchargement du modèle Face Detailer...",
 
@@ -1937,6 +1938,12 @@ const fr: Record<string, string> = {
   "generation.toast.failed_validation": "Échec de la génération — un modèle ou VAE est peut-être mal configuré. Vérifiez les paramètres des modèles.",
 
   "generation.toast.failed_detail": "Échec de la génération : {message}",
+  "generation.error.out_of_memory": "Mémoire GPU insuffisante. Essayez une taille d'image plus petite ou moins d'étapes, fermez les autres applications GPU ou activez le mode faible VRAM. Réduire la résolution aide généralement le plus.",
+  "generation.error.vae_incompatible": "Le VAE sélectionné n'est pas compatible avec ce checkpoint. Choisissez un VAE compatible ou réglez le VAE sur Automatique pour utiliser le VAE intégré au checkpoint.",
+  "generation.error.model_not_found": "'{model}' n'est pas disponible dans ComfyUI. Resélectionnez votre modèle ou redémarrez ComfyUI si vous venez d'ajouter ou de renommer le fichier.",
+  "generation.error.model_not_found_generic": "Un modèle sélectionné n'est pas disponible dans ComfyUI. Vérifiez vos paramètres de modèle et de VAE, ou redémarrez ComfyUI si vous venez d'ajouter ou de renommer un fichier.",
+  "generation.error.missing_node": "Ce workflow nécessite un nœud personnalisé qui n'est pas installé : {node}. Installez-le dans ComfyUI et redémarrez.",
+  "generation.error.component_mismatch": "Ces composants de modèle ne sont pas compatibles entre eux. Assurez-vous que le checkpoint, le VAE, les LoRA et le CLIP appartiennent tous à la même famille de modèles (par exemple tous SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -707,6 +707,7 @@ const it: Record<string, string> = {
   "generation.error_failed": "Generazione non riuscita",
   "generation.error_model_config": "Generazione non riuscita — un modello o VAE potrebbe non essere configurato correttamente. Controlla le impostazioni del modello.",
   "generation.error_failed_message": "Generazione non riuscita: {message}",
+  "generation.gen_time_label": "Tempo di generazione totale",
   "generation.error_cancelled": "Generazione annullata",
   "generation.downloading_facefix": "Download modello Face Detailer...",
 
@@ -1911,6 +1912,12 @@ const it: Record<string, string> = {
   "generation.toast.failed_validation": "Generazione non riuscita — un modello o VAE potrebbe non essere configurato correttamente. Controlla le impostazioni dei modelli.",
 
   "generation.toast.failed_detail": "Generazione non riuscita: {message}",
+  "generation.error.out_of_memory": "Memoria GPU esaurita. Prova con una dimensione dell'immagine più piccola o meno passi, chiudi altre app che usano la GPU o attiva la modalità a bassa VRAM. Ridurre la risoluzione di solito aiuta di più.",
+  "generation.error.vae_incompatible": "Il VAE selezionato non è compatibile con questo checkpoint. Scegli un VAE compatibile oppure imposta il VAE su Automatico per usare il VAE incluso nel checkpoint.",
+  "generation.error.model_not_found": "'{model}' non è disponibile in ComfyUI. Riseleziona il modello o riavvia ComfyUI se hai appena aggiunto o rinominato il file.",
+  "generation.error.model_not_found_generic": "Un modello selezionato non è disponibile in ComfyUI. Controlla le impostazioni di modello e VAE oppure riavvia ComfyUI se hai appena aggiunto o rinominato un file.",
+  "generation.error.missing_node": "Questo workflow richiede un nodo personalizzato non installato: {node}. Installalo in ComfyUI e riavvia.",
+  "generation.error.component_mismatch": "Questi componenti del modello non sono compatibili tra loro. Assicurati che checkpoint, VAE, LoRA e CLIP appartengano tutti alla stessa famiglia di modelli (ad esempio tutti SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -728,6 +728,7 @@ const ja: Record<string, string> = {
   "generation.error_failed": "生成に失敗しました",
   "generation.error_model_config": "生成に失敗しました — モデルまたはVAEが正しく設定されていない可能性があります。モデル設定を確認してください。",
   "generation.error_failed_message": "生成に失敗しました: {message}",
+  "generation.gen_time_label": "総生成時間",
   "generation.error_cancelled": "生成をキャンセルしました",
   "generation.downloading_facefix": "Face Detailerモデルをダウンロード中...",
 
@@ -1936,6 +1937,12 @@ const ja: Record<string, string> = {
   "generation.toast.failed_validation": "生成に失敗しました — モデルまたは VAE の設定を確認してください。",
 
   "generation.toast.failed_detail": "生成に失敗しました: {message}",
+  "generation.error.out_of_memory": "GPUメモリが不足しています。画像サイズを小さくするかステップ数を減らす、他のGPUアプリを閉じる、または低VRAMモードを有効にしてください。解像度を下げるのが最も効果的です。",
+  "generation.error.vae_incompatible": "選択したVAEはこのチェックポイントと互換性がありません。対応するVAEを選ぶか、VAEを「自動」に設定してチェックポイント内蔵のVAEを使用してください。",
+  "generation.error.model_not_found": "'{model}' はComfyUIで利用できません。モデルを選び直すか、ファイルを追加・名前変更した直後の場合はComfyUIを再起動してください。",
+  "generation.error.model_not_found_generic": "選択したモデルがComfyUIで利用できません。モデルとVAEの設定を確認するか、ファイルを追加・名前変更した直後の場合はComfyUIを再起動してください。",
+  "generation.error.missing_node": "このワークフローには未インストールのカスタムノードが必要です: {node}。ComfyUIにインストールして再起動してください。",
+  "generation.error.component_mismatch": "これらのモデルコンポーネントは組み合わせできません。チェックポイント、VAE、LoRA、CLIPがすべて同じモデルファミリー(例: すべてSDXL)であることを確認してください。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -707,6 +707,7 @@ const ko: Record<string, string> = {
   "generation.error_failed": "생성 실패",
   "generation.error_model_config": "생성 실패 — 모델 또는 VAE가 올바르게 설정되지 않았을 수 있습니다. 모델 설정을 확인하세요.",
   "generation.error_failed_message": "생성 실패: {message}",
+  "generation.gen_time_label": "총 생성 시간",
   "generation.error_cancelled": "생성이 취소되었습니다",
   "generation.downloading_facefix": "Face Detailer 모델 다운로드 중...",
 
@@ -1911,6 +1912,12 @@ const ko: Record<string, string> = {
   "generation.toast.failed_validation": "생성 실패 — 모델 또는 VAE 설정을 확인하세요.",
 
   "generation.toast.failed_detail": "생성 실패: {message}",
+  "generation.error.out_of_memory": "GPU 메모리가 부족합니다. 이미지 크기를 줄이거나 스텝 수를 낮추고, 다른 GPU 앱을 닫거나 저VRAM 모드를 켜보세요. 해상도를 낮추는 것이 가장 효과적입니다.",
+  "generation.error.vae_incompatible": "선택한 VAE가 이 체크포인트와 호환되지 않습니다. 호환되는 VAE를 선택하거나 VAE를 자동으로 설정해 체크포인트에 내장된 VAE를 사용하세요.",
+  "generation.error.model_not_found": "'{model}'을(를) ComfyUI에서 사용할 수 없습니다. 모델을 다시 선택하거나, 방금 파일을 추가하거나 이름을 변경했다면 ComfyUI를 다시 시작하세요.",
+  "generation.error.model_not_found_generic": "선택한 모델을 ComfyUI에서 사용할 수 없습니다. 모델과 VAE 설정을 확인하거나, 방금 파일을 추가하거나 이름을 변경했다면 ComfyUI를 다시 시작하세요.",
+  "generation.error.missing_node": "이 워크플로에는 설치되지 않은 커스텀 노드가 필요합니다: {node}. ComfyUI에 설치하고 다시 시작하세요.",
+  "generation.error.component_mismatch": "이 모델 구성 요소들이 서로 맞지 않습니다. 체크포인트, VAE, LoRA, CLIP이 모두 같은 모델 계열(예: 모두 SDXL)인지 확인하세요.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -707,6 +707,7 @@ const pt: Record<string, string> = {
   "generation.error_failed": "Falha na geração",
   "generation.error_model_config": "Falha na geração — um modelo ou VAE pode não estar configurado corretamente. Verifique as configurações do modelo.",
   "generation.error_failed_message": "Falha na geração: {message}",
+  "generation.gen_time_label": "Tempo total de geração",
   "generation.error_cancelled": "Geração cancelada",
   "generation.downloading_facefix": "Baixando modelo Face Detailer...",
 
@@ -1912,6 +1913,12 @@ const pt: Record<string, string> = {
   "generation.toast.failed_validation": "Geração falhou — um modelo ou VAE pode estar mal configurado. Verifique as configurações de modelos.",
 
   "generation.toast.failed_detail": "Geração falhou: {message}",
+  "generation.error.out_of_memory": "Sem memória de GPU. Tente um tamanho de imagem menor ou menos passos, feche outros apps que usam a GPU ou ative o modo de pouca VRAM. Reduzir a resolução costuma ajudar mais.",
+  "generation.error.vae_incompatible": "O VAE selecionado não é compatível com este checkpoint. Escolha um VAE compatível ou defina o VAE como Automático para usar o VAE incluído no checkpoint.",
+  "generation.error.model_not_found": "'{model}' não está disponível no ComfyUI. Selecione o modelo novamente ou reinicie o ComfyUI se você acabou de adicionar ou renomear o arquivo.",
+  "generation.error.model_not_found_generic": "Um modelo selecionado não está disponível no ComfyUI. Verifique as configurações de modelo e VAE ou reinicie o ComfyUI se você acabou de adicionar ou renomear um arquivo.",
+  "generation.error.missing_node": "Este fluxo de trabalho precisa de um nó personalizado que não está instalado: {node}. Instale-o no ComfyUI e reinicie.",
+  "generation.error.component_mismatch": "Esses componentes do modelo não combinam entre si. Verifique se o checkpoint, o VAE, os LoRAs e o CLIP são todos da mesma família de modelos (por exemplo, todos SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -707,6 +707,7 @@ const ru: Record<string, string> = {
   "generation.error_failed": "Генерация не удалась",
   "generation.error_model_config": "Генерация не удалась — модель или VAE могут быть настроены неправильно. Проверьте настройки модели.",
   "generation.error_failed_message": "Генерация не удалась: {message}",
+  "generation.gen_time_label": "Общее время генерации",
   "generation.error_cancelled": "Генерация отменена",
   "generation.downloading_facefix": "Скачивание модели Face Detailer...",
 
@@ -1911,6 +1912,12 @@ const ru: Record<string, string> = {
   "generation.toast.failed_validation": "Генерация не удалась — модель или VAE могут быть настроены неверно. Проверьте настройки моделей.",
 
   "generation.toast.failed_detail": "Генерация не удалась: {message}",
+  "generation.error.out_of_memory": "Недостаточно памяти GPU. Попробуйте уменьшить размер изображения или число шагов, закройте другие приложения, использующие GPU, или включите режим низкого VRAM. Снижение разрешения обычно помогает больше всего.",
+  "generation.error.vae_incompatible": "Выбранный VAE несовместим с этим чекпойнтом. Выберите подходящий VAE или установите для VAE значение «Автоматически», чтобы использовать встроенный VAE чекпойнта.",
+  "generation.error.model_not_found": "«{model}» недоступна в ComfyUI. Выберите модель заново или перезапустите ComfyUI, если вы только что добавили или переименовали файл.",
+  "generation.error.model_not_found_generic": "Выбранная модель недоступна в ComfyUI. Проверьте настройки модели и VAE или перезапустите ComfyUI, если вы только что добавили или переименовали файл.",
+  "generation.error.missing_node": "Для этого рабочего процесса нужен пользовательский узел, который не установлен: {node}. Установите его в ComfyUI и перезапустите.",
+  "generation.error.component_mismatch": "Эти компоненты модели несовместимы друг с другом. Убедитесь, что чекпойнт, VAE, LoRA и CLIP относятся к одному семейству моделей (например, все SDXL).",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -707,6 +707,7 @@ const zhTw: Record<string, string> = {
   "generation.error_failed": "生成失敗",
   "generation.error_model_config": "生成失敗 — 模型或 VAE 可能設定不正確。請檢查模型設定。",
   "generation.error_failed_message": "生成失敗：{message}",
+  "generation.gen_time_label": "總生成時間",
   "generation.error_cancelled": "生成已取消",
   "generation.downloading_facefix": "正在下載 Face Detailer 模型...",
 
@@ -1911,6 +1912,12 @@ const zhTw: Record<string, string> = {
   "generation.toast.failed_validation": "生成失敗 — 模型或 VAE 可能設定不正確，請檢查模型設定。",
 
   "generation.toast.failed_detail": "生成失敗：{message}",
+  "generation.error.out_of_memory": "GPU 記憶體不足。請嘗試更小的圖片尺寸或更少的步數，關閉其他佔用 GPU 的應用程式，或啟用低顯存模式。降低解析度通常最有效。",
+  "generation.error.vae_incompatible": "所選 VAE 與此檢查點不相容。請選擇相符的 VAE，或將 VAE 設為自動以使用檢查點內建的 VAE。",
+  "generation.error.model_not_found": "ComfyUI 中沒有「{model}」。請重新選擇模型，或者如果你剛新增或重新命名了檔案，請重新啟動 ComfyUI。",
+  "generation.error.model_not_found_generic": "ComfyUI 中沒有所選的模型。請檢查模型和 VAE 設定，或者如果你剛新增或重新命名了檔案，請重新啟動 ComfyUI。",
+  "generation.error.missing_node": "此工作流程需要一個尚未安裝的自訂節點：{node}。請在 ComfyUI 中安裝並重新啟動。",
+  "generation.error.component_mismatch": "這些模型元件彼此不相容。請確保檢查點、VAE、LoRA 和 CLIP 都屬於同一模型系列（例如都是 SDXL）。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -707,6 +707,7 @@ const zh: Record<string, string> = {
   "generation.error_failed": "生成失败",
   "generation.error_model_config": "生成失败 — 模型或 VAE 可能配置不正确。请检查模型设置。",
   "generation.error_failed_message": "生成失败：{message}",
+  "generation.gen_time_label": "总生成时间",
   "generation.error_cancelled": "生成已取消",
   "generation.downloading_facefix": "正在下载 Face Detailer 模型...",
 
@@ -1953,6 +1954,12 @@ const zh: Record<string, string> = {
   "generation.toast.failed_validation": "生成失败 — 模型或 VAE 可能配置不正确，请检查模型设置。",
 
   "generation.toast.failed_detail": "生成失败：{message}",
+  "generation.error.out_of_memory": "GPU 内存不足。请尝试更小的图像尺寸或更少的步数，关闭其他占用 GPU 的应用，或启用低显存模式。降低分辨率通常最有效。",
+  "generation.error.vae_incompatible": "所选 VAE 与此检查点不兼容。请选择匹配的 VAE，或将 VAE 设为自动以使用检查点内置的 VAE。",
+  "generation.error.model_not_found": "ComfyUI 中没有“{model}”。请重新选择模型，或者如果你刚添加或重命名了文件，请重启 ComfyUI。",
+  "generation.error.model_not_found_generic": "ComfyUI 中没有所选的模型。请检查模型和 VAE 设置，或者如果你刚添加或重命名了文件，请重启 ComfyUI。",
+  "generation.error.missing_node": "此工作流需要一个尚未安装的自定义节点：{node}。请在 ComfyUI 中安装并重启。",
+  "generation.error.component_mismatch": "这些模型组件互不匹配。请确保检查点、VAE、LoRA 和 CLIP 都属于同一模型系列（例如都是 SDXL）。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -130,6 +130,8 @@ type ToastOptions = {
   persistent?: boolean;
   actionLabel?: string;
   onAction?: () => void;
+  /** Auto-dismiss delay in ms (ignored when persistent). Defaults to 2000. */
+  durationMs?: number;
 };
 type GalleryToast = {
   message: string;
@@ -137,6 +139,7 @@ type GalleryToast = {
   persistent?: boolean;
   actionLabel?: string;
   onAction?: () => void;
+  durationMs?: number;
 };
 
 class GalleryStore {
@@ -476,7 +479,7 @@ class GalleryStore {
       this._toastTimer = setTimeout(() => {
         this.toast = null;
         this._toastTimer = null;
-      }, 2000);
+      }, toastOptions.durationMs ?? 2000);
     } else {
       this._toastTimer = null;
     }

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -7,6 +7,10 @@ export interface QueuedPrompt {
   wasUpscaled: boolean;
   params: GenerationParams;
   enqueuedAt: number;
+  /** Timestamp when this prompt started executing (set in setActivePrompt). */
+  startedAt?: number;
+  /** Total wall-clock generation time in ms (computed in completePrompt). */
+  durationMs?: number;
 }
 
 class ProgressStore {
@@ -294,8 +298,18 @@ class ProgressStore {
       this.previewImage = null;
       this.samplingPass = 0;
       this._lastProgressNode = null;
-      this.generationStartTime = Date.now();
+      const now = Date.now();
+      this.generationStartTime = now;
       this._startElapsedTimer();
+
+      // Stamp the start time on the matching pending prompt so completePrompt
+      // can compute the total generation time even across concurrent prompts.
+      const idx = this.pendingPrompts.findIndex((p) => p.promptId === promptId);
+      if (idx >= 0 && this.pendingPrompts[idx].startedAt == null) {
+        const next = [...this.pendingPrompts];
+        next[idx] = { ...next[idx], startedAt: now };
+        this.pendingPrompts = next;
+      }
     }
   }
 
@@ -313,6 +327,12 @@ class ProgressStore {
       this._lastCompletedWasUpscaled = item.wasUpscaled;
       if (item.params != null && item.params.seed != null && item.params.seed >= 0) {
         this.lastCompletedSeed = item.params.seed;
+      }
+      // Capture total generation time. Prefer the per-prompt startedAt (robust
+      // across concurrent prompts); fall back to the shared generationStartTime.
+      const startedAt = item.startedAt ?? this.generationStartTime;
+      if (startedAt != null) {
+        item.durationMs = Date.now() - startedAt;
       }
     }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -176,6 +176,8 @@ export interface OutputImage {
   displayTempFilename?: string;
   file_size_bytes?: number;
   generated_at_ms?: number;
+  /** Total wall-clock generation time in ms for this image (top-left badge). */
+  generationTimeMs?: number;
   metadata?: Record<string, string> | null;
 }
 

--- a/src/lib/utils/generationErrors.ts
+++ b/src/lib/utils/generationErrors.ts
@@ -78,7 +78,7 @@ function extractMissingModel(raw: string): string | undefined {
   const m = raw.match(/(\w+):\s*'([^']+)'\s+not in/i);
   if (m) return m[2];
   // Also handle the node_errors JSON `details` form without quotes.
-  const m2 = raw.match(/(?:ckpt_name|vae_name|lora_name|control_net_name|unet_name|clip_name|model_name|upscale_model)[^A-Za-z0-9]+([\w.\- ]+\.(?:safetensors|ckpt|pt|pth|bin|gguf))/i);
+  const m2 = raw.match(/(?:ckpt_name|vae_name|lora_name|control_net_name|unet_name|clip_name|model_name|upscale_model)[^A-Za-z0-9]+([^'"\r\n,;]+?\.(?:safetensors|ckpt|pt|pth|bin|gguf))/i);
   if (m2) return m2[1].trim();
   return undefined;
 }

--- a/src/lib/utils/generationErrors.ts
+++ b/src/lib/utils/generationErrors.ts
@@ -1,0 +1,244 @@
+import { isStyleTransferExecutionError } from "./styleTransferNodes.js";
+
+/**
+ * Result of classifying a ComfyUI generation/execution failure into a
+ * user-actionable message. Callers translate `messageKey` with `locale.t`.
+ */
+export interface ClassifiedGenerationError {
+  /** i18n key for the toast/inline message. */
+  messageKey: string;
+  /** Interpolation params for the i18n key. */
+  params?: Record<string, string | number>;
+  /** Suggested display duration (ms). Longer for detailed, actionable text. */
+  durationMs?: number;
+  /** True when the failure is style-transfer related and that state should be auto-cleared. */
+  clearStyleTransfer?: boolean;
+}
+
+/** Longer dwell time so users can actually read the actionable guidance. */
+const ACTIONABLE_MS = 8000;
+
+/**
+ * Accepts either a raw ComfyUI WebSocket `execution_error` payload (desktop:
+ * { exception_message, exception_type, node_type, traceback, ... }), a
+ * server-synthesized payload (browser: { error }), or a raw error string
+ * (HTTP /prompt submission failures surfaced as AppError strings).
+ */
+type ErrorInput = string | Record<string, unknown> | null | undefined;
+
+interface Extracted {
+  /** Combined, lowercased searchable text from all available fields. */
+  haystack: string;
+  /** Original-case combined text (for value extraction). */
+  raw: string;
+  nodeType: string;
+}
+
+function asText(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) return v.map(asText).join("\n");
+  if (typeof v === "object") {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return "";
+    }
+  }
+  return String(v);
+}
+
+function extract(input: ErrorInput): Extracted {
+  if (input == null) return { haystack: "", raw: "", nodeType: "" };
+  if (typeof input === "string") {
+    return { haystack: input.toLowerCase(), raw: input, nodeType: "" };
+  }
+  const parts = [
+    asText(input.error),
+    asText(input.exception_message),
+    asText(input.exception_type),
+    asText(input.node_type),
+    asText(input.traceback),
+    asText(input.details),
+    asText(input.message),
+  ].filter(Boolean);
+  const raw = parts.join("\n");
+  return {
+    haystack: raw.toLowerCase(),
+    raw,
+    nodeType: asText(input.node_type),
+  };
+}
+
+/**
+ * Pulls the offending value out of a ComfyUI "value not in list" validation
+ * error, e.g. `ckpt_name: 'sih-v1.5.safetensors' not in [...]` -> the filename.
+ */
+function extractMissingModel(raw: string): string | undefined {
+  const m = raw.match(/(\w+):\s*'([^']+)'\s+not in/i);
+  if (m) return m[2];
+  // Also handle the node_errors JSON `details` form without quotes.
+  const m2 = raw.match(/(?:ckpt_name|vae_name|lora_name|control_net_name|unet_name|clip_name|model_name|upscale_model)[^A-Za-z0-9]+([\w.\- ]+\.(?:safetensors|ckpt|pt|pth|bin|gguf))/i);
+  if (m2) return m2[1].trim();
+  return undefined;
+}
+
+/** Pulls a missing/unknown node class name out of the error text. */
+function extractMissingNode(raw: string): string | undefined {
+  const m =
+    raw.match(/node type[: ]+'?([\w.\-]+)'?\s+(?:does not exist|not found|is not)/i) ||
+    raw.match(/'?([\w.\-]+)'?\s+is not (?:installed|registered|a recognized node)/i) ||
+    raw.match(/cannot find (?:the )?node[: ]+'?([\w.\-]+)'?/i);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Classify a generation failure into the most specific, actionable message we
+ * can. Order matters: most specific signatures first, generic fallbacks last.
+ */
+export function classifyGenerationError(input: ErrorInput): ClassifiedGenerationError {
+  const { haystack, raw, nodeType } = extract(input);
+  const node = nodeType.toLowerCase();
+
+  // 1. Style transfer (missing/broken Untwisting RoPE nodes).
+  if (isStyleTransferExecutionError(raw)) {
+    return {
+      messageKey: "generation.style_transfer.execution_failed",
+      clearStyleTransfer: true,
+      durationMs: ACTIONABLE_MS,
+    };
+  }
+
+  // 2. Out of GPU memory. Highest-value actionable error.
+  if (
+    haystack.includes("out of memory") ||
+    haystack.includes("outofmemoryerror") ||
+    haystack.includes("cuda error: out of memory") ||
+    (haystack.includes("alloc") && haystack.includes("memory") && haystack.includes("cuda"))
+  ) {
+    return { messageKey: "generation.error.out_of_memory", durationMs: ACTIONABLE_MS };
+  }
+
+  // 3. VAE incompatible with the checkpoint's latent format. The signature is a
+  // VAEDecode/VAEEncode node raising an IndexError inside the memory-estimation
+  // lambda (e.g. a 3D/video VAE like qwen_image_vae paired with an SD/SDXL
+  // checkpoint, where shape[4] does not exist).
+  const isVaeNode = node.includes("vae") || haystack.includes("vaedecode") || haystack.includes("vaeencode");
+  if (
+    (isVaeNode &&
+      (haystack.includes("tuple index out of range") ||
+        haystack.includes("memory_used_decode") ||
+        haystack.includes("memory_used_encode"))) ||
+    haystack.includes("memory_used_decode") ||
+    haystack.includes("memory_used_encode")
+  ) {
+    return { messageKey: "generation.error.vae_incompatible", durationMs: ACTIONABLE_MS };
+  }
+
+  // 4. A selected model file is no longer available to ComfyUI (renamed, moved,
+  // or the validation cache is stale).
+  if (
+    haystack.includes("value_not_in_list") ||
+    haystack.includes("value not in list") ||
+    haystack.includes("prompt_outputs_failed_validation") ||
+    haystack.includes("not in list")
+  ) {
+    const model = extractMissingModel(raw);
+    if (model) {
+      return {
+        messageKey: "generation.error.model_not_found",
+        params: { model },
+        durationMs: ACTIONABLE_MS,
+      };
+    }
+    return { messageKey: "generation.error.model_not_found_generic", durationMs: ACTIONABLE_MS };
+  }
+
+  // 5. A required custom node isn't installed.
+  if (
+    haystack.includes("does not exist") ||
+    haystack.includes("is not installed") ||
+    haystack.includes("is not a recognized node") ||
+    (haystack.includes("node type") && haystack.includes("not found"))
+  ) {
+    const nodeName = extractMissingNode(raw);
+    if (nodeName) {
+      return {
+        messageKey: "generation.error.missing_node",
+        params: { node: nodeName },
+        durationMs: ACTIONABLE_MS,
+      };
+    }
+  }
+
+  // 6. Tensor shape mismatch: usually mixing model components from different
+  // families (e.g. an SDXL VAE/LoRA with an SD1.5 checkpoint).
+  if (
+    haystack.includes("shapes cannot be multiplied") ||
+    haystack.includes("size mismatch") ||
+    (haystack.includes("expected") && haystack.includes("channels")) ||
+    haystack.includes("dimension out of range") ||
+    haystack.includes("must match the size")
+  ) {
+    return { messageKey: "generation.error.component_mismatch", durationMs: ACTIONABLE_MS };
+  }
+
+  // 7. ComfyUI HTTP /prompt returned a structured error body. Surface its
+  // message if we can parse it.
+  const apiMatch = raw.match(/API error \(\d+\): ([\s\S]+)/);
+  if (apiMatch) {
+    try {
+      const parsed = JSON.parse(apiMatch[1]);
+      // Prefer the most specific detail available.
+      const nodeErrors = parsed?.node_errors;
+      if (nodeErrors && typeof nodeErrors === "object") {
+        for (const key of Object.keys(nodeErrors)) {
+          const errs = nodeErrors[key]?.errors;
+          if (Array.isArray(errs) && errs.length > 0) {
+            const detail = errs[0]?.details || errs[0]?.message;
+            if (detail) {
+              const model = extractMissingModel(String(detail));
+              if (model) {
+                return {
+                  messageKey: "generation.error.model_not_found",
+                  params: { model },
+                  durationMs: ACTIONABLE_MS,
+                };
+              }
+              return {
+                messageKey: "generation.toast.failed_detail",
+                params: { message: String(detail) },
+                durationMs: ACTIONABLE_MS,
+              };
+            }
+          }
+        }
+      }
+      if (parsed?.error?.message) {
+        return {
+          messageKey: "generation.toast.failed_detail",
+          params: { message: String(parsed.error.message) },
+          durationMs: ACTIONABLE_MS,
+        };
+      }
+    } catch {
+      /* fall through to generic */
+    }
+  }
+
+  // 8. Generic fallback. If we have any exception message, show it rather than
+  // a bare "Generation failed".
+  if (typeof input === "object" && input) {
+    const detail = asText(input.exception_message) || asText(input.error);
+    const trimmed = detail.trim();
+    if (trimmed && !trimmed.startsWith("{") && trimmed.length <= 200) {
+      return {
+        messageKey: "generation.toast.failed_detail",
+        params: { message: trimmed },
+        durationMs: ACTIONABLE_MS,
+      };
+    }
+  }
+
+  return { messageKey: "generation.toast.failed" };
+}

--- a/src/lib/utils/localeFormat.ts
+++ b/src/lib/utils/localeFormat.ts
@@ -110,6 +110,22 @@ export function formatDateTime(
   return date.toLocaleString(intlLocale(appLocale), options);
 }
 
+/** Compact wall-clock duration for the gen-time badge: "12.3s", "1m 05s". */
+export function formatGenerationTime(ms: number, appLocale: string): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) {
+    return `${formatDecimalTrimmed(totalSeconds, appLocale, 1)}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.round(totalSeconds - minutes * 60);
+  // Carry a 60s round-up into the minute so we never render "1m 60s".
+  if (seconds === 60) {
+    return `${formatInteger(minutes + 1, appLocale)}m 00s`;
+  }
+  return `${formatInteger(minutes, appLocale)}m ${String(seconds).padStart(2, "0")}s`;
+}
+
 /** Parse typed decimals — accepts `,` or `.` as decimal separator. */
 export function parseLocaleDecimal(raw: string): number {
   const trimmed = raw.trim();


### PR DESCRIPTION
## What's New in v1.4.25

### Clearer error messages
- Generation failures are now classified into specific, actionable causes instead of a generic "Generation failed". Covered: out-of-memory, incompatible VAE, checkpoint/model not in list, missing custom node, component/shape mismatch.
- Desktop-mode errors no longer go blank: the raw ComfyUI `execution_error` payload has no top-level message field, so the classifier reads `exception_message` / `exception_type` / `node_type` / `traceback` instead.
- Actionable error toasts dwell longer (8s) before dismissing.

### Generation time
- Total generation time now shows in the top-left corner of the result preview.
- Hovering a session-gallery thumbnail shows that image's generation time in the top-left corner.

## Implementation notes
- New centralized classifier `src/lib/utils/generationErrors.ts` (pure, testable) used by both the `execution_error` listener in `App.svelte` and the catch path in `GenerateButton.svelte`.
- Per-prompt timing captured on `QueuedPrompt` (`startedAt` set in `setActivePrompt`, `durationMs` computed in `completePrompt`), threaded through `finalizeOutputImages` onto each `OutputImage.generationTimeMs`.
- New `formatGenerationTime` helper in `localeFormat.ts` ("12.3s" / "1m 05s").
- Added `generation.gen_time_label` plus 6 error keys; verified key + placeholder parity across all 11 locales (2057 keys each).

## Validation
- `npm run build`: pass
- `cargo check`: pass (compiles as v1.4.25)
- i18n parity: 11/11 locales

## Bot triage (steps 1-2)
- Open PRs are 10 routine dependabot bumps (#319-328) and 2 drafts (#294, #305), all unrelated to this release. No release-blocking bot Fix items.