### PR TITLE
v1.4.27: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.27
+
+### Fixes and maintenance
+- **Artist gallery previews load over LAN again**: grid thumbnails, prefetched images, and the lightbox now carry the auth token in browser/LAN mode, so they no longer fail with a 401 from the proxy.
+
+---
+
 ## What's New in v1.4.26
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.27
+
+### Fixes and maintenance
+- **Artist gallery previews load over LAN again**: grid thumbnails, prefetched images, and the lightbox now carry the auth token in browser/LAN mode, so they no longer fail with a 401 from the proxy.
+
+---
+
 ## What's New in v1.4.26
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.26"
+version = "1.4.27"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.26"
+version = "1.4.27"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -146,7 +146,7 @@
   async function openHit(hit: ArtistSearchHit, index = -1) {
     // Instant open: build entry immediately from cached search index data
     const imageUrl = store.manifest && hit.hasImage && hit.imageId
-      ? `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.${imgExt()}`
+      ? proxiedCdnUrl(`${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${hit.imageId}.${imgExt()}`)
       : "";
     store.lightboxEntry = { tag: hit.tag, slug: hit.slug, imageId: hit.imageId, imageUrl, objectKey: "", postCount: hit.postCount, belowThreshold: hit.belowThreshold, b: hit.b, aliases: [], hasImage: hit.hasImage };
     store.lightboxIndex = index;
@@ -243,7 +243,7 @@
     const variant = Math.min(store.resolveVariant(hit.slug), count);
     const imageId = imageIdForVariant(hit, variant);
     if (!imageId) return "";
-    return `${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${imageId}.${imgExt()}`;
+    return proxiedCdnUrl(`${store.manifest.imageBaseUrl}/${store.manifest.releasePrefix}/images/${imageId}.${imgExt()}`);
   }
 
   // Variant state for the open lightbox entry (kept in sync with its grid card).
@@ -478,7 +478,7 @@
     for (let p = start; p <= end; p++) {
       for (const hit of sortedEntries.slice((p - 1) * pageSize, p * pageSize)) {
         if (hit.hasImage && hit.imageId) {
-          urls.push(`${imageBaseUrl}/${releasePrefix}/images/${hit.imageId}.${imgExt()}`);
+          urls.push(proxiedCdnUrl(`${imageBaseUrl}/${releasePrefix}/images/${hit.imageId}.${imgExt()}`));
         }
       }
     }

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -1,6 +1,5 @@
 import { createArtistGalleryClient } from "./client.js";
 import { cdnFetch, proxiedCdnUrl } from "../utils/cdnFetch.js";
-import { isBrowserMode } from "../utils/ipc.js";
 import type {
   ArtistEntry,
   ArtistGalleryClient,
@@ -160,19 +159,12 @@ export class ArtistGalleryStore {
     this.manifestError = null;
     try {
       const manifest = await this.client.loadManifest();
-      // In browser/server mode, rewrite the manifest's `imageBaseUrl` so that
-      // image URLs used by `<img src>` and `imageCache.fetch()` go through the
-      // server's `/internal-api/_cdn/...` proxy. Otherwise the CDN's missing
-      // CORS headers block every fetch from the gallery's origin (e.g.
-      // `mooshieui.gpu.garden`). In Tauri mode the CDN is hit directly because
-      // image element loads bypass CORS and JSON fetches are routed through
-      // the `cdn_proxy_fetch` command.
-      if (isBrowserMode && manifest.imageBaseUrl?.startsWith("https://cdn.mooshieblob.com")) {
-        manifest.imageBaseUrl = manifest.imageBaseUrl.replace(
-          "https://cdn.mooshieblob.com",
-          "/internal-api/_cdn",
-        );
-      }
+      // `imageBaseUrl` stays absolute (cdn.mooshieblob.com). The browser-mode
+      // proxy rewrite (`/internal-api/_cdn/...`) AND the LAN auth-token
+      // injection happen at the point of use via `proxiedCdnUrl()` / `cachedSrc`.
+      // Rewriting the base here would drop the token — a query param can't ride
+      // on a base URL that later has `/images/...` concatenated onto it — so
+      // every `<img src>` would be rejected with a 401 by the LAN auth gate.
       this.manifest = manifest;
     } catch (err) {
       this.manifestError = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
### Fixes and maintenance
- **Artist gallery previews load over LAN again**: grid thumbnails, the preload prefetch, and the lightbox now route their image URLs through `proxiedCdnUrl()`, which performs the browser-mode proxy rewrite and appends the auth token. Previously `imageBaseUrl` was pre-rewritten to the bare `/internal-api/_cdn` path (dropping the token), so raw `<img src>` loads were rejected with a 401 by the LAN auth gate. Mirrors the v1.4.26 manifest fix.

Version bump 1.4.26 → 1.4.27 across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` (and `Cargo.lock`), with `RELEASE_NOTES.md` and `CHANGELOG.md` updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFdfy8sN8H6N8gmxKexZu1)_