### PR TITLE
chore(comfyui): bump pinned ComfyUI to v0.28.0

### DIFF
--- a/src-tauri/src/comfyui_version.rs
+++ b/src-tauri/src/comfyui_version.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 /// whatever `master` happened to be at install time. The scheduled
 /// `comfyui-compat` workflow opens a bot PR bumping this constant once the
 /// custom-node smoke test passes against a newer ComfyUI release.
-pub const COMFYUI_REF: &str = "v0.26.0";
+pub const COMFYUI_REF: &str = "v0.28.0";
 
 /// Read the installed ComfyUI version from its `comfyui_version.py` file
 /// (`__version__ = "0.26.0"`). Returns `None` if the file is missing or


### PR DESCRIPTION
Bumps the pinned ComfyUI from v0.26.0 to v0.28.0.

The commit on this branch (fd530fb) was generated by the `comfyui-compat` workflow after its smoke test passed. The workflow could not open the PR itself because "Allow GitHub Actions to create and approve pull requests" is off for this repo, so it is opened here manually. The branch and commit are exactly what the bot pushed, unmodified.

## Smoke-test evidence

Run: https://github.com/Mooshieblob1/MooshieUI/actions/runs/30399064604

```
required nodes : MooshieSaveImage, MooshieFaceDetailer, MooshieSegmentDetailer,
                 MooshieSoftGuidance, MooshieSmartGuidance, NanoSaurLoader,
                 ApplyTiledDiffusion
PASS: all 7 required node classes registered (811 total nodes in /object_info).
```

## Why this matters beyond routine maintenance

Closes the root cause behind #511. ComfyUI v0.26.0 has no `int8_tensorwise` entry in `QUANT_ALGOS` (added in v0.27.0), and no `convrot_w4a4` (added in v0.28.0). Loading an int8convrot checkpoint on the pinned version raises a bare `KeyError` from `comfy/ops.py`, which reaches the user as "Generation failed: 'int8_tensorwise'". The v0.28.0 boot log in the run above shows the quantization kernels present:

```
quantize_int8_tensorwise, dequantize_int8_convrot_weight, convrot_w4a4_linear
```

## Review notes

- This is a two-release jump (v0.26.0 to v0.28.0), not a single step.
- The smoke test covers the bundled MooshieUI nodes only. External ControlNet and style-transfer packages are third-party git repos and are not exercised.
- The in-app updater preserves models, outputs, and custom nodes.
- Worth a manual generate-and-save pass on a dev install before release.
