### PR TITLE
copy gallery images to clipboard fully Rust-side

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "axum-server",
  "base64 0.22.1",
  "chrono",
+ "clipboard-win",
  "csv",
  "dirs",
  "env_logger",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,3 +90,6 @@ tar = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tar = "0.4"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+clipboard-win = "5"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1800,27 +1800,13 @@ fn infer_image_mime(bytes: &[u8], ext_hint: Option<&str>) -> &'static str {
 /// Much faster than decoding PNGs and preserves all metadata.
 #[cfg(target_os = "windows")]
 fn clipboard_set_file_drop_win(path: &std::path::Path) -> Result<(), AppError> {
-    use std::os::windows::process::CommandExt;
-    use std::process::Command;
-
-    let path_escaped = path.display().to_string().replace('\'', "''");
-    let ps_cmd = format!(
-        "Add-Type -AssemblyName System.Windows.Forms; \
-         $f = New-Object System.Collections.Specialized.StringCollection; \
-         $f.Add('{}'); \
-         [System.Windows.Forms.Clipboard]::SetFileDropList($f)",
-        path_escaped
-    );
-    let status = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &ps_cmd])
-        .creation_flags(0x08000000) // CREATE_NO_WINDOW
-        .status()
-        .map_err(|e| AppError::Other(format!("PowerShell failed: {}", e)))?;
-    if !status.success() {
-        return Err(AppError::Other(
-            "Failed to copy file to clipboard via PowerShell".into(),
-        ));
-    }
+    let path_str = path.to_string_lossy().into_owned();
+    // Guard must stay alive for the write; DoClear empties the clipboard first
+    // (the crate's default FileList setter leaves stale formats behind).
+    let _clip = clipboard_win::Clipboard::new_attempts(10)
+        .map_err(|e| AppError::Other(format!("Failed to open clipboard: {}", e)))?;
+    clipboard_win::raw::set_file_list_with(&[path_str.as_str()], clipboard_win::options::DoClear)
+        .map_err(|e| AppError::Other(format!("Failed to set clipboard file list: {}", e)))?;
     Ok(())
 }
 
@@ -2123,6 +2109,80 @@ pub async fn copy_image_to_clipboard(file_path: String) -> Result<(), AppError> 
         let mime = infer_image_mime(&image_bytes, ext_str.as_deref());
 
         native_clipboard_write(&image_bytes, mime)
