### PR TITLE
v1.7.5: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v1.7.5
+
+### Fixes and maintenance
+- **Generation mode labels no longer wrap in narrow panels**: the mode switcher labels read "Text to Image" and "Image to Image", which broke onto a second line when the generation panel was sized narrow. They are now the standard short forms "Txt2Img" and "Img2Img" in every language (Chinese already used compact forms and is unchanged).
+- **Combined prompt toggle joins the prompt action row**: the button that switches between separate positive and negative boxes and the single combined box sat by itself above the prompt. It now shares a row with the Enhance, Compose, and Regional prompt buttons.
+
+---
+
 ## What's New in v1.7.4
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v1.7.5
+
+### Fixes and maintenance
+- **Generation mode labels no longer wrap in narrow panels**: the mode switcher labels read "Text to Image" and "Image to Image", which broke onto a second line when the generation panel was sized narrow. They are now the standard short forms "Txt2Img" and "Img2Img" in every language (Chinese already used compact forms and is unchanged).
+- **Combined prompt toggle joins the prompt action row**: the button that switches between separate positive and negative boxes and the single combined box sat by itself above the prompt. It now shares a row with the Enhance, Compose, and Regional prompt buttons.
+
+---
+
 ## What's New in v1.7.4
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -269,15 +269,9 @@
           <span class="font-mono max-w-28 truncate">@{displayName}</span>
         </button>
       {/each}
