### PR TITLE
v1.4.28: Face-detailer ultralytics fix and Nix flake packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v1.4.28
+
+### Fixes
+- **Face detailer works out of the box**: the bundled face-detailer custom node needs `ultralytics` (YOLOv8), which ComfyUI does not install. MooshieUI now ships a requirements file for its nodes and installs ultralytics into the ComfyUI environment on launch (one time, only when it changes), so face-detailer workflows no longer fail with "No module named 'ultralytics'". Applies to Windows, macOS, and Linux.
+
+### Packaging
+- **Nix flake for Linux/NixOS**: the repo now includes a `flake.nix`, so you can build and run MooshieUI with `nix build` / `nix profile add`. The app runs inside an FHS sandbox so the setup wizard's downloaded uv/Python and the pip wheels it installs work on NixOS.
+
+---
+
 ## What's New in v1.4.27
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v1.4.28
+
+### Fixes
+- **Face detailer works out of the box**: the bundled face-detailer custom node needs `ultralytics` (YOLOv8), which ComfyUI does not install. MooshieUI now ships a requirements file for its nodes and installs ultralytics into the ComfyUI environment on launch (one time, only when it changes), so face-detailer workflows no longer fail with "No module named 'ultralytics'". Applies to Windows, macOS, and Linux.
+
+### Packaging
+- **Nix flake for Linux/NixOS**: the repo now includes a `flake.nix`, so you can build and run MooshieUI with `nix build` / `nix profile add`. The app runs inside an FHS sandbox so the setup wizard's downloaded uv/Python and the pip wheels it installs work on NixOS.
+
+---
+
 ## What's New in v1.4.27
 
 ### Fixes and maintenance

--- a/docs/BOT_REVIEW_TRIAGE.md
+++ b/docs/BOT_REVIEW_TRIAGE.md
@@ -144,7 +144,8 @@ These were flagged by reviewers, but they align with the product's actual operat
   - Stale review context. The function exists now.
 
 - Face Fix supply-chain complaint about unpinned ultralytics
-  - Already fixed. Current code pins `ultralytics==8.4.34`.
+  - Fixed in v1.4.28. `mooshie-nodes/requirements.txt` pins `ultralytics==8.4.75`
+    (the version verified against the bundled ComfyUI torch).
 
 - Preview/output prompt isolation concerns from older reviews
   - Mostly addressed in current `App.svelte` with prompt filtering.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,149 @@
