### PR TITLE
v1.9.1: fix Anima ControlNet against core AnimaLLLiteApply (#522)

### DIFF
--- a/.github/workflows/comfyui-compat.yml
+++ b/.github/workflows/comfyui-compat.yml
@@ -237,9 +237,9 @@ jobs:
           {
             echo "Automated ComfyUI compatibility check."
             echo
-            echo "The custom-node compatibility smoke test passed for ComfyUI ${TARGET} (current pin ${CURRENT}). Every bundled MooshieUI custom node registered against that ComfyUI release."
+            echo "The custom-node compatibility smoke test passed for ComfyUI ${TARGET} (current pin ${CURRENT}). Every bundled MooshieUI custom node registered against that ComfyUI release, and the core nodes the workflow builder emits by hand still take the inputs it wires."
             echo
-            echo "Scope: this check covers the bundled MooshieUI nodes only. External ControlNet and style-transfer packages are third-party git repos and are not covered by the smoke test."
+            echo "Scope: this check covers the bundled MooshieUI nodes plus the input signatures of the core ComfyUI nodes MooshieUI emits directly. External ControlNet and style-transfer packages are third-party git repos and are not covered by the smoke test."
             echo
             echo "The in-app updater preserves users' models, outputs, and custom nodes."
             echo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## What's New in v1.9.1
+
+### Fixes
+- **Anima ControlNet works again**: since v1.9.0, turning on ControlNet with an Anima model failed with "required input missing: model_patch" (issue #522). ComfyUI v0.29.0 added its own `AnimaLLLiteApply` node under the same name as the third-party extension MooshieUI was installing, and ComfyUI always keeps its own version when two nodes claim a name, so the extension could never load while the app kept sending the older node's inputs. MooshieUI now builds the workflow around ComfyUI's built-in node and no longer installs the extension. LLLite weights move from the controlnet folder to the model patches folder on the next start, since that is where the built-in loader looks, so presets and already-downloaded weights keep working with nothing to reinstall. On a ComfyUI older than 0.29 the panel now says to update rather than offering an install that cannot help.
+- **Logs can be read without saving a file first**: the desktop app can return the captured log text directly, the way browser mode already did, so grabbing a diagnostic dump no longer has to go through a save dialog.
+
+### Maintenance
+- The weekly ComfyUI compatibility check now verifies the inputs of the built-in nodes MooshieUI wires by hand, not just that those nodes exist. A renamed or reshaped input, which is what broke Anima ControlNet, now fails the check instead of reaching a generation.
+
+---
+
 ## What's New in v1.9.0
 
 ### New features

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,6 @@ RUN uv venv ${COMFYUI_PATH}/.venv --python python3.12 && \
 RUN mkdir -p ${COMFYUI_PATH}/custom_nodes && \
     git clone --depth=1 https://github.com/Fannovel16/comfyui_controlnet_aux.git \
         ${COMFYUI_PATH}/custom_nodes/comfyui_controlnet_aux && \
-    git clone --depth=1 https://github.com/kohya-ss/ComfyUI-Anima-LLLite.git \
-        ${COMFYUI_PATH}/custom_nodes/ComfyUI-Anima-LLLite && \
     git clone --depth=1 https://github.com/BigStationW/ComfyUi-Untwisting-RoPE.git \
         ${COMFYUI_PATH}/custom_nodes/ComfyUi-Untwisting-RoPE && \
     git clone --depth=1 https://github.com/BigStationW/ComfyUi-Scale-Image-to-Total-Pixels-Advanced.git \
@@ -126,7 +124,6 @@ RUN mkdir -p ${COMFYUI_PATH}/custom_nodes && \
     . ${COMFYUI_PATH}/.venv/bin/activate && \
     for req in \
         ${COMFYUI_PATH}/custom_nodes/comfyui_controlnet_aux/requirements.txt \
-        ${COMFYUI_PATH}/custom_nodes/ComfyUI-Anima-LLLite/requirements.txt \
         ${COMFYUI_PATH}/custom_nodes/ComfyUi-Untwisting-RoPE/requirements.txt \
         ${COMFYUI_PATH}/custom_nodes/ComfyUi-Scale-Image-to-Total-Pixels-Advanced/requirements.txt; do \
         if [ -f "$req" ]; then uv pip install -r "$req"; fi; \

--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ MooshieUI stands on the shoulders of a huge amount of open-source work. Sincere 
 Auto-installed into ComfyUI alongside MooshieUI's own nodes:
 
 - **[comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux)** (Fannovel16) - ControlNet preprocessors (Canny, Depth, OpenPose, LineArt, and more).
-- **[ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite)** (kohya-ss) - LLLite ControlNet support for Anima.
 - **[ComfyUi-Untwisting-RoPE](https://github.com/BigStationW/ComfyUi-Untwisting-RoPE)** and **[ComfyUi-Scale-Image-to-Total-Pixels-Advanced](https://github.com/BigStationW/ComfyUi-Scale-Image-to-Total-Pixels-Advanced)** (BigStationW) - training-free style transfer (the Anima style-transfer workflow is ported from Untwisting-RoPE's examples) and advanced image scaling.
 
 ### Research implemented by MooshieUI's own nodes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+## What's New in v1.9.1
+
+### Fixes
+- **Anima ControlNet works again**: since v1.9.0, turning on ControlNet with an Anima model failed with "required input missing: model_patch" (issue #522). ComfyUI v0.29.0 added its own `AnimaLLLiteApply` node under the same name as the third-party extension MooshieUI was installing, and ComfyUI always keeps its own version when two nodes claim a name, so the extension could never load while the app kept sending the older node's inputs. MooshieUI now builds the workflow around ComfyUI's built-in node and no longer installs the extension. LLLite weights move from the controlnet folder to the model patches folder on the next start, since that is where the built-in loader looks, so presets and already-downloaded weights keep working with nothing to reinstall. On a ComfyUI older than 0.29 the panel now says to update rather than offering an install that cannot help.
+- **Logs can be read without saving a file first**: the desktop app can return the captured log text directly, the way browser mode already did, so grabbing a diagnostic dump no longer has to go through a save dialog.
+
+### Maintenance
+- The weekly ComfyUI compatibility check now verifies the inputs of the built-in nodes MooshieUI wires by hand, not just that those nodes exist. A renamed or reshaped input, which is what broke Anima ControlNet, now fails the check instead of reaching a generation.
+
+---
+
 ## What's New in v1.9.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "MIT",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/comfyui-compat/smoke_test.py
+++ b/scripts/comfyui-compat/smoke_test.py
@@ -24,11 +24,12 @@ The list of required node classes and the ultralytics pin are parsed from
 
 Scope
 -----
-Covers the BUNDLED MooshieUI nodes only (the ones the app embeds and is directly
-responsible for). The external ControlNet / style-transfer packages
-(comfyui_controlnet_aux, ComfyUi-Untwisting-RoPE, ...) are third-party git repos
-cloned at runtime; their compatibility is their own maintainers' concern and is
-out of scope here. This limitation is logged, not silently skipped.
+Covers the BUNDLED MooshieUI nodes, plus the input signatures of the CORE
+ComfyUI nodes the workflow builder emits by hand. The external ControlNet /
+style-transfer packages (comfyui_controlnet_aux, ComfyUi-Untwisting-RoPE, ...)
+are third-party git repos cloned at runtime; their compatibility is their own
+maintainers' concern and is out of scope here. This limitation is logged, not
+silently skipped.
 
 Usage
 -----
@@ -84,6 +85,25 @@ DEFAULT_REQUIRED_CLASSES = [
 ]
 DEFAULT_MOOSHIE_REQUIREMENTS = "ultralytics==8.4.75\n"
 
+# Core ComfyUI node classes the workflow builder emits by hand, with the inputs
+# it wires. Registration alone proves nothing here: ComfyUI can keep a class
+# name while changing its input shape, and a custom node can claim a name that
+# core later takes over (core wins, silently). That is exactly how Anima
+# ControlNet broke in #522, where the class existed but wanted `model_patch`
+# instead of the third-party node's `lllite_name`. Checking the signature turns
+# that into a failed pin bump instead of a failed generation.
+REQUIRED_CORE_NODE_INPUTS = {
+    "ModelPatchLoader": ["name"],
+    "AnimaLLLiteApply": [
+        "model",
+        "model_patch",
+        "image",
+        "strength",
+        "start_percent",
+        "end_percent",
+    ],
+}
+
 
 def log(msg: str) -> None:
     print(msg, flush=True)
@@ -109,6 +129,25 @@ def parse_required_classes(nodes_rs: Path) -> list[str]:
         log("WARN: REQUIRED_MOOSHIE_NODE_CLASSES parsed empty; using built-in list")
         return list(DEFAULT_REQUIRED_CLASSES)
     return classes
+
+
+def check_core_node_inputs(object_info: dict) -> list[str]:
+    """Report every core node whose input spec no longer matches what we emit."""
+    problems = []
+    for node_class, expected in REQUIRED_CORE_NODE_INPUTS.items():
+        info = object_info.get(node_class)
+        if info is None:
+            problems.append(f"{node_class}: not registered")
+            continue
+        spec = info.get("input") or {}
+        present = set(spec.get("required") or {}) | set(spec.get("optional") or {})
+        missing = [name for name in expected if name not in present]
+        if missing:
+            problems.append(
+                f"{node_class}: missing input(s) {', '.join(missing)} "
+                f"(registered inputs: {', '.join(sorted(present)) or 'none'})"
+            )
+    return problems
 
 
 def parse_mooshie_requirements(nodes_rs: Path) -> str:
@@ -253,9 +292,11 @@ def main() -> int:
     log(f"repo root      : {repo_root}")
     log(f"ComfyUI dir    : {comfyui_dir}")
     log(f"required nodes : {', '.join(required)}")
+    log(f"core signatures: {', '.join(REQUIRED_CORE_NODE_INPUTS)}")
     log(
-        "scope note     : bundled MooshieUI nodes only; external ControlNet / "
-        "style-transfer git packages are NOT covered by this test."
+        "scope note     : bundled MooshieUI nodes and core node signatures only; "
+        "external ControlNet / style-transfer git packages are NOT covered by "
+        "this test."
     )
 
     log("\n[1/3] Deploying bundled MooshieUI nodes...")
@@ -279,9 +320,10 @@ def main() -> int:
         _terminate(proc)
         return 1
 
-    log("\n[3/3] Verifying required node classes are registered...")
+    log("\n[3/3] Verifying required node classes and core node signatures...")
     registered = set(object_info.keys())
     missing = [c for c in required if c not in registered]
+    signature_problems = check_core_node_inputs(object_info)
 
     _terminate(proc)
 
@@ -289,20 +331,29 @@ def main() -> int:
         "comfyui_dir": str(comfyui_dir),
         "required": required,
         "missing": missing,
+        "core_input_problems": signature_problems,
         "registered_count": len(registered),
-        "passed": not missing,
+        "passed": not missing and not signature_problems,
     }
     if args.summary_json:
         Path(args.summary_json).write_text(json.dumps(result, indent=2), encoding="utf-8")
 
     if missing:
         log(f"FAIL: {len(missing)} required node class(es) did not register: {', '.join(missing)}")
-        log("\nThese nodes likely failed to import against this ComfyUI version.")
-        log("----- ComfyUI log tail -----")
+        log("These nodes likely failed to import against this ComfyUI version.")
+    if signature_problems:
+        log(f"FAIL: {len(signature_problems)} core node input signature mismatch(es):")
+        for problem in signature_problems:
+            log(f"  - {problem}")
+        log("MooshieUI emits these core nodes directly, so a changed input shape "
+            "breaks generation at runtime rather than at startup (see #522).")
+    if missing or signature_problems:
+        log("\n----- ComfyUI log tail -----")
         log(tail(log_path))
         return 1
 
-    log(f"PASS: all {len(required)} required node classes registered "
+    log(f"PASS: all {len(required)} required node classes registered and "
+        f"{len(REQUIRED_CORE_NODE_INPUTS)} core node signatures intact "
         f"({len(registered)} total nodes in /object_info).")
     return 0
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -9,7 +9,13 @@ use crate::state::AppState;
 fn is_optional_model_category(category: &str) -> bool {
     matches!(
         category,
-        "diffusion_models" | "unet" | "text_encoders" | "clip" | "controlnet" | "ultralytics"
+        "diffusion_models"
+            | "unet"
+            | "text_encoders"
+            | "clip"
+            | "controlnet"
+            | "ultralytics"
+            | "model_patches"
     )
 }
 

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -36,26 +36,24 @@ const GGUF_PACKAGES: &[RequiredCustomNodePackage] = &[RequiredCustomNodePackage 
     verify_nodes: &["UnetLoaderGGUF", "CLIPLoaderGGUF"],
 }];
 
-const REQUIRED_CONTROLNET_PACKAGES: &[RequiredCustomNodePackage] = &[
-    RequiredCustomNodePackage {
-        name: "comfyui_controlnet_aux",
-        git_url: "https://github.com/Fannovel16/comfyui_controlnet_aux.git",
-        verify_nodes: &[
-            "CannyEdgePreprocessor",
-            "DepthAnythingV2Preprocessor",
-            "OpenposePreprocessor",
-            "LineArtPreprocessor",
-            "ScribblePreprocessor",
-            "HEDPreprocessor",
-            "FakeScribblePreprocessor",
-        ],
-    },
-    RequiredCustomNodePackage {
-        name: "ComfyUI-Anima-LLLite",
-        git_url: "https://github.com/kohya-ss/ComfyUI-Anima-LLLite.git",
-        verify_nodes: &["AnimaLLLiteApply"],
-    },
-];
+// Anima ControlNet-LLLite is deliberately absent: ComfyUI ships
+// `ModelPatchLoader` + `AnimaLLLiteApply` in core (comfy_extras/nodes_model_patch.py)
+// since v0.29.0, and `load_custom_node` ignores custom classes that shadow core
+// names, so installing kohya-ss/ComfyUI-Anima-LLLite could never take effect and
+// only made the app emit the unreachable third-party input shape (#522).
+const REQUIRED_CONTROLNET_PACKAGES: &[RequiredCustomNodePackage] = &[RequiredCustomNodePackage {
+    name: "comfyui_controlnet_aux",
+    git_url: "https://github.com/Fannovel16/comfyui_controlnet_aux.git",
+    verify_nodes: &[
+        "CannyEdgePreprocessor",
+        "DepthAnythingV2Preprocessor",
+        "OpenposePreprocessor",
+        "LineArtPreprocessor",
+        "ScribblePreprocessor",
+        "HEDPreprocessor",
+        "FakeScribblePreprocessor",
+    ],
+}];
 
 /// Substring present in [`format_missing_mooshie_nodes_error`] output.
 pub const MISSING_MOOSHIE_NODES_MARKER: &str = "has not loaded required MooshieUI custom nodes";

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -154,9 +154,65 @@ fn classify_flat_model_dir(path: &std::path::Path) -> &'static str {
         "clip"
     } else if name.contains("unet") || name.contains("diffusion") {
         "diffusion_models"
+    } else if name.contains("model_patch") || name.contains("modelpatch") {
+        "model_patches"
     } else {
         // Unknown flat directory — default to loras (most common fringe case)
         "loras"
+    }
+}
+
+/// Relocate Anima ControlNet-LLLite weights from `models/controlnet/` to
+/// `models/model_patches/`.
+///
+/// Releases up to v1.9.0 downloaded these into `models/controlnet/` because the
+/// third-party `AnimaLLLiteApply` took a `lllite_name` from that folder. Core
+/// ComfyUI now owns that class name and loads the weights through
+/// `ModelPatchLoader`, which only lists `models/model_patches/` (#522). Existing
+/// installs would otherwise show an empty model dropdown after upgrading.
+///
+/// Best-effort and non-fatal: a file already present at the destination is left
+/// alone (not deleted), and any IO failure is logged and skipped.
+fn migrate_anima_lllite_weights(comfyui_path: &str) {
+    let models = std::path::Path::new(comfyui_path).join("models");
+    let src_dir = models.join("controlnet");
+    let dest_dir = models.join("model_patches");
+
+    let entries = match std::fs::read_dir(&src_dir) {
+        Ok(entries) => entries,
+        // No controlnet dir yet (fresh install) — nothing to migrate.
+        Err(_) => return,
+    };
+
+    let mut moved = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.to_lowercase().starts_with("anima-lllite-") {
+            continue;
+        }
+        if !entry.path().is_file() {
+            continue;
+        }
+        let dest = dest_dir.join(&name);
+        if dest.exists() {
+            log::debug!("Anima LLLite weight {} already migrated, skipping", name);
+            continue;
+        }
+        if let Err(e) = std::fs::create_dir_all(&dest_dir) {
+            log::warn!("Failed to create {:?}: {}", dest_dir, e);
+            return;
+        }
+        match std::fs::rename(entry.path(), &dest) {
+            Ok(()) => moved += 1,
+            Err(e) => log::warn!("Failed to move Anima LLLite weight {}: {}", name, e),
+        }
+    }
+
+    if moved > 0 {
+        log::info!(
+            "Migrated {} Anima LLLite weight(s) from models/controlnet to models/model_patches",
+            moved
+        );
     }
 }
 
@@ -271,6 +327,8 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
             .join("main.py")
             .exists();
         if main_exists {
+            // Must run before launch: ComfyUI caches its model file lists at startup.
+            migrate_anima_lllite_weights(&config.comfyui_path);
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
                 .map_err(AppError::ProcessSpawnFailed)?;
             // Non-fatal: logs a warning on failure rather than blocking startup.
@@ -706,6 +764,14 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
                             "    Models/text_encoders\n",
                             "    Models/TextEncoders\n",
                             "    dlbackend/comfyui/models/text_encoders\n",
+                            // Anima ControlNet-LLLite weights load through core's
+                            // ModelPatchLoader, which reads this folder (not controlnet).
+                            "  model_patches: |\n",
+                            "    model_patches\n",
+                            "    ModelPatches\n",
+                            "    models/model_patches\n",
+                            "    Models/model_patches\n",
+                            "    dlbackend/comfyui/models/model_patches\n",
                         ),
                         idx = i + 1,
                         dir = quoted_dir
@@ -1146,6 +1212,8 @@ pub async fn start_worker_process(
             .join("main.py")
             .exists();
         if main_exists {
+            // Must run before launch: ComfyUI caches its model file lists at startup.
+            migrate_anima_lllite_weights(&config.comfyui_path);
             super::nodes::ensure_mooshie_nodes(&config.comfyui_path)
                 .map_err(AppError::ProcessSpawnFailed)?;
             // Non-fatal: logs a warning on failure rather than blocking startup.

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -303,6 +303,7 @@ fn known_model_subdirs() -> Vec<&'static str> {
         "diffusion_models",
         "text_encoders",
         "ultralytics",
+        "model_patches",
     ]
     .iter()
     .flat_map(|category| category_subdirs(category).iter().copied())
@@ -2238,15 +2239,50 @@ pub async fn copy_gallery_image_to_clipboard(
     }
 }
 
+/// Does an `/object_info/{class}` payload describe `node_class` with every name
+/// in `required_inputs` present in its input spec?
+///
+/// A class name alone is not proof the node is the one we emit for: ComfyUI lets
+/// two packages claim the same name (core wins), so `AnimaLLLiteApply` may exist
+/// while taking a completely different input shape (#522). Checking the inputs
+/// distinguishes them.
+pub(crate) fn node_info_matches(
+    info: &Value,
+    node_class: &str,
+    required_inputs: Option<&[String]>,
+) -> bool {
+    let Some(node) = info.get(node_class) else {
+        return false;
+    };
+    let Some(required_inputs) = required_inputs else {
+        return true;
+    };
+    let input = node.get("input");
+    required_inputs.iter().all(|name| {
+        ["required", "optional"].iter().any(|group| {
+            input
+                .and_then(|input| input.get(group))
+                .and_then(|group| group.get(name))
+                .is_some()
+        })
+    })
+}
+
 /// Check if a ComfyUI node class is available (used to detect custom node packages).
+/// Pass `required_inputs` to also assert the node's input signature.
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn check_node_available(
     state: State<'_, Arc<AppState>>,
     node_class: String,
+    required_inputs: Option<Vec<String>>,
 ) -> Result<bool, AppError> {
     match state.api_get(&format!("/object_info/{}", node_class)).await {
-        Ok(val) => Ok(val.get(&node_class).is_some()),
+        Ok(val) => Ok(node_info_matches(
+            &val,
+            &node_class,
+            required_inputs.as_deref(),
+        )),
         Err(_) => Ok(false),
     }
 }
@@ -5158,6 +5194,12 @@ pub(crate) fn category_subdirs(category: &str) -> &'static [&'static str] {
             "Models/TextEncoders",
         ],
         "ultralytics" => &["ultralytics", "models/ultralytics", "Models/ultralytics"],
