### PR TITLE
fix generation/gallery UX issues and add external LLM endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-desktop",
-  "version": "1.4.9",
+  "version": "1.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "1.4.9",
+      "version": "1.4.28",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -486,6 +486,9 @@ impl AppState {
     ) -> Result<(), AppError> {
         use tauri::Emitter;
 
+        // Drop any stale cancel flag from a previous attempt so this download starts clean (#399).
+        self.clear_download_cancel(filename);
+
         let models_dir = if let Some(dir) = dest_dir_override {
             std::path::PathBuf::from(dir)
         } else {
@@ -578,6 +581,23 @@ impl AppState {
         let mut resp = resp;
         while let Some(chunk) = resp.chunk().await? {
             use std::io::Write;
+            // Abort cleanly if the user cancelled this download (#399).
+            if self.is_download_cancelled(filename) {
+                drop(file);
+                let _ = std::fs::remove_file(&dest);
+                self.clear_download_cancel(filename);
+                app.emit(
+                    "download:progress",
+                    crate::setup::DownloadProgress {
+                        filename: filename.to_string(),
+                        downloaded,
+                        total,
+                        done: true,
+                    },
+                )
+                .ok();
+                return Err(AppError::Other(format!("Download cancelled: {}", filename)));
+            }
             if let Err(e) = file.write_all(&chunk) {
                 drop(file);
                 let _ = std::fs::remove_file(&dest);

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -809,6 +809,18 @@ pub async fn download_model(
         .await
 }
 
+/// Request cancellation of an in-progress model download by filename. The running
+/// download loop checks this flag each chunk, deletes the partial file and stops (#399).
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn cancel_download(
+    state: State<'_, Arc<AppState>>,
+    filename: String,
+) -> Result<(), AppError> {
+    state.request_download_cancel(&filename);
+    Ok(())
+}
+
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn save_image_file(image_bytes: Vec<u8>, path: String) -> Result<(), AppError> {

--- a/src-tauri/src/commands/prompt_assistant.rs
+++ b/src-tauri/src/commands/prompt_assistant.rs
@@ -13,6 +13,9 @@ pub struct LlmStatus {
     pub installed_models: Vec<String>,
     pub active_model: Option<String>,
     pub server_running: bool,
+    /// True when an external OpenAI-compatible endpoint is configured — the
+    /// assistant is usable even with no local model installed.
+    pub external_enabled: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -46,10 +49,12 @@ pub async fn list_llm_catalog() -> Result<Vec<LlmCatalogEntry>, AppError> {
 #[tauri::command]
 pub async fn llm_status(state: State<'_, Arc<AppState>>) -> Result<LlmStatus, AppError> {
     let pa = &state.prompt_assistant;
+    let external_enabled = state.config.read().await.llm_external_enabled;
     Ok(LlmStatus {
         installed_models: pa.installed_models(),
         active_model: pa.server.active_model(),
         server_running: pa.server.is_running(),
+        external_enabled,
     })
 }
 
@@ -113,50 +118,30 @@ async fn run_generation(
     // is no need to hard-block enhance/compose while a generation is queued. In
     // server mode `prompt_queue` is shared across users, where blocking meant one
     // person's generation locked the feature for everyone.
-    let (model_id, idle_secs) = {
+    let (model_id, idle_secs, ext_enabled, ext_base, ext_key, ext_model) = {
         let cfg = state.config.read().await;
         (
             cfg.prompt_assistant_model_id.clone(),
             cfg.prompt_assistant_idle_timeout_secs,
+            cfg.llm_external_enabled,
+            cfg.llm_external_base_url.clone(),
+            cfg.llm_external_api_key.clone(),
+            cfg.llm_external_model.clone(),
         )
     };
-    let model_id =
-        model_id.ok_or_else(|| AppError::LlmError("prompt_assistant.no_model".into()))?;
 
-    let hw = tokio::task::spawn_blocking(hardware::detect)
-        .await
-        .map_err(|e| AppError::LlmError(e.to_string()))?;
-
-    app.emit("llm:stage", "loading_model").ok();
-    let pa = state.prompt_assistant.clone();
-    let app2 = app.clone();
-    let progress = move |filename: &str, downloaded: u64, total: u64, done: bool| {
-        app2.emit(
-            "llm:download_progress",
-            DownloadProgress {
-                filename: filename.to_string(),
-                downloaded,
-                total,
-                done,
-            },
-        )
-        .ok();
+    // Resolve the model purpose (drives tag-only grounding). External endpoints are
+    // general-purpose chat models, so no local catalog entry / model id is required.
+    let purpose = if ext_enabled {
+        "natural_language".to_string()
+    } else {
+        let mid = model_id
+            .as_deref()
+            .ok_or_else(|| AppError::LlmError("prompt_assistant.no_model".into()))?;
+        catalog::entry(mid)
+            .map(|e| e.purpose)
+            .unwrap_or_else(|| "natural_language".to_string())
     };
-    let port = pa
-        .ensure_running(
-            &state.http_client,
-            &model_id,
-            hw.total_vram_mb,
-            idle_secs,
-            &progress,
-        )
-        .await?;
-
-    app.emit("llm:stage", "generating").ok();
-    // A purpose-built tag upsampler is always tag-only regardless of family.
-    let purpose = catalog::entry(&model_id)
-        .map(|e| e.purpose)
-        .unwrap_or_else(|| "natural_language".to_string());
     let tag_only = grounding::is_tag_only(&purpose, family);
     let candidates = grounding::retrieve_candidates(input, 40);
     let system = grounding::system_prompt(tag_only, mode, &candidates, opts.include_artists);
@@ -165,10 +150,61 @@ async fn run_generation(
         Some("detailed") => 384,
         _ => 192,
     };
-    let raw = pa
-        .server
-        .chat(&state.http_client, port, &system, input, max_tokens)
-        .await?;
+
+    let raw = if ext_enabled {
+        if ext_base.trim().is_empty() {
+            return Err(AppError::LlmError(
+                "External LLM endpoint is enabled but no base URL is set (Settings → Prompt Assistant).".into(),
+            ));
+        }
+        app.emit("llm:stage", "generating").ok();
+        crate::prompt_assistant::server::chat_external(
+            &state.http_client,
+            &ext_base,
+            &ext_key,
+            &ext_model,
+            &system,
+            input,
+            max_tokens,
+        )
+        .await?
+    } else {
+        let model_id =
+            model_id.ok_or_else(|| AppError::LlmError("prompt_assistant.no_model".into()))?;
+        let hw = tokio::task::spawn_blocking(hardware::detect)
+            .await
+            .map_err(|e| AppError::LlmError(e.to_string()))?;
+
+        app.emit("llm:stage", "loading_model").ok();
+        let pa = state.prompt_assistant.clone();
+        let app2 = app.clone();
+        let progress = move |filename: &str, downloaded: u64, total: u64, done: bool| {
+            app2.emit(
+                "llm:download_progress",
+                DownloadProgress {
+                    filename: filename.to_string(),
+                    downloaded,
+                    total,
+                    done,
+                },
+            )
+            .ok();
+        };
+        let port = pa
+            .ensure_running(
+                &state.http_client,
+                &model_id,
+                hw.total_vram_mb,
+                idle_secs,
+                &progress,
+            )
+            .await?;
+
+        app.emit("llm:stage", "generating").ok();
+        pa.server
+            .chat(&state.http_client, port, &system, input, max_tokens)
+            .await?
+    };
     let cleaned = grounding::repair(&raw, tag_only);
     // Enhance is additive: keep every user tag (named characters included) and don't
     // let the model switch a pinned attribute (a 1boy on a 1girl prompt, red hair on a

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -145,6 +145,20 @@ pub struct AppConfig {
     pub tls_cert_path: Option<String>,
     /// Optional TLS private key PEM path for the browser-mode web server.
     pub tls_key_path: Option<String>,
+    /// Prompt assistant: use an external OpenAI-compatible endpoint (LM Studio,
+    /// OpenAI, OpenRouter, ...) instead of the bundled local llama-server.
+    #[serde(default)]
+    pub llm_external_enabled: bool,
+    /// External LLM API root, e.g. `http://localhost:1234/v1` or `https://api.openai.com/v1`.
+    /// `/chat/completions` is appended.
+    #[serde(default)]
+    pub llm_external_base_url: String,
+    /// External LLM API key (sent as a Bearer token; leave empty for keyless local servers).
+    #[serde(default)]
+    pub llm_external_api_key: String,
+    /// External LLM model name (e.g. `gpt-4o-mini`, or the model id LM Studio exposes).
+    #[serde(default)]
+    pub llm_external_model: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -203,6 +217,10 @@ impl Default for AppConfig {
             theme_profiles: vec![],
             tls_cert_path: None,
             tls_key_path: None,
+            llm_external_enabled: false,
+            llm_external_base_url: String::new(),
+            llm_external_api_key: String::new(),
+            llm_external_model: String::new(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,6 +375,7 @@ pub fn run() {
             commands::api::get_output_image,
             commands::api::get_client_id,
             commands::api::download_model,
+            commands::api::cancel_download,
             commands::api::get_model_install_dirs,
             commands::api::list_model_files,
             commands::api::delete_model_file,

--- a/src-tauri/src/prompt_assistant/server.rs
+++ b/src-tauri/src/prompt_assistant/server.rs
@@ -387,6 +387,64 @@ impl Drop for InflightGuard<'_> {
     }
 }
 
+/// Send a chat completion to an external OpenAI-compatible endpoint (LM Studio,
+/// OpenAI, OpenRouter, ...) instead of the bundled local llama-server. `base_url`
+/// is the API root (e.g. `http://localhost:1234/v1` or `https://api.openai.com/v1`);
+/// `/chat/completions` is appended. Bearer auth is added when `api_key` is non-empty.
+pub async fn chat_external(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    system: &str,
+    user: &str,
+    max_tokens: u32,
+) -> Result<String, AppError> {
+    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let body = json!({
+        "model": model,
+        "messages": [
+            { "role": "system", "content": system },
+            { "role": "user", "content": user }
+        ],
+        "temperature": 0.7,
+        "max_tokens": max_tokens,
+        "stream": false
+    });
+    let mut req = client
+        .post(&url)
+        .json(&body)
+        .timeout(Duration::from_secs(120));
+    if !api_key.is_empty() {
+        req = req.bearer_auth(api_key);
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| AppError::LlmError(format!("External LLM request failed: {e}")))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let detail: String = resp
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(300)
+            .collect();
+        return Err(AppError::LlmError(format!(
+            "External LLM returned {status}: {detail}"
+        )));
+    }
+    let v: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| AppError::LlmError(format!("Bad external LLM response: {e}")))?;
+    Ok(v["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("")
+        .to_string())
+}
+
 /// Idle watchdog implemented as a free function so it can hold an Arc clone.
 pub fn start_idle_watchdog(server: std::sync::Arc<LlamaServer>, idle_secs: u64) {
     if server

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -515,6 +515,10 @@ pub struct AppState {
     pub model_requests: ModelRequestState,
     /// Notification system for global and per-user notifications.
     pub notifications: NotificationState,
+    /// Filenames whose in-progress model download has been asked to cancel.
+    /// `download_model_file` (and the browser-mode download loop) check this each
+    /// chunk and abort cleanly, deleting the partial file (#399).
+    pub download_cancels: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
 fn is_private_or_local_host(host: &str) -> bool {
@@ -569,12 +573,36 @@ impl AppState {
             last_preview_by_prompt: std::sync::RwLock::new(HashMap::new()),
             model_requests: ModelRequestState::new(),
             notifications: NotificationState::new(),
+            download_cancels: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
     pub async fn base_url(&self) -> String {
         let config = self.config.read().await;
         config.server_url.clone()
+    }
+
+    /// Request cancellation of an in-progress model download by filename (#399).
+    pub fn request_download_cancel(&self, filename: &str) {
+        if let Ok(mut set) = self.download_cancels.lock() {
+            set.insert(filename.to_string());
+        }
+    }
+
+    /// Whether a cancel has been requested for `filename`. Does not clear the flag.
+    pub fn is_download_cancelled(&self, filename: &str) -> bool {
+        self.download_cancels
+            .lock()
+            .map(|set| set.contains(filename))
+            .unwrap_or(false)
+    }
+
+    /// Clear any pending cancel flag for `filename` (called when a download
+    /// starts and when it finishes/aborts) so a later retry is not killed instantly.
+    pub fn clear_download_cancel(&self, filename: &str) {
+        if let Ok(mut set) = self.download_cancels.lock() {
+            set.remove(filename);
+        }
     }
 
     /// Free the prompt-assistant LLM's GPU memory before an image generation.

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -265,6 +265,7 @@ const MODELHUB_COMMANDS: &[&str] = &[
     "civitai_list_architectures",
     "civitai_lookup_hash",
     "download_model",
+    "cancel_download",
     "get_model_install_dirs",
 ];
 
@@ -4075,6 +4076,14 @@ async fn dispatch_command(
             Ok(serde_json::json!({ "content": content }))
         }
 
+        "cancel_download" => {
+            let filename = args["filename"]
+                .as_str()
+                .ok_or("Missing filename")?
+                .to_string();
+            state.request_download_cancel(&filename);
+            Ok(serde_json::Value::Null)
+        }
         "download_model" => {
             let url = args["url"].as_str().ok_or("Missing url")?.to_string();
             let category = args["category"]
@@ -4183,10 +4192,19 @@ async fn dispatch_command(
                     });
                 };
 
+            state.clear_download_cancel(&filename);
             progress_event(&event_tx, &filename, 0, total, false);
             let mut resp = resp;
             while let Some(chunk) = resp.chunk().await.map_err(|e| e.to_string())? {
                 use std::io::Write;
+                // Abort cleanly if the user cancelled this download (#399).
+                if state.is_download_cancelled(&filename) {
+                    drop(file);
+                    let _ = std::fs::remove_file(&dest);
+                    state.clear_download_cancel(&filename);
+                    progress_event(&event_tx, &filename, downloaded, total, true);
+                    return Err(format!("Download cancelled: {}", filename));
+                }
                 if let Err(e) = file.write_all(&chunk) {
                     drop(file);
                     let _ = std::fs::remove_file(&dest);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,7 +13,7 @@
   import { progress } from "./lib/stores/progress.svelte.js";
   import { gallery } from "./lib/stores/gallery.svelte.js";
   import { models } from "./lib/stores/models.svelte.js";
-  import { getOutputImage, uploadImageBytes, getConfig, readImageMetadata, getQueue, recoverPromptOutputs, readTempImage } from "./lib/utils/api.js";
+  import { uploadImageBytes, getConfig, readImageMetadata, getQueue, recoverPromptOutputs, readTempImage } from "./lib/utils/api.js";
   import { loadOutputImageForGenerationInput, uploadOutputImageForGenerationInput } from "./lib/utils/galleryActions.js";
   import { shouldSuppressRegionalChainGallerySave, clearRegionalChainGallerySuppress } from "./lib/utils/regionalChainGallery.js";
   import { generation } from "./lib/stores/generation.svelte.js";
@@ -1032,7 +1032,10 @@
       if (image.gallery_filename) {
         result = await interrogateGalleryImage(image.gallery_filename);
       } else {
-        const bytes = await getOutputImage(image.filename, image.subfolder);
+        // Session images aren't in the gallery DB yet, and their synthetic
+        // filename doesn't exist in ComfyUI's output dir — resolve the pixels
+        // from the in-memory session blob / temp file instead (issue #397).
+        const bytes = await gallery.resolveImagePngBytes(image);
         const uint8 = new Uint8Array(bytes);
         let binary = "";
         for (let i = 0; i < uint8.length; i++) {
@@ -1771,6 +1774,18 @@
   onMount(async () => {
     // Start heartbeat in browser mode to keep backend alive
     startHeartbeat();
+
+    // Suppress the native WebView context menu (the "Share", "Save As" (html),
+    // "Print" and "Send link to..." entries that point at tauri.localhost and make
+    // no sense in-app) everywhere except editable text, where the native
+    // copy/paste/spellcheck menu is still useful. App-specific right-click menus
+    // (gallery/session images, artist tags) call preventDefault themselves and are
+    // unaffected — this only blocks the default menu where nothing else handles it (#392).
+    window.addEventListener("contextmenu", (e) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('input, textarea, [contenteditable="true"]')) return;
+      e.preventDefault();
+    });
 
     // Restore window maximize state (Tauri only)
     if (isTauri) {

--- a/src/lib/components/downloads/DownloadBanner.svelte
+++ b/src/lib/components/downloads/DownloadBanner.svelte
@@ -54,6 +54,20 @@
               {locale.formatBytes(dl.downloaded)}{#if dl.speed > 0} · {locale.formatBytesPerSecond(dl.speed)}{/if}
             {/if}
           </span>
+
+          <button
+            class="shrink-0 flex h-5 w-5 items-center justify-center rounded text-neutral-500 hover:bg-neutral-700 hover:text-red-400 transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-500"
+            onclick={() => downloads.cancel(dl.filename)}
+            disabled={downloads.cancelling.has(dl.filename)}
+            title={locale.t('downloads.cancel')}
+            aria-label={locale.t('downloads.cancel')}
+          >
+            {#if downloads.cancelling.has(dl.filename)}
+              <div class="w-3 h-3 border-2 border-neutral-500 border-t-transparent rounded-full animate-spin"></div>
+            {:else}
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+            {/if}
+          </button>
         {/if}
       </div>
     {/each}

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -698,14 +698,14 @@
     <div class="flex items-center gap-0.5 px-1.5 py-1 rounded-lg bg-neutral-900/95 border border-neutral-700/80 shadow-lg shadow-black/40 backdrop-blur-sm">
       {#if !image.is_upscaled}
         <button
-          class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-indigo-600/80 text-neutral-300 hover:text-white transition-colors"
+          class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-neutral-700/80 text-neutral-300 hover:text-white transition-colors"
           title={locale.t('bottom_panel.upscale')}
           onclick={() => onupscale(image)}
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
         </button>
         <button
-          class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-indigo-600/80 text-neutral-300 hover:text-white transition-colors"
+          class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-neutral-700/80 text-neutral-300 hover:text-white transition-colors"
           title={locale.t('gallery.send_to_img2img')}
           onclick={() => onrefine(image)}
         >
@@ -728,7 +728,7 @@
         </button>
       {/if}
       <button
-        class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-indigo-600/80 text-neutral-300 hover:text-white transition-colors"
+        class="w-6 h-6 flex items-center justify-center rounded-md hover:bg-neutral-700/80 text-neutral-300 hover:text-white transition-colors"
         title={locale.t('bottom_panel.inpaint')}
         onclick={() => oninpaint(image)}
       >

--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -26,7 +26,7 @@
   import { gallery } from "../../stores/gallery.svelte.js";
   import { lazyThumbnail } from "../../utils/lazyThumbnail.js";
   import type { OutputImage, InterrogationResult } from "../../types/index.js";
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
   import BottomPanel from "./BottomPanel.svelte";
   import ContextMenu from "../ui/ContextMenu.svelte";
   import type { ContextMenuItem } from "../ui/ContextMenu.svelte";
@@ -644,12 +644,22 @@
     }
   }
 
+  /** Open the image-input section and scroll it into view so a "send to img2img"
+   *  action visibly lands somewhere — otherwise switching to img2img mode loads
+   *  the source image into a section the user may not have on screen (#398). */
+  async function revealImageInputSection() {
+    imageSectionOpen = true;
+    await tick();
+    sectionRefs['imageInputs']?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
   async function refineImage(image: OutputImage) {
     try {
       generation.inputImage = await uploadOutputImageForGenerationInput(image, "img2img_input.png");
       generation.mode = "img2img";
       generation.upscaleEnabled = false;
       gallery.showToast(locale.t('gallery.toast.loaded_img2img'), "success");
+      await revealImageInputSection();
     } catch (e) {
       console.error("Failed to set up refine:", e);
       gallery.showToast(locale.t('gallery.toast.failed_load'), "error");
@@ -662,6 +672,7 @@
       generation.mode = "img2img";
       generation.upscaleEnabled = true;
       gallery.showToast(locale.t('generation.toast.loaded_upscale'), "success");
+      await revealImageInputSection();
     } catch (e) {
       console.error("Failed to set up upscale:", e);
       gallery.showToast(locale.t('generation.toast.failed_load'), "error");
@@ -1385,6 +1396,18 @@
         e.preventDefault();
         e.stopPropagation();
         await handleMaskPaste();
+        return;
+      }
+
+      // No drop zone hovered. In a mode that consumes an input image, treat Ctrl+V
+      // as pasting into the image input so the advertised "Ctrl+V Paste" works without
+      // hovering the field first. handleImagePaste reads the system clipboard, so this
+      // also works on desktop where the paste event's clipboardData is empty for
+      // OS-copied images (#396).
+      if (generation.mode === "img2img" || generation.mode === "inpainting") {
+        e.preventDefault();
+        e.stopPropagation();
+        await handleImagePaste();
         return;
       }
 

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -67,7 +67,7 @@
   let _pendingAction = $state<"enhance" | "compose" | null>(null);
 
   async function onEnhanceClick() {
-    if (!promptAssistant.hasInstalledModel) {
+    if (!promptAssistant.isAvailable) {
       _pendingAction = "enhance";
       promptAssistant.setupModalOpen = true;
       return;
@@ -95,7 +95,7 @@
   }
 
   function onComposeClick() {
-    if (!promptAssistant.hasInstalledModel) {
+    if (!promptAssistant.isAvailable) {
       _pendingAction = "compose";
       promptAssistant.setupModalOpen = true;
       return;

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -263,27 +263,40 @@
     <div>
       <label class="flex items-center justify-between text-xs text-neutral-400 mb-1">
         <span>{locale.t('generation.sampler.seed')}<InfoTip text={locale.t('generation.sampler.seed_tip')} /></span>
-        <button
-          class="text-[10px] px-1.5 py-0.5 rounded {randomSeed
-            ? 'bg-indigo-600 text-white'
-            : 'bg-neutral-700 text-neutral-300'} transition-colors"
-          onclick={() => (generation.seed = randomSeed ? (progress.lastCompletedSeed ?? 0) : -1)}
-        >
-          {locale.t('generation.sampler.seed_random')}
-        </button>
-      </label>
-      {#if !randomSeed}
-        <input
-          type="number"
-          bind:value={generation.seed}
-          min="0"
-          class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
-        />
-      {:else}
-        <div class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-500">
-          {locale.t('generation.sampler.random_display')}
+        <div class="flex items-center gap-1">
+          {#if progress.lastCompletedSeed != null}
+            <button
+              class="text-[10px] px-1.5 py-0.5 rounded bg-neutral-700 text-neutral-300 hover:bg-neutral-600 transition-colors"
+              onclick={() => (generation.seed = progress.lastCompletedSeed!)}
+              title={locale.t('generation.sampler.seed_use_last_tip')}
+            >
+              {locale.t('generation.sampler.seed_use_last')}
+            </button>
+          {/if}
+          <button
+            class="text-[10px] px-1.5 py-0.5 rounded {randomSeed
+              ? 'bg-indigo-600 text-white'
+              : 'bg-neutral-700 text-neutral-300'} transition-colors"
+            onclick={() => (generation.seed = randomSeed ? (progress.lastCompletedSeed ?? 0) : -1)}
+          >
+            {locale.t('generation.sampler.seed_random')}
+          </button>
         </div>
-      {/if}
+      </label>
+      <!-- Single editable box: shows "Random" as a placeholder when RNG is on, and
+           typing a value switches off RNG automatically — no need to toggle first (#394). -->
+      <input
+        type="number"
+        min="0"
+        value={randomSeed ? '' : generation.seed}
+        placeholder={locale.t('generation.sampler.random_display')}
+        oninput={(e) => {
+          const raw = e.currentTarget.value.trim();
+          const n = Number(raw);
+          generation.seed = raw === '' || Number.isNaN(n) ? -1 : Math.max(0, Math.floor(n));
+        }}
+        class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+      />
     </div>
     <div use:scrollCapture>
       <label class="flex items-center justify-between text-xs text-neutral-400 mb-1">

--- a/src/lib/components/progress/PreviewImage.svelte
+++ b/src/lib/components/progress/PreviewImage.svelte
@@ -2,6 +2,7 @@
   import { progress } from "../../stores/progress.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
+  import { canvas } from "../../stores/canvas.svelte.js";
   import { models } from "../../stores/models.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
   import { generate, uploadImageBytes, downloadModel } from "../../utils/api.js";
@@ -120,6 +121,64 @@
     }
   }
 
+  /** Resolve the current preview image to a ComfyUI input/ filename, uploading the
+   *  client-held bytes (saved gallery image) or the preview URL (browser-mode blob:)
+   *  as needed. Returns null (and toasts) when there is no usable image. Shared by
+   *  Refine and the send-to-img2img / send-to-inpaint buttons. */
+  async function resolvePreviewUploadName(prefix: string): Promise<string | null> {
+    const savedImage = getActiveSavedImage();
+    if (!savedImage && !progress.lastOutputImage) {
+      gallery.showToast(locale.t("preview.not_available"), "info");
+      return null;
+    }
+    if (savedImage) {
+      const source = await loadOutputImageForGenerationInput(savedImage, `${prefix}_${Date.now()}.png`);
+      const upload = await uploadImageBytes(source.bytes, source.filename);
+      return upload.name;
+    }
+    const sourceUrl = previewSrc ?? progress.lastOutputImage;
+    if (!sourceUrl) {
+      gallery.showToast(locale.t("preview.not_available"), "info");
+      return null;
+    }
+    return uploadImageUrlForGenerationInput(sourceUrl, `${prefix}_${Date.now()}.png`);
+  }
+
+  /** Load the current preview into img2img mode without starting a generation (#391). */
+  async function sendToImg2img() {
+    try {
+      const uploadName = await resolvePreviewUploadName("img2img");
+      if (!uploadName) return;
+      generation.inputImage = uploadName;
+      generation.mode = "img2img";
+      generation.refineOnly = false;
+      generation.upscaleEnabled = false;
+      gallery.showToast(locale.t("gallery.toast.loaded_img2img"), "success");
+    } catch (e) {
+      console.error("Send to img2img failed:", e);
+      gallery.showToast(locale.t("gallery.toast.failed_load"), "error");
+    }
+  }
+
+  /** Load the current preview into inpainting mode (with canvas) without generating (#391). */
+  async function sendToInpaint() {
+    try {
+      const uploadName = await resolvePreviewUploadName("inpaint");
+      if (!uploadName) return;
+      generation.inputImage = uploadName;
+      generation.mode = "inpainting";
+      canvas.clearMask();
+      canvas.isCanvasMode = true;
+      const refUrl = previewSrc ?? progress.lastOutputImage;
+      if (refUrl) canvas.setReferenceImage(refUrl);
+      if (canvas.layers.length === 0) canvas.initCanvas(generation.width, generation.height);
+      gallery.showToast(locale.t("generation.toast.loaded_inpaint"), "success");
+    } catch (e) {
+      console.error("Send to inpaint failed:", e);
+      gallery.showToast(locale.t("gallery.toast.failed_load"), "error");
+    }
+  }
+
   async function upscaleImage() {
     // The Refine button takes the most-recent output and runs it back through
     // the upscale chain (MooshieUI's "refiner") at low denoise — analogous to
@@ -127,26 +186,9 @@
     //
     // ComfyUI needs a real input/ filename here. Browser-mode preview URLs can
     // be blob: URLs, so resolve the client-held bytes first and upload them.
-    const savedImage = getActiveSavedImage();
-    if (!savedImage && !progress.lastOutputImage) {
-      gallery.showToast(locale.t("preview.not_available"), "info");
-      return;
-    }
-
     try {
-      let uploadName: string;
-      if (savedImage) {
-        const source = await loadOutputImageForGenerationInput(savedImage, `refine_${Date.now()}.png`);
-        const upload = await uploadImageBytes(source.bytes, source.filename);
-        uploadName = upload.name;
-      } else {
-        const sourceUrl = previewSrc ?? progress.lastOutputImage;
-        if (!sourceUrl) {
-          gallery.showToast(locale.t("preview.not_available"), "info");
-          return;
-        }
-        uploadName = await uploadImageUrlForGenerationInput(sourceUrl, `refine_${Date.now()}.png`);
-      }
+      const uploadName = await resolvePreviewUploadName("refine");
+      if (!uploadName) return;
 
       const params = generation.toParams() as GenerationParams;
       params.mode = "img2img";
@@ -324,6 +366,22 @@
             {locale.t('preview.upscale')}
           </button>
         {/if}
+        <button
+          onclick={sendToImg2img}
+          class="flex items-center justify-center w-8 h-8 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg shadow-lg transition-colors"
+          title={locale.t('gallery.send_to_img2img')}
+          aria-label={locale.t('gallery.send_to_img2img')}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+        </button>
+        <button
+          onclick={sendToInpaint}
+          class="flex items-center justify-center w-8 h-8 bg-neutral-700 hover:bg-neutral-600 text-white rounded-lg shadow-lg transition-colors"
+          title={locale.t('gallery.send_to_inpaint')}
+          aria-label={locale.t('gallery.send_to_inpaint')}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19l7-7 3 3-7 7-3-3z"/><path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"/><path d="M2 2l7.586 7.586"/><circle cx="11" cy="11" r="2"/></svg>
+        </button>
         <button
           onclick={handleSave}
           class="flex items-center gap-1.5 bg-neutral-700 hover:bg-neutral-600 text-white text-xs font-medium px-3 py-1.5 rounded-lg shadow-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -3485,6 +3485,56 @@
                 class="w-full accent-indigo-500"
               />
             </div>
+
+            <!-- External OpenAI-compatible LLM endpoint (#389) -->
+            <div class="border-t border-neutral-800 pt-3 mt-1 space-y-3">
+              <label class="flex items-center justify-between gap-3 cursor-pointer">
+                <span>
+                  <span class="text-xs text-neutral-300 block">{locale.t('settings.prompt_assistant.external_title')}</span>
+                  <span class="text-[10px] text-neutral-500">{locale.t('settings.prompt_assistant.external_desc')}</span>
+                </span>
+                <input
+                  type="checkbox"
+                  bind:checked={config.llm_external_enabled}
+                  onchange={async () => { await autoSave(); await promptAssistant.refreshStatus(); }}
+                  class="accent-indigo-500 w-4 h-4 shrink-0"
+                />
+              </label>
+              {#if config.llm_external_enabled}
+                <div>
+                  <label class="text-xs text-neutral-400 block mb-1">{locale.t('settings.prompt_assistant.external_url')}</label>
+                  <input
+                    type="text"
+                    bind:value={config.llm_external_base_url}
+                    onchange={() => autoSave()}
+                    placeholder="http://localhost:1234/v1"
+                    class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+                  />
+                </div>
+                <div>
+                  <label class="text-xs text-neutral-400 block mb-1">{locale.t('settings.prompt_assistant.external_model')}</label>
+                  <input
+                    type="text"
+                    bind:value={config.llm_external_model}
+                    onchange={() => autoSave()}
+                    placeholder="gpt-4o-mini"
+                    class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+                  />
+                </div>
+                <div>
+                  <label class="text-xs text-neutral-400 block mb-1">{locale.t('settings.prompt_assistant.external_key')}</label>
+                  <input
+                    type="password"
+                    bind:value={config.llm_external_api_key}
+                    onchange={() => autoSave()}
+                    placeholder="sk-..."
+                    autocomplete="off"
+                    class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+                  />
+                  <p class="text-[10px] text-neutral-500 mt-1">{locale.t('settings.prompt_assistant.external_key_hint')}</p>
+                </div>
+              {/if}
+            </div>
           </div>
           {/if}
         </section>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -524,6 +524,8 @@ const de: Record<string, string> = {
   "generation.sampler.seed_tip": "Die Zahl, die die 'Zufälligkeit' des Bildes bestimmt. Gleicher Seed + gleiche Einstellungen = gleiches Bild. 'Zufällig' für Vielfalt, bestimmter Seed zum Reproduzieren von Ergebnissen.",
   "generation.sampler.seed_random": "Zufällig",
   "generation.sampler.random_display": "Zufällig",
+  "generation.sampler.seed_use_last": "Letzter",
+  "generation.sampler.seed_use_last_tip": "Den Seed der letzten Generierung verwenden",
   "generation.sampler.batch": "Batch",
   "generation.sampler.batch_tip": "Anzahl der gleichzeitig erzeugten Bilder. Mehr = höherer VRAM-Verbrauch, aber schnellerer Ergebnisvergleich.",
   "generation.sampler.denoise": "Entrauschen",
@@ -900,6 +902,7 @@ const de: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "Alle {count} in dieser Sitzung erzeugten Bilder löschen? Dies kann nicht rückgängig gemacht werden.",
 
   // ── Downloads ───────────────────────────────────────────
+  "downloads.cancel": "Download abbrechen",
   "downloads.downloading": "{filename} wird heruntergeladen",
   "downloads.downloaded": "{filename} heruntergeladen",
 
@@ -2151,6 +2154,12 @@ const de: Record<string, string> = {
   "settings.prompt_assistant.delete": "Löschen",
   "settings.prompt_assistant.unload_now": "Jetzt entladen",
   "settings.prompt_assistant.idle_timeout": "Leerlauf-Entladung nach",
+  "settings.prompt_assistant.external_title": "Externer LLM-Endpunkt",
+  "settings.prompt_assistant.external_desc": "Eine OpenAI-kompatible API (LM Studio, OpenAI, OpenRouter) statt des integrierten lokalen Modells verwenden.",
+  "settings.prompt_assistant.external_url": "API-Basis-URL",
+  "settings.prompt_assistant.external_model": "Modell",
+  "settings.prompt_assistant.external_key": "API-Schlüssel",
+  "settings.prompt_assistant.external_key_hint": "Für lokale Server ohne Schlüssel (z. B. LM Studio) leer lassen.",
   "prompt_assistant.enhance": "Verbessern",
   "prompt_assistant.compose": "Verfassen",
   "prompt_assistant.enhance_tooltip": "Aktuellen Prompt verbessern",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -577,6 +577,8 @@ const en: Record<string, string> = {
   "generation.sampler.seed_tip": "A number that determines the 'randomness' of your image. Same seed + same settings = same image. Use 'Random' for variety, or set a specific seed to reproduce or iterate on a result.",
   "generation.sampler.seed_random": "Rng",
   "generation.sampler.random_display": "Random",
+  "generation.sampler.seed_use_last": "Last",
+  "generation.sampler.seed_use_last_tip": "Use the seed from your last generation",
   "generation.sampler.batch": "Batch",
   "generation.sampler.batch_tip": "How many images to generate at once. Higher values use more VRAM but let you compare results quickly. Each image uses the same prompt but a different seed.",
   "generation.sampler.denoise": "Denoise",
@@ -1115,6 +1117,7 @@ const en: Record<string, string> = {
   "compare.grid_cells_failed": "Cell(s) {cells} failed — check checkpoint/model availability",
 
   // ── Downloads ───────────────────────────────────────────
+  "downloads.cancel": "Cancel download",
   "downloads.downloading": "Downloading {filename}",
   "downloads.downloaded": "Downloaded {filename}",
 
@@ -2190,6 +2193,12 @@ const en: Record<string, string> = {
   "settings.prompt_assistant.delete": "Delete",
   "settings.prompt_assistant.unload_now": "Unload now",
   "settings.prompt_assistant.idle_timeout": "Idle unload after",
+  "settings.prompt_assistant.external_title": "External LLM endpoint",
+  "settings.prompt_assistant.external_desc": "Use an OpenAI-compatible API (LM Studio, OpenAI, OpenRouter) instead of the bundled local model.",
+  "settings.prompt_assistant.external_url": "API base URL",
+  "settings.prompt_assistant.external_model": "Model",
+  "settings.prompt_assistant.external_key": "API key",
+  "settings.prompt_assistant.external_key_hint": "Leave empty for keyless local servers like LM Studio.",
   "prompt_assistant.enhance": "Enhance",
   "prompt_assistant.compose": "Compose",
   "prompt_assistant.enhance_tooltip": "Enhance the current prompt",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -546,6 +546,8 @@ const es: Record<string, string> = {
   "generation.sampler.seed_tip": "Un número que determina la 'aleatoriedad' de tu imagen. Misma semilla + mismos ajustes = misma imagen. Usa 'Aleatorio' para variedad, o establece una semilla específica para reproducir o iterar sobre un resultado.",
   "generation.sampler.seed_random": "Rng",
   "generation.sampler.random_display": "Aleatorio",
+  "generation.sampler.seed_use_last": "Última",
+  "generation.sampler.seed_use_last_tip": "Usar la semilla de la última generación",
   "generation.sampler.batch": "Lote",
   "generation.sampler.batch_tip": "Cuántas imágenes generar a la vez. Valores más altos usan más VRAM pero te permiten comparar resultados rápidamente. Cada imagen usa el mismo prompt pero una semilla diferente.",
   "generation.sampler.denoise": "Eliminación de ruido",
@@ -936,6 +938,7 @@ const es: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "¿Eliminar las {count} imágenes generadas en esta sesión? Esta acción no se puede deshacer.",
 
   // ── Descargas ───────────────────────────────────────────
+  "downloads.cancel": "Cancelar descarga",
   "downloads.downloading": "Descargando {filename}",
   "downloads.downloaded": "Descargado {filename}",
 
@@ -2177,6 +2180,12 @@ const es: Record<string, string> = {
   "settings.prompt_assistant.delete": "Eliminar",
   "settings.prompt_assistant.unload_now": "Descargar ahora",
   "settings.prompt_assistant.idle_timeout": "Descargar tras inactividad",
+  "settings.prompt_assistant.external_title": "Endpoint LLM externo",
+  "settings.prompt_assistant.external_desc": "Usar una API compatible con OpenAI (LM Studio, OpenAI, OpenRouter) en lugar del modelo local integrado.",
+  "settings.prompt_assistant.external_url": "URL base de la API",
+  "settings.prompt_assistant.external_model": "Modelo",
+  "settings.prompt_assistant.external_key": "Clave de API",
+  "settings.prompt_assistant.external_key_hint": "Déjalo vacío para servidores locales sin clave como LM Studio.",
   "prompt_assistant.enhance": "Mejorar",
   "prompt_assistant.compose": "Componer",
   "prompt_assistant.enhance_tooltip": "Mejorar el prompt actual",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -521,6 +521,8 @@ const fr: Record<string, string> = {
   "generation.sampler.seed_tip": "Un nombre qui détermine le « hasard » de votre image. Même graine + mêmes paramètres = même image. Utilisez « Aléatoire » pour la variété, ou définissez une graine spécifique pour reproduire ou itérer un résultat.",
   "generation.sampler.seed_random": "Aléa",
   "generation.sampler.random_display": "Aléatoire",
+  "generation.sampler.seed_use_last": "Dernier",
+  "generation.sampler.seed_use_last_tip": "Utiliser la graine de la dernière génération",
   "generation.sampler.batch": "Lot",
   "generation.sampler.batch_tip": "Nombre d'images à générer en une fois. Des valeurs plus élevées utilisent plus de VRAM mais permettent de comparer rapidement les résultats. Chaque image utilise le même prompt mais une graine différente.",
   "generation.sampler.denoise": "Débruitage",
@@ -906,6 +908,7 @@ const fr: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "Supprimer les {count} images générées pendant cette session ? Cette action est irréversible.",
 
   // ── Téléchargements ─────────────────────────────────────
+  "downloads.cancel": "Annuler le téléchargement",
   "downloads.downloading": "Téléchargement de {filename}",
   "downloads.downloaded": "{filename} téléchargé",
 
@@ -2174,6 +2177,12 @@ const fr: Record<string, string> = {
   "settings.prompt_assistant.delete": "Supprimer",
   "settings.prompt_assistant.unload_now": "Décharger maintenant",
   "settings.prompt_assistant.idle_timeout": "Décharger après inactivité",
+  "settings.prompt_assistant.external_title": "Point de terminaison LLM externe",
+  "settings.prompt_assistant.external_desc": "Utiliser une API compatible OpenAI (LM Studio, OpenAI, OpenRouter) au lieu du modèle local intégré.",
+  "settings.prompt_assistant.external_url": "URL de base de l'API",
+  "settings.prompt_assistant.external_model": "Modèle",
+  "settings.prompt_assistant.external_key": "Clé d'API",
+  "settings.prompt_assistant.external_key_hint": "Laisser vide pour les serveurs locaux sans clé comme LM Studio.",
   "prompt_assistant.enhance": "Améliorer",
   "prompt_assistant.compose": "Composer",
   "prompt_assistant.enhance_tooltip": "Améliorer le prompt actuel",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -508,6 +508,8 @@ const it: Record<string, string> = {
   "generation.sampler.seed_tip": "Un numero che determina la 'casualità' dell'immagine. Stesso seed + stesse impostazioni = stessa immagine. Usa 'Casuale' per varietà, o imposta un seed specifico per riprodurre un risultato.",
   "generation.sampler.seed_random": "Cas.",
   "generation.sampler.random_display": "Casuale",
+  "generation.sampler.seed_use_last": "Ultimo",
+  "generation.sampler.seed_use_last_tip": "Usa il seed dell'ultima generazione",
   "generation.sampler.batch": "Batch",
   "generation.sampler.batch_tip": "Quante immagini generare contemporaneamente. Valori più alti usano più VRAM ma permettono di confrontare i risultati velocemente.",
   "generation.sampler.denoise": "Denoising",
@@ -884,6 +886,7 @@ const it: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "Eliminare tutte le {count} immagini generate in questa sessione? L'operazione non può essere annullata.",
 
   // ── Download ────────────────────────────────────────────
+  "downloads.cancel": "Annulla download",
   "downloads.downloading": "Download {filename}",
   "downloads.downloaded": "{filename} scaricato",
 
@@ -2148,6 +2151,12 @@ const it: Record<string, string> = {
   "settings.prompt_assistant.delete": "Elimina",
   "settings.prompt_assistant.unload_now": "Scarica ora",
   "settings.prompt_assistant.idle_timeout": "Scarica dopo inattività",
+  "settings.prompt_assistant.external_title": "Endpoint LLM esterno",
+  "settings.prompt_assistant.external_desc": "Usa un'API compatibile con OpenAI (LM Studio, OpenAI, OpenRouter) invece del modello locale incluso.",
+  "settings.prompt_assistant.external_url": "URL base API",
+  "settings.prompt_assistant.external_model": "Modello",
+  "settings.prompt_assistant.external_key": "Chiave API",
+  "settings.prompt_assistant.external_key_hint": "Lascia vuoto per server locali senza chiave come LM Studio.",
   "prompt_assistant.enhance": "Migliora",
   "prompt_assistant.compose": "Componi",
   "prompt_assistant.enhance_tooltip": "Migliora il prompt attuale",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -521,6 +521,8 @@ const ja: Record<string, string> = {
   "generation.sampler.seed_tip": "画像の「ランダム性」を決定する数値。同じシード + 同じ設定 = 同じ画像。多様性を求めるなら「ランダム」、結果を再現・改良するなら特定のシードを設定。",
   "generation.sampler.seed_random": "乱数",
   "generation.sampler.random_display": "ランダム",
+  "generation.sampler.seed_use_last": "前回",
+  "generation.sampler.seed_use_last_tip": "前回の生成のシードを使用",
   "generation.sampler.batch": "バッチ",
   "generation.sampler.batch_tip": "一度に生成する画像数。値が大きいほどVRAMを使用しますが、結果をすばやく比較できます。各画像は同じプロンプトで異なるシードを使用します。",
   "generation.sampler.denoise": "デノイズ",
@@ -906,6 +908,7 @@ const ja: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "このセッションで生成した {count} 枚の画像をすべて削除しますか？この操作は元に戻せません。",
 
   // ── ダウンロード ────────────────────────────────────────
+  "downloads.cancel": "ダウンロードをキャンセル",
   "downloads.downloading": "{filename}をダウンロード中",
   "downloads.downloaded": "{filename}をダウンロード済み",
 
@@ -2173,6 +2176,12 @@ const ja: Record<string, string> = {
   "settings.prompt_assistant.delete": "削除",
   "settings.prompt_assistant.unload_now": "今すぐアンロード",
   "settings.prompt_assistant.idle_timeout": "アイドル後にアンロード",
+  "settings.prompt_assistant.external_title": "外部LLMエンドポイント",
+  "settings.prompt_assistant.external_desc": "内蔵のローカルモデルの代わりにOpenAI互換API（LM Studio、OpenAI、OpenRouter）を使用します。",
+  "settings.prompt_assistant.external_url": "APIベースURL",
+  "settings.prompt_assistant.external_model": "モデル",
+  "settings.prompt_assistant.external_key": "APIキー",
+  "settings.prompt_assistant.external_key_hint": "LM Studioなどキー不要のローカルサーバーでは空のままにします。",
   "prompt_assistant.enhance": "改善",
   "prompt_assistant.compose": "作成",
   "prompt_assistant.enhance_tooltip": "現在のプロンプトを改善",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -508,6 +508,8 @@ const ko: Record<string, string> = {
   "generation.sampler.seed_tip": "이미지의 '무작위성'을 결정하는 숫자. 같은 시드 + 같은 설정 = 같은 이미지. 다양성을 원하면 '랜덤', 결과를 재현하려면 특정 시드를 설정하세요.",
   "generation.sampler.seed_random": "랜덤",
   "generation.sampler.random_display": "랜덤",
+  "generation.sampler.seed_use_last": "마지막",
+  "generation.sampler.seed_use_last_tip": "마지막 생성의 시드 사용",
   "generation.sampler.batch": "배치",
   "generation.sampler.batch_tip": "한 번에 생성할 이미지 수. 값이 클수록 VRAM을 더 사용하지만 결과를 빠르게 비교할 수 있습니다.",
   "generation.sampler.denoise": "디노이즈",
@@ -884,6 +886,7 @@ const ko: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "이 세션에서 생성한 이미지 {count}개를 모두 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
 
   // ── 다운로드 ────────────────────────────────────────────
+  "downloads.cancel": "다운로드 취소",
   "downloads.downloading": "{filename} 다운로드 중",
   "downloads.downloaded": "{filename} 다운로드 완료",
 
@@ -2148,6 +2151,12 @@ const ko: Record<string, string> = {
   "settings.prompt_assistant.delete": "삭제",
   "settings.prompt_assistant.unload_now": "지금 언로드",
   "settings.prompt_assistant.idle_timeout": "유휴 후 언로드",
+  "settings.prompt_assistant.external_title": "외부 LLM 엔드포인트",
+  "settings.prompt_assistant.external_desc": "내장 로컬 모델 대신 OpenAI 호환 API(LM Studio, OpenAI, OpenRouter)를 사용합니다.",
+  "settings.prompt_assistant.external_url": "API 기본 URL",
+  "settings.prompt_assistant.external_model": "모델",
+  "settings.prompt_assistant.external_key": "API 키",
+  "settings.prompt_assistant.external_key_hint": "LM Studio 같은 키가 필요 없는 로컬 서버에서는 비워 두세요.",
   "prompt_assistant.enhance": "개선",
   "prompt_assistant.compose": "작성",
   "prompt_assistant.enhance_tooltip": "현재 프롬프트 개선",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -508,6 +508,8 @@ const pt: Record<string, string> = {
   "generation.sampler.seed_tip": "Um número que determina a 'aleatoriedade' da sua imagem. Mesmo seed + mesmas configurações = mesma imagem. Use 'Aleatório' para variedade, ou defina um seed específico para reproduzir ou iterar um resultado.",
   "generation.sampler.seed_random": "Aleat.",
   "generation.sampler.random_display": "Aleatório",
+  "generation.sampler.seed_use_last": "Última",
+  "generation.sampler.seed_use_last_tip": "Usar a seed da última geração",
   "generation.sampler.batch": "Lote",
   "generation.sampler.batch_tip": "Quantas imagens gerar de uma vez. Valores mais altos usam mais VRAM, mas permitem comparar resultados rapidamente.",
   "generation.sampler.denoise": "Ruído",
@@ -884,6 +886,7 @@ const pt: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "Excluir todas as {count} imagens geradas nesta sessão? Isso não pode ser desfeito.",
 
   // ── Downloads ───────────────────────────────────────────
+  "downloads.cancel": "Cancelar download",
   "downloads.downloading": "Baixando {filename}",
   "downloads.downloaded": "{filename} baixado",
 
@@ -2149,6 +2152,12 @@ const pt: Record<string, string> = {
   "settings.prompt_assistant.delete": "Excluir",
   "settings.prompt_assistant.unload_now": "Descarregar agora",
   "settings.prompt_assistant.idle_timeout": "Descarregar após inatividade",
+  "settings.prompt_assistant.external_title": "Endpoint LLM externo",
+  "settings.prompt_assistant.external_desc": "Usar uma API compatível com OpenAI (LM Studio, OpenAI, OpenRouter) em vez do modelo local integrado.",
+  "settings.prompt_assistant.external_url": "URL base da API",
+  "settings.prompt_assistant.external_model": "Modelo",
+  "settings.prompt_assistant.external_key": "Chave de API",
+  "settings.prompt_assistant.external_key_hint": "Deixe vazio para servidores locais sem chave como o LM Studio.",
   "prompt_assistant.enhance": "Melhorar",
   "prompt_assistant.compose": "Compor",
   "prompt_assistant.enhance_tooltip": "Melhorar o prompt atual",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -508,6 +508,8 @@ const ru: Record<string, string> = {
   "generation.sampler.seed_tip": "Число, определяющее 'случайность' вашего изображения. Тот же сид + те же настройки = то же изображение. Используйте 'Случайный' для разнообразия или задайте конкретный сид для воспроизведения результата.",
   "generation.sampler.seed_random": "Случ.",
   "generation.sampler.random_display": "Случайный",
+  "generation.sampler.seed_use_last": "Последний",
+  "generation.sampler.seed_use_last_tip": "Использовать сид последней генерации",
   "generation.sampler.batch": "Пакет",
   "generation.sampler.batch_tip": "Сколько изображений генерировать за раз. Большие значения используют больше VRAM, но позволяют быстро сравнить результаты.",
   "generation.sampler.denoise": "Шумоподавление",
@@ -884,6 +886,7 @@ const ru: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "Удалить все изображения, созданные в этой сессии ({count})? Это действие нельзя отменить.",
 
   // ── Загрузки ────────────────────────────────────────────
+  "downloads.cancel": "Отменить загрузку",
   "downloads.downloading": "Скачивание {filename}",
   "downloads.downloaded": "{filename} скачан",
 
@@ -2148,6 +2151,12 @@ const ru: Record<string, string> = {
   "settings.prompt_assistant.delete": "Удалить",
   "settings.prompt_assistant.unload_now": "Выгрузить сейчас",
   "settings.prompt_assistant.idle_timeout": "Выгрузить после простоя",
+  "settings.prompt_assistant.external_title": "Внешний LLM-эндпоинт",
+  "settings.prompt_assistant.external_desc": "Использовать OpenAI-совместимый API (LM Studio, OpenAI, OpenRouter) вместо встроенной локальной модели.",
+  "settings.prompt_assistant.external_url": "Базовый URL API",
+  "settings.prompt_assistant.external_model": "Модель",
+  "settings.prompt_assistant.external_key": "Ключ API",
+  "settings.prompt_assistant.external_key_hint": "Оставьте пустым для локальных серверов без ключа, например LM Studio.",
   "prompt_assistant.enhance": "Улучшить",
   "prompt_assistant.compose": "Составить",
   "prompt_assistant.enhance_tooltip": "Улучшить текущий промпт",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -508,6 +508,8 @@ const zhTw: Record<string, string> = {
   "generation.sampler.seed_tip": "決定影像「隨機性」的數字。相同種子 + 相同設定 = 相同影像。想要多樣性用「隨機」，想要重現結果設定特定種子。",
   "generation.sampler.seed_random": "隨機",
   "generation.sampler.random_display": "隨機",
+  "generation.sampler.seed_use_last": "上次",
+  "generation.sampler.seed_use_last_tip": "使用上次生成的種子",
   "generation.sampler.batch": "批次",
   "generation.sampler.batch_tip": "一次生成的影像數量。數量越大顯存佔用越多，但可以更快比較結果。",
   "generation.sampler.denoise": "去雜訊",
@@ -884,6 +886,7 @@ const zhTw: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "刪除本次工作階段產生的全部 {count} 張圖片？此操作無法復原。",
 
   // ── 下載 ────────────────────────────────────────────────
+  "downloads.cancel": "取消下載",
   "downloads.downloading": "正在下載 {filename}",
   "downloads.downloaded": "{filename} 下載完成",
 
@@ -2148,6 +2151,12 @@ const zhTw: Record<string, string> = {
   "settings.prompt_assistant.delete": "刪除",
   "settings.prompt_assistant.unload_now": "立即卸載",
   "settings.prompt_assistant.idle_timeout": "閒置後卸載",
+  "settings.prompt_assistant.external_title": "外部 LLM 端點",
+  "settings.prompt_assistant.external_desc": "使用與 OpenAI 相容的 API（LM Studio、OpenAI、OpenRouter）取代內建的本機模型。",
+  "settings.prompt_assistant.external_url": "API 基礎 URL",
+  "settings.prompt_assistant.external_model": "模型",
+  "settings.prompt_assistant.external_key": "API 金鑰",
+  "settings.prompt_assistant.external_key_hint": "對於 LM Studio 等不需金鑰的本機伺服器，請留空。",
   "prompt_assistant.enhance": "改善",
   "prompt_assistant.compose": "撰寫",
   "prompt_assistant.enhance_tooltip": "改善目前的提示詞",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -508,6 +508,8 @@ const zh: Record<string, string> = {
   "generation.sampler.seed_tip": "决定图像'随机性'的数字。相同种子 + 相同设置 = 相同图像。想要多样性用'随机'，想要复现结果设置特定种子。",
   "generation.sampler.seed_random": "随机",
   "generation.sampler.random_display": "随机",
+  "generation.sampler.seed_use_last": "上次",
+  "generation.sampler.seed_use_last_tip": "使用上次生成的种子",
   "generation.sampler.batch": "批次",
   "generation.sampler.batch_tip": "一次生成的图像数量。数量越大显存占用越多，但可以更快比较结果。",
   "generation.sampler.denoise": "去噪",
@@ -884,6 +886,7 @@ const zh: Record<string, string> = {
   "bottom_panel.delete_all_confirm": "删除本次会话生成的全部 {count} 张图片？此操作无法撤销。",
 
   // ── 下载 ────────────────────────────────────────────────
+  "downloads.cancel": "取消下载",
   "downloads.downloading": "正在下载 {filename}",
   "downloads.downloaded": "{filename} 下载完成",
 
@@ -2149,6 +2152,12 @@ const zh: Record<string, string> = {
   "settings.prompt_assistant.delete": "删除",
   "settings.prompt_assistant.unload_now": "立即卸载",
   "settings.prompt_assistant.idle_timeout": "闲置后卸载",
+  "settings.prompt_assistant.external_title": "外部 LLM 端点",
+  "settings.prompt_assistant.external_desc": "使用与 OpenAI 兼容的 API（LM Studio、OpenAI、OpenRouter）替代内置的本地模型。",
+  "settings.prompt_assistant.external_url": "API 基础 URL",
+  "settings.prompt_assistant.external_model": "模型",
+  "settings.prompt_assistant.external_key": "API 密钥",
+  "settings.prompt_assistant.external_key_hint": "对于 LM Studio 等无需密钥的本地服务器，请留空。",
   "prompt_assistant.enhance": "改善",
   "prompt_assistant.compose": "撰写",
   "prompt_assistant.enhance_tooltip": "改善当前提示词",

--- a/src/lib/stores/downloads.svelte.ts
+++ b/src/lib/stores/downloads.svelte.ts
@@ -1,4 +1,5 @@
 import { ipcListen } from "../utils/ipc.js";
+import { cancelDownload } from "../utils/api.js";
 
 export interface DownloadEntry {
   filename: string;
@@ -21,6 +22,22 @@ class DownloadsStore {
     return this.active.size > 0;
   }
 
+  /** Whether a cancel request is pending for this filename (UI shows a spinner/disabled state) */
+  cancelling = $state<Set<string>>(new Set());
+
+  /** Ask the backend to cancel an in-progress download. The backend deletes the
+   *  partial file and emits a final `done` progress event, which clears the row. */
+  async cancel(filename: string) {
+    this.cancelling = new Set(this.cancelling.add(filename));
+    try {
+      await cancelDownload(filename);
+    } catch (e) {
+      console.error("Failed to cancel download:", e);
+      this.cancelling.delete(filename);
+      this.cancelling = new Set(this.cancelling);
+    }
+  }
+
   /** Start listening for download:progress events from the backend */
   async init() {
     await ipcListen("download:progress", (event: any) => {
@@ -35,6 +52,9 @@ class DownloadsStore {
         this.speedTracker.delete(data.filename);
         const entry: DownloadEntry = { ...data, speed: 0 };
         this.active = new Map(this.active.set(data.filename, entry));
+        if (this.cancelling.delete(data.filename)) {
+          this.cancelling = new Set(this.cancelling);
+        }
         setTimeout(() => {
           this.active.delete(data.filename);
           this.active = new Map(this.active);

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -731,44 +731,54 @@ class GalleryStore {
     return URL.createObjectURL(blob);
   }
 
+  /**
+   * Resolve an image's pixels to PNG bytes from whichever source is available:
+   * a persisted gallery file, the in-memory session blob, a browser-mode temp
+   * file, an object URL, or the ComfyUI output endpoint. Lets just-generated
+   * (not-yet-persisted) session images be saved/copied/interrogated without a
+   * 404 round-trip to ComfyUI for a filename that only exists in the gallery DB.
+   */
+  async resolveImagePngBytes(image: OutputImage): Promise<number[]> {
+    let bytes: number[] | null = null;
+    const isJxlGallery = image.gallery_filename?.endsWith(".jxl") ?? false;
+    if (image.gallery_filename) {
+      // JXL files are transcoded to PNG — universally compatible with metadata support.
+      bytes = isJxlGallery
+        ? await loadGalleryImagePng(image.gallery_filename)
+        : await loadGalleryImage(image.gallery_filename);
+    } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
+      bytes = await this._blobToPngBytes(image.sessionBlob);
+    } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
+      // Browser-mode JXL needs the pre-built display copy. If the temp file
+      // has expired, fall back to the session blob/display URL already held by the client.
+      const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
+      try {
+        bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
+      } catch (tempError) {
+        console.warn("Temp image fetch failed; falling back to session image:", tempError);
+        if (image.url) {
+          bytes = await this._fetchUrlToPngBytes(image.url);
+        } else if (image.sessionBlob) {
+          bytes = await this._blobToPngBytes(image.sessionBlob);
+        } else {
+          throw tempError;
+        }
+      }
+    } else if (image.url) {
+      bytes = await this._fetchUrlToPngBytes(image.url);
+    } else {
+      bytes = await getOutputImage(image.filename, image.subfolder);
+    }
+    if (!bytes) throw new Error(locale.t("gallery.error.image_bytes_unavailable"));
+    return this._ensurePngBytes(bytes);
+  }
+
   /** Save an image to a user-chosen location via native file dialog (or browser download). */
   async saveImageAs(image: OutputImage) {
     if (this.saving) return;
     this.saving = true;
     try {
-      let bytes: number[] | null = null;
-      const isJxlGallery = image.gallery_filename?.endsWith(".jxl") ?? false;
-      if (image.gallery_filename) {
-        // JXL files are transcoded to PNG — universally compatible with metadata support.
-        bytes = isJxlGallery
-          ? await loadGalleryImagePng(image.gallery_filename)
-          : await loadGalleryImage(image.gallery_filename);
-      } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
-        bytes = await this._blobToPngBytes(image.sessionBlob);
-      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
-        // Browser-mode JXL needs the pre-built display copy. If the temp file
-        // has expired, fall back to the session blob/display URL already held by the client.
-        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
-        try {
-          bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
-        } catch (tempError) {
-          console.warn("Temp image fetch failed; falling back to session image:", tempError);
-          if (image.url) {
-            bytes = await this._fetchUrlToPngBytes(image.url);
-          } else if (image.sessionBlob) {
-            bytes = await this._blobToPngBytes(image.sessionBlob);
-          } else {
-            throw tempError;
-          }
-        }
-      } else if (image.url) {
-        bytes = await this._fetchUrlToPngBytes(image.url);
-      } else {
-        bytes = await getOutputImage(image.filename, image.subfolder);
-      }
-      if (!bytes) throw new Error(locale.t("gallery.error.image_bytes_unavailable"));
-
-      bytes = await this._ensurePngBytes(bytes);
+      let bytes = await this.resolveImagePngBytes(image);
       if (image.metadata) {
         try {
           bytes = await embedPngMetadataBytes(bytes, image.metadata, generation.metadataMode);
@@ -834,38 +844,7 @@ class GalleryStore {
   /** Save an image directly to a specific directory (manual save mode). Embeds metadata. */
   async saveImageToDir(image: OutputImage, dir: string) {
     try {
-      let bytes: number[] | null = null;
-      const isJxlGallery = image.gallery_filename?.endsWith(".jxl") ?? false;
-      if (image.gallery_filename) {
-        // JXL → PNG so the saved file can be opened anywhere and supports metadata.
-        bytes = isJxlGallery
-          ? await loadGalleryImagePng(image.gallery_filename)
-          : await loadGalleryImage(image.gallery_filename);
-      } else if (image.sessionBlob && image.sessionBlob.type !== "image/jxl") {
-        bytes = await this._blobToPngBytes(image.sessionBlob);
-      } else if (isBrowserMode && (image.displayTempFilename || image.tempFilename)) {
-        // Browser-mode JXL needs the pre-built display copy. If the temp file
-        // has expired, fall back to the session blob/display URL already held by the client.
-        const fetchFilename = image.displayTempFilename ?? image.tempFilename!;
-        try {
-          bytes = await this._tempImageToPngBytes(fetchFilename, fetchFilename);
-        } catch (tempError) {
-          console.warn("Temp image fetch failed; falling back to session image:", tempError);
-          if (image.url) {
-            bytes = await this._blobUrlToPngBytes(image.url);
-          } else if (image.sessionBlob) {
-            bytes = await this._blobToPngBytes(image.sessionBlob);
-          } else {
-            throw tempError;
-          }
-        }
-      } else if (image.url) {
-        bytes = await this._fetchUrlToPngBytes(image.url);
-      } else {
-        bytes = await getOutputImage(image.filename, image.subfolder);
-      }
-      if (!bytes) throw new Error(locale.t("gallery.error.image_bytes_unavailable"));
-      bytes = await this._ensurePngBytes(bytes);
+      let bytes = await this.resolveImagePngBytes(image);
       const filename = pngNormalizedFilename(image.filename || `image_${Date.now()}.png`);
       if (image.metadata) {
         bytes = await embedPngMetadataBytes(bytes, image.metadata, generation.metadataMode);

--- a/src/lib/stores/promptAssistant.svelte.ts
+++ b/src/lib/stores/promptAssistant.svelte.ts
@@ -46,6 +46,12 @@ class PromptAssistantStore {
     return !!this.status && this.status.installed_models.length > 0;
   }
 
+  /** True when the assistant can run: a local model is installed, or an external
+   *  OpenAI-compatible endpoint is configured. Gates the enhance/compose actions. */
+  get isAvailable(): boolean {
+    return this.hasInstalledModel || !!this.status?.external_enabled;
+  }
+
   /** Launch-time bootstrap: detect hardware, load catalog + status, pre-select. */
   async init(): Promise<void> {
     try {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -264,6 +264,14 @@ export interface AppConfig {
   webhook_allow_private_targets: boolean;
   theme_profile_id: string | null;
   theme_profiles: ThemeProfile[];
+  /** Prompt assistant: use an external OpenAI-compatible endpoint instead of the local llama-server. */
+  llm_external_enabled: boolean;
+  /** External LLM API root, e.g. http://localhost:1234/v1 or https://api.openai.com/v1. */
+  llm_external_base_url: string;
+  /** External LLM API key (Bearer token; empty for keyless local servers). */
+  llm_external_api_key: string;
+  /** External LLM model name (e.g. gpt-4o-mini). */
+  llm_external_model: string;
 }
 
 export interface ThemeTone {
@@ -376,6 +384,7 @@ export interface LlmStatus {
   installed_models: string[];
   active_model: string | null;
   server_running: boolean;
+  external_enabled: boolean;
 }
 
 export interface PromptAssistantOpts {

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -141,6 +141,11 @@ export async function downloadModel(
   return ipcInvoke("download_model", { url, category, filename, installDir, expectedSha256 });
 }
 
+/** Cancel an in-progress model download by filename. The backend deletes the partial file. */
+export async function cancelDownload(filename: string): Promise<void> {
+  return ipcInvoke("cancel_download", { filename });
+}
+
 export interface ModelInstallDir {
   path: string;
   label: string;


### PR DESCRIPTION
## Summary

A batch of generation and gallery UX fixes, plus a new external-LLM-endpoint feature, addressing recently reported issues.

### Bug fixes
- #397: "Get image tags" returned a 404 on session images. Interrogation now reads the in-memory image bytes instead of fetching a gallery-only filename from ComfyUI.
- #396 (partial): Ctrl+V paste into the img2img / inpainting input now works. It reads the system clipboard and no longer requires hovering the drop zone first.
- #395: the upscale, send-to-img2img and inpaint icons in the session bar were forced near-black by a greedy global CSS rule (intended for solid accent buttons). Fixed so they use the correct neutral colour.
- #394: the seed field is directly editable. Typing a seed turns RNG off automatically; clearing it goes back to Random.
- #392: the native WebView context menu (Share, Save As, Print) is now suppressed except on text fields.

### UX
- #398: sending an image to img2img (Refine / Send to img2img / Upscale) now reveals and scrolls the image-input section into view.
- #393: a "Last" button to reuse the previous generation's seed.
- #399: a cancel (X) button on in-progress downloads (desktop and browser), which deletes the partial file.
- #391: "Send to img2img" and "Send to inpaint" buttons on the main preview, plus clipboard paste into i2i / inpaint.

### Feature
- #389: external OpenAI-compatible LLM endpoint (LM Studio, OpenAI, OpenRouter, and similar). New Settings > Prompt Assistant section for base URL, model and API key. Compose and Enhance route there when enabled, instead of the bundled local llama.cpp server.

### Validation
- `npm run build`: pass
- `cargo check`: pass
- New i18n keys added to all 11 locale files.

### Not included
- #396 drag-and-drop: the Tauri drag path looks correct and is pending a repro from the reporter.
- #390 (Danbooru-aware spell checker): a separate, larger effort.