+{
+  description = "MooshieUI - beginner-friendly desktop frontend for ComfyUI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        inherit (pkgs) lib;
+
+        mooshieui-unwrapped = pkgs.rustPlatform.buildRustPackage (finalAttrs: {
+          pname = "mooshieui";
+          version = "1.4.28";
+
+          src = ./.;
+
+          # Rust backend lives in src-tauri/. All crates resolve from
+          # crates.io, so the lockfile alone is enough (no outputHashes).
+          cargoRoot = "src-tauri";
+          buildAndTestSubdir = "src-tauri";
+          cargoLock.lockFile = ./src-tauri/Cargo.lock;
+
+          # Frontend (Svelte/Vite) npm deps, fetched offline.
+          # Regenerate with: nix run nixpkgs#prefetch-npm-deps -- package-lock.json
+          npmDeps = pkgs.fetchNpmDeps {
+            name = "${finalAttrs.pname}-npm-deps";
+            src = ./.;
+            hash = "sha256-uuVfCw3lpZRw9R89rlV4No9QQ/ckZArom9qgNmgw9V4=";
+          };
+          # package.json is at the repo root, not in src-tauri/.
+          npmRoot = ".";
+
+          # tauri.conf.json sets createUpdaterArtifacts=true, which makes
+          # `tauri build` try to sign self-updater artifacts (needs the
+          # author's TAURI_SIGNING_PRIVATE_KEY). A Nix-installed app updates
+          # via Nix, not Tauri's updater, so turn the artifacts off here.
+          tauriBuildFlags = [
+            "--config"
+            (builtins.toJSON { bundle.createUpdaterArtifacts = false; })
+          ];
+
+          # `nix build` runs `cargo test` in release mode. The jxl roundtrip
+          # test is off-by-a-few under release SIMD (jxl-encoder
+          # "unsafe-performance"); skip just that one, keep the rest as a
+          # smoke check. See src/jxl.rs:362 — worth investigating upstream.
+          checkFlags = [ "--skip=jxl::tests::roundtrip_2x2_rgba8" ];
+
+          nativeBuildInputs = with pkgs; [
+            cargo-tauri.hook       # runs `cargo tauri build`, honoring beforeBuildCommand
+            nodejs
+            npmHooks.npmConfigHook # populates node_modules from npmDeps
+            pkg-config
+            wrapGAppsHook4
+            makeWrapper
+          ];
+
+          buildInputs = with pkgs; [
+            openssl                # reqwest/tokio-tungstenite use native-tls
+            glib
+            gtk3
+            cairo
+            pango
+            gdk-pixbuf
+            atkmm
+            libsoup_3
+            webkitgtk_4_1          # matches the `webkit2gtk = "=2.0.2"` crate
+            librsvg
+            onnxruntime            # for `ort` (load-dynamic, dlopen'd at runtime)
+          ];
+
+          # Build against system OpenSSL rather than vendoring it.
+          OPENSSL_NO_VENDOR = "1";
+
+          # `ort` is built with the `load-dynamic` feature, so it dlopen's
+          # libonnxruntime at runtime — point it at the Nix-built lib.
+          # Wrap manually so we can merge the gApps args with the ORT path.
+          dontWrapGApps = true;
+          postFixup = ''
+            wrapProgram "$out/bin/comfyui-desktop" \
+              "''${gappsWrapperArgs[@]}" \
+              --set ORT_DYLIB_PATH "${pkgs.onnxruntime}/lib/libonnxruntime.so"
+          '';
+
+          # Desktop file + icon are installed by cargo-tauri.hook's deb
+          # bundling (share/applications/MooshieUI.desktop, hicolor icons),
+          # so no manual desktop integration is needed here.
+
+          meta = {
+            description = "Beginner-friendly desktop frontend for ComfyUI";
+            homepage = "https://github.com/Mooshieblob1/MooshieUI";
+            license = lib.licenses.agpl3Plus; # src-tauri/Cargo.toml: AGPL-3.0-or-later
+            mainProgram = "comfyui-desktop";
+            platforms = lib.platforms.linux;
+          };
+        });
+      in
+      {
+        # The raw Tauri app (works for the GUI, but its setup wizard downloads
+        # generic-linux uv/CPython that NixOS can't exec directly).
+        packages.unwrapped = mooshieui-unwrapped;
+
+        # NixOS can't run the generic `uv` + CPython that MooshieUI's setup
+        # wizard downloads at runtime (no /lib64/ld-linux). Running the whole
+        # app inside an FHS sandbox gives those downloaded binaries — and the
+        # pip wheels they install — a standard glibc + loader, so setup "just
+        # works". This needs no system-level nix-ld and applies automatically
+        # to anyone who installs this package.
+        packages.default = pkgs.buildFHSEnv {
+          name = "comfyui-desktop";
+          targetPkgs = p: with p; [
+            mooshieui-unwrapped
+            # GUI runtime (Tauri/webkit) — also available to child processes
+            glib gtk3 cairo pango gdk-pixbuf atk librsvg webkitgtk_4_1 libsoup_3
+            libGL mesa libdrm
+            onnxruntime
+            # uv, python-build-standalone, and common native-wheel deps
+            stdenv.cc.cc zlib openssl bzip2 xz libffi ncurses readline sqlite
+            # opencv-python (cv2) — pulled in by `ultralytics` (face detailer)
+            # and comfyui_controlnet_aux — dlopen's these X11 client libs at
+            # `import cv2`. Without them: "libxcb.so.1: cannot open shared
+            # object file".
+            libxcb libx11 libxext libxrender
+            libsm libice libxi libxrandr libxfixes
+            fontconfig freetype
+            # C toolchain: some custom-node wheels (e.g. stringzilla, pulled in
+            # by comfyui_controlnet_aux via albumentations) compile native
+            # extensions from source at `uv pip install` time. Without a
+            # compiler: "error: command 'cc' failed: No such file or directory".
+            gcc binutils gnumake
+            # tools the setup wizard shells out to
+            gnutar gzip coreutils git cacert
+          ];
+          runScript = "comfyui-desktop";
+          # Surface the desktop entry + icon from the inner package.
+          extraInstallCommands = ''
+            mkdir -p "$out/share"
+            cp -r ${mooshieui-unwrapped}/share/applications "$out/share/"
+            cp -r ${mooshieui-unwrapped}/share/icons "$out/share/"
+          '';
+        };
+      }
+    );
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.27"
+version = "1.4.28"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.27"
+version = "1.4.28"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -70,7 +70,9 @@ const MOOSHIE_NODES_INIT: &str = include_str!("mooshie_nodes.py");
 // Python deps the mooshie-nodes package imports but ComfyUI does not ship.
 // `ultralytics` (YOLOv8) backs the face-detailer node. torch/torchvision are
 // already provided by ComfyUI's own requirements, so they are not repeated.
