### PR TITLE
fix comfyui compat smoke test installing cuda torchaudio

### DIFF
--- a/.github/workflows/comfyui-compat.yml
+++ b/.github/workflows/comfyui-compat.yml
@@ -132,9 +132,14 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           # CPU-only torch first so the unpinned torch in ComfyUI's requirements
-          # is already satisfied and pip does not pull a CUDA build.
-          pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          # is already satisfied and pip does not pull a CUDA build. torchaudio
+          # must be in this list too: ComfyUI imports it via comfy/sd.py, and
+          # leaving it to requirements.txt pulls the CUDA wheel from PyPI, which
+          # then fails to dlopen libcudart on the CPU runner.
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r comfyui-target/requirements.txt
+          # Fail loudly here rather than as an opaque boot crash later.
+          python -c "import torch, torchvision, torchaudio; print(f'torch {torch.__version__} / torchvision {torchvision.__version__} / torchaudio {torchaudio.__version__}')"
           # ultralytics backs the face-detailer node; pin parsed from nodes.rs
           # (single source of truth) via Python to avoid grep -P portability issues.
           PIN=$(python -c 'import re; t=open("src-tauri/src/comfyui/nodes.rs",encoding="utf-8").read(); m=re.search(r"MOOSHIE_NODES_REQUIREMENTS:\s*&str\s*=\s*\"([^\"]*)\"", t); print((m.group(1).encode().decode("unicode_escape").strip()) if m else "ultralytics")')


### PR DESCRIPTION
Follow-up to #512. With detection fixed, the smoke test ran for the first time and immediately failed, but not on a ComfyUI incompatibility. It failed on a second latent bug in the same workflow.

## What happened

The install step pre-installed only `torch` and `torchvision` from the PyTorch CPU wheel index, then ran `pip install -r comfyui-target/requirements.txt`. That file also lists `torchaudio`, which therefore resolved from default PyPI as a CUDA build. ComfyUI imports torchaudio at boot through `comfy/sd.py` (`comfy/ldm/lightricks/vae/audio_vae.py`), so the runner died before serving `/object_info`:

```
OSError: libcudart.so.13: cannot open shared object file: No such file or directory
...
OSError: Could not load this library: .../torchaudio/lib/_torchaudio.abi3.so
ERROR: ComfyUI exited early with code 1 before serving /object_info.
```

`torchaudio` has been in ComfyUI's `requirements.txt` since at least v0.26.0, so this bug was present from the day the workflow was added. It was invisible because the detect job failed first and the smoke test never actually executed.

## Changes

- Install `torchaudio` from the same CPU index as `torch` and `torchvision`, so all three are CPU builds and version-matched.
- Assert all three import right after install, so a wheel-resolution problem fails at the install step with a clear message instead of as an opaque ComfyUI boot crash 30 lines into a traceback.

Failing run for reference: https://github.com/Mooshieblob1/MooshieUI/actions/runs/30398576996

Note the detect job in that run worked correctly, which is the part #512 fixed:

```
Pin file    : src-tauri/src/comfyui_version.rs
Current pin : v0.26.0
Candidate   : v0.28.0
Newer       : true
```

## Checks

Workflow-only change. YAML parses; no frontend, Rust, or locale files touched. Real verification is the re-dispatch against v0.28.0 once this lands.
