### PR TITLE
v1.7.6: exact large-seed handling, gallery seed/steps/CFG search, Interrogate hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## What's New in v1.7.6
+
+### Fixes
+- **Large seeds are preserved exactly**: ComfyUI seeds use the full 63-bit range, but the app carried them as JavaScript numbers, which only hold 53 bits precisely. A seed like 8173306563118891294 was silently rounded, so reusing it from an image's metadata, remixing, or building a regional inpaint chain reproduced a different image than the one it came from. Seeds are now carried as exact decimal strings from the seed box all the way to ComfyUI and back, so any seed round-trips faithfully. The seed field accepts the full range, and settings saved by an older version load unchanged.
+- **Gallery search reads MooshieUI's own seed, steps, and CFG**: the gallery index expected these values as numbers, but MooshieUI writes them into image metadata as strings, so pictures generated in-app were indexed with no seed, steps, or CFG and did not turn up when filtering the gallery by those fields. The index now reads either form.
+
+### Improvements
+- **A one-time hint points to the relocated Interrogate button**: the Interrogate tool moved from the panel list to the sidebar in an earlier release, and returning users could not find where it went (issue #488). A small dismissible bubble now points at the sidebar button; opening Interrogate once, or closing the bubble, hides it for good.
+
+---
+
 ## What's New in v1.7.5
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+## What's New in v1.7.6
+
+### Fixes
+- **Large seeds are preserved exactly**: ComfyUI seeds use the full 63-bit range, but the app carried them as JavaScript numbers, which only hold 53 bits precisely. A seed like 8173306563118891294 was silently rounded, so reusing it from an image's metadata, remixing, or building a regional inpaint chain reproduced a different image than the one it came from. Seeds are now carried as exact decimal strings from the seed box all the way to ComfyUI and back, so any seed round-trips faithfully. The seed field accepts the full range, and settings saved by an older version load unchanged.
+- **Gallery search reads MooshieUI's own seed, steps, and CFG**: the gallery index expected these values as numbers, but MooshieUI writes them into image metadata as strings, so pictures generated in-app were indexed with no seed, steps, or CFG and did not turn up when filtering the gallery by those fields. The index now reads either form.
+
+### Improvements
+- **A one-time hint points to the relocated Interrogate button**: the Interrogate tool moved from the panel list to the sidebar in an earlier release, and returning users could not find where it went (issue #488). A small dismissible bubble now points at the sidebar button; opening Interrogate once, or closing the bubble, hides it for good.
+
+---
+
 ## What's New in v1.7.5
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.7.5"
+version = "1.7.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.7.5"
+version = "1.7.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -92,6 +92,40 @@ pub struct PositiveRegion {
     pub strength: f64,
 }
 
+/// Seeds are 63-bit and exceed JavaScript's 2^53 safe-integer range, so they
+/// must cross the IPC/JSON boundary as strings. Serializes an i64 as a decimal
+/// string; accepts a string or a bare number (old persisted settings/clients).
+pub mod seed_string {
+    use serde::{de, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &i64, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&v.to_string())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<i64, D::Error> {
+        struct SeedVisitor;
+        impl<'de> de::Visitor<'de> for SeedVisitor {
+            type Value = i64;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a seed as an integer or string")
+            }
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<i64, E> {
+                Ok(v)
+            }
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<i64, E> {
+                Ok(v as i64)
+            }
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<i64, E> {
+                Ok(v as i64)
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<i64, E> {
+                v.trim().parse::<i64>().map_err(de::Error::custom)
+            }
+        }
+        d.deserialize_any(SeedVisitor)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenerationParams {
     pub mode: String,
@@ -112,6 +146,7 @@ pub struct GenerationParams {
     pub scheduler: String,
     pub steps: u32,
     pub cfg: f64,
+    #[serde(with = "seed_string")]
     pub seed: i64,
     pub width: u32,
     pub height: u32,

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -8,9 +8,12 @@ use crate::state::AppState;
 use crate::templates;
 
 /// Response from the generate command, includes the resolved seed.
+/// The seed is serialized as a string: 63-bit values exceed JavaScript's
+/// 2^53 safe-integer range and would be silently rounded as a JSON number.
 #[derive(serde::Serialize)]
 pub struct GenerateResponse {
     pub prompt_id: String,
+    #[serde(serialize_with = "crate::comfyui::types::seed_string::serialize")]
     pub seed: i64,
 }
 

--- a/src-tauri/src/gallery_index.rs
+++ b/src-tauri/src/gallery_index.rs
@@ -121,6 +121,18 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+/// Read a JSON value as i64, accepting either a number or a decimal string.
+fn json_i64(v: &serde_json::Value) -> Option<i64> {
+    v.as_i64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
+}
+
+/// Read a JSON value as f64, accepting either a number or a decimal string.
+fn json_f64(v: &serde_json::Value) -> Option<f64> {
+    v.as_f64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse().ok()))
+}
+
 /// Parse the embedded SwarmUI `sui_image_params` JSON into queryable columns.
 fn extract_params(metadata: &HashMap<String, String>) -> ParsedParams {
     let mut p = ParsedParams::default();
@@ -144,9 +156,11 @@ fn extract_params(metadata: &HashMap<String, String>) -> ParsedParams {
                     .get("scheduler")
                     .and_then(|x| x.as_str())
                     .map(str::to_owned);
-                p.cfg = obj.get("cfgscale").and_then(|x| x.as_f64());
-                p.steps = obj.get("steps").and_then(|x| x.as_i64());
-                p.seed = obj.get("seed").and_then(|x| x.as_i64());
+                // MooshieUI writes these SwarmUI values as JSON strings (see
+                // metadata::format_swarmui_json); SwarmUI itself uses numbers.
+                p.cfg = obj.get("cfgscale").and_then(json_f64);
+                p.steps = obj.get("steps").and_then(json_i64);
+                p.seed = obj.get("seed").and_then(json_i64);
                 p.width = obj.get("width").and_then(|x| x.as_i64());
                 p.height = obj.get("height").and_then(|x| x.as_i64());
             }

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2803,10 +2803,11 @@ async fn dispatch_command(
                 }
             });
 
-            // Return immediately — the frontend tracks progress via SSE/WebSocket events
+            // Return immediately — the frontend tracks progress via SSE/WebSocket events.
+            // Seed as a string: 63-bit values exceed JS's 2^53 safe-integer range.
             Ok(serde_json::json!({
                 "prompt_id": placeholder_id,
-                "seed": seed,
+                "seed": seed.to_string(),
                 "queue_position": queue_pos,
                 "queue_total": queue_total,
             }))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1118,6 +1118,17 @@
   let showInterrogateQuickModal = $state(false);
   let interrogateSidebarBtn = $state<HTMLButtonElement | undefined>();
 
+  // One-time speech bubble pointing at the sidebar interrogate button, for
+  // users who knew the feature from its pre-v1.6.0 spot in the panel list
+  // (issue #488). UI layout pref → localStorage, like the combined-prompt
+  // toggle. Using the button also dismisses it: the feature was found.
+  const INTERROGATE_HINT_KEY = "mooshieui.hint.interrogate-sidebar.v1";
+  let showInterrogateHint = $state(localStorage.getItem(INTERROGATE_HINT_KEY) !== "true");
+  function dismissInterrogateHint() {
+    showInterrogateHint = false;
+    try { localStorage.setItem(INTERROGATE_HINT_KEY, "true"); } catch {}
+  }
+
   /** Shared runner for the quick-interrogate flows: opens the results modal,
    *  wires the progress/stage listeners, then runs the supplied IPC call. */
   async function runQuickInterrogation(previewUrl: string | null, run: () => Promise<InterrogationResult>) {
@@ -1464,7 +1475,9 @@
 
       if (mode === "seed") {
         if (metadata.seed !== undefined) {
-          generation.seed = Number(metadata.seed) || generation.seed;
+          // Assign the string as-is: Number() would round 63-bit seeds past 2^53.
+          const seed = metadata.seed.trim();
+          if (/^\d+$/.test(seed)) generation.seed = seed;
           gallery.showToast(locale.t("gallery.toast.applied_seed"), "success");
         } else {
           gallery.showToast(locale.t("gallery.toast.no_seed"), "info");
@@ -1516,12 +1529,14 @@
       }
 
       if (mode === "remix") {
-        generation.seed = -1;
+        generation.seed = "-1";
         gallery.showToast(locale.t("gallery.toast.loaded_remix"), "success");
         return;
       }
 
-      if (metadata.seed !== undefined) generation.seed = Number(metadata.seed) || generation.seed;
+      if (metadata.seed !== undefined && /^\d+$/.test(metadata.seed.trim())) {
+        generation.seed = metadata.seed.trim();
+      }
       gallery.showToast(locale.t("gallery.toast.applied_settings"), "success");
     } catch (e) {
       console.error("Failed to apply metadata:", e);
@@ -3065,30 +3080,62 @@
 
     <div class="flex-1"></div>
 
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <button
-      bind:this={interrogateSidebarBtn}
-      class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {showInterrogateQuickModal
-        ? 'bg-indigo-600 text-white'
-        : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200'} mx-auto"
-      onclick={() => (showInterrogateQuickModal = true)}
-      ondragenter={(e) => { e.preventDefault(); startInterrogateHoverTimer(); }}
-      ondragover={(e) => { e.preventDefault(); }}
-      ondragleave={cancelInterrogateHoverTimer}
-      title={locale.t('generation.interrogate.title')}
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="w-4.5 h-4.5 pointer-events-none"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        ><path d="M3 7V5a2 2 0 0 1 2-2h2" /><path d="M17 3h2a2 2 0 0 1 2 2v2" /><path d="M21 17v2a2 2 0 0 1-2 2h-2" /><path d="M7 21H5a2 2 0 0 1-2-2v-2" /><circle cx="12" cy="12" r="3" /><path d="m16 16-1.5-1.5" /></svg
+    <div class="relative mx-auto">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <button
+        bind:this={interrogateSidebarBtn}
+        class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {showInterrogateQuickModal
+          ? 'bg-indigo-600 text-white'
+          : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200'}"
+        onclick={() => { dismissInterrogateHint(); showInterrogateQuickModal = true; }}
+        ondragenter={(e) => { e.preventDefault(); startInterrogateHoverTimer(); }}
+        ondragover={(e) => { e.preventDefault(); }}
+        ondragleave={cancelInterrogateHoverTimer}
+        title={locale.t('generation.interrogate.title')}
       >
-    </button>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="w-4.5 h-4.5 pointer-events-none"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><path d="M3 7V5a2 2 0 0 1 2-2h2" /><path d="M17 3h2a2 2 0 0 1 2 2v2" /><path d="M21 17v2a2 2 0 0 1-2 2h-2" /><path d="M7 21H5a2 2 0 0 1-2-2v-2" /><circle cx="12" cy="12" r="3" /><path d="m16 16-1.5-1.5" /></svg
+        >
+      </button>
+      {#if showInterrogateHint}
+        <div
+          role="status"
+          class="absolute left-full top-1/2 z-50 ml-3 w-56 -translate-y-1/2 rounded-lg border border-[var(--theme-accent-500)] bg-neutral-800 p-2.5 pr-7 shadow-xl shadow-black/40"
+        >
+          <div
+            class="absolute top-1/2 -left-1.25 h-2 w-2 -translate-y-1/2 rotate-45 border-b border-l border-[var(--theme-accent-500)] bg-neutral-800"
+          ></div>
+          <p class="text-xs leading-snug text-neutral-200">
+            {locale.t("generation.interrogate.hint_moved")}
+          </p>
+          <button
+            class="absolute top-1 right-1 flex h-5 w-5 items-center justify-center rounded text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200"
+            onclick={dismissInterrogateHint}
+            aria-label={locale.t("common.close")}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-3 w-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg
+            >
+          </button>
+        </div>
+      {/if}
+    </div>
 
     <button
       class="w-8 h-8 rounded-lg flex items-center justify-center transition-colors {currentPage ===

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -502,8 +502,8 @@
       }
 
       // Use shared seed for random seeds so the grid is consistent
-      if (params.seed < 0) {
-        params.seed = sharedSeed;
+      if (params.seed === "-1") {
+        params.seed = String(sharedSeed);
       }
 
       try {

--- a/src/lib/components/generation/SamplerSettings.svelte
+++ b/src/lib/components/generation/SamplerSettings.svelte
@@ -7,7 +7,7 @@
   import EditableValue from "../ui/EditableValue.svelte";
   import { scrollCapture } from "../../utils/scrollCapture.js";
 
-  let randomSeed = $derived(generation.seed === -1);
+  let randomSeed = $derived(generation.seed === "-1");
   const activeModelName = $derived((generation.diffusionModel || generation.checkpoint || "").toLowerCase());
   const hasAnimaRecommendation = $derived(generation.isAnima || activeModelName.includes("anima"));
   const hasJuiceRecommendation = $derived(
@@ -277,23 +277,24 @@
             class="text-[10px] px-1.5 py-0.5 rounded {randomSeed
               ? 'bg-indigo-600 text-white'
               : 'bg-neutral-700 text-neutral-300'} transition-colors"
-            onclick={() => (generation.seed = randomSeed ? (progress.lastCompletedSeed ?? 0) : -1)}
+            onclick={() => (generation.seed = randomSeed ? (progress.lastCompletedSeed ?? "0") : "-1")}
           >
             {locale.t('generation.sampler.seed_random')}
           </button>
         </div>
       </label>
       <!-- Single editable box: shows "Random" as a placeholder when RNG is on, and
-           typing a value switches off RNG automatically — no need to toggle first (#394). -->
+           typing a value switches off RNG automatically — no need to toggle first (#394).
+           type="text": a number input would round 63-bit seeds past 2^53. -->
       <input
-        type="number"
-        min="0"
+        type="text"
+        inputmode="numeric"
         value={randomSeed ? '' : generation.seed}
         placeholder={locale.t('generation.sampler.random_display')}
         oninput={(e) => {
-          const raw = e.currentTarget.value.trim();
-          const n = Number(raw);
-          generation.seed = raw === '' || Number.isNaN(n) ? -1 : Math.max(0, Math.floor(n));
+          const digits = e.currentTarget.value.replace(/\D/g, '');
+          if (e.currentTarget.value !== digits) e.currentTarget.value = digits;
+          generation.seed = digits === '' ? "-1" : digits;
         }}
         class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
       />

--- a/src/lib/stores/compare.svelte.ts
+++ b/src/lib/stores/compare.svelte.ts
@@ -16,7 +16,8 @@ export interface CellSnapshot {
   scheduler: string;
   steps: number;
   cfg: number;
-  seed: number;
+  /** Decimal string ("-1" = random) — 63-bit seeds exceed JS's safe-integer range. */
+  seed: string;
   width: number;
   height: number;
   denoise: number;
@@ -261,7 +262,7 @@ class CompareStore {
       const name = snap.checkpoint.split(/[\\/]/).pop()?.replace(/\.[^.]+$/, "") ?? snap.checkpoint;
       diffs.push(name.length > 18 ? name.slice(0, 16) + "…" : name);
     }
-    if (snap.seed !== ref.seed && snap.seed !== -1) diffs.push(locale.t("compare.summary.seed", { seed: String(snap.seed) }));
+    if (snap.seed !== ref.seed && snap.seed !== "-1") diffs.push(locale.t("compare.summary.seed", { seed: snap.seed }));
     if (snap.steps !== ref.steps) diffs.push(locale.t("compare.summary.steps", { steps: String(snap.steps) }));
     if (snap.cfg !== ref.cfg) diffs.push(locale.t("compare.summary.cfg", { cfg: String(snap.cfg) }));
     if (snap.samplerName !== ref.samplerName) diffs.push(snap.samplerName);
@@ -357,7 +358,7 @@ class CompareStore {
       if (snap.scheduler !== ref.scheduler) diffs.push(snap.scheduler);
       if (snap.steps !== ref.steps) diffs.push(locale.t("compare.summary.steps", { steps: String(snap.steps) }));
       if (snap.cfg !== ref.cfg) diffs.push(locale.t("compare.summary.cfg", { cfg: String(snap.cfg) }));
-      if (snap.seed !== ref.seed && snap.seed !== -1) diffs.push(locale.t("compare.summary.seed", { seed: String(snap.seed) }));
+      if (snap.seed !== ref.seed && snap.seed !== "-1") diffs.push(locale.t("compare.summary.seed", { seed: snap.seed }));
       if (snap.width !== ref.width || snap.height !== ref.height) {
         diffs.push(locale.t("compare.summary.dimensions", { width: String(snap.width), height: String(snap.height) }));
       }

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -360,7 +360,8 @@ class GenerationStore {
   scheduler = $state("sgm_uniform");
   steps = $state(20);
   cfg = $state(1.4);
-  seed = $state(-1);
+  // Decimal string ("-1" = random): 63-bit seeds exceed JS's safe-integer range.
+  seed = $state("-1");
   width = $state(512);
   height = $state(512);
   batchSize = $state(1);
@@ -1453,7 +1454,8 @@ class GenerationStore {
         if (saved.scheduler) this.scheduler = saved.scheduler;
         if (saved.steps) this.steps = saved.steps;
         if (saved.cfg !== undefined) this.cfg = saved.cfg;
-        if (saved.seed !== undefined) this.seed = saved.seed;
+        // String(...) coerces seeds persisted as numbers by older versions.
+        if (saved.seed !== undefined) this.seed = String(saved.seed);
         if (saved.width) this.width = saved.width;
         if (saved.height) this.height = saved.height;
         if (saved.batchSize) this.batchSize = saved.batchSize;

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -43,8 +43,8 @@ class ProgressStore {
   /** Persists wasUpscaled from the last completed prompt (for PreviewImage overlay). */
   private _lastCompletedWasUpscaled = $state(false);
 
-  /** The seed used by the most recently completed generation. */
-  lastCompletedSeed = $state<number | null>(null);
+  /** The seed used by the most recently completed generation (decimal string). */
+  lastCompletedSeed = $state<string | null>(null);
 
   /** Global queue position for this user's next prompt (0 = generating now). */
   queuePosition = $state<number | null>(null);
@@ -337,7 +337,7 @@ class ProgressStore {
 
     if (item) {
       this._lastCompletedWasUpscaled = item.wasUpscaled;
-      if (item.params != null && item.params.seed != null && item.params.seed >= 0) {
+      if (item.params != null && item.params.seed != null && item.params.seed !== "-1") {
         this.lastCompletedSeed = item.params.seed;
       }
       // Capture total generation time. Prefer the per-prompt startedAt (robust

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -96,7 +96,8 @@ export interface GenerationParams {
   scheduler: string;
   steps: number;
   cfg: number;
-  seed: number;
+  /** Decimal string ("-1" = random) — 63-bit seeds exceed JS's safe-integer range. */
+  seed: string;
   width: number;
   height: number;
   batch_size: number;

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -31,7 +31,8 @@ export async function getEmbeddings(): Promise<string[]> {
 
 export interface GenerateResponse {
   prompt_id: string;
-  seed: number;
+  /** Decimal string — 63-bit seeds exceed JS's safe-integer range. */
+  seed: string;
   queue_position?: number;
   queue_total?: number;
 }

--- a/src/lib/utils/metadataImport.ts
+++ b/src/lib/utils/metadataImport.ts
@@ -141,8 +141,9 @@ function applySampler(meta: Record<string, string>): boolean {
     if (!isNaN(v)) { generation.denoise = v; applied = true; }
   }
   if (meta.seed) {
-    const v = parseInt(meta.seed, 10);
-    if (!isNaN(v)) { generation.seed = v; applied = true; }
+    // Keep the seed as a string: parseInt would round 63-bit seeds past 2^53.
+    const trimmed = meta.seed.trim();
+    if (/^\d+$/.test(trimmed)) { generation.seed = trimmed; applied = true; }
   }
   return applied;
 }

--- a/src/lib/utils/regionalChainSeed.ts
+++ b/src/lib/utils/regionalChainSeed.ts
@@ -1,13 +1,20 @@
-/** Stay within Number.MAX_SAFE_INTEGER so IPC/JSON does not round seeds. */
-const REGIONAL_CHAIN_SEED_MOD = 2_147_483_000;
+/** Keep derived seeds small and well-spread; BigInt keeps the math exact. */
+const REGIONAL_CHAIN_SEED_MOD = 2_147_483_000n;
 
 /**
- * Derive a distinct, IPC-safe seed for each regional inpaint chain step.
- * Large ComfyUI seeds (e.g. 8173306563118891294) lose precision in JSON and
- * every chain step would otherwise get the same rounded value.
+ * Derive a distinct seed for each regional inpaint chain step.
+ * Seeds are decimal strings ("-1" = random): 63-bit values exceed
+ * Number.MAX_SAFE_INTEGER, so the arithmetic runs in BigInt.
  */
-export function regionalChainStepSeed(baseSeed: number, regionIndex: number): number {
-  if (baseSeed < 0) return -1;
-  const base = Math.abs(Math.floor(baseSeed)) % REGIONAL_CHAIN_SEED_MOD;
-  return (base + (regionIndex + 1) * 9973) % REGIONAL_CHAIN_SEED_MOD;
+export function regionalChainStepSeed(baseSeed: string, regionIndex: number): string {
+  let parsed: bigint;
+  try {
+    parsed = BigInt(baseSeed.trim());
+  } catch {
+    return "-1";
+  }
+  if (parsed < 0n) return "-1";
+  const base = parsed % REGIONAL_CHAIN_SEED_MOD;
+  const step = (base + BigInt(regionIndex + 1) * 9973n) % REGIONAL_CHAIN_SEED_MOD;
+  return step.toString();
 }

--- a/src/lib/utils/regionalInpaintChain.ts
+++ b/src/lib/utils/regionalInpaintChain.ts
@@ -29,7 +29,7 @@ export interface RegionalInpaintChainCallbacks {
   submit: (
     params: GenerationParams,
     ctx: RegionalInpaintChainStepContext,
-  ) => Promise<{ promptId: string; seed: number }>;
+  ) => Promise<{ promptId: string; seed: string }>;
   onStep?: (info: { phase: "base" | "region"; index: number; total: number }) => void;
   onWaitingForOutput?: () => void;
   shouldCancel?: () => boolean;


### PR DESCRIPTION
## What's New in v1.7.6

### Fixes
- **Large seeds are preserved exactly**: ComfyUI seeds use the full 63-bit range, but the app carried them as JavaScript numbers, which only hold 53 bits precisely. A seed like 8173306563118891294 was silently rounded, so reusing it from an image's metadata, remixing, or building a regional inpaint chain reproduced a different image than the one it came from. Seeds are now carried as exact decimal strings from the seed box through IPC to ComfyUI and back (Rust `seed_string` serde module accepting either form for old persisted settings). The seed field is now a numeric text input accepting the full range.
- **Gallery search reads MooshieUI's own seed, steps, and CFG**: the gallery index expected these SwarmUI values as numbers, but MooshieUI writes them into metadata as strings, so in-app images were indexed with empty seed/steps/CFG and did not match those gallery filters. The index now reads either form.

### Improvements
- **A one-time hint points to the relocated Interrogate button**: the Interrogate tool moved from the panel list to the sidebar in an earlier release (issue #488). A small dismissible bubble now points at the sidebar button; opening Interrogate once, or closing the bubble, hides it permanently (localStorage flag).

### Validation
- `cargo check` PASS, `npm run build` PASS, `cargo fmt --check` PASS, clippy clean on changed files.
- svelte-check shows no new type errors in the seed-refactor files (7 reported errors are all pre-existing, outside this diff).
- i18n parity: `generation.interrogate.hint_moved` present in all 12 locale files.

### Bot triage
- No open PRs are part of this release; the 14 open PRs are independent dependabot bumps. Release content is fresh working-tree work, so first bot review happens on this PR.