### PR TITLE
v1.7.7: WASM AVIF fallback so artist gallery images load on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v1.7.7
+
+### Fixes
+- **Artist gallery images now load on Linux**: the artist gallery serves its preview images as AVIF, which Windows and macOS decode natively but the Linux webview (WebKitGTK) is usually built without support for, so every thumbnail showed as a broken image (issue #507). The app now detects that at startup and, only on the affected webviews, decodes the images itself in WebAssembly and converts them to a format the webview can draw. Converted images are cached, so the work happens once per image rather than once per view. Windows and macOS are unaffected and keep loading images exactly as before.
+
+---
+
 ## What's New in v1.7.6
 
 ### Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v1.7.7
+
+### Fixes
+- **Artist gallery images now load on Linux**: the artist gallery serves its preview images as AVIF, which Windows and macOS decode natively but the Linux webview (WebKitGTK) is usually built without support for, so every thumbnail showed as a broken image (issue #507). The app now detects that at startup and, only on the affected webviews, decodes the images itself in WebAssembly and converts them to a format the webview can draw. Converted images are cached, so the work happens once per image rather than once per view. Windows and macOS are unaffected and keep loading images exactly as before.
+
+---
+
 ## What's New in v1.7.6
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "comfyui-desktop",
-  "version": "1.4.41",
+  "version": "1.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "1.4.41",
+      "version": "1.7.7",
       "license": "MIT",
       "dependencies": {
+        "@jsquash/avif": "^2.1.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",
@@ -522,6 +523,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsquash/avif": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@jsquash/avif/-/avif-2.1.1.tgz",
+      "integrity": "sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2517,6 +2527,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -14,6 +14,7 @@
     "check": "npm run build && npm run check:i18n && npm run check:types"
   },
   "dependencies": {
+    "@jsquash/avif": "^2.1.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.7.6"
+version = "1.7.7"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -893,6 +893,40 @@ pub async fn cdn_proxy_fetch(
     Ok(body)
 }
 
+/// Proxy a GET request to the Mooshieblob CDN and return the response body as
+/// base64. Same hardcoded-origin restriction as [`cdn_proxy_fetch`]; this
+/// variant exists for binary payloads (artist gallery AVIF images), which
+/// `resp.text()` would corrupt. Base64 rather than a byte array because the IPC
+/// transport is JSON on both desktop and browser mode.
+#[cfg(feature = "desktop")]
+#[tauri::command]
+pub async fn cdn_proxy_fetch_bytes(
+    state: State<'_, Arc<AppState>>,
+    path: String,
+) -> Result<String, AppError> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    let clean = path.trim_start_matches('/');
+    let url = format!("https://cdn.mooshieblob.com/{}", clean);
+    let resp = state
+        .http_client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| AppError::Other(format!("CDN fetch failed: {}", e)))?;
+    if !resp.status().is_success() {
+        return Err(AppError::ApiError {
+            status: resp.status().as_u16(),
+            message: format!("CDN returned {} for {}", resp.status(), clean),
+        });
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| AppError::Other(format!("CDN body read failed: {}", e)))?;
+    Ok(STANDARD.encode(&bytes))
+}
+
 /// Proxy a GET request to animadex.net (characters API only). Used by the Tauri
 /// desktop app for JSON fetches that would otherwise be blocked by CORS.
 /// Only paths under `api/characters/` are allowed — not an open proxy.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -411,6 +411,7 @@ pub fn run() {
             commands::api::civitai_lookup_image,
             commands::api::save_model_sidecar_thumbnail,
             commands::api::cdn_proxy_fetch,
+            commands::api::cdn_proxy_fetch_bytes,
             commands::api::animadex_proxy_fetch,
             commands::api::civitai_search_models,
             commands::api::civitai_get_model,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/artist-gallery/avifDecode.ts
+++ b/src/lib/artist-gallery/avifDecode.ts
@@ -1,0 +1,103 @@
+/**
+ * WASM AVIF decoder fallback for the artist gallery.
+ *
+ * The gallery dataset (index v2) is AVIF-only — the CDN has no WebP/JPEG
+ * variants of those objects.  WebView2 (Windows) and WKWebView (macOS) decode
+ * AVIF natively, but WebKitGTK on Linux is routinely built without AVIF
+ * support, so every artist image renders as a broken-image glyph there.
+ *
+ * This module decodes AVIF in WebAssembly and re-encodes to a format the
+ * webview can definitely draw.  It is imported dynamically and only on
+ * webviews that fail the native-AVIF probe, so Windows/macOS never load the
+ * ~1.2 MB decoder.
+ *
+ * Decodes run on the main thread rather than in a Worker: `module.decode()` is
+ * synchronous anyway, and a Worker adds a failure mode (module-worker support,
+ * `worker-src` CSP) on the exact platform this code exists to rescue.  Callers
+ * get one decode at a time with a yield in between so the browser can paint.
+ */
+
+import decodeAvif, { init as initAvifDecoder } from "@jsquash/avif/decode";
+import avifDecWasmUrl from "@jsquash/avif/codec/dec/avif_dec.wasm?url";
+
+let _ready: Promise<void> | null = null;
+
+/** Compile and initialise the decoder once per session. */
+function ensureDecoder(): Promise<void> {
+  if (!_ready) {
+    _ready = (async () => {
+      const response = await fetch(avifDecWasmUrl);
+      if (!response.ok) {
+        throw new Error(`AVIF decoder wasm HTTP ${response.status}`);
+      }
+      const wasmModule = await WebAssembly.compile(await response.arrayBuffer());
+      await initAvifDecoder({
+        // Instantiating the module ourselves avoids Emscripten's own
+        // `fetch(locateFile(...))`, which guesses the wasm path from
+        // `import.meta.url` and needs an `application/wasm` content type.
+        // Emscripten wants the *instance* handed back, not the module —
+        // jSquash's own `initEmscriptenModule` helper does the same thing.
+        // The params are annotated because jSquash's `ModuleOpts` type refers
+        // to an ambient namespace its package never actually ships.
+        instantiateWasm: (
+          imports: WebAssembly.Imports,
+          successCallback: (instance: WebAssembly.Instance) => void,
+        ) => {
+          const instance = new WebAssembly.Instance(wasmModule, imports);
+          successCallback(instance);
+          return instance.exports;
+        },
+      });
+    })().catch((e) => {
+      _ready = null; // let a later image retry
+      throw e;
+    });
+  }
+  return _ready;
+}
+
+/** Serialises decodes and yields between them so the UI stays responsive. */
+let _queue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Decode AVIF bytes and re-encode them as a blob the webview can render.
+ * Prefers WebP; webviews without a WebP encoder fall back to PNG per the
+ * canvas spec — bigger, but correct, and the result is cached so the work
+ * happens once per image.
+ */
+export function decodeAvifToBlob(bytes: ArrayBuffer): Promise<Blob> {
+  const run = _queue.then(
+    () => _transcode(bytes),
+    () => _transcode(bytes),
+  );
+  _queue = run.then(
+    () => new Promise((r) => setTimeout(r, 0)),
+    () => new Promise((r) => setTimeout(r, 0)),
+  );
+  return run;
+}
+
+async function _transcode(bytes: ArrayBuffer): Promise<Blob> {
+  await ensureDecoder();
+
+  const image = await decodeAvif(bytes);
+  if (!image) throw new Error("AVIF decode returned null");
+
+  const canvas = document.createElement("canvas");
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D canvas context unavailable");
+  ctx.putImageData(image, 0, 0);
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("canvas.toBlob produced no blob"));
+      },
+      "image/webp",
+      0.9,
+    );
+  });
+}

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -8,6 +8,7 @@
   import ArtistLightbox from "./ArtistLightbox.svelte";
   import FavouritesManager from "./FavouritesManager.svelte";
   import { proxiedCdnUrl } from "../../utils/cdnFetch.js";
