### PR TITLE
fix: parse weighted tag syntax in prompt spellcheck and clicks

### DIFF
--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -535,6 +535,24 @@
 
   function handleClickableSegmentMouseDown(event: MouseEvent, segment: PromptClickableSegment) {
     if (!textareaEl || !segment.clickable) return;
+    // Right-click is handled via oncontextmenu; don't clobber the selection here.
+    if (event.button !== 0) return;
+
+    // Second click on an already-selected segment: place the caret at the exact
+    // clicked character instead of re-selecting the whole segment. The first click
+    // keeps the whole-segment select (the weight-button workflow).
+    if (textareaEl.selectionStart === segment.start && textareaEl.selectionEnd === segment.end) {
+      const caret = getCaretFromPoint(event.clientX, event.clientY);
+      if (caret >= 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        textareaEl.focus();
+        textareaEl.setSelectionRange(caret, caret);
+        syncSelectionRange();
+        return;
+      }
+      // Caret unresolved: fall through to whole-segment select (still usable).
+    }
 
     event.preventDefault();
     event.stopPropagation();
@@ -549,6 +567,76 @@
     textareaEl.focus();
     textareaEl.setSelectionRange(segment.start, segment.end);
     syncSelectionRange();
+  }
+
+  /**
+   * Map a viewport point to an absolute character offset in the prompt, using the
+   * clickable/spellcheck overlay text nodes as the mirror layout. Each overlay
+   * covers [0, value.length) contiguously with one span per segment/piece, so the
+   * absolute offset is the summed length of preceding sibling spans plus the local
+   * caret offset — independent of which overlay the hit test lands on. Returns -1
+   * when the caret can't be resolved (caller falls back to native behavior).
+   */
+  function getCaretFromPoint(clientX: number, clientY: number): number {
+    let node: Node | null = null;
+    let localOffset = 0;
+    const doc = document as Document & {
+      caretRangeFromPoint?: (x: number, y: number) => Range | null;
+      caretPositionFromPoint?: (
+        x: number,
+        y: number,
+      ) => { offsetNode: Node; offset: number } | null;
+    };
+    if (typeof doc.caretRangeFromPoint === "function") {
+      const range = doc.caretRangeFromPoint(clientX, clientY);
+      if (range) {
+        node = range.startContainer;
+        localOffset = range.startOffset;
+      }
+    } else if (typeof doc.caretPositionFromPoint === "function") {
+      const pos = doc.caretPositionFromPoint(clientX, clientY);
+      if (pos) {
+        node = pos.offsetNode;
+        localOffset = pos.offset;
+      }
+    }
+    if (!node || node.nodeType !== Node.TEXT_NODE) return -1;
+    const span = node.parentElement;
+    const container = span?.parentElement ?? null;
+    if (!container || (container !== clickOverlayEl && container !== spellcheckOverlayEl)) {
+      return -1;
+    }
+    let offset = 0;
+    for (const child of Array.from(container.children)) {
+      if (child === span) return offset + localOffset;
+      offset += (child.textContent ?? "").length;
+    }
+    return -1;
+  }
+
+  /**
+   * Right-click on a clickable tag span: if it maps to an unknown-tag spellcheck
+   * piece, open the suggestion menu; otherwise let the native context menu show.
+   */
+  function handleClickableSegmentContextMenu(event: MouseEvent, segment: PromptClickableSegment) {
+    const piece = spellcheckPieces.find(
+      (p) => p.unknown && p.name !== null && p.start === segment.start && p.end === segment.end,
+    );
+    if (piece) openSpellMenu(event, piece);
+  }
+
+  /**
+   * Right-click anywhere in the textarea: covers underlined segments even when the
+   * clickable overlay is disabled. WebView2/Chromium moves the caret to the click
+   * point before `contextmenu` fires, so hit-test the caret against unknown pieces.
+   */
+  function handleTextareaContextMenu(event: MouseEvent) {
+    if (!textareaEl || !autocomplete.spellcheckEnabled) return;
+    const caret = textareaEl.selectionStart;
+    const piece = spellcheckPieces.find(
+      (p) => p.unknown && p.name !== null && caret >= p.start && caret <= p.end,
+    );
+    if (piece) openSpellMenu(event, piece);
   }
 
   function replaceRange(start: number, end: number, replacement: string) {
@@ -812,6 +900,7 @@
         onkeyup={syncSelectionRange}
       onblur={handleBlur}
       onscroll={syncScroll}
+      oncontextmenu={handleTextareaContextMenu}
     ></textarea>
 
     {#if showClickableOverlay}
@@ -834,6 +923,7 @@
                   : 'hover:bg-indigo-500/18 hover:shadow-[inset_0_0_0_1px_rgba(129,140,248,0.5)]'}"
               style="color: transparent;"
               onmousedown={(event) => handleClickableSegmentMouseDown(event, segment)}
+              oncontextmenu={(event) => handleClickableSegmentContextMenu(event, segment)}
             >{value.slice(segment.start, segment.end)}</span>
           {:else}
             <span style="color: transparent;">{value.slice(segment.start, segment.end)}</span>
@@ -851,11 +941,9 @@
       >
         {#each spellcheckPieces as piece (piece.start + ':' + piece.end)}
           {#if piece.unknown}
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
             <span
-              class="pointer-events-auto cursor-context-menu underline decoration-wavy decoration-red-500 underline-offset-2"
+              class="underline decoration-wavy decoration-red-500 underline-offset-2"
               style="color: transparent; text-decoration-skip-ink: none;"
-              oncontextmenu={(event) => openSpellMenu(event, piece)}
             >{value.slice(piece.start, piece.end)}</span>
           {:else}
             <span style="color: transparent;">{value.slice(piece.start, piece.end)}</span>

--- a/src/lib/utils/promptSpellcheck.ts
+++ b/src/lib/utils/promptSpellcheck.ts
@@ -60,14 +60,60 @@ export function damerauLevenshtein(a: string, b: string, max: number): number {
   return prev[bl] <= max ? prev[bl] : max + 1;
 }
 
-/** Extract the bare tag name from a clickable segment's raw text. */
+/**
+ * Extract the bare tag name from a clickable segment's raw text. Handles every
+ * weighted shape the clickable-range parser produces (A1111 `(name:1.2)`, plain
+ * `{name}`/`[name]`, InvokeAI trailing `(name)0.5` / `(name)++`, NAI `1.2::name::`).
+ * Multi-tag or nested groups return "" so `isKnownTag("")` treats them as known
+ * and they are never false-flagged with a red underline.
+ */
 function extractName(raw: string, start: number, end: number, weighted: boolean): string {
   const text = raw.slice(start, end);
   if (!weighted) return text;
-  // Strip one wrapper layer: (name:1.2) -> name, {name} -> name, [name] -> name.
+
+  // NAI numeric weight: N::name:: — starts with a digit, ends with "::".
+  if (/^\d/.test(text) && text.endsWith("::")) {
+    const sep = text.indexOf("::");
+    return sep === -1 ? "" : text.slice(sep + 2, -2).trim();
+  }
+
+  const open = text[0];
+
+  // InvokeAI trailing weight/emphasis on a flat group: (name)0.5, (name)++, (name)--.
+  // Opens with "(" but does not end with ")".
+  if (open === "(" && text[text.length - 1] !== ")") {
+    let depth = 0;
+    let closeIdx = -1;
+    for (let i = 0; i < text.length; i++) {
+      if (text[i] === "(") depth += 1;
+      else if (text[i] === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          closeIdx = i;
+          break;
+        }
+      }
+    }
+    if (closeIdx < 1) return "";
+    const inner = text.slice(1, closeIdx);
+    return /[,()[\]{}]/.test(inner) ? "" : inner.trim();
+  }
+
+  // Remaining forms wrap the name in a matching bracket pair.
+  const closeFor: Record<string, string> = { "(": ")", "{": "}", "[": "]" };
+  const close = closeFor[open];
+  if (!close || text[text.length - 1] !== close) return "";
+
   const inner = text.slice(1, -1);
-  const m = inner.match(/^(.*):\d*\.?\d+$/);
-  return m ? m[1] : inner;
+  if (open === "(") {
+    // A1111/NAI (name:1.2) — greedy capture up to the trailing :number.
+    const m = inner.match(/^(.*):\d*\.?\d+$/);
+    const name = m ? m[1] : inner;
+    return /[,()[\]{}]/.test(name) ? "" : name.trim();
+  }
+
+  // {name} or [name].
+  return /[,()[\]{}]/.test(inner) ? "" : inner.trim();
 }
 
 /**


### PR DESCRIPTION
Fixes #473

## Problem (v1.5.0 regression)

Prompt editing broke after v1.5.0:
1. The app's own "unknown tag" red wavy underlines appeared all over tags that use weight syntax.
2. Left-clicking a tag would not place the caret anywhere except at the very end of the prompt.

## Root cause

v1.5.0 added InvokeAI/NAI weight syntax (`(tag)0.5`, `(tag)++`, `1.5::tag::`) but `extractName()` in `promptSpellcheck.ts` only understood the old `(name:1.2)` shape. It mis-parsed the new shapes (`(tag)0.5` -> `tag)0.`), so the resulting "name" was never a known tag and every weighted tag got underlined as unknown.

The clicks broke because the spellcheck overlay spans were `pointer-events-auto` handling only `oncontextmenu`, silently swallowing left-clicks so they never reached the textarea to place a caret. With many tags underlined, only the trailing plain text remained clickable. Separately, the clickable overlay always selected the whole segment, so the caret could never land inside a tag.

## Fix

**Parsing (`promptSpellcheck.ts`)**: rewrote `extractName()` to understand all v1.5.0 weighted shapes: NAI numeric (`N::tag::`), InvokeAI trailing (`(tag)0.5` / `(tag)++` / `(tag)--`), A1111 (`(tag:1.2)`), and brace/bracket wraps. For nested or multi-tag segments it returns `""`, and since `isKnownTag("")` is `true`, unparseable segments are never flagged (conservative, no false reds).

**Clicks (`PromptTextarea.svelte`)**:
- The spellcheck overlay is now fully inert (no `pointer-events-auto`), so left-clicks pass through to the clickable overlay / textarea.
- Right-click on an underlined tag opens the suggestion menu via two new handlers (on the clickable span and on the textarea, the latter hit-testing the caret against unknown pieces).
- Two-click caret placement in the clickable overlay: first click selects the whole segment (preserving the weight-button workflow); a second click inside the already-selected segment places the caret at the exact clicked character via `caretRangeFromPoint`/`caretPositionFromPoint`, falling back gracefully when unavailable. Right-clicks no longer clobber the selection.

## Validation

`npm run build` and `npm run check` pass (0 errors in touched files). No new i18n keys. Manual dev-run recommended per the issue: mixed-syntax prompt underlines only genuinely-unknown tags; single click selects, second click places caret; right-click opens the suggestion menu.