### PR TITLE
v1.7.0: GGUF model support, text encoder hub filter, Windows console flash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## What's New in v1.7.0
+
+### New features
+- **GGUF quantized models**: `.gguf` diffusion models and text encoders now load and generate. Picking a `.gguf` file routes it through the GGUF loaders instead of the standard ones, and the required ComfyUI-GGUF nodes install automatically the first time ComfyUI is set up. This lets you run large models (Krea 2 and similar) on cards that cannot fit the full-precision weights. If the nodes cannot be installed, ComfyUI still starts normally and only GGUF models are unavailable.
+- **Text encoders in the Model Hub**: a Text Encoder filter joins the category list, so encoders are browsable and downloadable like any other model type, with a quick link for the Qwen3-VL 4B FP8 encoder used by Krea 2.
+
+### Improvements
+- **Model info panel reads GGUF files**: selecting a GGUF model previously left the info panel blank and the family stuck on "unknown", which meant split-model setups never got a text encoder type filled in. Family, turbo, and recommended encoder details now resolve from the filename, sidecar metadata, and hash lookups.
+
+### Fixes
+- **No more console window flashes on Windows**: installing custom nodes or pip packages, cloning repositories, and probing the GPU no longer pop up brief black console windows over the app.
+- **Faster generation page**: reading the GPU compute capability now uses a small dedicated probe. The generation page checks this on load and after each generation, and it previously ran the full attention backend scan (including toolchain lookups) every time.
+
+---
+
 ## What's New in v1.6.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## What's New in v1.7.0
+
+### New features
+- **GGUF quantized models**: `.gguf` diffusion models and text encoders now load and generate. Picking a `.gguf` file routes it through the GGUF loaders instead of the standard ones, and the required ComfyUI-GGUF nodes install automatically the first time ComfyUI is set up. This lets you run large models (Krea 2 and similar) on cards that cannot fit the full-precision weights. If the nodes cannot be installed, ComfyUI still starts normally and only GGUF models are unavailable.
+- **Text encoders in the Model Hub**: a Text Encoder filter joins the category list, so encoders are browsable and downloadable like any other model type, with a quick link for the Qwen3-VL 4B FP8 encoder used by Krea 2.
+
+### Improvements
+- **Model info panel reads GGUF files**: selecting a GGUF model previously left the info panel blank and the family stuck on "unknown", which meant split-model setups never got a text encoder type filled in. Family, turbo, and recommended encoder details now resolve from the filename, sidecar metadata, and hash lookups.
+
+### Fixes
+- **No more console window flashes on Windows**: installing custom nodes or pip packages, cloning repositories, and probing the GPU no longer pop up brief black console windows over the app.
+- **Faster generation page**: reading the GPU compute capability now uses a small dedicated probe. The generation page checks this on load and after each generation, and it previously ran the full attention backend scan (including toolchain lookups) every time.
+
+---
+
 ## What's New in v1.6.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
+use super::process::tokio_command_no_window;
+
 #[derive(Clone, Copy)]
 struct RequiredCustomNodePackage {
     name: &'static str,
@@ -24,6 +26,15 @@ const STYLE_TRANSFER_PACKAGES: &[RequiredCustomNodePackage] = &[
         verify_nodes: &["ImageScaleToTotalPixelsX"],
     },
 ];
