### PR TITLE
v1.7.1: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.7.1
+
+### Fixes
+- **Preview image fits the pane again**: the centered preview introduced in v1.6.0 was sized to the pane width, so whenever the pane was wider than it was tall (the usual shape once the bottom panel is open) the square preview grew taller than the space available and you had to scroll to see all of it. The preview now scales to whichever side fits, so it stays square, fully centered on both axes, and never needs scrolling.
+
+---
+
 ## What's New in v1.7.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.7.1
+
+### Fixes
+- **Preview image fits the pane again**: the centered preview introduced in v1.6.0 was sized to the pane width, so whenever the pane was wider than it was tall (the usual shape once the bottom panel is open) the square preview grew taller than the space available and you had to scroll to see all of it. The preview now scales to whichever side fits, so it stays square, fully centered on both axes, and never needs scrolling.
+
+---
+
 ## What's New in v1.7.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -2160,11 +2160,18 @@
       <div class="flex-1 min-w-0 flex flex-col overflow-hidden">
         <!-- Preview area -->
         <div
-          class="relative flex-1 min-h-0 p-6 {mobileFriendly ? 'pt-20' : ''} flex flex-col overflow-y-auto"
+          class="relative flex-1 min-h-0 p-6 {mobileFriendly ? 'pt-20' : ''} flex flex-col gap-4 overflow-hidden"
         >
-          <div class="m-auto w-full flex flex-col gap-4">
-            <ProgressBar />
-            <PreviewImage />
+          <ProgressBar />
+          <!-- The preview is a square (aspect-square), so it must be sized to the
+               SMALLER of the frame's width/height or it overflows. `max-w`/`max-h`
+               can't do this: clamping one axis of an aspect-ratio box doesn't feed
+               back into the other. `container-type: size` exposes the frame height
+               as `cqh`, so min(100%, 100cqh) picks the fitting side. -->
+          <div class="flex-1 min-h-0 flex items-center justify-center [container-type:size]">
+            <div class="w-[min(100%,100cqh)]">
+              <PreviewImage />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Fixes

- **Preview image fits the pane again**: the centered preview introduced in v1.6.0 was sized to the pane width, so whenever the pane was wider than it was tall (the usual shape once the bottom panel is open) the square preview grew taller than the space available and you had to scroll to see all of it. The preview now scales to whichever side fits, so it stays square, fully centered on both axes, and never needs scrolling.

## Release

- Version bumped to 1.7.1 in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`
- `RELEASE_NOTES.md` and `CHANGELOG.md` updated