### PR TITLE
v1.7.2: startup lock and collapsed-panel quality tag fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## What's New in v1.7.2
+
+### New features
+- **Startup lock**: while MooshieUI and ComfyUI are starting up, an "Initializing..." overlay covers the app content so nothing can be changed or typed until everything is loaded. Saved settings load in the background, and interacting before that finished could write half-loaded defaults over your saved values. The overlay clears as soon as ComfyUI connects, and immediately if auto-start is disabled or startup fails, so the status banner and its Start ComfyUI button stay reachable.
+
+### Fixes
+- **Quality tags now apply when the Model panel is collapsed**: model architecture detection only ran while the Model panel was open, so launching with it collapsed left the family as "unknown" and quality tags were skipped with no visible sign. Detection now runs no matter which panels are collapsed, so quality tags, model presets, and the recommended encoder and VAE all apply on launch.
+- **Typing during startup no longer resets settings**: saving was enabled before the saved settings finished loading, so a keystroke in the prompt box during startup could persist the in-memory defaults over what was on disk. This showed up most often as the auto quality tags toggle turning itself back off between launches.
+
+---
+
 ## What's New in v1.7.1
 
 ### Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+## What's New in v1.7.2
+
+### New features
+- **Startup lock**: while MooshieUI and ComfyUI are starting up, an "Initializing..." overlay covers the app content so nothing can be changed or typed until everything is loaded. Saved settings load in the background, and interacting before that finished could write half-loaded defaults over your saved values. The overlay clears as soon as ComfyUI connects, and immediately if auto-start is disabled or startup fails, so the status banner and its Start ComfyUI button stay reachable.
+
+### Fixes
+- **Quality tags now apply when the Model panel is collapsed**: model architecture detection only ran while the Model panel was open, so launching with it collapsed left the family as "unknown" and quality tags were skipped with no visible sign. Detection now runs no matter which panels are collapsed, so quality tags, model presets, and the recommended encoder and VAE all apply on launch.
+- **Typing during startup no longer resets settings**: saving was enabled before the saved settings finished loading, so a keystroke in the prompt box during startup could persist the in-memory defaults over what was on disk. This showed up most often as the auto quality tags toggle turning itself back off between launches.
+
+---
+
 ## What's New in v1.7.1
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.7.0"
+version = "1.7.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,6 +10,7 @@
   import ModelHubPage from "./lib/components/modelhub/ModelHubPage.svelte";
   import { ArtistGalleryPage } from "./lib/artist-gallery/index.js";
   import { connection } from "./lib/stores/connection.svelte.js";
+  import { startup } from "./lib/stores/startup.svelte.js";
   import { progress } from "./lib/stores/progress.svelte.js";
   import { gallery } from "./lib/stores/gallery.svelte.js";
   import { models } from "./lib/stores/models.svelte.js";
@@ -284,6 +285,26 @@
     autocomplete.notifyModelChanged(
       generation.isAnima || generation.isWan || generation.isQwen,
     );
+  });
+
+  // Model family/spec detection lives here rather than in ModelSelector, which
+  // is unmounted while the Model panel is collapsed. Quality-tag injection keys
+  // off generation.modelFamily, so detection has to run panel state aside.
+  $effect(() => {
+    const checkpoint = generation.checkpoint;
+    const diffusionModel = generation.diffusionModel;
+    const useSplitModel = generation.useSplitModel;
+    // Read eagerly: clearing a manual override must re-trigger detection, and
+    // the async body below runs after the tracking window has closed.
+    void generation.modelFamilyOverrides;
+
+    if (useSplitModel && diffusionModel) {
+      void generation.fetchAndApplyModelMetadata("diffusion_models", diffusionModel);
+    } else if (checkpoint) {
+      void generation.fetchAndApplyModelMetadata("checkpoints", checkpoint);
+    } else {
+      generation.clearModelMetadata();
+    }
   });
 
   // Document-level keyboard handler for lightbox (fallback for browser focus issues)