-      <button
-        type="button"
-        onclick={() => (combinedMode = !combinedMode)}
-        class="shrink-0 text-neutral-400 hover:text-neutral-200 transition-colors p-0.5"
-        title={combinedMode ? locale.t('generation.prompts.combined_mode_split') : locale.t('generation.prompts.combined_mode_toggle')}
-        aria-label={combinedMode ? locale.t('generation.prompts.combined_mode_split') : locale.t('generation.prompts.combined_mode_toggle')}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
-      </button>
+      {#if combinedMode && activeTab === "negative"}
+        {@render combineToggle()}
+      {/if}
       </div>
     </div>
     {#if combinedMode && activeTab === "negative"}
@@ -318,23 +312,26 @@
           <span class="text-[10px] text-neutral-400">{locale.t("prompt_assistant.loading_model")}</span>
         {/if}
       </div>
-      <button
-        type="button"
-        disabled={!regionalPromptingSupported}
-        onclick={() => {
-          if (!regionalPromptingSupported) {
-            gallery.showToast(locale.t("generation.regional.unsupported"), "warning");
-            return;
-          }
-          onOpenRegionalPrompt?.();
-        }}
-        class="rounded-lg border px-2 py-0.5 text-[10px] transition-colors disabled:cursor-not-allowed {regionalPromptingSupported
-          ? 'border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-indigo-500 hover:text-indigo-200'
-          : 'border-neutral-800 bg-neutral-950 text-neutral-500'}"
-        title={!regionalPromptingSupported ? locale.t("generation.regional.unsupported") : undefined}
-      >
-        {locale.t("generation.regional.button", { count: String(generation.regionalPrompts.length) })}
-      </button>
+      <div class="flex items-center gap-1.5">
+        <button
+          type="button"
+          disabled={!regionalPromptingSupported}
+          onclick={() => {
+            if (!regionalPromptingSupported) {
+              gallery.showToast(locale.t("generation.regional.unsupported"), "warning");
+              return;
+            }
+            onOpenRegionalPrompt?.();
+          }}
+          class="rounded-lg border px-2 py-0.5 text-[10px] transition-colors disabled:cursor-not-allowed {regionalPromptingSupported
+            ? 'border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-indigo-500 hover:text-indigo-200'
+            : 'border-neutral-800 bg-neutral-950 text-neutral-500'}"
+          title={!regionalPromptingSupported ? locale.t("generation.regional.unsupported") : undefined}
+        >
+          {locale.t("generation.regional.button", { count: String(generation.regionalPrompts.length) })}
+        </button>
+        {@render combineToggle()}
+      </div>
     </div>
     {#if generation.isAnima}
       <div class="text-[10px] text-amber-400/80 mb-1">{locale.t('generation.prompts.anima_artist_tip')}</div>
@@ -354,6 +351,18 @@
     <ExtraPromptBoxList side="positive" />
     {/if}
   </div>
+
+  {#snippet combineToggle()}
+    <button
+      type="button"
+      onclick={() => (combinedMode = !combinedMode)}
+      class="shrink-0 text-neutral-400 hover:text-neutral-200 transition-colors p-0.5"
+      title={combinedMode ? locale.t('generation.prompts.combined_mode_split') : locale.t('generation.prompts.combined_mode_toggle')}
+      aria-label={combinedMode ? locale.t('generation.prompts.combined_mode_split') : locale.t('generation.prompts.combined_mode_toggle')}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+    </button>
+  {/snippet}
 
   {#snippet negativeFields()}
   <div class="transition-opacity {generation.disablesNegativePrompt ? 'opacity-40 pointer-events-none' : ''}">

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -480,8 +480,8 @@ const de: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generierung ─────────────────────────────────────────
-  "generation.mode.txt2img": "Text zu Bild",
-  "generation.mode.img2img": "Bild zu Bild",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   "generation.prompts.title": "Prompts",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -498,8 +498,8 @@ const en: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generation ──────────────────────────────────────────
-  "generation.mode.txt2img": "Text to Image",
-  "generation.mode.img2img": "Image to Image",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   // Prompts

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -465,8 +465,8 @@ const es: Record<string, string> = {
   // ── Generación ──────────────────────────────────────────
   "generation.notification.image_ready_body": "Tu generación completada está lista para ver.",
   "generation.notification.images_ready_body": "{count} imágenes generadas están listas para ver.",
-  "generation.mode.txt2img": "Texto a imagen",
-  "generation.mode.img2img": "Imagen a imagen",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   // Prompts

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -468,8 +468,8 @@ const fr: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Génération ──────────────────────────────────────────
-  "generation.mode.txt2img": "Texte vers image",
-  "generation.mode.img2img": "Image vers image",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   // Prompts

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -459,8 +459,8 @@ const it: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Generazione ─────────────────────────────────────────
-  "generation.mode.txt2img": "Testo a immagine",
-  "generation.mode.img2img": "Immagine a immagine",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   "generation.prompts.title": "Prompt",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -468,8 +468,8 @@ const ja: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── 生成 ────────────────────────────────────────────────
-  "generation.mode.txt2img": "テキストから画像",
-  "generation.mode.img2img": "画像から画像",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "インペインティング",
 
   // プロンプト

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -459,8 +459,8 @@ const ko: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── 생성 ────────────────────────────────────────────────
-  "generation.mode.txt2img": "텍스트에서 이미지",
-  "generation.mode.img2img": "이미지에서 이미지",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "인페인팅",
 
   "generation.prompts.title": "프롬프트",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -497,8 +497,8 @@ const pl: Record<string, string> = {
   "settings.advanced_mode.cancel": "Anuluj",
 
   // ── Generation ──────────────────────────────────────────
-  "generation.mode.txt2img": "Tekst na obraz",
-  "generation.mode.img2img": "Obraz na obraz",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   // Prompts

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -459,8 +459,8 @@ const pt: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Geração ─────────────────────────────────────────────
-  "generation.mode.txt2img": "Texto para Imagem",
-  "generation.mode.img2img": "Imagem para Imagem",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Inpainting",
 
   "generation.prompts.title": "Prompts",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -459,8 +459,8 @@ const ru: Record<string, string> = {
   "settings.advanced_mode.cancel": "Cancel",
 
   // ── Генерация ───────────────────────────────────────────
-  "generation.mode.txt2img": "Текст в изображение",
-  "generation.mode.img2img": "Изображение в изображение",
+  "generation.mode.txt2img": "Txt2Img",
+  "generation.mode.img2img": "Img2Img",
   "generation.mode.inpainting": "Инпейнтинг",
 
   "generation.prompts.title": "Промпты",


### PR DESCRIPTION
UI polish for the generation panel:

- Shorten the generation mode labels to "Txt2Img" and "Img2Img" in all locales so they no longer wrap onto two lines in narrow panels (Chinese locales already used compact forms and are unchanged)
- Move the combined/split prompt toggle out of the prompt header and onto the same row as the Enhance, Compose, and Regional prompt buttons
- Bump version to 1.7.5 in package.json, Cargo.toml, tauri.conf.json; update RELEASE_NOTES.md and CHANGELOG.md