### PR TITLE
show package versions in the attention backend status

### DIFF
--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -6973,9 +6973,18 @@ pub async fn check_attention_backend_core(
                 let stdout = String::from_utf8_lossy(&o.stdout);
                 let known = ["sageattention", "flash-attn", "triton", "triton-windows"];
                 for line in stdout.lines() {
-                    let pkg = line.split_whitespace().next().unwrap_or("").to_lowercase();
+                    let mut cols = line.split_whitespace();
+                    let pkg = cols.next().unwrap_or("").to_lowercase();
                     if known.iter().any(|k| pkg == *k) {
-                        venv_packages.push(pkg);
+                        // Keep `uv pip list`'s version column. SageAttention v1 and v2
+                        // both install under the package name `sageattention`, so the
+                        // bare name cannot tell a user which one is active — and the
+                        // v2 wheel's local version (e.g. "2.2.0+cu128torch2.9.1.post6")
+                        // also shows whether it matches the venv's torch build.
+                        match cols.next() {
+                            Some(version) => venv_packages.push(format!("{} {}", pkg, version)),
+                            None => venv_packages.push(pkg),
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Asked in #520: the Installed packages row under Settings > Performance reads `sageattention, triton-windows`, and the reporter could not tell whether that meant SageAttention v1 or v2.

It cannot. Both versions install under the package name `sageattention`, and `check_attention_backend_core` kept only the first whitespace column from `uv pip list`, discarding the version.

Now it keeps the version, so the row reads:

```
sageattention 2.2.0+cu128torch2.9.1.post6, triton-windows 3.4.0.post21
```

That distinguishes v1 from v2, and the v2 wheel's local version also exposes which torch/CUDA build it was compiled against, which matters because a wheel mismatched to the venv's torch can import and then fall back at runtime.

Display-only change. `venv_packages` is consumed in exactly one place (a `join(", ")` in SettingsPage.svelte), so nothing does exact-name matching on it. No new locale keys.

`cargo check` and `cargo fmt --check` pass.