+        "model_patches" => &[
+            "model_patches",
+            "ModelPatches",
+            "models/model_patches",
+            "Models/model_patches",
+        ],
         _ => &[],
     }
 }
@@ -5813,22 +5855,31 @@ fn collect_image_files_recursive(
     Ok(())
 }
 
-/// Export application logs and system information to a user-chosen file
-/// for troubleshooting. Collects:
+/// Export application logs and system information for troubleshooting. Collects:
 /// - ComfyUI subprocess stderr log
 /// - App config (sanitized)
 /// - Basic system/platform info
 /// - Rust-side log path references
+///
+/// With `destination`, writes the report to that path and returns an empty
+/// object. Without it, returns `{ content }` so callers that only want the text
+/// (diagnostics copy, error reports) get the Rust-side logs too. The browser
+/// branch in `webserver.rs` has the same contract.
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn export_logs(
     state: State<'_, Arc<AppState>>,
-    destination: String,
+    destination: Option<String>,
     frontend_logs: Option<Vec<String>>,
-) -> Result<(), AppError> {
+) -> Result<Value, AppError> {
     let output = build_diagnostic_log(&state, frontend_logs).await;
-    std::fs::write(&destination, &output)?;
-    Ok(())
+    match destination {
+        Some(path) => {
+            std::fs::write(&path, &output)?;
+            Ok(json!({}))
+        }
+        None => Ok(json!({ "content": output })),
+    }
 }
 
 /// Shallow-recursive walk collecting managed model files (`.safetensors`,