+
+// GGUF-quantized diffusion models / text encoders cannot be loaded by core
+// ComfyUI loaders; the workflow builder emits UnetLoaderGGUF / CLIPLoaderGGUF
+// for .gguf files, which this package provides.
+const GGUF_PACKAGES: &[RequiredCustomNodePackage] = &[RequiredCustomNodePackage {
+    name: "ComfyUI-GGUF",
+    git_url: "https://github.com/city96/ComfyUI-GGUF.git",
+    verify_nodes: &["UnetLoaderGGUF", "CLIPLoaderGGUF"],
+}];
 
 const REQUIRED_CONTROLNET_PACKAGES: &[RequiredCustomNodePackage] = &[
     RequiredCustomNodePackage {
@@ -55,6 +66,9 @@ pub const MISSING_CONTROLNET_NODES_MARKER: &str = "Required ControlNet custom no
 /// Substring present in [`verify_required_style_transfer_nodes`] error output.
 pub const MISSING_STYLE_TRANSFER_NODES_MARKER: &str =
     "Required style transfer custom nodes failed to load";
+
+/// Substring present in [`verify_required_gguf_nodes`] error output.
+pub const MISSING_GGUF_NODES_MARKER: &str = "Required GGUF custom nodes failed to load";
 
 const REQUIRED_MOOSHIE_NODE_CLASSES: &[&str] = &[
     "MooshieSaveImage",
@@ -347,6 +361,82 @@ pub async fn ensure_required_style_transfer_nodes(
     Ok(())
 }
 
+/// Ensure the ComfyUI-GGUF loader nodes are present so .gguf diffusion models
+/// and text encoders can be used. Failures are logged as warnings and do not
+/// block core startup.
+pub async fn ensure_required_gguf_nodes(
+    comfyui_path: &str,
+    venv_path: &str,
+    network_proxy: Option<&str>,
+    pip_index_url: Option<&str>,
+) -> Result<(), String> {
+    let custom_nodes = Path::new(comfyui_path).join("custom_nodes");
+    std::fs::create_dir_all(&custom_nodes).map_err(|e| {
+        format!(
+            "Failed to create ComfyUI custom_nodes directory at '{}': {}",
+            custom_nodes.display(),
+            e
+        )
+    })?;
+
+    let mut failures = Vec::new();
+    for package in GGUF_PACKAGES {
+        if let Err(e) = ensure_custom_node_package(
+            &custom_nodes,
+            venv_path,
+            network_proxy,
+            pip_index_url,
+            *package,
+        )
+        .await
+        {
+            log::warn!(
+                "GGUF custom node '{}' setup failed (optional): {}",
+                package.name,
+                e
+            );
+            failures.push(format!("{}: {}", package.name, e));
+        }
+    }
+
+    if failures.is_empty() {
+        log::info!("Ensured required GGUF custom node packages");
+    } else {
+        log::warn!(
+            "Some GGUF custom node packages could not be installed ({}). \
+             GGUF (.gguf) models are unavailable until these install.",
+            failures.join("; ")
+        );
+    }
+    Ok(())
+}
+
+/// Verify GGUF loader node classes (UnetLoaderGGUF / CLIPLoaderGGUF).
+pub async fn verify_required_gguf_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+) -> Result<(), String> {
+    let mut missing = Vec::new();
+
+    for attempt in 0..5 {
+        missing = missing_required_gguf_nodes(http_client, base_url).await?;
+        if missing.is_empty() {
+            log::info!("Verified required GGUF custom node classes");
+            return Ok(());
+        }
+
+        if attempt < 4 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    Err(format!(
+        "{}: {}. Check the ComfyUI log for custom-node import errors.",
+        MISSING_GGUF_NODES_MARKER,
+        missing.join(", ")
+    ))
+}
+
 /// Verify that ComfyUI actually loaded every custom node class required by the
 /// built-in ControlNet presets. Directory presence alone is not enough because
 /// custom-node import failures leave the class missing from /object_info.
@@ -558,7 +648,7 @@ async fn clone_custom_node(
     target_dir: &Path,
     network_proxy: Option<&str>,
 ) -> Result<(), String> {
-    let mut cmd = tokio::process::Command::new("git");
+    let mut cmd = tokio_command_no_window("git");
     cmd.args(["clone", "--depth=1", git_url]).arg(target_dir);
     apply_network_proxy(&mut cmd, network_proxy);
     let output = cmd
@@ -609,14 +699,14 @@ async fn install_requirements_if_needed(
     let uv_path = find_uv_bin(venv_path).await;
     let use_uv = uv_path.is_some();
     let mut command = if let Some(uv_path) = uv_path {
-        let mut command = tokio::process::Command::new(uv_path);
+        let mut command = tokio_command_no_window(uv_path);
         command
             .args(["pip", "install", "-r"])
             .arg(requirements)
             .env("VIRTUAL_ENV", venv_path);
         command
     } else {
-        let mut command = tokio::process::Command::new(resolve_pip_bin(venv_path));
+        let mut command = tokio_command_no_window(resolve_pip_bin(venv_path));
         command.args(["install", "-r"]).arg(requirements);
         command
     };
@@ -662,7 +752,7 @@ async fn find_uv_bin(venv_path: &str) -> Option<PathBuf> {
     }
 
     let global_uv = PathBuf::from("uv");
-    let status = tokio::process::Command::new(&global_uv)
+    let status = tokio_command_no_window(&global_uv)
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -730,6 +820,13 @@ async fn missing_required_style_transfer_nodes(
     base_url: &str,
 ) -> Result<Vec<String>, String> {
     missing_packages_nodes(http_client, base_url, STYLE_TRANSFER_PACKAGES).await
+}
+
+async fn missing_required_gguf_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Vec<String>, String> {
+    missing_packages_nodes(http_client, base_url, GGUF_PACKAGES).await
 }
 
 async fn missing_packages_nodes(

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -47,6 +47,22 @@ pub(crate) fn std_command_no_window(program: &str) -> std::process::Command {
     cmd
 }
 
+/// `tokio::process::Command` that does not flash a console window on Windows.
+pub(crate) fn tokio_command_no_window(
+    program: impl AsRef<std::ffi::OsStr>,
+) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(program);
+    #[cfg(windows)]
+    {
+        // `tokio::process::Command` exposes `creation_flags` inherently, so the
+        // `CommandExt` import is unused on Windows — kept to mirror the std twin.
+        #[allow(unused_imports)]
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    cmd
+}
+
 /// Detect whether the system has a Blackwell (compute capability 12.x) NVIDIA GPU.
 /// Returns `true` if any installed GPU has compute capability >= 12.0.
 fn has_blackwell_gpu() -> bool {
@@ -282,6 +298,14 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             )
             .await
             .map_err(AppError::ProcessSpawnFailed)?;
+            super::nodes::ensure_required_gguf_nodes(
+                &config.comfyui_path,
+                &config.venv_path,
+                config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
+            )
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
         }
     }
 
@@ -340,6 +364,8 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             &config.server_url,
         )
         .await;
+        let gguf_ok =
+            super::nodes::verify_required_gguf_nodes(&state.http_client, &config.server_url).await;
 
         if mooshie_ok.is_ok() {
             if let Err(e) = controlnet_ok {
@@ -352,6 +378,13 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             if let Err(e) = style_transfer_ok {
                 log::warn!(
                     "ComfyUI at {} is running but optional style transfer nodes are missing: {}",
+                    config.server_url,
+                    e
+                );
+            }
+            if let Err(e) = gguf_ok {
+                log::warn!(
+                    "ComfyUI at {} is running but optional GGUF nodes are missing: {}",
                     config.server_url,
                     e
                 );
@@ -837,6 +870,11 @@ pub async fn wait_for_ready(state: &AppState, timeout_secs: u64) -> Result<(), A
                     e
                 );
             }
+            if let Err(e) =
+                super::nodes::verify_required_gguf_nodes(&state.http_client, &base_url).await
+            {
+                log::warn!("GGUF custom nodes not loaded at startup (optional): {}", e);
+            }
             mark_legacy_worker_idle(state).await;
             return Ok(());
         }
@@ -1135,6 +1173,14 @@ pub async fn start_worker_process(
             )
             .await
             .map_err(AppError::ProcessSpawnFailed)?;
+            super::nodes::ensure_required_gguf_nodes(
+                &config.comfyui_path,
+                &config.venv_path,
+                config.network_proxy.as_deref(),
+                config.pip_index_url.as_deref(),
+            )
+            .await
+            .map_err(AppError::ProcessSpawnFailed)?;
         }
     }
 
@@ -1155,6 +1201,8 @@ pub async fn start_worker_process(
             &worker.base_url,
         )
         .await;
+        let gguf_ok =
+            super::nodes::verify_required_gguf_nodes(&state.http_client, &worker.base_url).await;
 
         if mooshie_ok.is_ok() {
             if let Err(e) = controlnet_ok {
@@ -1169,6 +1217,15 @@ pub async fn start_worker_process(
             if let Err(e) = style_transfer_ok {
                 log::warn!(
                     "Worker {} (GPU {}): optional style transfer nodes missing at {}: {}",
+                    worker.id,
+                    worker.gpu_index,
+                    worker.base_url,
+                    e
+                );
+            }
+            if let Err(e) = gguf_ok {
+                log::warn!(
+                    "Worker {} (GPU {}): optional GGUF nodes missing at {}: {}",
                     worker.id,
                     worker.gpu_index,
                     worker.base_url,
@@ -1406,6 +1463,15 @@ pub async fn wait_for_worker_ready(
                     e
                 );
             }
+            if let Err(e) =
+                super::nodes::verify_required_gguf_nodes(&state.http_client, &worker.base_url).await
+            {
+                log::warn!(
+                    "Worker {}: GGUF custom nodes not loaded (optional): {}",
+                    worker.id,
+                    e
+                );
+            }
             let mut status = worker.status.write().await;
             *status = WorkerStatus::Idle;
             log::info!(
@@ -1564,6 +1630,15 @@ pub async fn wait_all_workers_ready(state: &AppState, timeout_secs: u64) {
                     {
                         log::warn!(
                             "Worker {}: style transfer custom nodes not loaded (optional): {}",
+                            worker_id,
+                            e
+                        );
+                    }
+                    if let Err(e) =
+                        super::nodes::verify_required_gguf_nodes(&http_client, &base_url).await
+                    {
+                        log::warn!(
+                            "Worker {}: GGUF custom nodes not loaded (optional): {}",
                             worker_id,
                             e
                         );

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 #[cfg(feature = "desktop")]
 use tauri::{AppHandle, Emitter, State};
 
+use crate::comfyui::process::tokio_command_no_window;
 use crate::comfyui::types::*;
 use crate::error::AppError;
 use crate::state::AppState;
@@ -2232,7 +2233,7 @@ pub async fn install_custom_node(
     // git clone — stream stderr for progress (git writes progress to stderr)
     emit_progress("clone", &format!("Cloning {}...", node_name), false);
 
-    let mut git_cmd = tokio::process::Command::new("git");
+    let mut git_cmd = tokio_command_no_window("git");
     git_cmd
         .args([
             "clone",
@@ -2290,7 +2291,7 @@ pub async fn install_custom_node(
         let uv_path = resolve_uv_bin(&venv_path);
 
         let mut pip_child = if uv_path.exists() {
-            let mut cmd = tokio::process::Command::new(&uv_path);
+            let mut cmd = tokio_command_no_window(&uv_path);
             cmd.args(["pip", "install", "-r", &req_file.to_string_lossy()])
                 .env("VIRTUAL_ENV", &venv_path)
                 .stdout(std::process::Stdio::piped())
@@ -2310,7 +2311,7 @@ pub async fn install_custom_node(
             #[cfg(not(target_os = "windows"))]
             let pip_path = venv_base.join("bin").join("pip");
 
-            let mut cmd = tokio::process::Command::new(&pip_path);
+            let mut cmd = tokio_command_no_window(&pip_path);
             cmd.args(["install", "-r", &req_file.to_string_lossy()])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped());
@@ -2398,7 +2399,7 @@ pub async fn install_pip_package(
     let uv_path = resolve_uv_bin(&venv_path);
 
     let output = if uv_path.exists() {
-        let mut cmd = tokio::process::Command::new(&uv_path);
+        let mut cmd = tokio_command_no_window(&uv_path);
         cmd.args(["pip", "install", &package])
             .env("VIRTUAL_ENV", &venv_path);
         crate::comfyui::nodes::apply_pip_install_options(
@@ -2418,7 +2419,7 @@ pub async fn install_pip_package(
         #[cfg(not(target_os = "windows"))]
         let pip_path = venv_base.join("bin").join("pip");
 
-        let mut cmd = tokio::process::Command::new(&pip_path);
+        let mut cmd = tokio_command_no_window(&pip_path);
         cmd.args(["install", &package]);
         crate::comfyui::nodes::apply_pip_install_options(
             &mut cmd,
@@ -2461,7 +2462,7 @@ pub async fn check_python_import(
     };
 
     let python_path = resolve_venv_python_bin(&venv_path);
-    let output = tokio::process::Command::new(&python_path)
+    let output = tokio_command_no_window(&python_path)
         .args(["-c", &format!("import {}", module)])
         .output()
         .await
@@ -3928,7 +3929,13 @@ pub(crate) async fn read_modelspec_internal(
     )
     .ok_or_else(|| AppError::Other(format!("File not found: {}", filename)))?;
 
-    if !filename.ends_with(".safetensors") {
+    // GGUF files have no safetensors header, but filename heuristics, sidecar
+    // metadata, and hash lookups still apply. Without them a GGUF diffusion
+    // model (e.g. Krea-2-Turbo-Q5_K_S.gguf) stays family "unknown" and the
+    // split-model text-encoder type is never resolved.
+    let is_safetensors = filename.ends_with(".safetensors");
+    let is_gguf = filename.to_ascii_lowercase().ends_with(".gguf");
+    if !is_safetensors && !is_gguf {
         return Ok(None);
     }
 
@@ -3993,12 +4000,13 @@ pub(crate) async fn read_modelspec_internal(
         }
     }
 
-    if result
-        .get("is_sdxl_like")
-        .is_some_and(|value| value == "true")
-        || result
-            .get("base_model")
-            .is_some_and(|base_model| is_sdxl_like_family(model_family_from_base_model(base_model)))
+    if is_safetensors
+        && (result
+            .get("is_sdxl_like")
+            .is_some_and(|value| value == "true")
+            || result.get("base_model").is_some_and(|base_model| {
+                is_sdxl_like_family(model_family_from_base_model(base_model))
+            }))
     {
         if let Some(runtime_meta) = read_safetensors_runtime_metadata(&path)? {
             result.extend(runtime_meta);
@@ -4025,8 +4033,13 @@ pub(crate) async fn read_modelspec_internal(
     // trigger phrase, ...) for the model info panel. Header-only read — no
     // hashing. Runtime keys resolved above take precedence. This also populates
     // an inferred `architecture` (from tensor-key patterns) when the file has no
-    // declared modelspec.architecture.
-    if let Ok(Some(display_meta)) = read_safetensors_modelspec(&path) {
+    // declared modelspec.architecture. Safetensors only — GGUF has no such header.
+    let display_meta = if is_safetensors {
+        read_safetensors_modelspec(&path).ok().flatten()
+    } else {
+        None
+    };
+    if let Some(display_meta) = display_meta {
         for (key, value) in display_meta {
             result.entry(key).or_insert(value);
         }
@@ -6217,6 +6230,15 @@ pub async fn check_attention_backend(
     check_attention_backend_core(&state).await
 }
 
+/// Lightweight probe for just the GPU compute capability (single `nvidia-smi` shell-out).
+/// The gen page calls this on mount and after every generation, so it must stay cheap —
+/// unlike `check_attention_backend`, it does not shell out to `uv`/`nvcc`.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn get_compute_capability() -> Result<Option<f32>, AppError> {
+    Ok(detect_compute_capability())
+}
+
 /// Core of `check_attention_backend`, shared by the desktop Tauri command and the
 /// browser-mode dispatch arm. Lists the attention packages present in the venv and
 /// computes per-backend support from GPU compute capability, OS, and `nvcc`.
@@ -6234,11 +6256,9 @@ pub async fn check_attention_backend_core(
     // List installed attention packages in the venv
     let mut venv_packages = Vec::new();
     if uv.exists() {
-        let output = tokio::process::Command::new(&uv)
-            .args(["pip", "list", "--python", &venv_python.to_string_lossy()])
-            .output()
-            .await
-            .ok();
+        let mut cmd = tokio_command_no_window(&uv);
+        cmd.args(["pip", "list", "--python", &venv_python.to_string_lossy()]);
+        let output = cmd.output().await.ok();
 
         if let Some(o) = output {
             if o.status.success() {
@@ -6397,7 +6417,7 @@ pub async fn install_attention_backend_core(
     if is_windows {
         uninstall_old.push("triton-windows");
     }
-    let _ = tokio::process::Command::new(&uv)
+    let _ = tokio_command_no_window(&uv)
         .args(&uninstall_old)
         .output()
         .await;
@@ -6439,7 +6459,7 @@ pub async fn install_attention_backend_core(
             _ => unreachable!(),
         };
 
-        let mut cmd = tokio::process::Command::new(&uv);
+        let mut cmd = tokio_command_no_window(&uv);
         cmd.arg("pip")
             .arg("install")
             .arg("--python")
@@ -6477,7 +6497,7 @@ pub async fn install_attention_backend_core(
         } else {
             "flash_attn"
         };
-        let verify = tokio::process::Command::new(&venv_python)
+        let verify = tokio_command_no_window(&venv_python)
             .args(["-c", &format!("import {}", import_name)])
             .output()
             .await
@@ -6488,10 +6508,7 @@ pub async fn install_attention_backend_core(
             emit("Verification failed — rolling back...");
             let mut rollback: Vec<&str> = vec!["pip", "uninstall", "--python", &python_str];
             rollback.extend(base_names.iter().copied());
-            let _ = tokio::process::Command::new(&uv)
-                .args(&rollback)
-                .output()
-                .await;
+            let _ = tokio_command_no_window(&uv).args(&rollback).output().await;
             return Err(AppError::Other(format!(
                 "Installed {} but could not import it: {}. Rolled back; keeping the previous backend.",
                 backend,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -453,6 +453,7 @@ pub fn run() {
             commands::api::read_clipboard_image,
             commands::api::get_gpu_stats,
             commands::api::check_attention_backend,
+            commands::api::get_compute_capability,
             commands::api::install_attention_backend,
             setup::check_setup,
             setup::detect_gpu,

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1019,10 +1019,12 @@ async fn amd_pytorch_index_url() -> &'static str {
 /// Pick the correct PyTorch CUDA wheel index for NVIDIA GPUs.
 /// Blackwell (compute ≥ 12.0) needs cu130+; older GPUs use cu128.
 async fn nvidia_pytorch_index_url() -> &'static str {
-    let output = tokio::process::Command::new("nvidia-smi")
-        .args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"])
-        .output()
-        .await;
+    let output = {
+        let mut cmd = tokio::process::Command::new("nvidia-smi");
+        cmd.args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"]);
+        hide_window(&mut cmd);
+        cmd.output().await
+    };
 
     if let Ok(o) = output {
         if o.status.success() {

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -213,10 +213,18 @@ pub fn load_model_nodes(
     } else if params.use_split_model {
         // UNETLoader for diffusion model. Pass both unet_name and model_name for compatibility
         // across standard ComfyUI and custom nodes (e.g. ComfyUI-Flow-Control).
+        // GGUF quantized models cannot be loaded by core UNETLoader — route them
+        // through the ComfyUI-GGUF custom node instead (installed at ComfyUI setup).
         let unet_name = params.diffusion_model.as_deref().unwrap_or("");
         let unet_id = next_id.to_string();
-        workflow.insert(
-            unet_id.clone(),
+        let unet_node = if unet_name.to_ascii_lowercase().ends_with(".gguf") {
+            json!({
+                "class_type": "UnetLoaderGGUF",
+                "inputs": {
+                    "unet_name": unet_name
+                }
+            })
+        } else {
             json!({
                 "class_type": "UNETLoader",
                 "inputs": {
@@ -224,20 +232,27 @@ pub fn load_model_nodes(
                     "model_name": unet_name,
                     "weight_dtype": "default"
                 }
-            }),
-        );
+            })
+        };
+        workflow.insert(unet_id.clone(), unet_node);
         model_source = (unet_id, 0);
         next_id += 1;
 
-        // CLIPLoader for text encoder
+        // CLIPLoader for text encoder (GGUF-quantized encoders need CLIPLoaderGGUF)
         let clip_id = next_id.to_string();
         let clip_type = params.clip_type.as_deref().unwrap_or("wan");
+        let clip_name = params.clip_model.as_deref().unwrap_or("");
+        let clip_class = if clip_name.to_ascii_lowercase().ends_with(".gguf") {
+            "CLIPLoaderGGUF"
+        } else {
+            "CLIPLoader"
+        };
         workflow.insert(
             clip_id.clone(),
             json!({
-                "class_type": "CLIPLoader",
+                "class_type": clip_class,
                 "inputs": {
-                    "clip_name": params.clip_model.as_deref().unwrap_or(""),
+                    "clip_name": clip_name,
                     "type": clip_type
                 }
             }),

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1992,6 +1992,10 @@ async fn dispatch_command(
                 .map_err(|e| e.to_string())?;
             serde_json::to_value(&status).map_err(|e| e.to_string())
         }
+        "get_compute_capability" => {
+            let cc = crate::commands::api::detect_compute_capability_pub();
+            serde_json::to_value(cc).map_err(|e| e.to_string())
+        }
         "install_attention_backend" => {
             let backend = args["backend"]
                 .as_str()
@@ -3177,7 +3181,7 @@ async fn dispatch_command(
 
             emit("clone", &format!("Cloning {}...", node_name), false);
 
-            let mut git_cmd = tokio::process::Command::new("git");
+            let mut git_cmd = crate::comfyui::process::tokio_command_no_window("git");
             git_cmd
                 .args([
                     "clone",
@@ -3203,7 +3207,7 @@ async fn dispatch_command(
                 emit("pip", "Installing Python dependencies...", false);
                 let uv_path = crate::commands::api::resolve_uv_bin_pub(&venv_path);
                 let pip_status = if uv_path.exists() {
-                    let mut cmd = tokio::process::Command::new(&uv_path);
+                    let mut cmd = crate::comfyui::process::tokio_command_no_window(&uv_path);
                     cmd.args(["pip", "install", "-r", &req_file.to_string_lossy()])
                         .env("VIRTUAL_ENV", &venv_path);
                     crate::comfyui::nodes::apply_pip_install_options(
@@ -3221,7 +3225,7 @@ async fn dispatch_command(
                     let pip_path = venv_base.join("Scripts").join("pip.exe");
                     #[cfg(not(target_os = "windows"))]
                     let pip_path = venv_base.join("bin").join("pip");
-                    let mut cmd = tokio::process::Command::new(&pip_path);
+                    let mut cmd = crate::comfyui::process::tokio_command_no_window(&pip_path);
                     cmd.args(["install", "-r", &req_file.to_string_lossy()]);
                     crate::comfyui::nodes::apply_pip_install_options(
                         &mut cmd,
@@ -3266,7 +3270,7 @@ async fn dispatch_command(
             let uv_path = crate::commands::api::resolve_uv_bin_pub(&venv_path);
 
             let output = if uv_path.exists() {
-                let mut cmd = tokio::process::Command::new(&uv_path);
+                let mut cmd = crate::comfyui::process::tokio_command_no_window(&uv_path);
                 cmd.args(["pip", "install", &package])
                     .env("VIRTUAL_ENV", &venv_path);
                 crate::comfyui::nodes::apply_pip_install_options(
@@ -3284,7 +3288,7 @@ async fn dispatch_command(
                 let pip_path = venv_base.join("Scripts").join("pip.exe");
                 #[cfg(not(target_os = "windows"))]
                 let pip_path = venv_base.join("bin").join("pip");
-                let mut cmd = tokio::process::Command::new(&pip_path);
+                let mut cmd = crate::comfyui::process::tokio_command_no_window(&pip_path);
                 cmd.args(["install", &package]);
                 crate::comfyui::nodes::apply_pip_install_options(
                     &mut cmd,
@@ -3318,7 +3322,7 @@ async fn dispatch_command(
             drop(config);
 
             let python_path = crate::commands::api::resolve_venv_python_bin(&venv_path);
-            let output = tokio::process::Command::new(&python_path)
+            let output = crate::comfyui::process::tokio_command_no_window(&python_path)
                 .args(["-c", &format!("import {}", module)])
                 .output()
                 .await

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -9,7 +9,7 @@
   import InfoTip from "../ui/InfoTip.svelte";
   import { scrollCapture } from "../../utils/scrollCapture.js";
   import { MODEL_FAMILIES, TURBO_MODEL_VARIANTS } from "../../utils/modelFamily.js";
-  import type { ModelFamily } from "../../utils/modelFamily.js";
+  import type { ModelFamily, TurboModelVariant } from "../../utils/modelFamily.js";
 
   interface ModelFile {
     filename: string;
@@ -374,6 +374,12 @@
     return filename.endsWith(".safetensors") || filename.toLowerCase().endsWith(".gguf");
   }
 
+  function toTurboModelVariant(value: string | undefined): TurboModelVariant {
+    return TURBO_MODEL_VARIANTS.includes(value as TurboModelVariant)
+      ? (value as TurboModelVariant)
+      : "none";
+  }
+
   async function loadModelSpec(category: string, filename: string) {
     if (!filename || !supportsModelSpec(filename)) {
       loadedModelMetadataKey = "";
@@ -434,9 +440,7 @@
         modelspecHeaderVPred: spec?.header_v_pred === "true",
         modelFamily: family,
         modelIsSdxlLike: spec?.is_sdxl_like === "true",
-        modelTurboVariant: TURBO_MODEL_VARIANTS.includes(spec?.turbo_model_variant as any)
-          ? spec!.turbo_model_variant
-          : "none",
+        modelTurboVariant: toTurboModelVariant(spec?.turbo_model_variant),
         modelRecommendedVae: spec?.recommended_vae ?? null,
         modelRecommendedClipModel: spec?.recommended_clip_model ?? null,
         modelRecommendedClipType: spec?.recommended_clip_type ?? null,

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -367,8 +367,15 @@
     }
   }
 
+  // GGUF models carry no safetensors header, but the backend still resolves
+  // family/turbo/recommended-encoder info from the filename and sidecars —
+  // without this, GGUF split models (e.g. Krea 2 quants) never get a clip type.
+  function supportsModelSpec(filename: string): boolean {
+    return filename.endsWith(".safetensors") || filename.toLowerCase().endsWith(".gguf");
+  }
+
   async function loadModelSpec(category: string, filename: string) {
-    if (!filename || !filename.endsWith(".safetensors")) {
+    if (!filename || !supportsModelSpec(filename)) {
       loadedModelMetadataKey = "";
       isModelMetadataLoading = false;
       modelSpec = null;

--- a/src/lib/components/modelhub/ModelHubPage.svelte
+++ b/src/lib/components/modelhub/ModelHubPage.svelte
@@ -90,6 +90,7 @@
     { value: "vae", label: locale.t("modelhub.filter.vae") },
     { value: "controlnet", label: locale.t("modelhub.filter.controlnet") },
     { value: "embeddings", label: locale.t("modelhub.filter.textual_inversion") },
+    { value: "text_encoders", label: locale.t("modelhub.filter.text_encoder") },
   ]);
 
   const hfQuickLinks = [
@@ -110,6 +111,12 @@
       url: "https://huggingface.co/Acly/Omni-SR/resolve/main/OmniSR_X4_DIV2K.safetensors",
       filename: "OmniSR_X4_DIV2K.safetensors",
       category: "upscale_models",
+    },
+    {
+      label: "Qwen3-VL 4B FP8 (Krea 2)",
+      url: "https://huggingface.co/Comfy-Org/Krea-2/resolve/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors",
+      filename: "qwen3vl_4b_fp8_scaled.safetensors",
+      category: "text_encoders",
     },
   ] as const;
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -868,6 +868,7 @@ const de: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Textual Inversion",
+  "modelhub.filter.text_encoder": "Text-Encoder",
   "modelhub.search_placeholder": "Modellname, Ersteller, Stil...",
 
   "modelhub.sort.highest_rated": "Höchste Bewertung",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1032,6 +1032,7 @@ const en: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Textual Inversion",
+  "modelhub.filter.text_encoder": "Text Encoder",
 
   "modelhub.search_placeholder": "Model name, creator, style...",
 

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -905,6 +905,7 @@ const es: Record<string, string> = {
   "modelhub.filter.upscaler": "Escalador",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Inversión textual",
+  "modelhub.filter.text_encoder": "Codificador de texto",
   "modelhub.search_placeholder": "Nombre del modelo, creador, estilo...",
 
   "modelhub.sort.highest_rated": "Mejor valorados",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -869,6 +869,7 @@ const fr: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Inversion textuelle",
+  "modelhub.filter.text_encoder": "Encodeur de texte",
   "modelhub.search_placeholder": "Nom du modèle, créateur, style...",
 
   "modelhub.sort.highest_rated": "Mieux notés",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -847,6 +847,7 @@ const it: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Textual Inversion",
+  "modelhub.filter.text_encoder": "Encoder di testo",
   "modelhub.search_placeholder": "Nome del modello, creatore, stile...",
 
   "modelhub.sort.highest_rated": "Più votati",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -869,6 +869,7 @@ const ja: Record<string, string> = {
   "modelhub.filter.upscaler": "アップスケーラー",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "テクスチャルインバージョン",
+  "modelhub.filter.text_encoder": "テキストエンコーダー",
   "modelhub.search_placeholder": "モデル名、作成者、スタイル...",
 
   "modelhub.sort.highest_rated": "最高評価",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -847,6 +847,7 @@ const ko: Record<string, string> = {
   "modelhub.filter.upscaler": "업스케일러",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "텍스트 인버전",
+  "modelhub.filter.text_encoder": "텍스트 인코더",
   "modelhub.search_placeholder": "모델명, 제작자, 스타일...",
 
   "modelhub.sort.highest_rated": "최고 평점",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1031,6 +1031,7 @@ const pl: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Inwersja tekstualna",
+  "modelhub.filter.text_encoder": "Enkoder tekstu",
 
   "modelhub.search_placeholder": "Nazwa modelu, twórca, styl...",
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -847,6 +847,7 @@ const pt: Record<string, string> = {
   "modelhub.filter.upscaler": "Upscaler",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Textual Inversion",
+  "modelhub.filter.text_encoder": "Codificador de texto",
   "modelhub.search_placeholder": "Nome do modelo, criador, estilo...",
 
   "modelhub.sort.highest_rated": "Mais Bem Avaliados",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -847,6 +847,7 @@ const ru: Record<string, string> = {
   "modelhub.filter.upscaler": "Апскейлер",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "Textual Inversion",
+  "modelhub.filter.text_encoder": "Текстовый энкодер",
   "modelhub.search_placeholder": "Имя модели, автор, стиль...",
 
   "modelhub.sort.highest_rated": "С наивысшим рейтингом",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -847,6 +847,7 @@ const zhTw: Record<string, string> = {
   "modelhub.filter.upscaler": "放大器",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "文字反轉",
+  "modelhub.filter.text_encoder": "文字編碼器",
   "modelhub.search_placeholder": "模型名稱、創作者、風格...",
 
   "modelhub.sort.highest_rated": "最高評分",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -847,6 +847,7 @@ const zh: Record<string, string> = {
   "modelhub.filter.upscaler": "放大器",
   "modelhub.filter.vae": "VAE",
   "modelhub.filter.textual_inversion": "文本反转",
+  "modelhub.filter.text_encoder": "文本编码器",
   "modelhub.search_placeholder": "模型名称、创作者、风格...",
 
   "modelhub.sort.highest_rated": "最高评分",

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -727,8 +727,7 @@ export async function checkAttentionBackend(): Promise<AttentionBackendStatus> {
 }
 
 export async function getComputeCapability(): Promise<number | null> {
-  const status = await checkAttentionBackend();
-  return status.compute_capability;
+  return ipcInvoke("get_compute_capability");
 }
 
 export async function installAttentionBackend(backend: string): Promise<void> {


### PR DESCRIPTION
## What's New in v1.7.0

### New features
- **GGUF quantized models**: `.gguf` diffusion models and text encoders now load and generate. The workflow builder emits `UnetLoaderGGUF` / `CLIPLoaderGGUF` for `.gguf` filenames instead of the core `UNETLoader` / `CLIPLoader`, and the ComfyUI-GGUF custom node package installs automatically at ComfyUI setup. Install and verification failures are logged as warnings and do not block startup, so ComfyUI still runs with only GGUF models unavailable.
- **Text encoders in the Model Hub**: a Text Encoder filter joins the category list, plus a quick link for the Qwen3-VL 4B FP8 encoder used by Krea 2.

### Improvements
- **Model info panel reads GGUF files**: `read_modelspec_internal` previously bailed on anything that was not `.safetensors`, leaving GGUF models at family "unknown" and never resolving the split-model text encoder type. Filename heuristics, sidecar metadata, and hash lookups now apply to `.gguf` as well; safetensors-header-only reads stay gated behind `is_safetensors`.

### Fixes
- **No more console window flashes on Windows**: a new `tokio_command_no_window` helper applies `CREATE_NO_WINDOW` across custom node clones, pip/uv installs, python import checks, and the `nvidia-smi` probe, in both the Tauri and browser-mode paths.
- **Faster generation page**: new `get_compute_capability` command does a single `nvidia-smi` shell-out. The gen page calls this on mount and after every generation, and it previously ran the full `checkAttentionBackend` scan (including `uv` and `nvcc` lookups) each time.

## Validation
- `cargo check` passes; `Cargo.lock` refreshed to 1.7.0
- `npm run build` passes
- `cargo fmt --check` passes; no new clippy warnings on changed lines
- i18n parity verified: `modelhub.filter.text_encoder` present in all 12 locale files
- Versions match across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`

## Bot triage (steps 1-2)
No release-blocking bot findings. The 9 open PRs targeting main are all dependabot dependency bumps, none superseded by or blocking this release.