### PR TITLE
fix: recover refined images reliably in browser mode (#436)

### DIFF
--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2416,24 +2416,26 @@ async fn dispatch_command(
             let ids = state.prompt_queue.related_ids(prompt_id);
             let mut cached = Vec::new();
             {
-                let mut outputs = state.output_image_cache.write().unwrap();
+                // Read without removing so a later reconcile pass can retry
+                // recovery if the client's image fetch fails. The entries are
+                // cleaned up by the TEMP_EVENT_CACHE_TTL reactor, so leaving
+                // them in place does not leak.
+                let outputs = state.output_image_cache.read().unwrap();
                 for id in &ids {
-                    if let Some(files) = outputs.remove(id) {
-                        cached.extend(files);
+                    if let Some(files) = outputs.get(id) {
+                        cached.extend(files.iter().cloned());
                     }
                 }
             }
             let mut seen = std::collections::HashSet::new();
             cached.retain(|f| seen.insert(f.clone()));
+            // Return every cached output. Recovery only runs when the client
+            // received zero images, so a Hires Fix prompt (pre-upscale +
+            // refined) must yield both here rather than only the last.
             let images: Vec<serde_json::Value> = cached
                 .into_iter()
                 .map(|f| serde_json::json!({ "temp_filename": f }))
                 .collect();
-            let images = if images.len() > 1 {
-                vec![images.last().cloned().unwrap()]
-            } else {
-                images
-            };
             Ok(serde_json::json!({ "images": images }))
         }
         "interrupt_generation" => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,8 +113,10 @@
   let pendingOutputImages = new Map<string, Array<{ blob: Blob; url: string; tempFilename?: string; displayTempFilename?: string }>>();
   /** In-flight output_image fetch promises per prompt_id (for SSE race-condition avoidance). */
   let pendingOutputFetches = new Map<string, Promise<void>[]>();
-  /** Wait for pending fetches with a hard time limit to prevent hanging. */
-  const FETCH_TIMEOUT_MS = 30_000;
+  /** Wait for pending fetches with a hard time limit to prevent hanging.
+   *  Sized to leave room for fetchTempImageWithRetry's backoff (~5.6s) plus the
+   *  transfer of a large upscaled/16-bit refined image over a slow remote link. */
+  const FETCH_TIMEOUT_MS = 45_000;
   const GENERATION_DONE_TOAST_VISIBLE_MS = 6_000;
   const GENERATION_DONE_TOAST_EXIT_MS = 220;
   type PrimaryPage = "generate" | "gallery" | "modelhub" | "artists" | "characters" | "settings";
@@ -127,19 +129,28 @@
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, FETCH_TIMEOUT_MS));
     await Promise.race([Promise.allSettled(fetches), timeout]);
   }