@@ -667,6 +688,8 @@
   }
 
   function showComfyStartupIssue(raw: unknown, fallbackMessage = "") {
+    // Startup failed — release the lock so the error banner and settings are usable.
+    startup.locked = false;
     const parsed = parseComfyServerError(raw, fallbackMessage);
     externalComfyPayload = parsed;
     externalComfyOpen = true;
@@ -2117,6 +2140,14 @@
   let autoStartEnabled = $state(true); // will be read from config
 
   async function initApp() {
+    // Block interaction until ComfyUI is reachable. Settings load asynchronously,
+    // and a save triggered mid-load would persist in-memory defaults over the
+    // restored values; model-family detection is in flight over the same window.
+    startup.locked = true;
+    // Never let the lock stick if no unlock path is reached (unreachable server,
+    // dropped event); the banner still reports the real startup state.
+    setTimeout(() => { startup.locked = false; }, 120_000);
+
     // Apply UI preferences (theme, font scale) immediately
     try {
       const cfg = await getConfig();
@@ -2147,6 +2178,7 @@
         console.log("Connection event:", event.payload);
         connection.connected = event.payload.connected;
         if (event.payload.connected) {
+          startup.locked = false;
           startupStatus = "";
           startupStatusKind = "idle";
           models.refresh().then(() => {
@@ -2156,6 +2188,9 @@
       }),
       ipcListen("comfyui:server_ready", async () => {
         console.log("Server ready event received");
+        // Unlock here too: with zero installed checkpoints connection.connected
+        // is never set, so the connection handler above would never fire.
+        startup.locked = false;
         startupStatus = "";
         startupStatusKind = "idle";
         // Load models now that server is up
@@ -2688,9 +2723,11 @@
               connection.connected = true;
               generation.applyDefaultsIfNeeded(models.checkpoints, models.vaes);
             }
+            startup.locked = false;
             startupStatus = "";
             startupStatusKind = "idle";
           } catch (e) {
+            startup.locked = false;
             console.error("Model refresh failed (already running):", e);
           }
         }
@@ -2699,6 +2736,9 @@
         showComfyStartupIssue(e, String(e));
       }
     } else {
+      // Manual mode: nothing is starting, so the user needs the UI (and the
+      // banner's start button) immediately.
+      startup.locked = false;
       startupStatus = locale.t("app.status.auto_start_disabled");
       startupStatusKind = "manual";
     }
@@ -3216,7 +3256,17 @@
         {/if}
       </div>
     {/if}
-    <div class="flex-1 overflow-hidden md:min-h-0 md:rounded-xl md:bg-neutral-950">
+    <div class="relative flex-1 overflow-hidden md:min-h-0 md:rounded-xl md:bg-neutral-950">
+    {#if startup.locked}
+      <div
+        class="absolute inset-0 z-50 flex flex-col items-center justify-center gap-3 bg-neutral-950/70 backdrop-blur-[2px]"
+        role="status"
+        aria-label={locale.t("app.startup.initializing")}
+      >
+        <div class="h-6 w-6 animate-spin rounded-full border-2 border-indigo-400 border-t-transparent"></div>
+        <span class="text-sm text-neutral-300">{locale.t("app.startup.initializing")}</span>
+      </div>
+    {/if}
     {#if currentPage === "generate"}
       <GenerationPage />
     {:else if currentPage === "gallery"}

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -3,13 +3,13 @@
   import { models } from "../../stores/models.svelte.js";
   import { autocomplete } from "../../stores/autocomplete.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
-  import { downloadModel, findModelByHash, hashModelFile, readModelSpec, getComputeCapability, type ModelSpec } from "../../utils/api.js";
+  import { downloadModel, findModelByHash, hashModelFile, getComputeCapability } from "../../utils/api.js";
   import { ipcListen } from "../../utils/ipc.js";
   import { onMount, onDestroy, tick } from "svelte";
   import InfoTip from "../ui/InfoTip.svelte";
   import { scrollCapture } from "../../utils/scrollCapture.js";
-  import { MODEL_FAMILIES, TURBO_MODEL_VARIANTS } from "../../utils/modelFamily.js";
-  import type { ModelFamily, TurboModelVariant } from "../../utils/modelFamily.js";
+  import { MODEL_FAMILIES, familyIsSdxlLike } from "../../utils/modelFamily.js";
+  import type { ModelFamily } from "../../utils/modelFamily.js";
 
   interface ModelFile {
     filename: string;
@@ -260,34 +260,12 @@
     },
   ];
 
-  let loadedModelMetadataKey = $state("");
-  let latestModelMetadataRequestId = 0;
-  let isModelMetadataLoading = $state(false);
   let showArchitecturePicker = $state(false);
-
-  let modelSpec = $state<ModelSpec | null>(null);
-  let modelSpecUnavailable = $state(false);
   let showModelInfo = $state(false);
 
-  /** Display-only ModelSpec fields shown in the model info panel. */
-  const MODEL_SPEC_DISPLAY_FIELDS = [
-    "title",
-    "author",
-    "description",
-    "architecture",
-    "hash",
-    "resolution",
-    "prediction_type",
-    "trigger_phrase",
-    "usage_hint",
-    "tags",
-    "license",
-  ] as const;
-
-  function specHasDisplayFields(spec: ModelSpec | null): boolean {
-    if (!spec) return false;
-    return MODEL_SPEC_DISPLAY_FIELDS.some((field) => !!spec[field]);
-  }
+  // Read-only views of the store state that App.svelte's detection effect fills in.
+  const modelSpec = $derived(generation.modelSpec);
+  const modelSpecUnavailable = $derived(generation.modelSpecUnavailable);
 
   /** Strip HTML tags and convert to readable plain text. */
   function stripHtml(html: string): string {
@@ -306,44 +284,28 @@
       .trim();
   }
 
-  function familyIsSdxlLike(family: ModelFamily): boolean {
-    return ["sdxl", "illustrious", "pony", "mugen"].includes(family);
-  }
-
-  function currentModelMetadataKey(): string {
-    if (generation.useSplitModel && generation.diffusionModel) {
-      return `diffusion_models::${generation.diffusionModel}`;
-    }
-    if (generation.checkpoint) {
-      return `checkpoints::${generation.checkpoint}`;
-    }
-    return "";
-  }
-
   function currentFamilyOverride(): ModelFamily | null {
-    const modelKey = currentModelMetadataKey();
+    const modelKey = generation.currentModelMetadataKey();
     return modelKey ? generation.modelFamilyOverrides[modelKey] ?? null : null;
   }
 
   function architectureBadgeLabel(): string {
-    if (!currentModelMetadataKey()) return "";
+    if (!generation.currentModelMetadataKey()) return "";
     const manualOverride = currentFamilyOverride();
     if (manualOverride) return manualOverride;
-    if (isModelMetadataLoading) return locale.t("generation.model.architecture_detecting");
+    if (generation.isModelMetadataLoading) return locale.t("generation.model.architecture_detecting");
     return generation.modelFamily === "unknown" ? "undefined" : generation.modelFamily;
   }
 
   function applyCurrentModelFamilyOverride(family: ModelFamily | null): void {
-    const modelKey = currentModelMetadataKey();
+    const modelKey = generation.currentModelMetadataKey();
     if (!modelKey) return;
 
-    latestModelMetadataRequestId += 1;
-    isModelMetadataLoading = false;
     showArchitecturePicker = false;
     generation.setModelFamilyOverride(modelKey, family);
 
     if (family) {
-      loadedModelMetadataKey = modelKey;
+      generation.prepareManualOverride(modelKey);
       generation.applyModelMetadata({
         modelspecPredictionType: null,
         modelspecPredictKey: null,
@@ -359,123 +321,9 @@
       return;
     }
 
-    loadedModelMetadataKey = "";
-    if (generation.useSplitModel && generation.diffusionModel) {
-      loadModelSpec("diffusion_models", generation.diffusionModel);
-    } else if (generation.checkpoint) {
-      loadModelSpec("checkpoints", generation.checkpoint);
-    }
-  }
-
-  // GGUF models carry no safetensors header, but the backend still resolves
-  // family/turbo/recommended-encoder info from the filename and sidecars —
-  // without this, GGUF split models (e.g. Krea 2 quants) never get a clip type.
-  function supportsModelSpec(filename: string): boolean {
-    return filename.endsWith(".safetensors") || filename.toLowerCase().endsWith(".gguf");
-  }
-
-  function toTurboModelVariant(value: string | undefined): TurboModelVariant {
-    return TURBO_MODEL_VARIANTS.includes(value as TurboModelVariant)
-      ? (value as TurboModelVariant)
-      : "none";
-  }
-
-  async function loadModelSpec(category: string, filename: string) {
-    if (!filename || !supportsModelSpec(filename)) {
-      loadedModelMetadataKey = "";
-      isModelMetadataLoading = false;
-      modelSpec = null;
-      modelSpecUnavailable = false;
-      generation.applyModelMetadata({
-        modelspecPredictionType: null,
-        modelspecPredictKey: null,
-        modelspecHeaderVPred: false,
-        modelFamily: "unknown",
-        modelIsSdxlLike: false,
-        modelTurboVariant: "none",
-        modelRecommendedVae: null,
-        modelRecommendedClipModel: null,
-        modelRecommendedClipType: null,
-      });
-      return;
-    }
-    const metadataKey = `${category}::${filename}`;
-    const manualOverride = generation.modelFamilyOverrides[metadataKey] ?? null;
-    if (manualOverride) {
-      loadedModelMetadataKey = metadataKey;
-      isModelMetadataLoading = false;
-      modelSpec = null;
-      modelSpecUnavailable = false;
-      generation.applyModelMetadata({
-        modelspecPredictionType: null,
-        modelspecPredictKey: null,
-        modelspecHeaderVPred: false,
-        modelFamily: manualOverride,
-        modelIsSdxlLike: familyIsSdxlLike(manualOverride),
-        modelTurboVariant: "none",
-        modelRecommendedVae: null,
-        modelRecommendedClipModel: null,
-        modelRecommendedClipType: null,
-      });
-      generation.applyModelSpecificPreset();
-      return;
-    }
-    if (metadataKey === loadedModelMetadataKey && generation.modelFamily !== "unknown") return;
-    const requestId = ++latestModelMetadataRequestId;
-    isModelMetadataLoading = true;
-    try {
-      const spec = await readModelSpec(category, filename);
-      if (requestId !== latestModelMetadataRequestId) return;
-      if (currentModelMetadataKey() !== metadataKey) return;
-
-      modelSpec = specHasDisplayFields(spec) ? spec : null;
-      modelSpecUnavailable = !modelSpec;
-
-      const family = (spec?.family as ModelFamily | undefined) ?? "unknown";
-      loadedModelMetadataKey = metadataKey;
-      isModelMetadataLoading = false;
-      generation.applyModelMetadata({
-        modelspecPredictionType: spec?.prediction_type ?? null,
-        modelspecPredictKey: spec?.predict_key ?? null,
-        modelspecHeaderVPred: spec?.header_v_pred === "true",
-        modelFamily: family,
-        modelIsSdxlLike: spec?.is_sdxl_like === "true",
-        modelTurboVariant: toTurboModelVariant(spec?.turbo_model_variant),
-        modelRecommendedVae: spec?.recommended_vae ?? null,
-        modelRecommendedClipModel: spec?.recommended_clip_model ?? null,
-        modelRecommendedClipType: spec?.recommended_clip_type ?? null,
-      });
-      generation.ensureRecommendedSplitClip(models.textEncoders);
-      generation.ensureRecommendedSplitVae(models.vaes);
-      if (family === "krea2") {
-        // Fire-and-forget: may kick off a multi-GB download; progress shows
-        // in the shared download rows under the model button.
-        void ensureKrea2Encoder();
-      }
-      generation.applyModelSpecificPreset();
-      if (family === "unknown") {
-        loadedModelMetadataKey = "";
-      }
-    } catch {
-      if (requestId !== latestModelMetadataRequestId) return;
-      if (currentModelMetadataKey() !== metadataKey) return;
-
-      loadedModelMetadataKey = "";
-      isModelMetadataLoading = false;
-      modelSpec = null;
-      modelSpecUnavailable = true;
-      generation.applyModelMetadata({
-        modelspecPredictionType: null,
-        modelspecPredictKey: null,
-        modelspecHeaderVPred: false,
-        modelFamily: "unknown",
-        modelIsSdxlLike: false,
-        modelTurboVariant: "none",
-        modelRecommendedVae: null,
-        modelRecommendedClipModel: null,
-        modelRecommendedClipType: null,
-      });
-    }
+    // Clearing the override changes generation.modelFamilyOverrides, which the
+    // App-level detection effect tracks — it re-runs the backend fetch for us.
+    generation.invalidateModelMetadataCache();
   }
 
   // Krea 2 only works with the Qwen3-VL 4B text encoder (12x2560 = 30720-dim
@@ -581,13 +429,12 @@
     }
   }
 
+  // Family detection itself lives in an App.svelte $effect (it has to run while
+  // this panel is collapsed). The encoder download stays here because it drives
+  // this component's progress rows, so it only runs while the panel is open.
   $effect(() => {
-    if (generation.useSplitModel && generation.diffusionModel) {
-      loadModelSpec("diffusion_models", generation.diffusionModel);
-    } else if (generation.checkpoint) {
-      loadModelSpec("checkpoints", generation.checkpoint);
-    } else {
-      isModelMetadataLoading = false;
+    if (generation.modelFamily === "krea2" && generation.useSplitModel) {
+      void ensureKrea2Encoder();
     }
   });
 
@@ -1075,7 +922,7 @@
     generation.useSplitModel = true;
     generation.diffusionModel = filename;
     generation.checkpoint = filename;
-    await loadModelSpec("diffusion_models", filename);
+    await generation.fetchAndApplyModelMetadata("diffusion_models", filename);
     generation.applyModelSpecificPreset();
   }
 
@@ -1228,11 +1075,11 @@
   <div class="relative">
     <div class="mb-1 flex items-center justify-between gap-2">
       <label class="block text-xs text-neutral-400">{locale.t('generation.model.checkpoint')}<InfoTip text={locale.t('generation.model.checkpoint_tip')} /></label>
-      {#if currentModelMetadataKey()}
+      {#if generation.currentModelMetadataKey()}
         <div bind:this={architecturePickerEl} class="relative shrink-0">
           <button
             type="button"
-            class="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors cursor-pointer {isModelMetadataLoading
+            class="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors cursor-pointer {generation.isModelMetadataLoading
               ? 'bg-amber-600/15 text-amber-300 border-amber-600/30 hover:bg-amber-600/25'
               : currentFamilyOverride()
                 ? 'bg-indigo-600/20 text-indigo-300 border-indigo-600/30 hover:bg-indigo-600/30'

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -37,6 +37,7 @@ const de: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "Wird initialisiert...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -82,6 +82,7 @@ const en: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "Initializing...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -55,6 +55,7 @@ const es: Record<string, string> = {
   "app.status.starting": "Iniciando...",
   "app.status.starting_comfyui": "Iniciando ComfyUI...",
   "app.status.connecting": "Conectando...",
+  "app.startup.initializing": "Inicializando...",
   "app.status.failed_to_start": "Error al iniciar: {message}",
   "app.status.unknown_error": "error desconocido",
   "app.status.auto_start_disabled": "ComfyUI no iniciado (inicio automático desactivado)",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -37,6 +37,7 @@ const fr: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "Initialisation...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -39,6 +39,7 @@ const it: Record<string, string> = {
     "app.status.starting": "Starting...",
     "app.status.starting_comfyui": "Starting ComfyUI...",
     "app.status.connecting": "Connecting...",
+    "app.startup.initializing": "Inizializzazione...",
     "app.status.failed_to_start": "Failed to start: {message}",
     "app.status.unknown_error": "unknown error",
     "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -39,6 +39,7 @@ const ja: Record<string, string> = {
     "app.status.starting": "Starting...",
     "app.status.starting_comfyui": "Starting ComfyUI...",
     "app.status.connecting": "Connecting...",
+    "app.startup.initializing": "初期化中...",
     "app.status.failed_to_start": "Failed to start: {message}",
     "app.status.unknown_error": "unknown error",
     "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -39,6 +39,7 @@ const ko: Record<string, string> = {
     "app.status.starting": "Starting...",
     "app.status.starting_comfyui": "Starting ComfyUI...",
     "app.status.connecting": "Connecting...",
+    "app.startup.initializing": "초기화 중...",
     "app.status.failed_to_start": "Failed to start: {message}",
     "app.status.unknown_error": "unknown error",
     "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -81,6 +81,7 @@ const pl: Record<string, string> = {
   "app.status.starting": "Uruchamianie...",
   "app.status.starting_comfyui": "Uruchamianie ComfyUI...",
   "app.status.connecting": "Łączenie...",
+  "app.startup.initializing": "Inicjalizacja...",
   "app.status.failed_to_start": "Uruchomienie nie powiodło się: {message}",
   "app.status.unknown_error": "nieznany błąd",
   "app.status.auto_start_disabled": "ComfyUI nie uruchomiono (automatyczne uruchamianie wyłączone)",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -39,6 +39,7 @@ const pt: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "A inicializar...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -39,6 +39,7 @@ const ru: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "Инициализация...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -39,6 +39,7 @@ const zhTw: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "初始化中...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -39,6 +39,7 @@ const zh: Record<string, string> = {
   "app.status.starting": "Starting...",
   "app.status.starting_comfyui": "Starting ComfyUI...",
   "app.status.connecting": "Connecting...",
+  "app.startup.initializing": "初始化中...",
   "app.status.failed_to_start": "Failed to start: {message}",
   "app.status.unknown_error": "unknown error",
   "app.status.auto_start_disabled": "ComfyUI not started (auto-start disabled)",

--- a/src/lib/stores/autocomplete.svelte.ts
+++ b/src/lib/stores/autocomplete.svelte.ts
@@ -383,7 +383,6 @@ class AutocompleteStore {
 
   async loadSettings() {
     try {
-      this._storeReady = true;
       const saved = await ipcStore.get<Record<string, any>>(STORE_KEY);
       if (saved) {
         if (saved.enabled === false) this.enabled = false;
@@ -416,6 +415,10 @@ class AutocompleteStore {
       }
     } catch (e) {
       console.error("Failed to load autocomplete settings:", e);
+    } finally {
+      // See generation.loadSettings(): only ready once the persisted values
+      // (and builtin tags) are in memory, so early saves can't clobber them.
+      this._storeReady = true;
     }
   }
 

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -14,7 +14,10 @@ import {
   TURBO_MODEL_VARIANTS,
   signalsIndicateVPred,
   familyRequiresSeparateClip,
+  familyIsSdxlLike,
+  toTurboModelVariant,
 } from "../utils/modelFamily.js";
+import { readModelSpec, type ModelSpec } from "../utils/api.js";
 import type { ModelFamily, TurboModelVariant } from "../utils/modelFamily.js";
 import type {
   ExtraPromptBox,
@@ -30,6 +33,34 @@ import { promptPresets } from "./promptPresets.svelte.js";
 const STORE_KEY = "generation-settings";
 const PROMPT_HISTORY_KEY = "mooshieui.promptHistory.v1";
 const MAX_PROMPT_HISTORY = 100;
+
+/** ModelSpec fields the model info panel renders; a spec with none is treated as empty. */
+const MODEL_SPEC_DISPLAY_FIELDS = [
+  "title",
+  "author",
+  "description",
+  "architecture",
+  "hash",
+  "resolution",
+  "prediction_type",
+  "trigger_phrase",
+  "usage_hint",
+  "tags",
+  "license",
+] as const;
+
+/** Every model signal cleared — used for no model, unsupported files, and failed detection. */
+const UNKNOWN_MODEL_METADATA = {
+  modelspecPredictionType: null,
+  modelspecPredictKey: null,
+  modelspecHeaderVPred: false,
+  modelFamily: "unknown" as ModelFamily,
+  modelIsSdxlLike: false,
+  modelTurboVariant: "none" as TurboModelVariant,
+  modelRecommendedVae: null,
+  modelRecommendedClipModel: null,
+  modelRecommendedClipType: null,
+};
 
 export interface GenerationToParamsOptions {
   fixedPresetChoices?: ReadonlyMap<string, string>;
@@ -462,6 +493,16 @@ class GenerationStore {
   modelRecommendedClipType = $state<string | null>(null);
   /** Manual per-model family override keyed by `category::filename`. */
   modelFamilyOverrides = $state<Record<string, ModelFamily>>({});
+  /** True while a read_modelspec call is in flight for the current model. */
+  isModelMetadataLoading = $state(false);
+  /** ModelSpec for the current model, or null when it carries no display fields. */
+  modelSpec = $state<ModelSpec | null>(null);
+  /** True when the backend returned no usable spec for the current model. */
+  modelSpecUnavailable = $state(false);
+  /** `category::filename` the metadata above was resolved for. */
+  private _loadedModelMetadataKey = "";
+  /** Guards against out-of-order read_modelspec responses. */
+  private _latestModelMetadataRequestId = 0;
   get mode(): GenerationMode {
     return this._mode;
   }
@@ -712,6 +753,116 @@ class GenerationStore {
     }
     this.modelFamilyOverrides = next;
     this.saveSettings();
+  }
+
+  /** `category::filename` identifying the currently selected model. */
+  currentModelMetadataKey(): string {
+    if (this.useSplitModel && this.diffusionModel) {
+      return `diffusion_models::${this.diffusionModel}`;
+    }
+    if (this.checkpoint) return `checkpoints::${this.checkpoint}`;
+    return "";
+  }
+
+  /** Reset every model signal to its unknown-model default. */
+  clearModelMetadata(): void {
+    this._latestModelMetadataRequestId += 1;
+    this._loadedModelMetadataKey = "";
+    this.isModelMetadataLoading = false;
+    this.modelSpec = null;
+    this.modelSpecUnavailable = false;
+    this.applyModelMetadata(UNKNOWN_MODEL_METADATA);
+  }
+
+  /**
+   * Record a manual family override as the resolved metadata for `cacheKey` so
+   * the App-level effect treats it as loaded instead of re-running detection.
+   */
+  prepareManualOverride(cacheKey: string): void {
+    this._latestModelMetadataRequestId += 1;
+    this._loadedModelMetadataKey = cacheKey;
+    this.isModelMetadataLoading = false;
+    this.modelSpec = null;
+    this.modelSpecUnavailable = false;
+  }
+
+  /** Drop the cached key so the next fetch re-runs backend detection. */
+  invalidateModelMetadataCache(): void {
+    this._latestModelMetadataRequestId += 1;
+    this._loadedModelMetadataKey = "";
+    this.isModelMetadataLoading = false;
+  }
+
+  /**
+   * Resolve and apply family/spec metadata for the selected model. Driven by an
+   * $effect in App.svelte rather than ModelSelector: that component is unmounted
+   * whenever the Model panel is collapsed, and quality-tag injection in
+   * toParams() keys off modelFamily, so it was silently skipped in that state.
+   */
+  async fetchAndApplyModelMetadata(category: string, filename: string): Promise<void> {
+    // GGUF carries no safetensors header, but the backend still resolves
+    // family/turbo/recommended-encoder info from the filename and sidecars.
+    const supportsSpec =
+      filename.endsWith(".safetensors") || filename.toLowerCase().endsWith(".gguf");
+    if (!filename || !supportsSpec) {
+      this.clearModelMetadata();
+      return;
+    }
+
+    const metadataKey = `${category}::${filename}`;
+    const manualOverride = this.modelFamilyOverrides[metadataKey] ?? null;
+    if (manualOverride) {
+      this.prepareManualOverride(metadataKey);
+      this.applyModelMetadata({
+        ...UNKNOWN_MODEL_METADATA,
+        modelFamily: manualOverride,
+        modelIsSdxlLike: familyIsSdxlLike(manualOverride),
+      });
+      this.applyModelSpecificPreset();
+      return;
+    }
+
+    if (metadataKey === this._loadedModelMetadataKey && this.modelFamily !== "unknown") return;
+
+    const requestId = ++this._latestModelMetadataRequestId;
+    this.isModelMetadataLoading = true;
+    try {
+      const spec = await readModelSpec(category, filename);
+      if (requestId !== this._latestModelMetadataRequestId) return;
+      if (this.currentModelMetadataKey() !== metadataKey) return;
+
+      this.modelSpec = MODEL_SPEC_DISPLAY_FIELDS.some((field) => !!spec?.[field]) ? spec : null;
+      this.modelSpecUnavailable = !this.modelSpec;
+
+      const family = (spec?.family as ModelFamily | undefined) ?? "unknown";
+      this._loadedModelMetadataKey = metadataKey;
+      this.isModelMetadataLoading = false;
+      this.applyModelMetadata({
+        modelspecPredictionType: spec?.prediction_type ?? null,
+        modelspecPredictKey: spec?.predict_key ?? null,
+        modelspecHeaderVPred: spec?.header_v_pred === "true",
+        modelFamily: family,
+        modelIsSdxlLike: spec?.is_sdxl_like === "true",
+        modelTurboVariant: toTurboModelVariant(spec?.turbo_model_variant),
+        modelRecommendedVae: spec?.recommended_vae ?? null,
+        modelRecommendedClipModel: spec?.recommended_clip_model ?? null,
+        modelRecommendedClipType: spec?.recommended_clip_type ?? null,
+      });
+      this.ensureRecommendedSplitClip(models.textEncoders);
+      this.ensureRecommendedSplitVae(models.vaes);
+      this.applyModelSpecificPreset();
+      // Nothing resolved — clear the key so a later selection retries detection.
+      if (family === "unknown") this._loadedModelMetadataKey = "";
+    } catch {
+      if (requestId !== this._latestModelMetadataRequestId) return;
+      if (this.currentModelMetadataKey() !== metadataKey) return;
+
+      this._loadedModelMetadataKey = "";
+      this.isModelMetadataLoading = false;
+      this.modelSpec = null;
+      this.modelSpecUnavailable = true;
+      this.applyModelMetadata(UNKNOWN_MODEL_METADATA);
+    }
   }
 
   ensureRecommendedSplitClip(encoders: string[], save = false): void {
@@ -1292,7 +1443,6 @@ class GenerationStore {
 
   async loadSettings() {
     try {
-      this._storeReady = true;
       const saved = await ipcStore.get<Record<string, any>>(STORE_KEY);
       if (saved) {
         const savedMode = isGenerationMode(saved.mode) ? saved.mode : this._mode;
@@ -1454,6 +1604,11 @@ class GenerationStore {
       }
     } catch (e) {
       console.error("Failed to load settings:", e);
+    } finally {
+      // Must stay after the awaited read: saveSettings() is a no-op until this
+      // flips, so a keystroke during startup can't persist defaults over the
+      // restored values. Set on the error path too, or saves break for good.
+      this._storeReady = true;
     }
   }
 

--- a/src/lib/stores/startup.svelte.ts
+++ b/src/lib/stores/startup.svelte.ts
@@ -1,0 +1,14 @@
+/**
+ * Startup interaction lock.
+ *
+ * Leaf store (no feature-store imports). App.svelte owns the lifecycle: it
+ * engages the lock when initApp() begins and releases it once ComfyUI is
+ * reachable, startup fails, or auto-start is disabled. The lock never
+ * re-engages afterwards, so a mid-session reconnect can't block the UI.
+ */
+class StartupStore {
+  /** Blocks all app content interaction while MooshieUI and ComfyUI start up. */
+  locked = $state(false);
+}
+
+export const startup = new StartupStore();

--- a/src/lib/utils/modelFamily.ts
+++ b/src/lib/utils/modelFamily.ts
@@ -124,3 +124,15 @@ export const SPLIT_ONLY_FAMILIES: ReadonlySet<ModelFamily> = new Set([
 export function familyRequiresSeparateClip(family: ModelFamily | null | undefined): boolean {
   return !!family && SPLIT_ONLY_FAMILIES.has(family);
 }
+
+/** SDXL-architecture families, used when a manual override skips backend detection. */
+export function familyIsSdxlLike(family: ModelFamily): boolean {
+  return (["sdxl", "illustrious", "pony", "mugen"] as ReadonlyArray<ModelFamily>).includes(family);
+}
+
+/** Coerce a raw ModelSpec string into a known turbo variant. */
+export function toTurboModelVariant(value: string | undefined): TurboModelVariant {
+  return TURBO_MODEL_VARIANTS.includes(value as TurboModelVariant)
+    ? (value as TurboModelVariant)
+    : "none";
+}


### PR DESCRIPTION
## What's in this release

### New features
- **Startup lock**: an "Initializing..." overlay covers the app content while MooshieUI and ComfyUI start up, so nothing can be changed or typed before settings finish loading. Clears when ComfyUI connects, and immediately when auto-start is disabled or startup fails so the status banner stays reachable.

### Fixes
- **Quality tags apply with the Model panel collapsed**: architecture detection previously lived in a `$effect` inside `ModelSelector.svelte`, which is only rendered when the Model panel is expanded. Launching collapsed meant the metadata fetch never ran, `generation.modelFamily` stayed "unknown", and every family check in `toParams()` was false, so quality tags were silently skipped. Detection moved into the generation store and is now driven from an always-mounted effect in `App.svelte`.
- **Typing during startup no longer resets settings**: `loadSettings()` in the generation and autocomplete stores set `_storeReady = true` before the awaited store read, so any interaction during the load window persisted in-memory defaults over the saved values. The flag now flips in a `finally` block after the read resolves, and still gets set on the error path so saves are never blocked permanently.

## Notes
- No Rust logic changes; `Cargo.lock` moves only for the version bump.
- New i18n key `app.startup.initializing` added to all 12 locale files (parity verified: 2247 keys).
- Known limitation carried over: the Krea 2 encoder auto-download still only fires while a ModelSelector is mounted, since it drives that component's progress rows. Family detection and quality tags are unaffected.

## Checks
- `npm run build` passed
- `cargo check --manifest-path src-tauri/Cargo.toml` passed
- Bot triage on open PRs: the 9 open PRs are all dependabot bumps with green checks and no review comments, none release-blocking.