+    }
+}
+
+/// Copy a gallery image to the system clipboard entirely on the Rust side.
+/// JXL images are decoded once and encoded to a single metadata-bearing PNG —
+/// no image bytes ever cross the IPC boundary (the old flow shipped a
+/// multi-megabyte PNG over IPC four times). Non-JXL images are put on the
+/// clipboard straight from disk.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn copy_gallery_image_to_clipboard(
+    filename: String,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    metadata_mode: Option<String>,
+) -> Result<(), AppError> {
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return Err(AppError::Other("Invalid filename".into()));
+    }
+    let dir = crate::config::gallery_dir()
+        .ok_or_else(|| AppError::Other("Cannot find gallery directory".into()))?;
+    let path = resolve_gallery_image_path(&dir, &filename)
+        .map_err(|e| AppError::Other(format!("{}: {}", e, filename)))?;
+
+    if filename.ends_with(".jxl") {
+        let jxl_bytes = std::fs::read(&path)?;
+        let mode = crate::metadata::MetadataMode::from_str(
+            metadata_mode.as_deref().unwrap_or("text_chunk"),
+        );
+        let params = metadata.filter(|m| !m.is_empty());
+        let png_bytes = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, String> {
+            let img = crate::jxl::decode_to_rgba8(&jxl_bytes).map_err(|e| e.to_string())?;
+            // Prefer the metadata the frontend already holds; fall back to
+            // whatever is embedded in the JXL itself.
+            let params = params.or_else(|| {
+                crate::metadata::read_image_metadata(&jxl_bytes)
+                    .ok()
+                    .flatten()
+            });
+            match params {
+                Some(p) => crate::metadata::encode_png_with_metadata_rgba8(
+                    &img.rgba, img.width, img.height, &p, mode,
+                ),
+                None => crate::jxl::encode_rgba8_png(&img.rgba, img.width, img.height)
+                    .map_err(|e| e.to_string()),
+            }
+        })
+        .await
+        .map_err(|e| AppError::Other(format!("Task panicked: {}", e)))?
+        .map_err(AppError::Other)?;
+
+        native_clipboard_write(&png_bytes, "image/png")
+    } else {
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| AppError::Other(e.to_string()))?;
+
+        #[cfg(target_os = "windows")]
+        {
+            clipboard_set_file_drop_win(&canonical)
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let image_bytes = std::fs::read(&canonical)
+                .map_err(|e| AppError::Other(format!("Failed to read image file: {}", e)))?;
+
+            let ext_str = canonical
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.to_ascii_lowercase());
+            let mime = infer_image_mime(&image_bytes, ext_str.as_deref());
+
+            native_clipboard_write(&image_bytes, mime)
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -404,6 +404,7 @@ pub fn run() {
             commands::api::rename_gallery_image,
             commands::api::copy_image_to_clipboard,
             commands::api::copy_bytes_to_clipboard,
+            commands::api::copy_gallery_image_to_clipboard,
             commands::api::find_model_by_hash,
             commands::api::hash_model_file,
             commands::api::civitai_lookup_hash,

--- a/src-tauri/src/metadata.rs
+++ b/src-tauri/src/metadata.rs
@@ -173,6 +173,59 @@ pub fn embed_png_metadata(
     Ok(output)
 }
 
+/// Encode raw 8-bit RGBA pixels as a PNG with embedded metadata in a single
+/// pass. Fast path for callers that already hold decoded pixels (e.g. after a
+/// JXL decode), avoiding the decode/re-encode round-trip of
+/// [`embed_png_metadata`]. 8-bit only — the JXL decoder always yields RGBA8.
+pub fn encode_png_with_metadata_rgba8(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    params: &HashMap<String, String>,
+    mode: MetadataMode,
+) -> Result<Vec<u8>, String> {
+    let json_text = format_swarmui_json(params);
+
+    let mut pixel_buf = rgba.to_vec();
+    let effective_mode = if mode == MetadataMode::StealthAlpha || mode == MetadataMode::Both {
+        match encode_stealth_alpha(&mut pixel_buf, width, height, 4, &json_text) {
+            Ok(()) => mode,
+            Err(e) => {
+                log::warn!(
+                    "Stealth alpha encoding failed ({}), falling back to text_chunk only",
+                    e
+                );
+                pixel_buf.copy_from_slice(rgba);
+                MetadataMode::TextChunk
+            }
+        }
+    } else {
+        mode
+    };
+
+    let mut output = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut output, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+
+        if effective_mode == MetadataMode::TextChunk || effective_mode == MetadataMode::Both {
+            encoder
+                .add_text_chunk("parameters".to_string(), json_text)
+                .map_err(|e| format!("Failed to add text chunk: {}", e))?;
+        }
+
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| format!("PNG encode error: {}", e))?;
+        writer
+            .write_image_data(&pixel_buf)
+            .map_err(|e| format!("PNG write error: {}", e))?;
+    }
+
+    Ok(output)
+}
+
 /// Read metadata from PNG bytes.
 /// Tries stealth alpha first, then PNG text chunks (SwarmUI JSON → A1111 fallback).
 pub fn read_png_metadata(image_bytes: &[u8]) -> Result<Option<HashMap<String, String>>, String> {

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -14,6 +14,7 @@ import {
   getOutputImage,
   copyImageToClipboard,
   copyBytesToClipboard,
+  copyGalleryImageToClipboard,
   getGalleryImagePath,
   getStorageInfo,
   readImageMetadata,
@@ -1000,18 +1001,14 @@ class GalleryStore {
       // Tauri mode: prefer native clipboard
       if (image.gallery_filename) {
         if (image.gallery_filename.endsWith(".jxl")) {
-          // JXL can't be pasted as an image from the raw file path —
-          // transcode to PNG first and copy bytes via native clipboard.
-          // PNG transcode strips metadata, so re-embed it client-side.
-          let pngBytes = await loadGalleryImagePng(image.gallery_filename);
-          if (image.metadata) {
-            try {
-              pngBytes = await embedPngMetadataBytes(pngBytes, image.metadata, generation.metadataMode);
-            } catch (e) {
-              console.warn("Failed to embed PNG metadata into JXL clipboard copy:", e);
-            }
-          }
-          await copyBytesToClipboard(pngBytes, "png");
+          // JXL can't be pasted as an image from the raw file path — the
+          // backend transcodes to PNG (with metadata embedded) and puts it on
+          // the clipboard in one call, so no image bytes cross IPC.
+          await copyGalleryImageToClipboard(
+            image.gallery_filename,
+            image.metadata ?? undefined,
+            generation.metadataMode,
+          );
         } else {
           const path = await getGalleryImagePath(image.gallery_filename);
           await copyImageToClipboard(path);

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -965,7 +965,8 @@ class GalleryStore {
         if (!fetchUrl && galleryFilename) {
           fetchUrl = await fullImageUrl(galleryFilename);
         }
-        if (!fetchUrl) fetchUrl = image.url || (this.selectedImage === image ? this.lightboxUrl : null);
+        if (!fetchUrl)
+          fetchUrl = (image.url || (this.selectedImage === image ? this.lightboxUrl : null)) ?? undefined;
         if (fetchUrl) {
           try {
             const resp = await fetch(fetchUrl);

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -544,6 +544,15 @@ export async function copyBytesToClipboard(bytes: number[], ext: string): Promis
   return ipcInvoke("copy_bytes_to_clipboard", { bytes, ext });
 }
 
+/** Copy a gallery image to the clipboard fully Rust-side (no image bytes cross IPC). */
+export async function copyGalleryImageToClipboard(
+  filename: string,
+  metadata?: Record<string, string>,
+  metadataMode?: string,
+): Promise<void> {
+  return ipcInvoke("copy_gallery_image_to_clipboard", { filename, metadata, metadataMode });
+}
+
 export async function getGalleryImagePath(filename: string): Promise<string> {
   return ipcInvoke("get_gallery_image_path", { filename });
 }


### PR DESCRIPTION
Moves gallery-image clipboard copying fully to the Rust side.

- New `copy_gallery_image_to_clipboard` command: JXL images are decoded once and re-encoded to a single metadata-bearing PNG in Rust, so no image bytes cross IPC (the old flow shipped a multi-megabyte PNG over IPC several times). Non-JXL images go to the clipboard straight from disk.
- Replaces the PowerShell `Set-FileDropList` clipboard hack on Windows with the `clipboard-win` crate (adds `clipboard-win = "5"` as a Windows-only dependency).
- Adds `encode_png_with_metadata_rgba8` in metadata.rs as a fast path that encodes already-decoded RGBA8 pixels with embedded metadata in one pass.
- Frontend gallery store now calls the single backend command for JXL copies instead of transcode + embed + copy-bytes round-trips.