### PR TITLE
ci(release): use GHCR registry cache for docker build on hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,5 +351,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ env.USE_NUC_RUNNER == 'true' && 'type=local,src=/home/blob/ci-cache/docker/mooshieui' || 'type=gha' }}
-          cache-to: ${{ env.USE_NUC_RUNNER == 'true' && 'type=local,dest=/home/blob/ci-cache/docker/mooshieui,mode=max' || 'type=gha,mode=min,ignore-error=true' }}
+          # Hosted runners cache to a dedicated :buildcache tag in the same GHCR
+          # package (pushed with the existing GITHUB_TOKEN, no PAT needed). This
+          # sidesteps the 10 GB GitHub Actions cache cap that was evicting the
+          # multi-GB CUDA/torch layer and turning ~5 min builds into ~20 min ones.
+          # mode=max caches every stage; a cache miss/outage falls back to a full
+          # build (ignore-error), never a failure.
+          cache-from: ${{ env.USE_NUC_RUNNER == 'true' && 'type=local,src=/home/blob/ci-cache/docker/mooshieui' || format('type=registry,ref={0}:buildcache', steps.docker-vars.outputs.image) }}
+          cache-to: ${{ env.USE_NUC_RUNNER == 'true' && 'type=local,dest=/home/blob/ci-cache/docker/mooshieui,mode=max' || format('type=registry,ref={0}:buildcache,mode=max,ignore-error=true', steps.docker-vars.outputs.image) }}


### PR DESCRIPTION
## Why
`docker-publish` regressed from ~5 min (v0.9.x–v1.0.3) to ~15–29 min from v1.0.6 onward, with no Dockerfile or workflow change. Root cause: the ~4 GB CUDA/torch layer lives in the GitHub Actions cache (`type=gha`), and the repo now sits at 9.51 GB against the hard 10 GB GHA cache cap. LRU eviction drops that layer between runs, forcing a full torch/ComfyUI rebuild almost every release.

## Change
On GitHub-hosted runners, move the Docker build cache off `type=gha` and onto a registry-backed cache stored as a `:buildcache` tag in the existing GHCR package:

- `cache-from/to: type=registry,ref=ghcr.io/mooshieblob1/mooshieui:buildcache`, `mode=max`
- No 10 GB cap, so the torch layer survives between runs
- Also frees ~4–5 GB of the GHA cache budget for the desktop `build` jobs' Rust caches
- The NUC path (`type=local`) is unchanged

## No new secrets
The `:buildcache` tag is pushed with the existing `GITHUB_TOKEN` (`permissions: packages: write` already set) to the same package the job already pushes `:latest` to. No PAT required.

## Safety
- Published tags (`latest`, semver, short_sha) are untouched; consumers pulling `:latest` are unaffected.
- `ignore-error=true`: a cache miss or GHCR hiccup falls back to a full build, never a failure. (GHCR is already a hard dependency of this job since it pushes the image there.)
- First run after merge is a one-time cold build that seeds `:buildcache`.

No cleanup workflow included; for a public package the orphaned untagged cache manifests cost nothing.