### PR TITLE
v1.4.36: One-click in-app bug reports file GitHub issues via hosted proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.36
+
+### Error reporting
+- **One-click bug reports that file a real issue**: when something goes wrong, the in-app "report this" action now sends the report to a hosted service that opens a GitHub issue for you and hands back the link, no GitHub account or sign-in required. Reports arrive already labeled and enriched with your app version, OS, and error details, and identical repeats are folded into the existing issue instead of piling up duplicates. If the service is ever unreachable, the app falls back to the previous behavior of opening a prefilled issue in your browser, so a report is never lost. No error text or credentials are sent anywhere unless you choose to submit a report.
+
+---
+
 ## What's New in v1.4.35
 
 ### Diagnostics

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.36
+
+### Error reporting
+- **One-click bug reports that file a real issue**: when something goes wrong, the in-app "report this" action now sends the report to a hosted service that opens a GitHub issue for you and hands back the link, no GitHub account or sign-in required. Reports arrive already labeled and enriched with your app version, OS, and error details, and identical repeats are folded into the existing issue instead of piling up duplicates. If the service is ever unreachable, the app falls back to the previous behavior of opening a prefilled issue in your browser, so a report is never lost. No error text or credentials are sent anywhere unless you choose to submit a report.
+
+---
+
 ## What's New in v1.4.35
 
 ### Diagnostics

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.35"
+version = "1.4.36"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.35"
+version = "1.4.36"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.35",
+  "version": "1.4.36",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.4.36

Version bump and changelog for the report-proxy sub-project, which merged in #428 and is now deployed and live.

### Error reporting
- The in-app "report this" action now posts to a hosted proxy that files a GitHub issue and returns the link, no GitHub account required. Reports are labeled and enriched (app version, OS, error details); identical repeats are deduped onto the existing issue. If the proxy is unreachable, the app falls back to the previous prefilled-issue-in-browser behavior. Report endpoint is on by default (config.rs), so this ships to users with this release.

### Release contents
- Version bump to 1.4.36 across package.json, Cargo.toml, tauri.conf.json (+ Cargo.lock).
- RELEASE_NOTES.md and CHANGELOG.md updated.

### Validation
- cargo check: pass
- npm run build: pass

### Bot triage
- No open PRs; #428 (only merged PR since v1.4.35) had no outstanding bot Fix items.