### PR TITLE
make i18n parity output deterministic and guard missing en.ts

### DIFF
--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -2,7 +2,11 @@ import fs from "fs";
 import path from "path";
 
 const dir = "src/lib/locales";
-const files = fs.readdirSync(dir).filter((f) => f.endsWith(".ts"));
+// Sort once so every section below reports in a deterministic, platform-independent
+// order (readdirSync order is not guaranteed).
+const files = fs.readdirSync(dir)
+  .filter((f) => f.endsWith(".ts"))
+  .sort();
 
 function parseKeys(file) {
   const content = fs.readFileSync(path.join(dir, file), "utf8");
@@ -29,10 +33,15 @@ function sameSet(a, b) {
 const all = Object.fromEntries(files.map((f) => [f, parseKeys(f)]));
 const en = all["en.ts"];
 
+if (!en) {
+  console.error(`ERROR: ${dir}/en.ts not found. It is the source of truth for i18n parity.`);
+  process.exit(1);
+}
+
 let failed = false;
 
 console.log("Key counts:");
-for (const f of files.sort()) console.log(`  ${f}: ${all[f].size}`);
+for (const f of files) console.log(`  ${f}: ${all[f].size}`);
 
 console.log("\nParity vs en.ts:");
 for (const f of files) {


### PR DESCRIPTION
## Summary

Two small robustness fixes to the i18n parity checker (`scripts/check-i18n-parity.mjs`), the deferred Minors from the contributor-guardrails work (#463). No behavior change to the gate's pass/fail result.

## Changes

- **Deterministic output:** sort the locale file list once at read time so the "Key counts", "Parity vs en.ts", and "Untranslated" sections all report in a stable, platform-independent order. Previously the parity section followed `readdirSync` order, which is not guaranteed across platforms.
- **Clear error when `en.ts` is missing:** guard the source-of-truth lookup so an absent `src/lib/locales/en.ts` prints a clear message and exits 1, instead of throwing a raw `TypeError` from `[...en.keys()]`.

## Testing

- `node scripts/check-i18n-parity.mjs` on the real locales: exits 0, all 12 files at 2226 keys, sections now alphabetically ordered.
- Ran the script against a temp locales dir with no `en.ts`: prints the clear error and exits 1.
