### PR TITLE
v1.4.29: Model Hub CivitAI fixes and tag spellcheck menu fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## What's New in v1.4.29
+
+### Prompt tag spell check
+- **Danbooru tag-aware spell checker**: unknown or misspelled prompt tags are now underlined, and right-clicking one offers "did you mean" suggestions drawn from the Danbooru tag set. The browser's native spell check is disabled inside the prompt so it no longer fights the tag checker. The whole feature can be toggled in Settings.
+- **Suggestion menu replaces tags reliably**: choosing a "did you mean" suggestion now replaces the tag as intended. The menu previously closed itself before the replacement could apply, and it now also dismisses when you edit the prompt so it never acts on a stale position.
+
+### Model Hub
+- **One CivitAI API key**: the Model Hub and Settings now share a single CivitAI API key instead of keeping two separate copies. An existing key is migrated automatically, so entering it in either place now applies everywhere.
+- **Filenames fill in from direct URLs**: pasting a direct download URL now reads the filename from the server and fills in the save-as name automatically, instead of leaving it blank.
+- **Clearer CivitAI download failures**: a failed CivitAI download (401, 403, or 404) now explains the likely cause, that the model version may have been removed or that it requires an account that can view restricted or mature content, and points you to the shared API key in Settings, instead of showing a bare "404 Not Found".
+
+### Generation and gallery
+- **Generation and gallery UX fixes**: a batch of generation and gallery issues are resolved.
+- **External LLM endpoint**: the prompt assistant can now be pointed at an external LLM endpoint.
+- **Higher auto VRAM threshold**: automatic VRAM high-mode now engages at 24 GB.
+- **Linux image paste**: Ctrl+V now pastes an image into image-to-image and inpaint on Linux.
+
+### Maintenance
+- Dependency updates across the Rust and frontend packages.
+
+---
+
 ## What's New in v1.4.28
 
 ### Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+## What's New in v1.4.29
+
+### Prompt tag spell check
+- **Danbooru tag-aware spell checker**: unknown or misspelled prompt tags are now underlined, and right-clicking one offers "did you mean" suggestions drawn from the Danbooru tag set. The browser's native spell check is disabled inside the prompt so it no longer fights the tag checker. The whole feature can be toggled in Settings.
+- **Suggestion menu replaces tags reliably**: choosing a "did you mean" suggestion now replaces the tag as intended. The menu previously closed itself before the replacement could apply, and it now also dismisses when you edit the prompt so it never acts on a stale position.
+
+### Model Hub
+- **One CivitAI API key**: the Model Hub and Settings now share a single CivitAI API key instead of keeping two separate copies. An existing key is migrated automatically, so entering it in either place now applies everywhere.
+- **Filenames fill in from direct URLs**: pasting a direct download URL now reads the filename from the server and fills in the save-as name automatically, instead of leaving it blank.
+- **Clearer CivitAI download failures**: a failed CivitAI download (401, 403, or 404) now explains the likely cause, that the model version may have been removed or that it requires an account that can view restricted or mature content, and points you to the shared API key in Settings, instead of showing a bare "404 Not Found".
+
+### Generation and gallery
+- **Generation and gallery UX fixes**: a batch of generation and gallery issues are resolved.
+- **External LLM endpoint**: the prompt assistant can now be pointed at an external LLM endpoint.
+- **Higher auto VRAM threshold**: automatic VRAM high-mode now engages at 24 GB.
+- **Linux image paste**: Ctrl+V now pastes an image into image-to-image and inpaint on Linux.
+
+### Maintenance
+- Dependency updates across the Rust and frontend packages.
+
+---
+
 ## What's New in v1.4.28
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.28"
+version = "1.4.29"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.28"
+version = "1.4.29"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -20,6 +20,13 @@ fn is_huggingface_url(url: &str) -> bool {
         .is_some_and(|host| host == "huggingface.co" || host.ends_with(".huggingface.co"))
 }
 