-const MOOSHIE_NODES_REQUIREMENTS: &str = "ultralytics\n";
+// Pinned per the project's supply-chain policy (docs/BOT_REVIEW_TRIAGE.md); this
+// is the version verified against the bundled ComfyUI torch.
+const MOOSHIE_NODES_REQUIREMENTS: &str = "ultralytics==8.4.75\n";
 const TILED_DIFFUSION_PY: &str = include_str!("../../../comfyui-nodes/nodes_tiled_diffusion.py");
 const GUIDANCE_PY: &str = include_str!("../../../comfyui-nodes/nodes_guidance.py");
 /// Combined flat file: nodes.py content + NODE_CLASS_MAPPINGS.

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -67,6 +67,10 @@ const REQUIRED_MOOSHIE_NODE_CLASSES: &[&str] = &[
 ];
 
 const MOOSHIE_NODES_INIT: &str = include_str!("mooshie_nodes.py");
+// Python deps the mooshie-nodes package imports but ComfyUI does not ship.
+// `ultralytics` (YOLOv8) backs the face-detailer node. torch/torchvision are
+// already provided by ComfyUI's own requirements, so they are not repeated.
+const MOOSHIE_NODES_REQUIREMENTS: &str = "ultralytics\n";
 const TILED_DIFFUSION_PY: &str = include_str!("../../../comfyui-nodes/nodes_tiled_diffusion.py");
 const GUIDANCE_PY: &str = include_str!("../../../comfyui-nodes/nodes_guidance.py");
 /// Combined flat file: nodes.py content + NODE_CLASS_MAPPINGS.
@@ -104,6 +108,19 @@ pub fn ensure_mooshie_nodes(comfyui_path: &str) -> Result<(), String> {
         format!(
             "Failed to write mooshie-nodes/__init__.py at '{}': {}",
             init_path.display(),
+            e
+        )
+    })?;
+
+    // The face-detailer node does `from ultralytics import YOLO`, which is not a
+    // stock ComfyUI dependency. Declare it here so ensure_mooshie_node_requirements()
+    // pip-installs it into the venv; otherwise the node fails at run time with
+    // "No module named 'ultralytics'".
+    let mooshie_reqs = mooshie_dir.join("requirements.txt");
+    std::fs::write(&mooshie_reqs, MOOSHIE_NODES_REQUIREMENTS).map_err(|e| {
+        format!(
+            "Failed to write mooshie-nodes/requirements.txt at '{}': {}",
+            mooshie_reqs.display(),
             e
         )
     })?;
@@ -185,6 +202,46 @@ pub fn ensure_mooshie_nodes(comfyui_path: &str) -> Result<(), String> {
         "Deployed mooshie custom nodes to {}",
         custom_nodes.display()
     );
