### PR TITLE
v1.4.41: In-box prompt token counter and remembered panel collapse state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v1.4.41
+
+### Improvements
+- **Token counter moved into the prompt box**: the CLIP token estimate now sits unobtrusively in the top-right corner inside each prompt field, shown as a compact `count/limit` (it still turns amber when a prompt spills past the 75-token chunk boundary).
+- **Panel collapse state is remembered**: collapsing the left, right, or bottom panel now persists across restarts, so your layout stays the way you left it. Expanding a restored-collapsed panel brings back its previous size.
+
+---
+
 ## What's New in v1.4.40
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v1.4.41
+
+### Improvements
+- **Token counter moved into the prompt box**: the CLIP token estimate now sits unobtrusively in the top-right corner inside each prompt field, shown as a compact `count/limit` (it still turns amber when a prompt spills past the 75-token chunk boundary).
+- **Panel collapse state is remembered**: collapsing the left, right, or bottom panel now persists across restarts, so your layout stays the way you left it. Expanding a restored-collapsed panel brings back its previous size.
+
+---
+
 ## What's New in v1.4.40
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.4.40",
+  "version": "1.4.41",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.4.40"
+version = "1.4.41"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.4.40"
+version = "1.4.41"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.4.40",
+  "version": "1.4.41",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -760,20 +760,26 @@
     try {
       const raw = localStorage.getItem(PANEL_LAYOUT_KEY);
       if (raw) {
-        const s = JSON.parse(raw) as { left?: number; right?: number; bottom?: number };
+        const s = JSON.parse(raw) as {
+          left?: number; right?: number; bottom?: number;
+          leftCollapsed?: boolean; rightCollapsed?: boolean; bottomCollapsed?: boolean;
+        };
         return {
           left: typeof s.left === "number" ? Math.min(LEFT_MAX, Math.max(LEFT_MIN, s.left)) : LEFT_DEFAULT,
           right: typeof s.right === "number" ? Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, s.right)) : RIGHT_DEFAULT,
           bottom: typeof s.bottom === "number" ? Math.min(BOTTOM_MAX, Math.max(BOTTOM_MIN, s.bottom)) : BOTTOM_DEFAULT,
+          leftCollapsed: s.leftCollapsed === true,
+          rightCollapsed: s.rightCollapsed === true,
+          bottomCollapsed: s.bottomCollapsed === true,
         };
       }
     } catch {}
-    return { left: LEFT_DEFAULT, right: RIGHT_DEFAULT, bottom: BOTTOM_DEFAULT };
+    return { left: LEFT_DEFAULT, right: RIGHT_DEFAULT, bottom: BOTTOM_DEFAULT, leftCollapsed: false, rightCollapsed: false, bottomCollapsed: false };
   }
 
   function savePanelLayout() {
     try {
-      localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify({ left: leftWidth, right: rightWidth, bottom: bottomHeight }));
+      localStorage.setItem(PANEL_LAYOUT_KEY, JSON.stringify({ left: leftWidth, right: rightWidth, bottom: bottomHeight, leftCollapsed, rightCollapsed, bottomCollapsed }));
     } catch {}
   }
 
@@ -792,15 +798,16 @@
   let rightWidth = $state(_savedLayout.right);
   let bottomHeight = $state(_savedLayout.bottom);
 
-  // Panel collapse state
-  let leftCollapsed = $state(false);
-  let rightCollapsed = $state(false);
-  let bottomCollapsed = $state(false);
+  // Panel collapse state (restored from persisted layout)
+  let leftCollapsed = $state(_savedLayout.leftCollapsed);
+  let rightCollapsed = $state(_savedLayout.rightCollapsed);
+  let bottomCollapsed = $state(_savedLayout.bottomCollapsed);
 
-  // Store pre-collapse widths/heights so we can restore them
-  let leftWidthBeforeCollapse = LEFT_DEFAULT;
-  let rightWidthBeforeCollapse = RIGHT_DEFAULT;
-  let bottomHeightBeforeCollapse = BOTTOM_DEFAULT;
+  // Store pre-collapse widths/heights so we can restore them. Seed from the saved
+  // sizes so expanding a panel that was restored as collapsed brings back its real size.
+  let leftWidthBeforeCollapse = _savedLayout.left;
+  let rightWidthBeforeCollapse = _savedLayout.right;
+  let bottomHeightBeforeCollapse = _savedLayout.bottom;
 
   function toggleLeftPanel() {
     if (mobileFriendly) {
@@ -815,6 +822,7 @@
       leftWidthBeforeCollapse = leftWidth;
       leftCollapsed = true;
     }
+    savePanelLayout();
   }
 
   function toggleRightPanel() {
@@ -830,6 +838,7 @@
       rightWidthBeforeCollapse = rightWidth;
       rightCollapsed = true;
     }
+    savePanelLayout();
   }
 
   function toggleBottomPanel() {
@@ -845,6 +854,7 @@
       bottomHeightBeforeCollapse = bottomHeight;
       bottomCollapsed = true;
     }
+    savePanelLayout();
   }
 
   let dragging = $state<"left" | "right" | "bottom" | null>(null);

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -792,12 +792,6 @@
     {#if !hasSelection}
       <span class="min-w-0 truncate text-[10px] text-neutral-600" title={locale.t('generation.prompt.weight_select_hint')}>{locale.t('generation.prompt.weight_select_hint')}</span>
     {/if}
-    <span
-      class="ml-auto shrink-0 tabular-nums text-[10px] {tokenOverflow ? 'text-amber-400' : 'text-neutral-500'}"
-      title={locale.t('generation.prompt.tokens_tip')}
-    >
-      {tokenCount}/{tokenLimit} {locale.t('generation.prompt.tokens')}
-    </span>
   </div>
   <div class="relative">
     {#if showBackdrop}
@@ -874,6 +868,12 @@
         {/each}
       </div>
     {/if}
+
+    <span
+      class="pointer-events-none absolute top-1.5 z-[4] rounded bg-neutral-900/70 px-1 tabular-nums text-[10px] {tokenOverflow ? 'text-amber-400' : 'text-neutral-500'}"
+      style="right: {scrollbarWidth + 6}px;"
+      title={locale.t('generation.prompt.tokens_tip')}
+    >{tokenCount}/{tokenLimit}</span>
   </div>
 
   {#if showSuggestions}


### PR DESCRIPTION
## What's New in v1.4.41

### Improvements
- **Token counter moved into the prompt box**: the CLIP token estimate now sits in the top-right corner inside each prompt field as a compact `count/limit` (no "tokens" label), still turning amber past the 75-token chunk boundary. Uses `pointer-events-none` so it never blocks typing.
- **Panel collapse state is remembered**: left/right/bottom panel collapse now persists via the existing `mooshieui.panelLayout` localStorage record, so the layout survives restarts. Expanding a restored-collapsed panel restores its previous size (pre-collapse sizes seed from saved widths). Mobile behaviour unchanged.

### Validation
- Frontend `npm run build` (vite): passed.
- Rust: no source changes (version-string bump only); `Cargo.lock` updated to match. Full `cargo check` could not run locally due to pre-existing flake env drift (npm-deps hash mismatch); authoritative Rust build runs in CI.

No open PRs to triage; no bot findings outstanding at cut time.