### PR TITLE
fix: reliably capture logs in in-app error reports

### DIFF
--- a/src/lib/errors/reportError.ts
+++ b/src/lib/errors/reportError.ts
@@ -2,8 +2,79 @@ import type { FriendlyError, ReportPayload, ReportSink } from "./types.js";
 import { appVersion, appMode, platformInfo } from "../utils/platformInfo.js";
 import { openExternalUrl } from "../utils/openExternal.js";
 import { exportLogsContent, getConfig } from "../utils/api.js";
+import { getLogSnapshot } from "../utils/log-buffer.js";
 
 export const GITHUB_REPO = "Mooshieblob1/MooshieUI";
+
+/**
+ * Ceiling for the server-side log build. In browser/hosted mode `exportLogsContent()`
+ * is a REST round-trip that can stall (slow diagnostic build, expired auth, dropped
+ * connection); without a cap a hung request would silently cost us the whole log.
+ */
+const LOG_CAPTURE_TIMEOUT_MS = 8000;
+
+/** Reject `p` if it has not settled within `ms`. Does not cancel the underlying work. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`log capture timed out after ${ms}ms`)),
+      ms,
+    );
+    p.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+function errReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  const s = String(err);
+  return s === "[object Object]" ? "unknown error" : s;
+}
+
+/**
+ * Build a fallback log from what we already hold client-side when the server-built
+ * log is unavailable. The frontend ring buffer captures console output, uncaught
+ * errors, and unhandled rejections, so it is genuinely useful on its own. If even
+ * that is empty, return an explicit marker so a report can never again arrive with
+ * no log and no explanation (the failure that produced issue #454).
+ */
+function fallbackLog(why: string): string {
+  const { os, arch } = platformInfo();
+  const snapshot = getLogSnapshot();
+  const header = [
+    `(diagnostics: server log capture failed: ${why})`,
+    `app ${appVersion()} | mode ${appMode()} | ${os}/${arch}`,
+    "--- frontend log buffer follows ---",
+  ].join("\n");
+  if (snapshot.length > 0) return `${header}\n${snapshot.join("\n")}`;
+  return `(log capture failed: ${why}; frontend log buffer empty)`;
+}
+
+/**
+ * Capture a diagnostics log for a report, degrading gracefully so a report ALWAYS
+ * carries a log or an explicit reason it is missing. Never throws.
+ *
+ * Order: full server-built log (time-bounded) -> frontend ring buffer -> marker.
+ */
+async function captureDiagnosticLog(): Promise<string> {
+  try {
+    // Send the whole log — the proxy attaches the full text (chunked into issue
+    // comments past GitHub's body limit) so nothing useful is lost.
+    const content = await withTimeout(exportLogsContent(), LOG_CAPTURE_TIMEOUT_MS);
+    if (content && content.trim()) return content;
+    return fallbackLog("server returned an empty log");
+  } catch (err) {
+    return fallbackLog(errReason(err));
+  }
+}
 
 /** Assemble a structured report from a resolved error. */
 export async function buildReportPayload(
@@ -12,16 +83,7 @@ export async function buildReportPayload(
   includeLogs = false,
 ): Promise<ReportPayload> {
   const { os, arch } = platformInfo();
-  let logsTail: string | undefined;
-  if (includeLogs) {
-    try {
-      // Send the whole log — the proxy attaches the full text (chunked into
-      // issue comments past GitHub's body limit) so nothing useful is lost.
-      logsTail = await exportLogsContent();
-    } catch {
-      logsTail = undefined;
-    }
-  }
+  const logsTail = includeLogs ? await captureDiagnosticLog() : undefined;
   return {
     errorCode: error.code,
     rawMessage: error.raw,
@@ -68,8 +130,10 @@ function issueBody(p: ReportPayload): string {
 class PrefilledIssueSink implements ReportSink {
   async submit(payload: ReportPayload): Promise<{ issueUrl?: string }> {
     // Copy full diagnostics to clipboard since URL length is capped near 8 KB.
+    // captureDiagnosticLog never throws and always yields a log or an explicit
+    // reason, so the user has something useful to paste even if the build failed.
     try {
-      const logs = await exportLogsContent();
+      const logs = await captureDiagnosticLog();
       await globalThis.navigator?.clipboard?.writeText(logs);
     } catch {
       // Clipboard may be unavailable; the issue still opens.


### PR DESCRIPTION
In-app error reports could silently ship with no diagnostic log (see #454). In browser mode the log fetch was untimed and a bare catch swallowed failures, so a slow or failing server call produced an empty report.

Now log capture (buildReportPayload and the clipboard fallback) goes through captureDiagnosticLog(), which:

- wraps the server log fetch in an 8s timeout
- falls back to the client-side ring buffer if the server call fails or returns empty
- never emits an empty log: a (log capture failed: reason) marker plus environment header is always included so a report without logs is self-explaining

Frontend-only. npm run build passes.