### PR TITLE
ci(release): fix empty CARGO_TARGET_DIR in build-server on hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,10 +256,22 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Build server binary
+      # NUC path pins cargo home/target into the persistent cache dir. Split from the
+      # hosted path because an empty CARGO_TARGET_DIR (the old ternary fallback) makes
+      # cargo abort with "the target directory is set to an empty string".
+      - name: Build server binary (NUC)
+        if: env.USE_NUC_RUNNER == 'true'
         env:
-          CARGO_HOME: ${{ env.USE_NUC_RUNNER == 'true' && '/home/blob/.cargo' || '' }}
-          CARGO_TARGET_DIR: ${{ env.USE_NUC_RUNNER == 'true' && '/home/blob/ci-cache/mooshieui/target' || '' }}
+          CARGO_HOME: /home/blob/.cargo
+          CARGO_TARGET_DIR: /home/blob/ci-cache/mooshieui/target
+        run: |
+          cd src-tauri
+          cargo build --release --no-default-features --features server --bin mooshieui-server
+
+      # Hosted runners use cargo defaults (CARGO_HOME=~/.cargo, target=src-tauri/target)
+      # so the rust-cache action and the upload path below line up.
+      - name: Build server binary
+        if: env.USE_NUC_RUNNER != 'true'
         run: |
           cd src-tauri
           cargo build --release --no-default-features --features server --bin mooshieui-server


### PR DESCRIPTION
## Problem
The v1.4.41 `Build & Release` run failed: the `build-server` job aborted with

```
error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable
```

## Cause
The `Build server binary` step set `CARGO_TARGET_DIR`/`CARGO_HOME` via a ternary that falls back to `''` when `USE_NUC_RUNNER != 'true'`. Since #439 moved all jobs to GitHub-hosted runners (`USE_NUC_RUNNER='false'`), those vars became empty strings and cargo rejects an empty target dir.

## Fix
Split the step: a NUC-only variant keeps the persistent cache paths, and the hosted variant sets nothing so cargo uses its defaults (`~/.cargo`, `src-tauri/target`) which already line up with the rust-cache action and the artifact upload path.

Cascade unblocked: `build-server` → `docker-publish` (was skipped). Desktop Windows/Linux artifacts and the v1.4.41 GitHub Release already published successfully; re-dispatching `release.yml` for `v1.4.41` after this merges will produce the server binary and Docker image.