### PR TITLE
raise auto VRAM high-mode threshold to 24 GB

### DIFF
--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1322,10 +1322,10 @@ async fn detect_vram_mb() -> u64 {
 
 /// Choose the best VRAM mode based on detected VRAM.
 fn recommended_vram_mode(vram_mb: u64) -> &'static str {
-    if vram_mb >= 8000 {
-        "high" // 8 GB+ — keep everything in VRAM
+    if vram_mb >= 24000 {
+        "high" // 24 GB+ — --highvram keeps everything resident; only safe with headroom
     } else if vram_mb >= 4000 {
-        "normal" // 4-8 GB — load fully for sampling, offload between gens
+        "normal" // 4-24 GB — load fully for sampling, offload between gens
     } else if vram_mb > 0 {
         "low" // < 4 GB
     } else {


### PR DESCRIPTION
Setup auto-assigned `--highvram` to any GPU with 8 GB+, which on 8-24 GB cards causes VRAM thrashing and driver sysmem fallback (intermittent multi-minute generation stalls). Reported in #346 on a 12 GB RTX 4070 Ti that was never manually set to high.

`--highvram` is only safe with real headroom, so the auto threshold now requires 24 GB. Cards in the 8-24 GB range fall to "normal" (ComfyUI default offload behaviour), matching the multi-GPU heuristic in gpu_manager.rs.

Only affects fresh setups; existing persisted configs are unchanged.