@@ -5888,6 +5939,7 @@ fn append_models_section(output: &mut String, comfyui_path: &str, extra_model_pa
         "diffusion_models",
         "text_encoders",
         "ultralytics",
+        "model_patches",
     ];
     const MAX_FILES_PER_CATEGORY: usize = 200;
 

--- a/src-tauri/src/templates/controlnet.rs
+++ b/src-tauri/src/templates/controlnet.rs
@@ -81,8 +81,18 @@ pub fn inject_controlnet(result: &mut WorkflowResult, params: &ControlNetParam) 
     result.negative_source = (cn_apply_id, 1);
 }
 
-/// Inject Anima ControlNet-LLLite via kohya-ss/ComfyUI-Anima-LLLite.
-/// Unlike standard ControlNet, the LLLite node patches MODEL and returns MODEL.
+/// Inject Anima ControlNet-LLLite. Unlike standard ControlNet, the LLLite node
+/// patches MODEL and returns MODEL, so it rewires the sampler's model input
+/// rather than the conditioning.
+///
+/// Targets ComfyUI core's `ModelPatchLoader` -> `AnimaLLLiteApply` pair
+/// (`comfy_extras/nodes_model_patch.py`, core since v0.29.0). Core registers
+/// `AnimaLLLiteApply` under the same class name as kohya-ss/ComfyUI-Anima-LLLite
+/// and wins that collision (`load_custom_node` ignores custom classes that
+/// shadow core ones), so the third-party signature (`lllite_name` naming a file
+/// in `models/controlnet/`, plus `preserve_wrapper`) is unreachable and was
+/// failing validation with `required_input_missing: model_patch` (#522).
+/// Weights now load through `ModelPatchLoader` from `models/model_patches/`.
 pub fn inject_anima_lllite(
     result: &mut WorkflowResult,
     params: &ControlNetParam,
@@ -154,17 +164,25 @@ pub fn inject_anima_lllite(
         None
     };
 
+    let patch_loader_id = next_id.to_string();
+    workflow.insert(
+        patch_loader_id.clone(),
+        json!({
+            "class_type": "ModelPatchLoader",
+            "inputs": {
+                "name": params.controlnet_model.as_deref().unwrap_or("")
+            }
+        }),
+    );
+    *next_id += 1;
+
     let mut inputs = serde_json::Map::new();
     inputs.insert("model".into(), json!([model_source.0, model_source.1]));
-    inputs.insert(
-        "lllite_name".into(),
-        json!(params.controlnet_model.as_deref().unwrap_or("")),
-    );
+    inputs.insert("model_patch".into(), json!([patch_loader_id, 0]));
     inputs.insert("image".into(), json!([image_source.0, image_source.1]));
     inputs.insert("strength".into(), json!(params.strength));
     inputs.insert("start_percent".into(), json!(params.start_percent));
     inputs.insert("end_percent".into(), json!(params.end_percent));
-    inputs.insert("preserve_wrapper".into(), json!(true));
     if let Some((mask_node, mask_output)) = mask_source {
         inputs.insert("mask".into(), json!([mask_node, mask_output]));
     }
@@ -341,17 +359,41 @@ mod tests {
         }
     }
 
