### PR TITLE
v1.4.26: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.26
+
+### Fixes and maintenance
+- **Artist gallery loads over LAN again**: in browser/LAN mode the artist gallery manifest, shard, and search-index requests now carry the auth token, so they no longer fail with a 401 from the proxy.
+
+---
+
 ## What's New in v1.4.25
 
 This release makes generation failures explain themselves and adds a per-image generation-time readout.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.26
+
+### Fixes and maintenance
+- **Artist gallery loads over LAN again**: in browser/LAN mode the artist gallery manifest, shard, and search-index requests now carry the auth token, so they no longer fail with a 401 from the proxy.
+
+---
+
 ## What's New in v1.4.25
 
 This release makes generation failures explain themselves and adds a per-image generation-time readout.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.25"
+version = "1.4.26"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.25"
+version = "1.4.26"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -1,8 +1,8 @@
-import { isBrowserMode } from "../utils/ipc.js";
-
-const CDN_BASE = isBrowserMode
-  ? "/internal-api/_cdn"
-  : "https://cdn.mooshieblob.com";
+// Always the absolute CDN origin. In browser/LAN mode `cdnFetch`/`proxiedCdnUrl`
+// rewrite this to the `/internal-api/_cdn/...` proxy AND append the auth token;
+// pre-rewriting to the proxy path here would bypass that token injection and get
+// rejected with a 401 by the LAN auth gate (proxy_request_authed).
+const CDN_BASE = "https://cdn.mooshieblob.com";
 
 class ConnectionStore {
   connected = $state(false);


### PR DESCRIPTION
### Fixes and maintenance
- **Artist gallery loads over LAN again**: in browser/LAN mode the artist gallery manifest, shard, and search-index requests now carry the auth token, so they no longer fail with a 401 from the proxy.

Version bump 1.4.25 → 1.4.26 across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` (and `Cargo.lock`), with `RELEASE_NOTES.md` and `CHANGELOG.md` updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFdfy8sN8H6N8gmxKexZu1)_