### PR TITLE
v1.8.1: ComfyUI v0.28.0 pin, quant format error, prompt overlay alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v1.8.1
+
+### Fixes
+- **Models using newer quantization formats load again**: MooshieUI pins the ComfyUI version it installs and updates to, and that pin had fallen two releases behind. A model saved in a quantization format newer than the pin was not recognised, and generation stopped with a bare "int8_tensorwise" that gave no clue the installed ComfyUI was the problem (issue #511). The pin is now ComfyUI v0.28.0, which covers both int8_tensorwise and convrot_w4a4. Existing installs pick it up from Update ComfyUI under Settings > Performance.
+- **An unsupported quantization format now explains itself**: when a model uses a format the installed ComfyUI does not know, the error names the format and tells you to update ComfyUI or choose a non-quantized version of the model, instead of showing the raw format string on its own.
+- **Prompt highlighting stays lined up with the prompt**: the coloured pills behind scheduled prompts, and the clickable tag targets, are drawn on invisible layers sitting over the prompt box, and those layers could wrap their text at different points than the box itself. From the first mismatch onwards every highlight drifted, ending up a line down and well off to the side, and clicking a tag could land on a different one. The layers now mirror the prompt exactly, and highlights are positioned from measured text rather than from redrawn text, so they hold their place at any window width, font size, and display scaling. A tag broken across two lines now highlights as a single tag.
+
+---
+
 ## What's New in v1.8.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v1.8.1
+
+### Fixes
+- **Models using newer quantization formats load again**: MooshieUI pins the ComfyUI version it installs and updates to, and that pin had fallen two releases behind. A model saved in a quantization format newer than the pin was not recognised, and generation stopped with a bare "int8_tensorwise" that gave no clue the installed ComfyUI was the problem (issue #511). The pin is now ComfyUI v0.28.0, which covers both int8_tensorwise and convrot_w4a4. Existing installs pick it up from Update ComfyUI under Settings > Performance.
+- **An unsupported quantization format now explains itself**: when a model uses a format the installed ComfyUI does not know, the error names the format and tells you to update ComfyUI or choose a non-quantized version of the model, instead of showing the raw format string on its own.
+- **Prompt highlighting stays lined up with the prompt**: the coloured pills behind scheduled prompts, and the clickable tag targets, are drawn on invisible layers sitting over the prompt box, and those layers could wrap their text at different points than the box itself. From the first mismatch onwards every highlight drifted, ending up a line down and well off to the side, and clicking a tag could land on a different one. The layers now mirror the prompt exactly, and highlights are positioned from measured text rather than from redrawn text, so they hold their place at any window width, font size, and display scaling. A tag broken across two lines now highlights as a single tag.
+
+---
+
 ## What's New in v1.8.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Patch release. Version bumped to 1.8.1 in package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json (plus Cargo.lock), with matching entries prepended to RELEASE_NOTES.md and CHANGELOG.md.

## Ships

- #514 pinned ComfyUI moved from v0.26.0 to v0.28.0, which is what actually fixes issue #511. v0.27.0 added the int8_tensorwise quantization format and v0.28.0 added convrot_w4a4; neither existed in the pinned version, and comfy/ops.py indexes QUANT_ALGOS directly, so an unknown format escaped as a bare KeyError.
- #512 actionable error for an unsupported quantization format, named format plus what to do about it, with i18n across all 12 locales.
- #515 prompt textarea highlight and click overlay alignment.

## Internal, not in the release notes

- #512 also repaired the ComfyUI compatibility workflow, which had never completed a run. It grepped COMFYUI_REF out of setup.rs, but the constant moved to comfyui_version.rs in v1.4.34, two days before the workflow's first scheduled run, so all four scheduled runs died at step one and no pin-bump PR was ever opened. Pin location is now content-based.
- #513 fixed the smoke test installing a CUDA torchaudio build on a CPU runner. That failure was masked by the one above, since the workflow never got far enough to hit it.
- Actions is now permitted to open PRs, so the compat bot can raise its own pin bumps from here on.

## Validation

- cargo check passes, Cargo.lock updated to 1.8.1
- npm run build passes
- i18n parity OK
- Compat smoke test against ComfyUI v0.28.0 passed in run 30399064604: all 7 required custom node classes registered, 811 nodes total in /object_info

## Bot triage

No bot reviews were posted on #512, #513, #514 or #515. The reviews, review-comments and issue-comments endpoints all return empty for each. Nothing to fix, skip or defer.

## Caveat

The smoke test proves node registration across the two-release ComfyUI jump, not that a full generate-and-save completes.