+    /// Guards the core `ModelPatchLoader` -> `AnimaLLLiteApply` shape. Emitting
+    /// the third-party `lllite_name` / `preserve_wrapper` inputs instead fails
+    /// validation on every ComfyUI >= 0.29 (#522).
     #[test]
-    fn inject_anima_lllite_preserves_wrapper_and_rewires_sampler() {
+    fn inject_anima_lllite_loads_model_patch_and_rewires_sampler() {
         let mut result = sample_workflow_result();
 
         inject_anima_lllite(&mut result, &sample_controlnet(), None);
 
         let apply_id = result.model_source.0.clone();
         let apply_node = result.workflow.get(&apply_id).unwrap();
+        assert_eq!(
+            apply_node.get("class_type").unwrap(),
+            &json!("AnimaLLLiteApply")
+        );
         let inputs = apply_node.get("inputs").unwrap();
 
-        assert_eq!(inputs.get("preserve_wrapper").unwrap(), &json!(true));
+        assert!(inputs.get("lllite_name").is_none());
+        assert!(inputs.get("preserve_wrapper").is_none());
+
+        let patch_source = inputs.get("model_patch").unwrap().as_array().unwrap();
+        let patch_id = patch_source[0].as_str().unwrap();
+        let patch_node = result.workflow.get(patch_id).unwrap();
+        assert_eq!(
+            patch_node.get("class_type").unwrap(),
+            &json!("ModelPatchLoader")
+        );
+        assert_eq!(
+            patch_node
+                .get("inputs")
+                .and_then(|i| i.get("name"))
+                .unwrap(),
+            &json!("anima-lllite-test.safetensors")
+        );
+
         assert_eq!(
             result
                 .workflow
@@ -360,6 +402,31 @@ mod tests {
                 .and_then(|inputs| inputs.get("model"))
                 .unwrap(),
             &json!([apply_id, 0])
+        );
+    }
+
+    #[test]
+    fn inject_anima_lllite_wires_mask_for_inpainting_preset() {
+        let mut result = sample_workflow_result();
+        let mut params = sample_controlnet();
+        params.preset = Some("inpainting".into());
+
+        inject_anima_lllite(&mut result, &params, Some("mask.png"));
+
+        let apply_node = result.workflow.get(&result.model_source.0).unwrap();
+        let mask_source = apply_node
+            .get("inputs")
+            .and_then(|inputs| inputs.get("mask"))
+            .and_then(|mask| mask.as_array())
+            .expect("inpainting preset must wire a mask");
+        let mask_id = mask_source[0].as_str().unwrap();
+        assert_eq!(
+            result
+                .workflow
+                .get(mask_id)
+                .and_then(|node| node.get("class_type"))
+                .unwrap(),
+            &json!("LoadImageMask")
         );
     }
 }

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4062,8 +4062,17 @@ async fn dispatch_command(
                 .as_str()
                 .ok_or("Missing nodeClass")?
                 .to_string();
+            let required_inputs: Option<Vec<String>> = args["requiredInputs"].as_array().map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            });
             match state.api_get(&format!("/object_info/{}", node_class)).await {
-                Ok(val) => Ok(serde_json::json!(val.get(&node_class).is_some())),
+                Ok(val) => Ok(serde_json::json!(crate::commands::api::node_info_matches(
+                    &val,
+                    &node_class,
+                    required_inputs.as_deref()
+                ))),
                 Err(_) => Ok(serde_json::json!(false)),
             }
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/ControlNetSettings.svelte
+++ b/src/lib/components/generation/ControlNetSettings.svelte
@@ -22,6 +22,8 @@
     getPresetDefaults,
     getPresetModel,
     getPresetPreprocessor,