+fn is_civitai_url(url: &str) -> bool {
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(|host| host.to_ascii_lowercase()))
+        .is_some_and(|host| host == "civitai.com" || host.ends_with(".civitai.com"))
+}
+
 pub fn huggingface_token_for_url(url: &str) -> Option<String> {
     if !is_huggingface_url(url) {
         return None;
@@ -39,9 +46,74 @@ pub fn download_status_error_message(url: &str, status: reqwest::StatusCode) -> 
         format!(
             "Failed to download {url}: HTTP {status}. This Hugging Face file requires access; set HF_TOKEN, HUGGINGFACE_HUB_TOKEN, or HUGGINGFACE_TOKEN, or install the file manually."
         )
+    } else if is_civitai_url(url) && matches!(status.as_u16(), 401 | 403 | 404) {
+        format!(
+            "Failed to download {url}: HTTP {status}. CivitAI rejected this download. The model version may have been removed, or it requires an account that can view restricted/mature content. Add a valid CivitAI API key in Settings (it is shared with the Model Hub) and confirm your account can access this model."
+        )
     } else {
         format!("Failed to download {url}: HTTP {status}")
     }
+}
+
+/// Decode a percent-encoded string (`%XX` sequences). Invalid sequences are kept
+/// verbatim. Used for RFC 5987 `filename*=UTF-8''...` Content-Disposition values.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Reject path separators / traversal so a server-supplied filename can never
+/// escape the destination directory.
+fn sanitize_download_filename(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_matches(|c| c == '"' || c == '\'').trim();
+    if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        return None;
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains('\0') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Extract a safe filename from a `Content-Disposition` header value, handling
+/// RFC 5987 `filename*=UTF-8''...` (percent-encoded) and quoted/plain `filename=`.
+fn filename_from_content_disposition(value: &str) -> Option<String> {
+    let lower = value.to_ascii_lowercase();
+
+    if let Some(idx) = lower.find("filename*=") {
+        let rest = &value[idx + "filename*=".len()..];
+        let token = rest.split(';').next().unwrap_or("").trim();
+        // Strip an optional `charset'lang'` prefix (e.g. `UTF-8''name`).
+        let encoded = token.rsplit('\'').next().unwrap_or(token);
+        if let Some(name) = sanitize_download_filename(&percent_decode(encoded)) {
+            return Some(name);
+        }
+    }
+
+    if let Some(idx) = lower.find("filename=") {
+        let rest = &value[idx + "filename=".len()..];
+        let token = rest.split(';').next().unwrap_or("");
+        if let Some(name) = sanitize_download_filename(token) {
+            return Some(name);
+        }
+    }
+
+    None
 }
 
 pub fn reject_non_model_download_content_type(
@@ -651,6 +723,55 @@ impl AppState {
         validate_downloaded_model_file(&dest, filename)?;
 
         Ok(())
+    }
+
+    /// Resolve the real filename a URL would download to, without downloading the
+    /// file. Sends a ranged GET so only headers (not the body) cross the wire,
+    /// follows redirects, and reads the `Content-Disposition` filename the server
+    /// reports — CivitAI download links carry the name there, not in the URL.
+    /// Auth is attached per host (CivitAI key from config, Hugging Face token from
+    /// env) so the lookup matches what an authenticated download would see, with no
+    /// cross-host token leakage. Returns `Ok(None)` (never an error) when no usable
+    /// filename is found, so callers can silently fall back to URL-based inference.
+    pub async fn resolve_download_filename(&self, url: &str) -> Result<Option<String>, AppError> {
+        let parsed = match reqwest::Url::parse(url) {
+            Ok(parsed) => parsed,
+            Err(_) => return Ok(None),
+        };
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return Ok(None);
+        }
+
+        let mut req = self
+            .http_client
+            .get(url)
+            .header(reqwest::header::RANGE, "bytes=0-0");
+        if is_civitai_url(url) {
+            let key = self.config.read().await.civitai_api_key.clone();
+            if let Some(key) = key.filter(|v| !v.trim().is_empty()) {
+                req = req.bearer_auth(key);
+            }
+        } else if let Some(token) = huggingface_token_for_url(url) {
+            req = req.bearer_auth(token);
+        }
+
+        let resp = match req.send().await {
+            Ok(resp) => resp,
+            Err(_) => return Ok(None),
+        };
+        let status = resp.status();
+        if !status.is_success() && status != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Ok(None);
+        }
+
+        let filename = resp
+            .headers()
+            .get(reqwest::header::CONTENT_DISPOSITION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(filename_from_content_disposition);
+        // Drop the response without reading the body so the file never streams.
+        drop(resp);
+        Ok(filename)
     }
 
     pub async fn get_output_image_bytes(

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -809,6 +809,20 @@ pub async fn download_model(
         .await
 }
 
+/// Resolve the real filename a download URL points to (read from the server's
+/// `Content-Disposition` header) without downloading the file. Returns `None`
+/// when the server reports no usable name, so the Model Hub can fall back to
+/// URL-based inference. Used to autopopulate the direct-download filename field,
+/// including for CivitAI links whose filename is not present in the URL.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn resolve_download_filename(
+    state: State<'_, Arc<AppState>>,
+    url: String,
+) -> Result<Option<String>, AppError> {
+    state.resolve_download_filename(&url).await
+}
+
 /// Request cancellation of an in-progress model download by filename. The running
 /// download loop checks this flag each chunk, deletes the partial file and stops (#399).
 #[cfg(feature = "desktop")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -375,6 +375,7 @@ pub fn run() {
             commands::api::get_output_image,
             commands::api::get_client_id,
             commands::api::download_model,
+            commands::api::resolve_download_filename,
             commands::api::cancel_download,
             commands::api::get_model_install_dirs,
             commands::api::list_model_files,

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -265,6 +265,7 @@ const MODELHUB_COMMANDS: &[&str] = &[
     "civitai_list_architectures",
     "civitai_lookup_hash",
     "download_model",
+    "resolve_download_filename",
     "cancel_download",
     "get_model_install_dirs",
 ];
@@ -4083,6 +4084,14 @@ async fn dispatch_command(
                 .to_string();
             state.request_download_cancel(&filename);
             Ok(serde_json::Value::Null)
+        }
+        "resolve_download_filename" => {
+            let url = args["url"].as_str().ok_or("Missing url")?.to_string();
+            let name = state
+                .resolve_download_filename(&url)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(serde_json::json!(name))
         }
         "download_model" => {
             let url = args["url"].as_str().ok_or("Missing url")?.to_string();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -526,9 +526,13 @@
 
   // Dismiss the right-click suggestion menu on any prompt edit: its items close over
   // fixed offsets, so editing the prompt while it is open would splice at stale positions.
+  // Only `value` may trigger this — reading spellMenuVisible reactively would make opening
+  // the menu (which sets it true) re-run the effect and immediately close it again.
   $effect(() => {
     void value;
-    if (spellMenuVisible) spellMenuVisible = false;
+    untrack(() => {
+      if (spellMenuVisible) spellMenuVisible = false;
+    });
   });
 
   function handleClickableSegmentMouseDown(event: MouseEvent, segment: PromptClickableSegment) {

--- a/src/lib/components/modelhub/ModelHubPage.svelte
+++ b/src/lib/components/modelhub/ModelHubPage.svelte
@@ -6,6 +6,7 @@
     getConfig,
     getModelInstallDirs,
     listCivitaiArchitectures,
+    resolveDownloadFilename,
     searchCivitaiModels,
     updateConfig,
     type ModelInstallDir,
@@ -410,21 +411,78 @@
     lastInferredDirectFilename = inferred;
   }
 
+  // Guards the async server-side filename lookup: only the newest request may
+  // write a result, and a pending debounce is cancelled when the URL changes.
+  let directFilenameResolveToken = 0;
+  let directFilenameResolveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function resolveDirectFilenameFromServer(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      return; // Not a full URL yet — keep the URL-inferred guess.
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+
+    const token = ++directFilenameResolveToken;
+    try {
+      // Pass the raw URL: the backend attaches per-host auth (CivitAI key /
+      // HF token) itself, so no token is leaked across hosts.
+      const resolved = await resolveDownloadFilename(trimmed);
+      if (token !== directFilenameResolveToken) return; // URL changed mid-flight.
+      const candidate = safeFilenameCandidate(resolved);
+      if (!candidate) return;
+      // Only overwrite when the user has not typed their own filename.
+      if (!directFilename.trim() || directFilename.trim() === lastInferredDirectFilename) {
+        directFilename = candidate;
+      }
+      lastInferredDirectFilename = candidate;
+    } catch {
+      // Best-effort: keep the URL-inferred name on failure.
+    }
+  }
+
   function handleDirectUrlInput(event: Event) {
     const value = (event.currentTarget as HTMLInputElement).value;
     directStatus = null;
     applyDirectUrlFilename(value);
+    // Debounce a server lookup that fills in names the URL itself does not carry
+    // (e.g. CivitAI /api/download/models/{id} links).
+    if (directFilenameResolveTimer) clearTimeout(directFilenameResolveTimer);
+    directFilenameResolveTimer = setTimeout(() => {
+      void resolveDirectFilenameFromServer(value);
+    }, 600);
   }
 
-  function loadApiKey() {
+  async function loadApiKey() {
+    // The CivitAI key now lives in AppConfig (shared with Settings and the backend
+    // lookup/download commands) instead of a separate localStorage copy.
+    let saved = "";
     try {
-      const saved = localStorage.getItem(CIVITAI_API_KEY_KEY) ?? "";
-      apiKey = saved;
-      apiKeyDraft = saved;
+      const cfg = await getConfig();
+      saved = (cfg.civitai_api_key ?? "").trim();
+      // One-time migration: older builds stored the key only in localStorage.
+      if (!saved) {
+        const legacy = (localStorage.getItem(CIVITAI_API_KEY_KEY) ?? "").trim();
+        if (legacy) {
+          saved = legacy;
+          cfg.civitai_api_key = legacy;
+          await updateConfig(cfg);
+        }
+      }
+      try {
+        localStorage.removeItem(CIVITAI_API_KEY_KEY);
+      } catch {
+        // Ignore storage failures — config is the source of truth.
+      }
     } catch {
-      apiKey = "";
-      apiKeyDraft = "";
+      saved = "";
     }
+    apiKey = saved;
+    apiKeyDraft = saved;
   }
 
   function loadCivitaiColumns() {
@@ -453,16 +511,8 @@
     keySaved = true;
     keyRecommended = false;
     error = null;
-    try {
-      if (normalized) {
-        localStorage.setItem(CIVITAI_API_KEY_KEY, normalized);
-      } else {
-        localStorage.removeItem(CIVITAI_API_KEY_KEY);
-      }
-    } catch {
-      // Ignore storage failures and keep runtime key only.
-    }
-    // Also persist to AppConfig so backend hash-lookup commands can use the key
+    // Persist to AppConfig — the single source of truth shared with Settings and
+    // the backend CivitAI lookup/download commands.
     getConfig().then((cfg) => {
       cfg.civitai_api_key = normalized || null;
       return updateConfig(cfg);
@@ -746,7 +796,21 @@
       return;
     }
 
-    const inferredFilename = inferDirectFilenameFromUrl(trimmedUrl);
+    let inferredFilename = inferDirectFilenameFromUrl(trimmedUrl);
+    // If neither the field nor the URL yields a name (e.g. a CivitAI download
+    // link), ask the server before giving up — covers the case where Download is
+    // clicked before the debounced lookup in handleDirectUrlInput has run.
+    if (!directFilename.trim() && !inferredFilename) {
+      try {
+        const resolved = safeFilenameCandidate(await resolveDownloadFilename(trimmedUrl));
+        if (resolved) {
+          inferredFilename = resolved;
+          lastInferredDirectFilename = resolved;
+        }
+      } catch {
+        // Fall through to the required-filename error below.
+      }
+    }
     const finalFilename = filenameWithOriginalExtension(
       directFilename.trim() || inferredFilename || "",
       inferredFilename,
@@ -893,7 +957,7 @@
   onMount(() => {
     let unlisten: (() => void) | null = null;
 
-    loadApiKey();
+    void loadApiKey();
     loadCivitaiColumns();
     loadArchitectureCache();
     void fetchArchitectures();
@@ -931,6 +995,7 @@
 
     return () => {
       if (unlisten) unlisten();
+      if (directFilenameResolveTimer) clearTimeout(directFilenameResolveTimer);
     };
   });
 </script>

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -146,6 +146,16 @@ export async function cancelDownload(filename: string): Promise<void> {
   return ipcInvoke("cancel_download", { filename });
 }
 
+/**
+ * Ask the backend for the real filename a download URL resolves to, read from the
+ * server's Content-Disposition header (no file is downloaded). Returns null when
+ * the server reports no usable name. Used to autopopulate the Model Hub direct
+ * download filename, including for CivitAI links whose name is not in the URL.
+ */
+export async function resolveDownloadFilename(url: string): Promise<string | null> {
+  return ipcInvoke("resolve_download_filename", { url });
+}
+
 export interface ModelInstallDir {
   path: string;
   label: string;


### PR DESCRIPTION
Release v1.4.29.

## New in this release branch

### Model Hub / CivitAI
- Unify the CivitAI API key so the Model Hub and Settings share one value (config-backed), with automatic one-time migration from the old separate Model Hub key.
- Autopopulate the save-as filename for direct download URLs by reading the Content-Disposition header from the server (new `resolve_download_filename` command, per-host auth, headers-only ranged GET). Falls back silently on any failure.
- Clearer CivitAI download error for 401/403/404: explains the version may be removed or requires an account that can view restricted/mature content, and points to the shared API key in Settings.

### Prompt tag spell check
- Fix the right-click "did you mean" menu doing nothing on desktop: an effect was reading the menu-visible state reactively and self-closing the menu before the replacement applied. Resolved with `untrack`.

## Also shipped (already merged to main since v1.4.28)
- Danbooru tag-aware spell checker for prompts (#406)
- Generation/gallery UX fixes and external LLM endpoint (#401)
- Ctrl+V image paste into i2i/inpaint on Linux (#402)
- Raise auto VRAM high-mode threshold to 24 GB (#405)
- Dependency updates (Rust and frontend)

## Notes
- Two stray pnpm artifacts in the working tree (a `pnpm-lock.yaml` dependency resync and a new `pnpm-workspace.yaml`) were deliberately excluded from this release; they are unrelated to the changes here and will be handled separately.
- Validation: `cargo check`, `cargo fmt --check`, and `npm run build` all pass; clippy reports no new warnings.
