### PR TITLE
v1.5.1: prompt editor, artist autocomplete, and quality-tag toggle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v1.5.1
+
+### Fixes
+- **Prompt editing works again with weight syntax**: v1.5.0's expanded weight and emphasis parsing made the editor draw red "unknown tag" underlines across valid weighted tags (`(tag)0.5`, `(tag)++`, `1.5::artist::`, and similar), and those underlined tags swallowed left clicks so the caret only landed at the end of the prompt. Weighted tags are now parsed correctly, so only genuinely unknown tags are underlined, and clicking a tag places the caret where you click (a second click inside a selected tag drops the caret on the exact character).
+- **Artist tags autocomplete on Illustrious and other danbooru models**: on non-Anima checkpoints the autocomplete list carried almost no artists, so artist names rarely completed and often showed up underlined as unknown. A bundled danbooru artist supplement is now merged in when that corpus is active, so artist tags suggest properly.
+- **"Enable custom quality tag" toggle stays put**: the Settings toggle that reveals the custom quality tag editor reset to off every time you left and returned to the Settings tab. It now persists across tab switches and restarts.
+
+---
+
 ## What's New in v1.5.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v1.5.1
+
+### Fixes
+- **Prompt editing works again with weight syntax**: v1.5.0's expanded weight and emphasis parsing made the editor draw red "unknown tag" underlines across valid weighted tags (`(tag)0.5`, `(tag)++`, `1.5::artist::`, and similar), and those underlined tags swallowed left clicks so the caret only landed at the end of the prompt. Weighted tags are now parsed correctly, so only genuinely unknown tags are underlined, and clicking a tag places the caret where you click (a second click inside a selected tag drops the caret on the exact character).
+- **Artist tags autocomplete on Illustrious and other danbooru models**: on non-Anima checkpoints the autocomplete list carried almost no artists, so artist names rarely completed and often showed up underlined as unknown. A bundled danbooru artist supplement is now merged in when that corpus is active, so artist tags suggest properly.
+- **"Enable custom quality tag" toggle stays put**: the Settings toggle that reveals the custom quality tag editor reset to off every time you left and returned to the Settings tab. It now persists across tab switches and restarts.
+
+---
+
 ## What's New in v1.5.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Patch release bundling the three bug fixes merged since v1.5.0.

## Fixes
- **Prompt editing with weight syntax (#473)**: v1.5.0's expanded weight/emphasis parsing caused false red "unknown tag" underlines across valid weighted tags (`(tag)0.5`, `(tag)++`, `1.5::artist::`) and those underlines swallowed left clicks so the caret only landed at the prompt end. `extractName` now parses every weighted shape; the spellcheck overlay is inert to left clicks; clicking a tag places the caret (second click inside a selected tag drops the caret on the exact character). Merged in #476.
- **Artist autocomplete on danbooru models (#465)**: non-Anima checkpoints had almost no artists in the corpus. A lazily-imported danbooru artist supplement is merged in when that corpus is active. Merged in #475.
- **Custom quality tag toggle persistence (#466)**: the Settings reveal toggle reset on tab switch because it was component-local state. Moved into the generation store with load guard + save round-trip. Merged in #474.

## Version
- package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json, Cargo.lock -> 1.5.1
- RELEASE_NOTES.md + CHANGELOG.md updated

## Validation
- `cargo check` and `npm run build` pass
- No new i18n keys; diff-scoped svelte-check clean

## Bot triage
No bot comments were posted on the three source PRs (#474/#475/#476).