### PR TITLE
fix comfyui compat pin detection and quant format error

### DIFF
--- a/.github/workflows/comfyui-compat.yml
+++ b/.github/workflows/comfyui-compat.yml
@@ -4,7 +4,7 @@ name: ComfyUI Compatibility Check
 # against them, and (on pass) opens a PR bumping the pinned COMFYUI_REF.
 #
 # Why: MooshieUI pins ComfyUI to a release tag (COMFYUI_REF in
-# src-tauri/src/setup.rs). Bumping it is usually safe for the app, but ComfyUI's
+# src-tauri/src/comfyui_version.rs). Bumping it is usually safe for the app, but ComfyUI's
 # internal refactors can break the bundled custom nodes (which import deep
 # ComfyUI internals). This workflow is the checker for that: it reproduces the
 # app's ensure_mooshie_nodes deploy, starts ComfyUI in CPU mode, and verifies
@@ -47,6 +47,7 @@ jobs:
       target_ref: ${{ steps.v.outputs.target_ref }}
       should_test: ${{ steps.v.outputs.should_test }}
       is_newer: ${{ steps.v.outputs.is_newer }}
+      pin_file: ${{ steps.v.outputs.pin_file }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,11 +61,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          CURRENT=$(grep -oP 'COMFYUI_REF:\s*&str\s*=\s*"\K[^"]+' src-tauri/src/setup.rs)
-          if [ -z "$CURRENT" ]; then
-            echo "::error::Could not parse COMFYUI_REF from src-tauri/src/setup.rs"
+          # Locate the pin by content, not by a hardcoded path. The constant has
+          # moved between modules once already (setup.rs -> comfyui_version.rs),
+          # and the hardcoded grep failed silently under `set -e` for weeks
+          # afterwards, so the whole check never ran. `|| true` keeps a no-match
+          # from killing the step before the explicit error below.
+          PIN_FILE=$(grep -rlE 'const COMFYUI_REF:[[:space:]]*&str[[:space:]]*=' src-tauri/src | head -n1 || true)
+          if [ -z "$PIN_FILE" ]; then
+            echo "::error::Could not locate the COMFYUI_REF declaration under src-tauri/src"
             exit 1
           fi
+          CURRENT=$(sed -nE 's/.*COMFYUI_REF:[[:space:]]*&str[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$PIN_FILE" | head -n1)
+          if [ -z "$CURRENT" ]; then
+            echo "::error::Could not parse COMFYUI_REF from $PIN_FILE"
+            exit 1
+          fi
+          echo "pin_file=$PIN_FILE" >> "$GITHUB_OUTPUT"
           echo "current_ref=$CURRENT" >> "$GITHUB_OUTPUT"
 
           if [ -n "${INPUT_TARGET}" ]; then
@@ -89,6 +101,7 @@ jobs:
             echo "should_test=false" >> "$GITHUB_OUTPUT"
           fi
 
+          echo "Pin file    : $PIN_FILE"
           echo "Current pin : $CURRENT"
           echo "Candidate   : $TARGET"
           echo "Newer       : $IS_NEWER"
@@ -162,10 +175,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT: ${{ needs.detect.outputs.current_ref }}
           TARGET: ${{ needs.detect.outputs.target_ref }}
+          PIN_FILE: ${{ needs.detect.outputs.pin_file }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           BRANCH="bot/comfyui-bump-${TARGET}"
+
+          if [ -z "${PIN_FILE}" ] || [ ! -f "${PIN_FILE}" ]; then
+            echo "::error::Pin file '${PIN_FILE}' from the detect job is missing. Aborting."
+            exit 1
+          fi
 
           # Idempotency: if an open PR for this exact bump already exists, stop.
           EXISTING=$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')
@@ -174,15 +193,15 @@ jobs:
             exit 0
           fi
 
-          # Bump exactly the one pinned-version line. setup.rs declares it as
+          # Bump exactly the one pinned-version line. The pin file declares it as
           #   pub const COMFYUI_REF: &str = "vX.Y.Z";
-          sed -i -E "s|(COMFYUI_REF:[[:space:]]*&str[[:space:]]*=[[:space:]]*\")[^\"]+(\";)|\1${TARGET}\2|" src-tauri/src/setup.rs
-          if git diff --quiet -- src-tauri/src/setup.rs; then
+          sed -i -E "s|(COMFYUI_REF:[[:space:]]*&str[[:space:]]*=[[:space:]]*\")[^\"]+(\";)|\1${TARGET}\2|" "$PIN_FILE"
+          if git diff --quiet -- "$PIN_FILE"; then
             echo "::error::COMFYUI_REF line was not changed (could not find the pin). Aborting."
             exit 1
           fi
           # Confirm the new value is exactly the candidate tag.
-          NEWPIN=$(grep -oP 'COMFYUI_REF:\s*&str\s*=\s*"\K[^"]+' src-tauri/src/setup.rs)
+          NEWPIN=$(sed -nE 's/.*COMFYUI_REF:[[:space:]]*&str[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$PIN_FILE" | head -n1)
           if [ "$NEWPIN" != "$TARGET" ]; then
             echo "::error::Post-edit pin is '$NEWPIN', expected '$TARGET'. Aborting."
             exit 1
@@ -191,7 +210,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add src-tauri/src/setup.rs
+          git add "$PIN_FILE"
           git commit -m "chore(comfyui): bump pinned ComfyUI to ${TARGET}"
           git push --force-with-lease --set-upstream origin "$BRANCH"
 

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -2014,6 +2014,7 @@ const de: Record<string, string> = {
   "generation.error.model_not_found_generic": "Ein ausgewähltes Modell ist in ComfyUI nicht verfügbar. Überprüfe deine Modell- und VAE-Einstellungen oder starte ComfyUI neu, falls du gerade eine Datei hinzugefügt oder umbenannt hast.",
   "generation.error.missing_node": "Dieser Workflow benötigt einen Custom Node, der nicht installiert ist: {node}. Installiere ihn in ComfyUI und starte neu.",
   "generation.error.component_mismatch": "Diese Modellkomponenten passen nicht zusammen. Stelle sicher, dass Checkpoint, VAE, LoRAs und CLIP alle zur selben Modellfamilie gehören (zum Beispiel alle SDXL).",
+  "generation.error.quant_format_unsupported": "Dieses Modell nutzt das Quantisierungsformat '{format}', das dein installiertes ComfyUI nicht unterstützt. Aktualisiere ComfyUI unter Einstellungen > Leistung oder wähle eine nicht quantisierte Version des Modells.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -77,6 +77,7 @@ const en: Record<string, string> = {
   "generation.error.model_not_found_generic": "A selected model isn't available in ComfyUI. Check your model and VAE settings, or restart ComfyUI if you just added or renamed a file.",
   "generation.error.missing_node": "This workflow needs a custom node that isn't installed: {node}. Install it in ComfyUI and restart.",
   "generation.error.component_mismatch": "These model components don't fit together. Make sure the checkpoint, VAE, LoRAs, and CLIP are all for the same model family (for example all SDXL).",
+  "generation.error.quant_format_unsupported": "This model uses the '{format}' quantization format, which your installed ComfyUI doesn't support. Update ComfyUI in Settings > Performance, or pick a non-quantized version of the model.",
 
   // ── App Status ─────────────────────────────────────────
   "app.status.starting": "Starting...",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -2046,6 +2046,7 @@ const es: Record<string, string> = {
   "generation.error.model_not_found_generic": "Un modelo seleccionado no está disponible en ComfyUI. Revisa la configuración de modelo y VAE, o reinicia ComfyUI si acabas de añadir o renombrar un archivo.",
   "generation.error.missing_node": "Este flujo de trabajo necesita un nodo personalizado que no está instalado: {node}. Instálalo en ComfyUI y reinicia.",
   "generation.error.component_mismatch": "Estos componentes del modelo no encajan entre sí. Asegúrate de que el checkpoint, el VAE, los LoRA y el CLIP sean de la misma familia de modelos (por ejemplo, todos SDXL).",
+  "generation.error.quant_format_unsupported": "Este modelo usa el formato de cuantización '{format}', que tu ComfyUI instalado no admite. Actualiza ComfyUI en Ajustes > Rendimiento, o elige una versión no cuantizada del modelo.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -2037,6 +2037,7 @@ const fr: Record<string, string> = {
   "generation.error.model_not_found_generic": "Un modèle sélectionné n'est pas disponible dans ComfyUI. Vérifiez vos paramètres de modèle et de VAE, ou redémarrez ComfyUI si vous venez d'ajouter ou de renommer un fichier.",
   "generation.error.missing_node": "Ce workflow nécessite un nœud personnalisé qui n'est pas installé : {node}. Installez-le dans ComfyUI et redémarrez.",
   "generation.error.component_mismatch": "Ces composants de modèle ne sont pas compatibles entre eux. Assurez-vous que le checkpoint, le VAE, les LoRA et le CLIP appartiennent tous à la même famille de modèles (par exemple tous SDXL).",
+  "generation.error.quant_format_unsupported": "Ce modèle utilise le format de quantification '{format}', que votre installation de ComfyUI ne prend pas en charge. Mettez ComfyUI à jour dans Paramètres > Performance, ou choisissez une version non quantifiée du modèle.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -2011,6 +2011,7 @@ const it: Record<string, string> = {
   "generation.error.model_not_found_generic": "Un modello selezionato non è disponibile in ComfyUI. Controlla le impostazioni di modello e VAE oppure riavvia ComfyUI se hai appena aggiunto o rinominato un file.",
   "generation.error.missing_node": "Questo workflow richiede un nodo personalizzato non installato: {node}. Installalo in ComfyUI e riavvia.",
   "generation.error.component_mismatch": "Questi componenti del modello non sono compatibili tra loro. Assicurati che checkpoint, VAE, LoRA e CLIP appartengano tutti alla stessa famiglia di modelli (ad esempio tutti SDXL).",
+  "generation.error.quant_format_unsupported": "Questo modello usa il formato di quantizzazione '{format}', che il ComfyUI installato non supporta. Aggiorna ComfyUI in Impostazioni > Prestazioni, oppure scegli una versione non quantizzata del modello.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -2036,6 +2036,7 @@ const ja: Record<string, string> = {
   "generation.error.model_not_found_generic": "選択したモデルがComfyUIで利用できません。モデルとVAEの設定を確認するか、ファイルを追加・名前変更した直後の場合はComfyUIを再起動してください。",
   "generation.error.missing_node": "このワークフローには未インストールのカスタムノードが必要です: {node}。ComfyUIにインストールして再起動してください。",
   "generation.error.component_mismatch": "これらのモデルコンポーネントは組み合わせできません。チェックポイント、VAE、LoRA、CLIPがすべて同じモデルファミリー(例: すべてSDXL)であることを確認してください。",
+  "generation.error.quant_format_unsupported": "このモデルは量子化形式「{format}」を使用していますが、インストール済みのComfyUIは対応していません。設定 > パフォーマンスでComfyUIを更新するか、量子化されていないバージョンのモデルを選んでください。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -2011,6 +2011,7 @@ const ko: Record<string, string> = {
   "generation.error.model_not_found_generic": "선택한 모델을 ComfyUI에서 사용할 수 없습니다. 모델과 VAE 설정을 확인하거나, 방금 파일을 추가하거나 이름을 변경했다면 ComfyUI를 다시 시작하세요.",
   "generation.error.missing_node": "이 워크플로에는 설치되지 않은 커스텀 노드가 필요합니다: {node}. ComfyUI에 설치하고 다시 시작하세요.",
   "generation.error.component_mismatch": "이 모델 구성 요소들이 서로 맞지 않습니다. 체크포인트, VAE, LoRA, CLIP이 모두 같은 모델 계열(예: 모두 SDXL)인지 확인하세요.",
+  "generation.error.quant_format_unsupported": "이 모델은 '{format}' 양자화 형식을 사용하지만 설치된 ComfyUI가 지원하지 않습니다. 설정 > 성능에서 ComfyUI를 업데이트하거나 양자화되지 않은 버전의 모델을 선택하세요.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -76,6 +76,7 @@ const pl: Record<string, string> = {
   "generation.error.model_not_found_generic": "Wybrany model jest niedostępny w ComfyUI. Sprawdź ustawienia modelu i VAE lub uruchom ponownie ComfyUI, jeśli właśnie dodałeś lub zmieniłeś nazwę pliku.",
   "generation.error.missing_node": "Ten przepływ pracy wymaga niestandardowego węzła, który nie jest zainstalowany: {node}. Zainstaluj go w ComfyUI i uruchom ponownie.",
   "generation.error.component_mismatch": "Te komponenty modelu nie pasują do siebie. Upewnij się, że checkpoint, VAE, LoRA i CLIP są przeznaczone dla tej samej rodziny modeli (np. wszystkie SDXL).",
+  "generation.error.quant_format_unsupported": "Ten model używa formatu kwantyzacji '{format}', którego zainstalowane ComfyUI nie obsługuje. Zaktualizuj ComfyUI w Ustawienia > Wydajność albo wybierz nieskwantyzowaną wersję modelu.",
 
   // ── App Status ─────────────────────────────────────────
   "app.status.starting": "Uruchamianie...",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -2012,6 +2012,7 @@ const pt: Record<string, string> = {
   "generation.error.model_not_found_generic": "Um modelo selecionado não está disponível no ComfyUI. Verifique as configurações de modelo e VAE ou reinicie o ComfyUI se você acabou de adicionar ou renomear um arquivo.",
   "generation.error.missing_node": "Este fluxo de trabalho precisa de um nó personalizado que não está instalado: {node}. Instale-o no ComfyUI e reinicie.",
   "generation.error.component_mismatch": "Esses componentes do modelo não combinam entre si. Verifique se o checkpoint, o VAE, os LoRAs e o CLIP são todos da mesma família de modelos (por exemplo, todos SDXL).",
+  "generation.error.quant_format_unsupported": "Este modelo usa o formato de quantização '{format}', que o seu ComfyUI instalado não suporta. Atualize o ComfyUI em Configurações > Desempenho, ou escolha uma versão não quantizada do modelo.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -2011,6 +2011,7 @@ const ru: Record<string, string> = {
   "generation.error.model_not_found_generic": "Выбранная модель недоступна в ComfyUI. Проверьте настройки модели и VAE или перезапустите ComfyUI, если вы только что добавили или переименовали файл.",
   "generation.error.missing_node": "Для этого рабочего процесса нужен пользовательский узел, который не установлен: {node}. Установите его в ComfyUI и перезапустите.",
   "generation.error.component_mismatch": "Эти компоненты модели несовместимы друг с другом. Убедитесь, что чекпойнт, VAE, LoRA и CLIP относятся к одному семейству моделей (например, все SDXL).",
+  "generation.error.quant_format_unsupported": "Эта модель использует формат квантизации '{format}', который не поддерживается установленным ComfyUI. Обновите ComfyUI в разделе Настройки > Производительность или выберите неквантизованную версию модели.",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -2011,6 +2011,7 @@ const zhTw: Record<string, string> = {
   "generation.error.model_not_found_generic": "ComfyUI 中沒有所選的模型。請檢查模型和 VAE 設定，或者如果你剛新增或重新命名了檔案，請重新啟動 ComfyUI。",
   "generation.error.missing_node": "此工作流程需要一個尚未安裝的自訂節點：{node}。請在 ComfyUI 中安裝並重新啟動。",
   "generation.error.component_mismatch": "這些模型元件彼此不相容。請確保檢查點、VAE、LoRA 和 CLIP 都屬於同一模型系列（例如都是 SDXL）。",
+  "generation.error.quant_format_unsupported": "此模型使用 '{format}' 量化格式，你安裝的 ComfyUI 並不支援。請在 設定 > 效能 中更新 ComfyUI，或改用未量化的模型版本。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -2053,6 +2053,7 @@ const zh: Record<string, string> = {
   "generation.error.model_not_found_generic": "ComfyUI 中没有所选的模型。请检查模型和 VAE 设置，或者如果你刚添加或重命名了文件，请重启 ComfyUI。",
   "generation.error.missing_node": "此工作流需要一个尚未安装的自定义节点：{node}。请在 ComfyUI 中安装并重启。",
   "generation.error.component_mismatch": "这些模型组件互不匹配。请确保检查点、VAE、LoRA 和 CLIP 都属于同一模型系列（例如都是 SDXL）。",
+  "generation.error.quant_format_unsupported": "该模型使用了 '{format}' 量化格式，你安装的 ComfyUI 不支持。请在 设置 > 效能 中更新 ComfyUI，或改用未量化的模型版本。",
 
   // ── Synced from en.ts (missing keys) ──
   "checkpoint.civitai_image_ref_placeholder": "CivitAI image URL or id",

--- a/src/lib/utils/generationErrors.ts
+++ b/src/lib/utils/generationErrors.ts
@@ -83,6 +83,51 @@ function extractMissingModel(raw: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Quantization formats ComfyUI has shipped in `QUANT_ALGOS`. Used to recognise a
+ * format name in a bare `KeyError` when no traceback is attached, without
+ * swallowing unrelated `KeyError`s.
+ */
+const KNOWN_QUANT_FORMATS = new Set([
+  "float8_e4m3fn",
+  "float8_e5m2",
+  "nvfp4",
+  "mxfp8",
+  "int8_tensorwise",
+  "convrot_w4a4",
+]);
+
+/** Shape of a quant-format name, so formats added upstream still match. */
+const QUANT_FORMAT_SHAPE = /^(?:int|uint|fp|float|nv|mx|convrot)[\w.]*$/i;
+
+/**
+ * Detects a checkpoint whose quantization format the installed ComfyUI is too
+ * old to understand, and returns that format name.
+ *
+ * ComfyUI dereferences `QUANT_ALGOS[module.quant_format]` in `comfy/ops.py`
+ * before the dispatch chain that would raise a readable
+ * `ValueError: Unsupported quantization format: X`, so an unknown format
+ * surfaces as a bare `KeyError` whose entire message is the format name -- e.g.
+ * an INT8 checkpoint on ComfyUI older than v0.27.0 reports just
+ * `'int8_tensorwise'`. Both forms mean the same thing to a user, so match the
+ * explicit one first and fall back to the KeyError.
+ */
+function extractUnsupportedQuantFormat(raw: string, haystack: string): string | undefined {
+  const explicit = raw.match(/unsupported quantization format:\s*'?([\w.\-]+)'?/i);
+  if (explicit) return explicit[1];
+
+  const key = raw.match(/KeyError:\s*'([^']+)'/) || raw.match(/(?:^|\n)\s*'([^'\s]+)'\s*(?:\n|$)/);
+  if (!key) return undefined;
+  const candidate = key[1];
+
+  // A traceback through the quant tables is proof on its own. Without one
+  // (browser mode can relay a thinner payload) require the key to actually look
+  // like a quantization format, so a stray KeyError is not misreported.
+  const fromQuantTable = haystack.includes("quant_algos") || haystack.includes("quant_format");
+  if (fromQuantTable || KNOWN_QUANT_FORMATS.has(candidate.toLowerCase())) return candidate;
+  return QUANT_FORMAT_SHAPE.test(candidate) && candidate.length >= 4 ? candidate : undefined;
+}
+
 /** Pulls a missing/unknown node class name out of the error text. */
 function extractMissingNode(raw: string): string | undefined {
   const m =
@@ -226,7 +271,20 @@ export function classifyGenerationError(input: ErrorInput): ClassifiedGeneration
     }
   }
 
-  // 8. Generic fallback. If we have any exception message, show it rather than
+  // 8. The checkpoint is quantized in a format the pinned ComfyUI predates
+  // (e.g. int8_tensorwise landed in ComfyUI v0.27.0). Left unclassified this
+  // reaches the user as a bare Python KeyError like `'int8_tensorwise'`, which
+  // says nothing about what to do. Updating ComfyUI is the fix.
+  const quantFormat = extractUnsupportedQuantFormat(raw, haystack);
+  if (quantFormat) {
+    return {
+      messageKey: "generation.error.quant_format_unsupported",
+      params: { format: quantFormat },
+      durationMs: ACTIONABLE_MS,
+    };
+  }
+
+  // 9. Generic fallback. If we have any exception message, show it rather than
   // a bare "Generation failed".
   if (typeof input === "object" && input) {
     const detail = asText(input.exception_message) || asText(input.error);


### PR DESCRIPTION
Two fixes behind issue #511 ("Generation failed: 'int8_tensorwise'").

## 1. The compatibility bot has never actually run

`comfyui-compat.yml` resolved the current pin with a hardcoded grep against `src-tauri/src/setup.rs`. `COMFYUI_REF` moved out of that file into `src-tauri/src/comfyui_version.rs` in v1.4.34 (6c9e2ce), two days before the workflow's first scheduled run. Under `set -euo pipefail` a no-match grep exits 1, so the step died in 8 to 14 seconds and every run since has failed at step 1. No pin-bump PR has ever been opened.

That is why we are still pinned to ComfyUI v0.26.0, and why issue #511 happened: `int8_tensorwise` landed upstream in v0.27.0.

Changes:

- Find the pin by content (`grep -rlE 'const COMFYUI_REF: &str ='` under `src-tauri/src`) rather than by hardcoded path, so the check survives the constant moving again.
- Guard the no-match case explicitly with `|| true` plus a clear error, instead of letting `set -e` kill the step silently.
- Export the resolved path as a `pin_file` job output, and have the bump job edit and verify that exact file.
- Replace `grep -oP` with `sed -nE` (no PCRE dependency), and assert the post-edit value equals the candidate tag before committing.

Verified locally against a copy of the repo: detection resolves `src-tauri/src/comfyui_version.rs` / `v0.26.0`, a simulated bump rewrites exactly the one pin line, and the no-match path fails with the intended error rather than an empty variable.

## 2. Unsupported quantization formats no longer leak a raw KeyError

`comfy/ops.py` does `QUANT_ALGOS[module.quant_format]` directly, so a checkpoint quantized in a format the installed ComfyUI predates raises a bare `KeyError` whose entire message is the format name. MooshieUI forwards that verbatim, so the user sees `Generation failed: 'int8_tensorwise'` and has nothing to act on.

`classifyGenerationError` now recognises both forms (the bare `KeyError` and newer ComfyUI's explicit `Unsupported quantization format:` `ValueError`) and returns an actionable message naming the format and pointing at Settings > Performance > Update ComfyUI.

To avoid mislabelling unrelated `KeyError`s, the bare-KeyError path only matches when the traceback goes through the quant tables, or the key is a known quant format, or it has the shape of one. Checked against the payload shapes that actually reach the classifier: desktop (traceback present), browser mode (thin `{error}` payload), the explicit ValueError, two unrelated KeyErrors that must not match, and the existing out-of-memory and model-not-found cases, which still take priority.

## Checks

- `npm run build`: pass
- `npm run check:i18n`: parity OK, 2262 keys across all 12 locales, `{format}` placeholder present in each
- `svelte-check`: no errors or warnings in any changed file
- No Rust changes

## Follow-up

This PR deliberately does not bump `COMFYUI_REF`. With the workflow repaired, the bot can run against v0.28.0 and open that bump itself, so the smoke test is real evidence rather than an assumption. Note the smoke test covers the bundled MooshieUI nodes only, not the external ControlNet or style-transfer repos, and v0.26.0 to v0.28.0 is a two-release jump.