+  import { cachedSrc } from "../imageCache.js";
   import { CharacterExplorer } from "../../animadex/index.js";
   import type { AnimadexCharacter } from "../../animadex/types.js";
   import { generation } from "../../stores/generation.svelte.js";
@@ -794,7 +795,7 @@
             <div class="relative aspect-3/4 w-full overflow-hidden rounded-t-lg bg-neutral-800">
               {#if url}
                 <img
-                  src={url}
+                  use:cachedSrc={url}
                   alt={hit.tag}
                   loading="eager"
                   decoding="auto"

--- a/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
+++ b/src/lib/artist-gallery/components/ArtistHoverPreview.svelte
@@ -50,7 +50,6 @@
   {:else if entry && entry.imageUrl && !failed}
     <img
       use:cachedSrc={entry.imageUrl}
-      src={entry.imageUrl}
       alt={entry.tag}
       loading="eager"
       decoding="async"

--- a/src/lib/artist-gallery/imageCache.ts
+++ b/src/lib/artist-gallery/imageCache.ts
@@ -2,24 +2,67 @@
  * Persistent image cache for artist gallery preview images.
  *
  * Uses the Cache API (available in both Tauri's webview and standard browsers)
- * to store artist images permanently until explicitly cleared.  This means:
- *
- *  - Desktop (Tauri): images survive app restarts, never re-downloaded.
- *  - Web hosting: each browser caches images locally after the first view,
- *    so subsequent page loads serve zero R2 Class-B operations for those images.
+ * to store artist images permanently until explicitly cleared, so each browser
+ * caches images locally after the first view and subsequent page loads serve
+ * zero R2 Class-B operations for those images.
  *
  * The CDN layer (Cloudflare in front of R2) handles cross-visitor caching once
  * objects are served with `Cache-Control: public, max-age=31536000, immutable`
  * (see scripts/r2_upload_anima.py – the upload script sets those headers).
  *
+ * Two paths exist because of what the environment can actually do:
+ *
+ *  - Desktop (Tauri), AVIF-capable webview: the CDN sends no CORS headers, so
+ *    `fetch` is blocked and this layer steps aside — `<img src>` loads the CDN
+ *    URL directly and the webview's own HTTP cache honours the immutable
+ *    headers above.
+ *  - Webview without AVIF support (WebKitGTK on Linux): the bytes are pulled
+ *    through the CDN proxy, decoded in WebAssembly, re-encoded to WebP/PNG,
+ *    and the *transcoded* result is what gets cached — so the decode cost is
+ *    paid once per image rather than once per view.
+ *
  * Usage:
  *   <img use:cachedSrc={entry.imageUrl} alt={entry.tag} />
  */
 
-import { proxiedCdnUrl } from "../utils/cdnFetch.js";
+import { cdnFetchBytes, isCdnUrl, proxiedCdnUrl } from "../utils/cdnFetch.js";
+import { isTauri } from "../utils/ipc.js";
 
 /** Cache storage bucket name.  Bump the version suffix to bust stale caches. */
 const CACHE_NAME = "anima-artist-images-v1";
+
+/**
+ * 1x1 red AVIF (314 bytes, produced by libavif) used to probe whether the
+ * webview can decode AVIF at all.  WebKitGTK on Linux frequently ships without
+ * AVIF support, which is what breaks the gallery there — the dataset has no
+ * WebP/JPEG fallbacks on the CDN.
+ */
+const AVIF_PROBE =
+  "data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAACAAAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAAABAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQAMAAAAABNjb2xybmNseAACAAIABoAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAAChtZGF0EgAKCBgABggQEDQgMhIYAAooooQARmzv9mB1+uPnYcA=";
+
+let _nativeAvif: Promise<boolean> | null = null;
+
+/** Whether this webview decodes AVIF natively.  Probed once per session. */
+export function supportsNativeAvif(): Promise<boolean> {
+  if (!_nativeAvif) {
+    _nativeAvif = new Promise<boolean>((resolve) => {
+      if (typeof Image === "undefined") {
+        resolve(true); // no DOM — nothing to render anyway
+        return;
+      }
+      const img = new Image();
+      // A webview that "loads" an undecodable image still reports 0x0.
+      img.onload = () => resolve(img.naturalWidth === 1 && img.naturalHeight === 1);
+      img.onerror = () => resolve(false);
+      img.src = AVIF_PROBE;
+    });
+  }
+  return _nativeAvif;
+}
+
+function isAvifUrl(url: string): boolean {
+  return /\.avif(?:$|[?#])/i.test(url);
+}
 
 /** In-memory map from CDN URL → blob-URL (avoids re-creating blob URLs for
  *  images already fetched this session but before the component unmounts). */
@@ -54,37 +97,76 @@ export async function fetchCachedArtistImage(url: string): Promise<string> {
   return promise;
 }
 
+/** Open the cache bucket, or null if the environment doesn't allow it. */
+async function openCache(): Promise<Cache | null> {
+  if (!hasCacheApi()) return null;
+  try {
+    return await caches.open(CACHE_NAME);
+  } catch {
+    return null;
+  }
+}
+
 async function _doFetch(url: string): Promise<string> {
   const requestUrl = proxiedCdnUrl(url);
+  const needsTranscode = isAvifUrl(url) && !(await supportsNativeAvif());
 
-  if (hasCacheApi()) {
+  // Tauri's webview can't `fetch` the CDN at all — it serves no
+  // `Access-Control-Allow-Origin` header for any origin the app runs under.
+  // Unless we're taking the transcode path (which pulls bytes through the Rust
+  // proxy instead) there is nothing this layer can cache, so bail out and let
+  // the caller fall back to a plain `<img src>`, which is exempt from CORS and
+  // hits the webview's own HTTP cache.
+  if (!needsTranscode && isTauri && isCdnUrl(requestUrl)) {
+    throw new Error("CDN fetch is CORS-blocked in the desktop webview");
+  }
+
+  const cache = await openCache();
+
+  // Cached entries are always in a directly-renderable format (the original
+  // bytes, or the WebP/PNG transcode of an AVIF), so a hit skips everything.
+  if (cache) {
     try {
-      const cache = await caches.open(CACHE_NAME);
       const cached = await cache.match(requestUrl);
-      if (cached) {
-        const blob = await cached.blob();
-        const blobUrl = URL.createObjectURL(blob);
-        _blobUrlMap.set(url, blobUrl);
-        return blobUrl;
-      }
+      if (cached) return _remember(url, await cached.blob());
     } catch {
       // Cache read failed — fall through to network fetch.
     }
   }
 
-  const response = await fetch(requestUrl, { credentials: "omit" });
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const blob = await _load(url, requestUrl, needsTranscode);
 
-  if (hasCacheApi()) {
+  if (cache) {
     try {
-      const cache = await caches.open(CACHE_NAME);
-      await cache.put(requestUrl, response.clone());
+      await cache.put(requestUrl, new Response(blob));
     } catch {
       // Cache write failed — non-fatal.
     }
   }
 
-  const blob = await response.blob();
+  return _remember(url, blob);
+}
+
+/** Load the image bytes, transcoding AVIF where the webview can't decode it. */
+async function _load(
+  url: string,
+  requestUrl: string,
+  needsTranscode: boolean,
+): Promise<Blob> {
+  if (needsTranscode) {
+    // `cdnFetchBytes` picks its own transport: the Rust proxy on desktop (where
+    // `fetch` is CORS-blocked), the same-origin proxy in browser/LAN mode.
+    const bytes = await cdnFetchBytes(url);
+    const { decodeAvifToBlob } = await import("./avifDecode.js");
+    return decodeAvifToBlob(bytes);
+  }
+
+  const response = await fetch(requestUrl, { credentials: "omit" });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.blob();
+}
+
+function _remember(url: string, blob: Blob): string {
   const blobUrl = URL.createObjectURL(blob);
   _blobUrlMap.set(url, blobUrl);
   return blobUrl;

--- a/src/lib/utils/cdnFetch.ts
+++ b/src/lib/utils/cdnFetch.ts
@@ -26,6 +26,11 @@ function withToken(url: string): string {
   return `${url}${sep}token=${encodeURIComponent(token)}`;
 }
 
+/** True for absolute CDN URLs (i.e. not already rewritten to the local proxy). */
+export function isCdnUrl(url: string): boolean {
+  return url.startsWith(CDN_PREFIX);
+}
+
 export function proxiedCdnUrl(url: string): string {
   if (isBrowserMode && url.startsWith(CDN_PREFIX)) {
     return withToken(`/internal-api/_cdn/${url.slice(CDN_PREFIX.length)}`);
@@ -66,3 +71,32 @@ export const cdnFetch: typeof fetch | undefined = isTauri || isBrowserMode
       return globalThis.fetch(input as RequestInfo, init);
     }) as typeof fetch
   : undefined;
+
+/**
+ * Fetch a CDN object as raw bytes.
+ *
+ * Browser/server mode goes through the same-origin `/internal-api/_cdn/...`
+ * proxy, which streams the body through untouched. Tauri desktop goes through
+ * the `cdn_proxy_fetch_bytes` command, because the CDN sends no
+ * `Access-Control-Allow-Origin` at all and the webview's `fetch` is therefore
+ * blocked for every origin the app runs under.
+ *
+ * Accepts either a raw CDN URL or one already run through `proxiedCdnUrl`.
+ */
+export async function cdnFetchBytes(url: string): Promise<ArrayBuffer> {
+  if (isTauri && url.startsWith(CDN_PREFIX)) {
+    const path = url.slice(CDN_PREFIX.length);
+    const b64 = await ipcInvoke<string>("cdn_proxy_fetch_bytes", { path });
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes.buffer;
+  }
+
+  // `proxiedCdnUrl` is idempotent, so a pre-proxied path passes through.
+  const response = await globalThis.fetch(proxiedCdnUrl(url), {
+    credentials: "omit",
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.arrayBuffer();
+}


### PR DESCRIPTION
Fixes #507.

The artist gallery dataset (index v2) is AVIF-only, and the CDN has no WebP or JPEG variants of those objects. WebView2 (Windows) and WKWebView (macOS) decode AVIF natively, but WebKitGTK on Linux is routinely built without AVIF support, so every artist image rendered as a broken-image glyph there. This is not a 1.7.6 regression, it has been broken on Linux desktop since the v2 dataset landed in v1.4.21.

## What changed

- New `src/lib/artist-gallery/avifDecode.ts`: a WASM AVIF decoder (`@jsquash/avif`) that is dynamically imported, so webviews with native AVIF never load the ~1.2 MB decoder. It compiles the wasm itself via `instantiateWasm`, which sidesteps Emscripten guessing the wasm path from `import.meta.url` and needing an `application/wasm` content type. Decoded pixels are re-encoded through a canvas to WebP (PNG fallback per spec).
- `imageCache.ts`: one-shot native-AVIF probe using a 314 byte 1x1 libavif image. On a webview that fails the probe, AVIF URLs are pulled as bytes, decoded in WASM, and the transcoded blob is what lands in the Cache API, so the decode cost is paid once per image ever rather than once per view.
- `cdnFetch.ts`: new `cdnFetchBytes()` and `isCdnUrl()`. The CDN sends no `Access-Control-Allow-Origin` for any origin, so the webview cannot `fetch` it at all and the bytes have to come through a proxy.
- `api.rs` / `lib.rs`: new `cdn_proxy_fetch_bytes` command, a binary sibling of the existing text-only `cdn_proxy_fetch` whose `resp.text()` would corrupt image bytes. Base64 because the IPC transport is JSON on both desktop and browser mode.
- `ArtistGalleryPage.svelte`: the main grid rendered a raw `src` and bypassed the cache layer entirely, so it now uses `use:cachedSrc` like every other render site.
- `ArtistHoverPreview.svelte`: dropped a redundant raw `src` that sat alongside `use:cachedSrc` and caused a duplicate request plus a broken-image flash.

Windows and macOS behaviour is deliberately unchanged: the cache layer bails out before doing any work when the webview decodes AVIF natively, so images still load via a plain `<img src>` off the webview's own HTTP cache (the objects ship as `immutable, max-age=31536000`). Without that guard, routing the grid through `cachedSrc` would have fired a doomed CORS fetch for every image on the platforms that already work.

No CSP changes are needed. `script-src 'wasm-unsafe-eval'`, `img-src blob:`, and `connect-src 'self'` already cover everything the fix does, and the wasm ships as a separate same-origin asset.

## Verification

`npm run build`, `cargo check`, `cargo fmt`, `cargo clippy` (no new warnings), and `svelte-check` (back to its pre-existing error count, none in changed files) all pass. The decoder was exercised against a real CDN image in Node: 720x926, 216 ms, output verified non-black.

Known limits: WebKitGTK could not be exercised from a Windows dev machine, and on Linux the first view of a grid page decodes images on the main thread serially at roughly 216 ms each, so a page fills in progressively before settling into the cache. A Web Worker was rejected deliberately, since module-worker support and `worker-src` CSP are extra failure modes on the exact platform this exists to rescue.