+    modelCategory,
+    type ControlNetModelEntry,
   } from "../../config/controlnet-presets.js";
   import { ipcListen, isTauri, authHeaders } from "../../utils/ipc.js";
   import { onMount } from "svelte";
@@ -30,8 +32,8 @@
 
   let preprocessorAvailable = $state<boolean | null>(null);
   let animaLlliteAvailable = $state<boolean | null>(null);
-  let installing = $state<"controlnet_aux" | "anima_lllite" | false>(false);
-  let installErrorFor = $state<{ controlnet_aux?: string | null; anima_lllite?: string | null }>({});
+  let installing = $state<"controlnet_aux" | false>(false);
+  let installErrorFor = $state<{ controlnet_aux?: string | null }>({});
   let installStep = $state("");
   let installMessage = $state("");
   let preprocessorPreviewPromptId = $state<string | null>(null);
@@ -75,6 +77,12 @@
           .filter((preset) => ANIMA_PRESET_IDS.includes(preset.id))
           .sort((a, b) => ANIMA_PRESET_IDS.indexOf(a.id) - ANIMA_PRESET_IDS.indexOf(b.id))
       : CONTROLNET_PRESETS,
+  );
+
+  // Anima routes through AnimaLLLiteApply, whose weights ModelPatchLoader reads
+  // from models/model_patches/; every other architecture uses ControlNetLoader.
+  const customModeModels = $derived(
+    generation.isAnima ? models.modelPatches : models.controlnetModels,
   );
 
   const selectedPresetPreprocessor = $derived(
@@ -129,11 +137,15 @@
       installStep = data.step;
       installMessage = data.message;
     });