-  /** Fetch a `_temp_image` URL, retrying once after a short delay. A transient
-   *  failure here (e.g. a 401 while the LAN session token refreshes) would
-   *  otherwise drop the final output image and leave the blurry progress
-   *  preview stuck as the displayed result. */
-  async function fetchTempImageWithRetry(url: string): Promise<Response> {
-    try {
-      const resp = await fetch(url, { headers: authHeaders() });
-      if (resp.ok) return resp;
-    } catch {
-      // fall through to retry
+  /** Fetch a `_temp_image` URL, retrying a few times with exponential backoff.
+   *  A transient failure here (e.g. a 401 while the LAN session token refreshes,
+   *  or a slow remote link) would otherwise drop the final output image and
+   *  leave the blurry progress preview stuck as the displayed result. The
+   *  refined/upscaled image is the largest payload the app ever fetches, so it
+   *  is the most likely to need more than one attempt before we give up. */
+  async function fetchTempImageWithRetry(url: string, attempts = 4): Promise<Response> {
+    let lastResp: Response | null = null;
+    for (let i = 0; i < attempts; i++) {
+      if (i > 0) {
+        // Backoff: 0.8s, 1.6s, 3.2s.
+        await new Promise((resolve) => setTimeout(resolve, 800 * 2 ** (i - 1)));
+      }
+      try {
+        const resp = await fetch(url, { headers: authHeaders() });
+        if (resp.ok) return resp;
+        lastResp = resp;
+      } catch {
+        // network error — retry
+      }
     }
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    return fetch(url, { headers: authHeaders() });
+    return lastResp ?? new Response(null, { status: 599, statusText: "fetch failed" });
   }
   let reconcileIntervalId: ReturnType<typeof setInterval> | null = null;
   let sseReconnectHandler: (() => void) | null = null;

--- a/src/lib/components/progress/ProgressBar.svelte
+++ b/src/lib/components/progress/ProgressBar.svelte
@@ -22,7 +22,7 @@
     </div>
     <div class="w-full h-2 bg-neutral-800 rounded-full overflow-hidden">
       <div
-        class="h-full rounded-full transition-[width] duration-200 {progress.regionalChainStatus && !progress.hasReliableStepProgress ? 'animate-pulse ' : ''}{progress.wasUpscaled && progress.samplingPass >= 2 ? 'bg-emerald-500' : 'bg-indigo-500'}"
+        class="h-full rounded-full transition-[width] duration-200 {progress.regionalChainStatus && !progress.hasReliableStepProgress ? 'animate-pulse ' : ''}{progress.isUpscalePhase ? 'bg-emerald-500' : 'bg-indigo-500'}"
         style="width: {progress.hasReliableStepProgress ? progress.percentage : 100}%"
       ></div>
     </div>

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -91,6 +91,18 @@ class ProgressStore {
     return this.activePrompt?.wasUpscaled ?? this._lastCompletedWasUpscaled;
   }
 
+  /** True when the active generation is in its upscale/refine sampling pass.
+   *  Normal hires-fix runs a base pass then an upscale pass (samplingPass >= 2).
+   *  The "Refine" button (refine_only) skips the base sampler, so its single
+   *  sampling pass IS the upscale pass — otherwise it would never show the
+   *  "upscaling" phase label or the emerald bar, making the refine look like it
+   *  never ran. */
+  get isUpscalePhase(): boolean {
+    if (!this.wasUpscaled) return false;
+    if (this.samplingPass >= 2) return true;
+    return this.activePrompt?.params?.refine_only === true && this.samplingPass >= 1;
+  }
+
   get lastParams(): GenerationParams | null {
     return this.activePrompt?.params ?? null;
   }
@@ -175,7 +187,7 @@ class ProgressStore {
         ? locale.t("progress.applying_style_reference_queued", { count: String(queuedSuffix) })
         : locale.t("progress.applying_style_reference");
     }
-    if (this.wasUpscaled && this.samplingPass >= 2) {
+    if (this.isUpscalePhase) {
       return this.queueCount > 1
         ? locale.t("progress.upscaling_queued", { count: String(queuedSuffix) })
         : locale.t("progress.upscaling");


### PR DESCRIPTION
Fixes #436 (browser mode: "stuck at 100%, cannot see any refines").

A refine / hires-fix runs the upscale chain as part of one ComfyUI prompt, and its finished image flows through the same delivery path as any generation. In browser mode that final image is HTTP-fetched from a temp endpoint, and the refined (upscaled, sometimes 16-bit) image is the largest payload the app fetches. When that fetch failed or timed out, completion fell back to the blurry live-preview frame, so the refine looked like it never appeared while the bar sat at 100%.

## Changes

- **Harden the temp-image fetch** (`src/App.svelte`): `fetchTempImageWithRetry` now makes 4 attempts with exponential backoff (0.8s to 3.2s) instead of a single retry, so a transient failure (slow remote link, or a 401 during a LAN token refresh) no longer drops the final image.
- **Widen `FETCH_TIMEOUT_MS`** 30s to 45s to leave room for the retries plus a large transfer.
- **Non-destructive, complete recovery** (`src-tauri/src/webserver.rs`): `recover_prompt_outputs` reads instead of removing from the cache so a later reconcile pass can retry, and returns every cached output so a Hires Fix prompt recovers both the pre-upscale and refined images instead of only the last. The 10 minute TTL reactor still cleans up.
- **Refine phase label** (`progress.svelte.ts` + `ProgressBar.svelte`): a `refine_only` pass runs a single sampler, so it never reached `samplingPass >= 2` and never showed the "upscaling" label or emerald bar. A new `isUpscalePhase` getter treats a refine-only pass as the upscale phase.

## Validation

- Frontend `npm run build`: passes.
- Rust compiles under the `server` feature (where `webserver.rs` lives); the desktop feature build only fails locally on a missing GTK system lib, unrelated to this change.
- No new i18n keys (reuses existing `progress.upscaling` keys).

No version bump / changelog / tag (non-release change).

---
_Generated by [Claude Code](https://claude.ai/code/session_013KScxNvVsBYfajmXBXUmdE)_