### PR TITLE
v1.4.34: Fix server/browser build regression from ComfyUI version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.34
+
+### Fixes
+- **Browser/server build**: fixed a regression that broke the server binary and Docker image builds. The ComfyUI version check shipped in v1.4.33 referenced a desktop-only module, so the hosted browser-mode build failed to compile. The shared version logic now lives in its own module compiled into both the desktop and server builds. Desktop installs were unaffected; this restores the browser and hosted deployments.
+
+---
+
 ## What's New in v1.4.33
 
 ### Models and downloads

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.34
+
+### Fixes
+- **Browser/server build**: fixed a regression that broke the server binary and Docker image builds. The ComfyUI version check shipped in v1.4.33 referenced a desktop-only module, so the hosted browser-mode build failed to compile. The shared version logic now lives in its own module compiled into both the desktop and server builds. Desktop installs were unaffected; this restores the browser and hosted deployments.
+
+---
+
 ## What's New in v1.4.33
 
 ### Models and downloads

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.33",
+  "version": "1.4.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.33"
+version = "1.4.34"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.33"
+version = "1.4.34"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui_version.rs
+++ b/src-tauri/src/comfyui_version.rs
@@ -1,0 +1,96 @@
+//! Installed-vs-target ComfyUI version reporting.
+//!
+//! This logic is shared by the desktop Tauri command
+//! ([`crate::setup::get_comfyui_version`]) and the browser-mode webserver
+//! dispatch, so it lives in its own module compiled for both the `desktop` and
+//! `server` builds rather than inside the desktop-only `setup` module.
+
+use std::path::Path;
+
+/// Pinned ComfyUI release tag that the app installs and updates to.
+///
+/// Fresh installs and the in-app "Update ComfyUI" action both target this exact
+/// tag, so every MooshieUI build runs against a known-good ComfyUI rather than
+/// whatever `master` happened to be at install time. The scheduled
+/// `comfyui-compat` workflow opens a bot PR bumping this constant once the
+/// custom-node smoke test passes against a newer ComfyUI release.
+pub const COMFYUI_REF: &str = "v0.26.0";
+
+/// Read the installed ComfyUI version from its `comfyui_version.py` file
+/// (`__version__ = "0.26.0"`). Returns `None` if the file is missing or
+/// unparseable (e.g. a very old ComfyUI without the version module).
+fn read_installed_comfyui_version(comfyui_dir: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(comfyui_dir.join("comfyui_version.py")).ok()?;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("__version__") {
+            if let Some(value) = rest.split('=').nth(1) {
+                let v = value.trim().trim_matches(|c| c == '"' || c == '\'');
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Parse a ComfyUI version string (`v0.26.0` / `0.26.0`) into numeric parts,
+/// tolerating trailing non-digits in any component.
+fn parse_comfyui_version(v: &str) -> Vec<u32> {
+    v.trim_start_matches('v')
+        .split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        })
+        .collect()
+}
+
+/// True when `installed` is strictly older than `target` (so an update is worth
+/// offering). A newer-or-equal install is not flagged, to avoid presenting a
+/// downgrade as an "update".
+fn comfyui_version_is_older(installed: &str, target: &str) -> bool {
+    let a = parse_comfyui_version(installed);
+    let b = parse_comfyui_version(target);
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        if x != y {
+            return x < y;
+        }
+    }
+    false
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct ComfyUiVersionInfo {
+    /// Version currently installed on disk, if detectable.
+    pub installed: Option<String>,
+    /// The pinned tag this MooshieUI build targets ([`COMFYUI_REF`]).
+    pub target: String,
+    /// True when the installed version is older than the pinned target.
+    pub update_available: bool,
+}
+
+/// Compute the installed-vs-target version report for a ComfyUI checkout.
+/// Shared by the desktop command and the browser-mode webserver dispatch.
+pub fn comfyui_version_info(comfyui_dir: &Path) -> ComfyUiVersionInfo {
+    let installed = read_installed_comfyui_version(comfyui_dir);
+    let update_available = match installed.as_deref() {
+        Some(v) => comfyui_version_is_older(v, COMFYUI_REF),
+        // An install with main.py but no comfyui_version.py predates the
+        // version module entirely, so it is always older than the pinned
+        // target. No main.py means ComfyUI isn't installed at all — that is
+        // the setup wizard's job, not the updater's.
+        None => comfyui_dir.join("main.py").exists(),
+    };
+    ComfyUiVersionInfo {
+        installed,
+        target: COMFYUI_REF.to_string(),
+        update_available,
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod auth;
 pub mod comfyui;
+#[cfg(any(feature = "desktop", feature = "server"))]
+pub mod comfyui_version;
 pub mod commands;
 pub mod config;
 pub mod error;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -4,18 +4,10 @@ use std::sync::Arc;
 use std::process::Stdio;
 use tauri::{AppHandle, Emitter, Manager};
 
+use crate::comfyui_version::{comfyui_version_info, ComfyUiVersionInfo, COMFYUI_REF};
 use crate::config;
 use crate::error::AppError;
 use crate::state::AppState;
-
-/// Pinned ComfyUI release tag that the app installs and updates to.
-///
-/// Fresh installs and the in-app "Update ComfyUI" action both target this exact
-/// tag, so every MooshieUI build runs against a known-good ComfyUI rather than
-/// whatever `master` happened to be at install time. The scheduled
-/// `comfyui-compat` workflow opens a bot PR bumping this constant once the
-/// custom-node smoke test passes against a newer ComfyUI release.
-pub const COMFYUI_REF: &str = "v0.26.0";
 
 /// Directory name GitHub's source archive expands to for [`COMFYUI_REF`].
 /// GitHub strips a leading `v` from the tag, e.g. `v0.26.0` -> `ComfyUI-0.26.0`.
@@ -2134,85 +2126,6 @@ pub async fn run_setup(
 }
 
 // ─── In-app ComfyUI updater ──────────────────────────────────────────────────
-
-/// Read the installed ComfyUI version from its `comfyui_version.py` file
-/// (`__version__ = "0.26.0"`). Returns `None` if the file is missing or
-/// unparseable (e.g. a very old ComfyUI without the version module).
-fn read_installed_comfyui_version(comfyui_dir: &Path) -> Option<String> {
-    let text = std::fs::read_to_string(comfyui_dir.join("comfyui_version.py")).ok()?;
-    for line in text.lines() {
-        let line = line.trim();
-        if let Some(rest) = line.strip_prefix("__version__") {
-            if let Some(value) = rest.split('=').nth(1) {
-                let v = value.trim().trim_matches(|c| c == '"' || c == '\'');
-                if !v.is_empty() {
-                    return Some(v.to_string());
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Parse a ComfyUI version string (`v0.26.0` / `0.26.0`) into numeric parts,
-/// tolerating trailing non-digits in any component.
-fn parse_comfyui_version(v: &str) -> Vec<u32> {
-    v.trim_start_matches('v')
-        .split('.')
-        .map(|part| {
-            part.chars()
-                .take_while(|c| c.is_ascii_digit())
-                .collect::<String>()
-                .parse()
-                .unwrap_or(0)
-        })
-        .collect()
-}
-
-/// True when `installed` is strictly older than `target` (so an update is worth
-/// offering). A newer-or-equal install is not flagged, to avoid presenting a
-/// downgrade as an "update".
-fn comfyui_version_is_older(installed: &str, target: &str) -> bool {
-    let a = parse_comfyui_version(installed);
-    let b = parse_comfyui_version(target);
-    for i in 0..a.len().max(b.len()) {
-        let x = a.get(i).copied().unwrap_or(0);
-        let y = b.get(i).copied().unwrap_or(0);
-        if x != y {
-            return x < y;
-        }
-    }
-    false
-}
-
-#[derive(Clone, serde::Serialize)]
-pub struct ComfyUiVersionInfo {
-    /// Version currently installed on disk, if detectable.
-    pub installed: Option<String>,
-    /// The pinned tag this MooshieUI build targets ([`COMFYUI_REF`]).
-    pub target: String,
-    /// True when the installed version is older than the pinned target.
-    pub update_available: bool,
-}
-
-/// Compute the installed-vs-target version report for a ComfyUI checkout.
-/// Shared by the desktop command and the browser-mode webserver dispatch.
-pub fn comfyui_version_info(comfyui_dir: &Path) -> ComfyUiVersionInfo {
-    let installed = read_installed_comfyui_version(comfyui_dir);
-    let update_available = match installed.as_deref() {
-        Some(v) => comfyui_version_is_older(v, COMFYUI_REF),
-        // An install with main.py but no comfyui_version.py predates the
-        // version module entirely, so it is always older than the pinned
-        // target. No main.py means ComfyUI isn't installed at all — that is
-        // the setup wizard's job, not the updater's.
-        None => comfyui_dir.join("main.py").exists(),
-    };
-    ComfyUiVersionInfo {
-        installed,
-        target: COMFYUI_REF.to_string(),
-        update_available,
-    }
-}
 
 /// Report the installed ComfyUI version against the pinned target so the
 /// Settings UI can offer an update.

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4061,7 +4061,7 @@ async fn dispatch_command(
             let config = state.config.read().await;
             let comfyui_dir = std::path::Path::new(&config.comfyui_path).to_path_buf();
             drop(config);
-            let info = crate::setup::comfyui_version_info(&comfyui_dir);
+            let info = crate::comfyui_version::comfyui_version_info(&comfyui_dir);
             Ok(serde_json::to_value(info).map_err(|e| e.to_string())?)
         }
         "fetch_release_notes" => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.33",
+  "version": "1.4.34",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Hotfix for the v1.4.33 release: the `build-server` job failed to compile, so the browser-mode server binary and Docker image were never published.

## Root cause

The ComfyUI version check added in v1.4.33 called `crate::setup::comfyui_version_info` from `webserver.rs`. The `setup` module is gated `#[cfg(feature = "desktop")]`, so it is absent from the `--no-default-features --features server` build, producing `error[E0433]: cannot find 'setup' in 'crate'`. The desktop and Windows builds compiled fine, which is why local `cargo check` (desktop features) did not catch it.

## Fix

Moved the shared version logic (`COMFYUI_REF`, `ComfyUiVersionInfo`, `comfyui_version_info`, and its private helpers) into a new `comfyui_version` module gated `#[cfg(any(feature = "desktop", feature = "server"))]`, compiled into both builds. `setup.rs` re-imports these for the desktop `get_comfyui_version` command and the updater; `webserver.rs` now calls `crate::comfyui_version::comfyui_version_info`.

## Validation

- `cargo check` (desktop, default features): pass
- `cargo check --no-default-features --features server --bin mooshieui-server`: pass (the previously failing build)
- `cargo fmt --check`: pass
- `npm run build`: pass

Desktop installs were unaffected by the regression; this restores the browser and hosted server deployments.