-    // Check if preprocessor and Anima LLLite nodes are installed
+    // Check the preprocessor package and the core Anima LLLite nodes.
+    // AnimaLLLiteApply is checked by input signature, not just by name: the old
+    // kohya-ss custom node registers the same class name with a `lllite_name`
+    // input instead of `model_patch`, and ComfyUI resolves that collision in
+    // core's favour, so the name alone says nothing about which one is loaded.
     try {
       [preprocessorAvailable, animaLlliteAvailable] = await Promise.all([
         nodePackageAvailable("comfyui_controlnet_aux", "CannyEdgePreprocessor"),
-        nodePackageAvailable("ComfyUI-Anima-LLLite", "AnimaLLLiteApply"),
+        checkNodeAvailable("AnimaLLLiteApply", ["model_patch"]).catch(() => false),
       ]);
     } catch {
       preprocessorAvailable = false;
@@ -145,8 +157,10 @@
     await ipcListen("comfyui:controlnet_preprocessor", handlePreprocessorPreviewEvent);
   });
 
-  function isModelInstalled(filename: string): boolean {
-    return models.controlnetModels.includes(filename);
+  function isModelInstalled(entry: ControlNetModelEntry): boolean {
+    const installed =
+      modelCategory(entry) === "model_patches" ? models.modelPatches : models.controlnetModels;
+    return installed.includes(entry.filename);
   }
 
   function applyPresetState(presetId: string) {
@@ -172,11 +186,11 @@
 
     const model = applyPresetState(presetId);
     if (model) {
-      if (!isModelInstalled(model.filename)) {
+      if (!isModelInstalled(model)) {
         downloading = model.filename;
         downloadError = null;
         try {
-          await downloadModel(model.url, "controlnet", model.filename);
+          await downloadModel(model.url, modelCategory(model), model.filename);
           await models.refresh();
         } catch (e) {
           downloadError = locale.t('generation.controlnet.download_failed', { error: String(e) });
@@ -277,7 +291,7 @@
 
   /** Generic node-package installer that handles clone → restart → verify flow */
   async function installNodePackage(
-    packageId: "controlnet_aux" | "anima_lllite",
+    packageId: "controlnet_aux",
     repoUrl: string,
     folderName: string,
     verifyNode: string,
@@ -345,16 +359,6 @@
       "comfyui_controlnet_aux",
       "CannyEdgePreprocessor",
       (available) => { preprocessorAvailable = available; },
-    );
-  }
-
-  async function installAnimaLllite() {
-    await installNodePackage(
-      "anima_lllite",
-      "https://github.com/kohya-ss/ComfyUI-Anima-LLLite.git",
-      "ComfyUI-Anima-LLLite",
-      "AnimaLLLiteApply",
-      (available) => { animaLlliteAvailable = available; },
     );
   }
 
@@ -535,49 +539,14 @@
   </div>
 
   {#if generation.controlnetEnabled}
-    <!-- Anima LLLite install warning -->
-    {#if generation.isAnima && animaLlliteAvailable === false && generation.controlnetMode === "preset"}
+    <!--
+      Anima LLLite comes from ComfyUI core (ModelPatchLoader + AnimaLLLiteApply),
+      so there is nothing to install: an older ComfyUI simply cannot run it.
+      Shown in custom mode too, since Anima routes through the same node there.
+    -->
+    {#if generation.isAnima && animaLlliteAvailable === false}
       <div class="bg-amber-900/30 border border-amber-700/50 rounded-lg px-3 py-2 text-xs text-amber-300">
-        {#if installing === "anima_lllite"}
-          <div class="space-y-2">
-            <div class="flex items-center gap-2">
-              <div class="w-3.5 h-3.5 shrink-0 border-2 border-amber-400 border-t-transparent rounded-full animate-spin"></div>
-              <span class="font-medium">
-                {#if installStep === "clone"}
-                  {locale.t('generation.controlnet.clone_step')}
-                {:else if installStep === "restart"}
-                  {locale.t('generation.controlnet.restart_step')}
-                {:else if installStep === "verify"}
-                  {locale.t('generation.controlnet.verify_step')}
-                {:else}
-                  {locale.t('generation.controlnet.installing_step')}
-                {/if}
-              </span>
-            </div>
-            {#if installMessage}
-              <div class="bg-neutral-900/60 rounded px-2 py-1.5 font-mono text-[10px] text-neutral-400 max-h-20 overflow-y-auto break-all">
-                {installMessage}
-              </div>
-            {/if}
-            <div class="w-full bg-amber-900/50 rounded-full h-1.5 overflow-hidden">
-              <div
-                class="bg-amber-400 h-full rounded-full transition-[width] duration-500"
-                style="width: {installStep === 'clone' ? '25' : installStep === 'restart' ? '80' : installStep === 'verify' ? '95' : '10'}%"
-              ></div>
-            </div>
-          </div>
-        {:else}
-          <p class="mb-1.5">{locale.t('generation.controlnet.anima_lllite_install')}</p>
-          <button
-            onclick={installAnimaLllite}
-            class="px-3 py-1 rounded bg-amber-700 hover:bg-amber-600 text-white text-xs transition-colors"
-          >
-            {locale.t('generation.controlnet.install_restart')}
-          </button>
-        {/if}
-        {#if installErrorFor["anima_lllite"]}
-          <p class="text-red-400 mt-1">{installErrorFor["anima_lllite"]}</p>
-        {/if}
+        {locale.t('generation.controlnet.anima_lllite_unsupported')}
       </div>
     {/if}
 
@@ -764,7 +733,7 @@
           class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
         >
           <option value={null}>{locale.t('generation.controlnet.select_model')}</option>
-          {#each models.controlnetModels as model}
+          {#each customModeModels as model}
             <option value={model}>{model}</option>
           {/each}
         </select>

--- a/src/lib/config/controlnet-presets.ts
+++ b/src/lib/config/controlnet-presets.ts
@@ -1,8 +1,22 @@
+/**
+ * ComfyUI models subdirectory a ControlNet weight belongs in. Anima LLLite
+ * weights load through core's `ModelPatchLoader`, which only lists
+ * `models/model_patches/`; everything else uses `ControlNetLoader`.
+ */
+export type ControlNetModelCategory = "controlnet" | "model_patches";
+
 export interface ControlNetModelEntry {
   filename: string;
   url: string;
   preprocessor?: string | null;
   defaults?: ControlNetDefaults;
+  /** Defaults to "controlnet" when omitted. */
+  category?: ControlNetModelCategory;
+}
+
+/** Resolve the models subdirectory for an entry. */
+export function modelCategory(entry: ControlNetModelEntry): ControlNetModelCategory {
+  return entry.category ?? "controlnet";
 }
 
 export interface ControlNetDefaults {
@@ -92,6 +106,7 @@ export const CONTROLNET_PRESETS: ControlNetPreset[] = [
       anima: {
         filename: "anima-lllite-depth-1.safetensors",
         url: "https://huggingface.co/Mooshie/Anima-LLLite/resolve/main/anima-lllite-depth-1.safetensors",
+        category: "model_patches",
         defaults: { strength: 1.2, startPercent: 0, endPercent: 1 },
       },
     },
@@ -153,6 +168,7 @@ export const CONTROLNET_PRESETS: ControlNetPreset[] = [
       anima: {
         filename: "anima-lllite-any-test-like-1-step1000.safetensors",
         url: "https://huggingface.co/Mooshie/Anima-LLLite/resolve/main/anima-lllite-any-test-like-1-step1000.safetensors",
+        category: "model_patches",
         defaults: { strength: 1.25, startPercent: 0, endPercent: 1 },
       },
     },
@@ -166,6 +182,7 @@ export const CONTROLNET_PRESETS: ControlNetPreset[] = [
       anima: {
         filename: "anima-lllite-any-test-like-1-step2000.safetensors",
         url: "https://huggingface.co/Mooshie/Anima-LLLite/resolve/main/anima-lllite-any-test-like-1-step2000.safetensors",
+        category: "model_patches",
         defaults: { strength: 1.0, startPercent: 0, endPercent: 1 },
       },
     },
@@ -180,6 +197,7 @@ export const CONTROLNET_PRESETS: ControlNetPreset[] = [
       anima: {
         filename: "anima-lllite-inpainting-v1.safetensors",
         url: "https://huggingface.co/Mooshie/Anima-LLLite/resolve/main/anima-lllite-inpainting-v1.safetensors",
+        category: "model_patches",
         defaults: { strength: 1.0, startPercent: 0, endPercent: 1 },
       },
     },

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1324,7 +1324,7 @@ const de: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Handgezeichnete Skizzenführung — verwandelt grobe Zeichnungen in Kunst",
   "generation.controlnet.preset_softedge": "Weiche Kanten",
   "generation.controlnet.preset_softedge_desc": "Weiche strukturelle Kanten (HED) — natürliche Kantenbewahrung",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -783,7 +783,7 @@ const en: Record<string, string> = {
   "generation.controlnet.select_model": "Select model...",
 
   // ControlNet — Anima LLLite
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1366,7 +1366,7 @@ const es: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Guía de bocetos a mano — convierte dibujos en arte",
   "generation.controlnet.preset_softedge": "Bordes suaves",
   "generation.controlnet.preset_softedge_desc": "Bordes estructurales suaves (HED) — preservación natural de bordes",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1328,7 +1328,7 @@ const fr: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Guidage de croquis à main levée — transforme les dessins bruts en art",
   "generation.controlnet.preset_softedge": "Contours doux",
   "generation.controlnet.preset_softedge_desc": "Contours structurels doux (HED) — préservation naturelle des contours",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1303,7 +1303,7 @@ const it: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Guida di schizzi a mano libera — trasforma i disegni grezzi in arte",
   "generation.controlnet.preset_softedge": "Bordi morbidi",
   "generation.controlnet.preset_softedge_desc": "Bordi strutturali morbidi (HED) — preservazione naturale dei bordi",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1328,7 +1328,7 @@ const ja: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "手描きスケッチのガイド — ラフな絵をアートに変換",
   "generation.controlnet.preset_softedge": "ソフトエッジ",
   "generation.controlnet.preset_softedge_desc": "ソフトな構造エッジ（HED） — 自然なエッジ保持",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1303,7 +1303,7 @@ const ko: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "손그림 스케치 가이드 — 러프한 그림을 예술로 변환",
   "generation.controlnet.preset_softedge": "소프트 엣지",
   "generation.controlnet.preset_softedge_desc": "부드러운 구조적 엣지 (HED) — 자연스러운 엣지 보존",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -782,7 +782,7 @@ const pl: Record<string, string> = {
   "generation.controlnet.select_model": "Wybierz model...",
 
   // ControlNet — Anima LLLite
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet wymaga rozszerzenia AnimaLLLite dla ComfyUI. Zainstaluj je, aby używać ControlNet z modelami Anima.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet wymaga ComfyUI 0.29 lub nowszego, które udostępnia węzeł AnimaLLLiteApply. Zaktualizuj ComfyUI, aby używać ControlNet z modelami Anima.",
   "generation.controlnet.prepare_preprocessor": "Podgląd preprocesora",
   "generation.controlnet.prepare_preprocessor_tip": "Uruchom preprocesor na obrazie sterującym i wyświetl podgląd wyniku przed generowaniem.",
   "generation.controlnet.preprocessor_preparing": "Przygotowywanie...",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1303,7 +1303,7 @@ const pt: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Guia de esboços à mão — transforma desenhos em arte",
   "generation.controlnet.preset_softedge": "Bordas suaves",
   "generation.controlnet.preset_softedge_desc": "Bordas estruturais suaves (HED) — preservação natural de bordas",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1303,7 +1303,7 @@ const ru: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "Направление по рукописному эскизу — превращает черновики в искусство",
   "generation.controlnet.preset_softedge": "Мягкие края",
   "generation.controlnet.preset_softedge_desc": "Мягкие структурные края (HED) — естественное сохранение краёв",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1303,7 +1303,7 @@ const zhTw: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "手繪草圖引導 — 將粗略的畫變成藝術",
   "generation.controlnet.preset_softedge": "軟邊緣",
   "generation.controlnet.preset_softedge_desc": "柔和的結構邊緣（HED） — 自然的邊緣保留",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1303,7 +1303,7 @@ const zh: Record<string, string> = {
   "generation.controlnet.preset_scribble_desc": "手绘草图引导 — 将粗略的画变成艺术",
   "generation.controlnet.preset_softedge": "软边缘",
   "generation.controlnet.preset_softedge_desc": "柔和的结构边缘（HED） — 自然的边缘保留",
-  "generation.controlnet.anima_lllite_install": "Anima ControlNet requires the AnimaLLLite ComfyUI extension. Install it to use ControlNet with Anima models.",
+  "generation.controlnet.anima_lllite_unsupported": "Anima ControlNet requires ComfyUI 0.29 or newer, which provides the AnimaLLLiteApply node. Update ComfyUI to use ControlNet with Anima models.",
   "generation.controlnet.prepare_preprocessor": "Preview preprocessor",
   "generation.controlnet.prepare_preprocessor_tip": "Run the preprocessor on the control image and preview the result before generating.",
   "generation.controlnet.preprocessor_preparing": "Preparing...",

--- a/src/lib/stores/models.svelte.ts
+++ b/src/lib/stores/models.svelte.ts
@@ -45,6 +45,8 @@ class ModelsStore {
   textEncoders = $state<string[]>([]);
   controlnetModels = $state<string[]>([]);
   ultralyticsModels = $state<string[]>([]);
+  /** ModelPatchLoader weights (`models/model_patches/`), e.g. Anima LLLite. */
+  modelPatches = $state<string[]>([]);
   loading = $state(false);
 
   async refresh() {
@@ -55,7 +57,7 @@ class ModelsStore {
       // layout) or `clip/` (legacy ComfyUI / Forge layout). Fetch both and
       // merge so the picker doesn't miss encoders in the legacy directory
       // (e.g. `qwen_3_8b_fp4mixed.safetensors` placed under `clip/`).
-      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, unetModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels] =
+      const [checkpoints, vaes, loras, samplerInfo, embeddings, upscaleModels, diffusionModels, unetModels, textEncoders, clipEncoders, controlnetModels, ultralyticsModels, modelPatches] =
         await Promise.all([
           getModels("checkpoints"),
           getModels("vae"),
@@ -69,6 +71,7 @@ class ModelsStore {
           getModels("clip").catch(() => [] as string[]),
           getModels("controlnet").catch(() => [] as string[]),
           getModels("ultralytics").catch(() => [] as string[]),
+          getModels("model_patches").catch(() => [] as string[]),
         ]);
 
       console.log("ModelsStore: got checkpoints:", checkpoints);
@@ -90,6 +93,7 @@ class ModelsStore {
         this.textEncoders,
         this.controlnetModels,
         this.ultralyticsModels,
+        this.modelPatches,
       ] = await Promise.all([
         mergeWithDiskModels("checkpoints", checkpoints),
         mergeWithDiskModels("vae", vaes),
@@ -101,6 +105,7 @@ class ModelsStore {
         mergeWithDiskModels("text_encoders", mergedEncoders),
         mergeWithDiskModels("controlnet", controlnetModels),
         mergeWithDiskModels("ultralytics", ultralyticsModels),
+        mergeWithDiskModels("model_patches", modelPatches),
       ]);
       this.diffusionModels = Array.from(new Set([...diffusionModelFiles, ...unetModelFiles])).sort((a, b) =>
         a.localeCompare(b, undefined, { sensitivity: "base" }),

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -736,8 +736,17 @@ export async function fetchCachedImage(url: string): Promise<string> {
   return ipcInvoke("fetch_cached_image", { url });
 }
 
-export async function checkNodeAvailable(nodeClass: string): Promise<boolean> {
-  return ipcInvoke("check_node_available", { nodeClass });
+/**
+ * Is a ComfyUI node class registered? Pass `requiredInputs` when the class name
+ * alone is ambiguous: ComfyUI lets a core node and a custom node claim the same
+ * name (core wins), so the registered class can have an entirely different input
+ * shape from the one the workflow builder emits.
+ */
+export async function checkNodeAvailable(
+  nodeClass: string,
+  requiredInputs?: string[],
+): Promise<boolean> {
+  return ipcInvoke("check_node_available", { nodeClass, requiredInputs });
 }
 
 export async function isCustomNodeInstalled(nodeName: string): Promise<boolean> {
@@ -1030,15 +1039,16 @@ export async function readClipboardImageSafe(): Promise<number[]> {
 }
 
 export async function exportLogs(destination: string): Promise<void> {
-  return ipcInvoke("export_logs", {
+  await ipcInvoke("export_logs", {
     destination,
     frontendLogs: getLogSnapshot(),
   });
 }
 
-// Browser/server mode: the backend has no meaningful local path to write to for
-// a remote browser, so it returns the diagnostic text and the caller triggers a
-// client-side download.
+// Omitting `destination` returns the diagnostic text instead of writing a file.
+// Used by the diagnostics copy button and error reports on desktop, and in
+// browser mode where the backend has no meaningful local path to write to for a
+// remote browser (the caller triggers a client-side download).
 export async function exportLogsContent(): Promise<string> {
   const res = await ipcInvoke<{ content: string }>("export_logs", {
     frontendLogs: getLogSnapshot(),


### PR DESCRIPTION
Fixes #522.

## Anima ControlNet

ComfyUI v0.29.0 (pinned in v1.9.0) added a core `AnimaLLLiteApply` with a different input shape from the kohya-ss extension of the same name. `load_custom_node` ignores custom classes that shadow core names, so the extension could never register while the app kept emitting the third-party inputs, and every Anima ControlNet generation failed with `required_input_missing: model_patch`.

- Workflow builder now emits `ModelPatchLoader` -> `AnimaLLLiteApply(model, model_patch, image, strength, start_percent, end_percent, mask?)`, with unit tests guarding the shape.
- Added the `model_patches` model category end to end (Rust category plumbing, extra model paths YAML, flat-dir classifier, diagnostic report, models store, preset config), since the core loader reads `models/model_patches/` rather than `models/controlnet/`.
- Existing `anima-lllite-*` weights are moved to `models/model_patches/` before ComfyUI launches, on both the main and worker paths, because ComfyUI caches its folder listings at startup.
- Readiness check compares the node's `/object_info` input spec instead of just its class name, since the name alone cannot tell core and the extension apart. The install-and-restart UI is replaced by a notice to update ComfyUI, and the custom-mode model dropdown lists model patches for Anima.
- Dropped the extension from the required package list, the Dockerfile, and the README credits.

## Diagnostics

`export_logs` takes an optional destination and returns the captured text when it is omitted, matching what browser mode already did.

## Regression guard

The ComfyUI compatibility smoke test now asserts the input signatures of the core nodes the builder emits by hand, so a repeat of this failure fails CI instead of a generation.

## Validation

`cargo check`, `cargo fmt --check`, `cargo test` (5 passed), `npm run build`, and `npm run check:i18n` all clean.
