### PR TITLE
ci(release): run all release jobs on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ permissions:
   contents: write
   packages: write
 
-# NUC runner only for build-server + docker-publish on official Mooshieblob1 releases.
-# Desktop build (Linux + Windows) always uses GitHub-hosted runners.
+# All jobs run on GitHub-hosted runners. The self-hosted NUC path is kept behind
+# this flag (flip back to the repository/actor check to re-enable it).
 env:
-  USE_NUC_RUNNER: ${{ github.repository == 'Mooshieblob1/MooshieUI' && github.actor == 'Mooshieblob1' }}
+  USE_NUC_RUNNER: 'false'
 
 jobs:
   build:
@@ -229,7 +229,7 @@ jobs:
   # Headless server binary (no webkit / Tauri deps required)
   # -------------------------------------------------------------------------
   build-server:
-    runs-on: ${{ github.repository == 'Mooshieblob1/MooshieUI' && github.actor == 'Mooshieblob1' && fromJSON('["self-hosted","mooshie-nuc","linux"]') || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -276,7 +276,7 @@ jobs:
   # -------------------------------------------------------------------------
   docker-publish:
     needs: build-server
-    runs-on: ${{ github.repository == 'Mooshieblob1/MooshieUI' && github.actor == 'Mooshieblob1' && fromJSON('["self-hosted","mooshie-nuc","linux"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Prepare local Docker build cache (NUC)


### PR DESCRIPTION
Switches the Build & Release workflow off the self-hosted NUC runner and back to GitHub-hosted runners for all jobs going forward.

## Changes
- `USE_NUC_RUNNER` is forced to `false` (kept as a flag so the NUC path can be re-enabled by flipping it back to the repository/actor check).
- `build-server` now runs on `ubuntu-22.04` (was the NUC runner for owner releases).
- `docker-publish` now runs on `ubuntu-latest` (was the NUC runner for owner releases).

The GitHub-hosted fallback paths already existed (they ran on forks and non-owner triggers), including the disk-cleanup step the CUDA/PyTorch Docker build needs, so this just makes them the default. The desktop `build` matrix already ran on hosted runners and is unchanged.

Does not affect the in-flight v1.4.40 release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CkQDbjQ5LGRNh684QZ6K9Q)_