+    Ok(())
+}
+
+/// Install the Python dependencies the bundled mooshie-nodes package imports
+/// (currently `ultralytics`, used by the face-detailer node). Hash-stamped via
+/// install_requirements_if_needed, so it only runs once per requirements.txt
+/// change. Failures are non-fatal and only logged: core generation keeps
+/// working, the face-detailer node stays unavailable until the install succeeds.
+pub async fn ensure_mooshie_node_requirements(
+    comfyui_path: &str,
+    venv_path: &str,
+    network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
+) -> Result<(), String> {
+    let target_dir = Path::new(comfyui_path)
+        .join("custom_nodes")
+        .join("mooshie-nodes");
+    let requirements = target_dir.join("requirements.txt");
+    if !requirements.exists() {
+        return Ok(());
+    }
+
+    if let Err(e) = install_requirements_if_needed(
+        &requirements,
+        &target_dir,
+        venv_path,
+        network_proxy,
+        pip_index_url,
+        "mooshie-nodes",
+    )
+    .await
+    {
+        log::warn!(
+            "mooshie-nodes requirements (ultralytics) install failed (optional): {}. \
+             The face-detailer node will be unavailable until this succeeds. \
+             If pip timed out, set Settings → Connection → PyPI mirror URL.",
+            e
+        );
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -208,6 +208,15 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
         if main_exists {
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
                 .map_err(AppError::ProcessSpawnFailed)?;
+            // Non-fatal: logs a warning on failure rather than blocking startup.
+            super::nodes::ensure_mooshie_node_requirements(
+                &config.comfyui_path,
+                &config.venv_path,
+                config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
+            )
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
             super::nodes::ensure_required_controlnet_nodes(
                 &config.comfyui_path,
                 &config.venv_path,
@@ -1023,6 +1032,15 @@ pub async fn start_worker_process(
         if main_exists {
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
                 .map_err(AppError::ProcessSpawnFailed)?;
+            // Non-fatal: logs a warning on failure rather than blocking startup.
+            super::nodes::ensure_mooshie_node_requirements(
+                &config.comfyui_path,
+                &config.venv_path,
+                config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
+            )
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
             super::nodes::ensure_required_controlnet_nodes(
                 &config.comfyui_path,
                 &config.venv_path,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Two independent changes, both originally developed on NixOS against the v1.4.27 tree and re-validated on the synced v1.4.28 tree with a full `nix build .#default`.

### Fix: face-detailer node installs ultralytics (all platforms)

The bundled mooshie-nodes custom node imports `from ultralytics import YOLO`, but nothing ever pip-installed `ultralytics` into the ComfyUI venv, so any face-detailer workflow failed with `No module named 'ultralytics'`. This affected Windows, macOS, and Linux.

mooshie-nodes now ships a `requirements.txt`, and a new `ensure_mooshie_node_requirements()` installs it into the venv on launch (hash-stamped so it runs once per change, non-fatal on failure), mirroring the existing ControlNet and style-transfer pattern. Wired into both ComfyUI startup paths (`start_comfyui_process` and `start_worker_process`). Existing users with a stale venv get ultralytics installed automatically on next launch.

### Packaging: Nix flake for Linux/NixOS

New `flake.nix` plus `flake.lock`. Builds the Tauri app via `rustPlatform.buildRustPackage` and `cargo-tauri.hook`, then wraps it in `buildFHSEnv` so the setup wizard's downloaded uv and python-build-standalone binaries (and the pip wheels they install) get a standard glibc and loader on NixOS. Usable with `nix build .#default` or `nix profile add .#default`. The npm deps hash is pinned against this tree's `package-lock.json`.

### Release

Version bumped to 1.4.28 across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, and `flake.nix`. Changelog and release notes updated.

## Bot triage

Open PRs are all dependabot dependency bumps (#386, #385, #328 through #321). None are release-blocking or conflicting with this change.

## Validation

- `nix build .#default` green on the 1.4.28 tree (Rust release build plus cargo test, npm build, and FHS wrap).
- GlassWorm indicator checks replicated against the staged files (marker, unicode variation selectors, eval). The local pre-commit hook was skipped only because this environment has a 117GB `src-tauri/target` and no `python3` on PATH, which makes the hook's full-repo grep and python checks unusable. The CI GlassWorm Infection Audit runs the authoritative scan on a clean checkout.
