### PR TITLE
docs: clarify what sponsorships cover in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Built with **Svelte 5** + **Rust**, it hides ComfyUI's node-graph complexity beh
   <em>MooshieUI is free and open source. If it saves you time or sparks joy, a sponsorship keeps the updates coming. No pressure, just gratitude. 🙏</em>
 </p>
 
+<p align="center">
+  <sub>Sponsorships mostly go toward covering running costs: domain hosting, the SaaS tools used to build MooshieUI, and GitHub Pro+ for CI/CD. Anything left over is fuel for more features.</sub>
+</p>
+
 ![MooshieUI Screenshot](docs/screenshot.avif)
 
 ---


### PR DESCRIPTION
Follow-up to the Sponsors CTA. Adds a short transparency note under the sponsor button explaining that sponsorships mostly cover running costs (domain hosting, the SaaS tools used to build MooshieUI, and GitHub Pro+ for CI/CD), with anything extra going toward more features.

Docs-only change, no code or i18n impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzzN1eA3HGw6Mf6t3sQZ7L)_