### PR TITLE
v1.4.38: Fix custom right-click menu position and stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.4.38
+
+### Bug fixes
+- **Right-click menus now open at the cursor and above panels**: the custom right-click menu introduced in the last update could appear far to the right of where you clicked and get clipped behind generation panels. It now opens exactly where you click and floats above everything, including the fullscreen image viewer.
+
+---
+
 ## What's New in v1.4.37
 
 ### Hires Fix and upscaling

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.4.38
+
+### Bug fixes
+- **Right-click menus now open at the cursor and above panels**: the custom right-click menu introduced in the last update could appear far to the right of where you clicked and get clipped behind generation panels. It now opens exactly where you click and floats above everything, including the fullscreen image viewer.
+
+---
+
 ## What's New in v1.4.37
 
 ### Hires Fix and upscaling

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.37"
+version = "1.4.38"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.37"
+version = "1.4.38"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.37",
+  "version": "1.4.38",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/ui/ContextMenu.svelte
+++ b/src/lib/components/ui/ContextMenu.svelte
@@ -33,6 +33,19 @@
     return Math.min(y, window.innerHeight - h - 8);
   });
 
+  // Portal the menu to <body> so `position: fixed` resolves against the viewport.
+  // Rendered inline, a transformed/`will-change-transform` ancestor (the generation
+  // panels) becomes the containing block, which shifts the menu right of the cursor
+  // and lets the panel's `overflow-hidden` clip it (#421 follow-up).
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
+
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -65,6 +78,7 @@
 {#if visible}
   <div
     bind:this={menuEl}
+    use:portal
     class="fixed z-[100] min-w-[180px] bg-neutral-800 border border-neutral-700 rounded-lg shadow-xl py-1 select-none"
     style="left: {clampedX}px; top: {clampedY}px;"
     role="menu"


### PR DESCRIPTION
## v1.4.38

Follow-up bug fix for the custom right-click menus added in #421.

### Bug fixes
- Custom context menu now opens at the cursor position instead of far to the right, and floats above generation panels and the fullscreen viewer instead of being clipped behind them.

### Root cause
The shared `ContextMenu` uses `position: fixed`, which is only viewport-relative when no ancestor establishes a containing block. The generation panels wrapping `PreviewImage` set `will-change: transform` plus explicit `transform:` and `overflow-hidden`, so the panel box became the containing block. That both offset the menu (left/top resolved against the panel, not the viewport) and clipped it (overflow-hidden). The lightbox `<img>` carries `will-change: transform` too.

### Fix
Added a `portal` action to the shared `ContextMenu.svelte` that appends the menu to `document.body`, matching the existing `PromptTextarea.svelte` / `InterrogateModal.svelte` pattern. Centralized in the shared component, so every call site is fixed at once. Menu stays at `z-[100]`, above the lightbox backdrop (`z-50`).

### Validation
- `npm run build` passed
- `cargo check` passed (version bump only in Rust)

No open PRs or new bot comments to triage this cycle.