### PR TITLE
install cu130 PyTorch so quantized models keep fast kernels

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -6591,6 +6591,26 @@ pub async fn build_diagnostic_log(state: &AppState, frontend_logs: Option<Vec<St
     let _ = writeln!(output, "=== ComfyUI Log ===");
     let log_path = std::env::temp_dir().join("comfyui-desktop-stderr.log");
     let _ = writeln!(output, "(Source: {})", log_path.display());
+    // This file is truncated only when MooshieUI spawns ComfyUI itself. When it
+    // attached to an already-running server instead, the contents can be from a
+    // much earlier launch with a different ComfyUI/PyTorch version, so stamp the
+    // age rather than let a stale log be read as the current session's.
+    if let Ok(age) = std::fs::metadata(&log_path)
+        .and_then(|m| m.modified())
+        .and_then(|t| {
+            std::time::SystemTime::now()
+                .duration_since(t)
+                .map_err(|e| std::io::Error::other(e.to_string()))
+        })
+    {
+        let secs = age.as_secs();
+        let _ = writeln!(
+            output,
+            "(Last written {}h {}m ago)",
+            secs / 3600,
+            (secs % 3600) / 60
+        );
+    }
     match std::fs::read_to_string(&log_path) {
         Ok(content) => {
             if content.is_empty() {

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1025,9 +1025,28 @@ async fn amd_pytorch_index_url() -> &'static str {
     "https://download.pytorch.org/whl/cpu"
 }
 
+/// "8.9" → (8, 9). `None` for anything that is not a numeric major.minor pair.
+fn parse_major_minor(s: &str) -> Option<(u32, u32)> {
+    let (major, minor) = s.trim().split_once('.')?;
+    Some((major.trim().parse().ok()?, minor.trim().parse().ok()?))
+}
+
 /// Pick the correct PyTorch CUDA wheel index for NVIDIA GPUs.
-/// Blackwell (compute ≥ 12.0) needs cu130+; older GPUs use cu128.
+///
+/// cu130 is the default for every GPU CUDA 13 still supports, and not only for
+/// Blackwell. `comfy-kitchen` — which provides the int4/int8 convrot kernels —
+/// enables its optimized CUDA and Triton backends only on a torch built against
+/// CUDA 13.0 or newer. On an older build it logs "You need pytorch with cu130 or
+/// higher to use optimized CUDA operations", marks both backends disabled, and
+/// leaves only eager, where a quantized checkpoint generates *slower* than its
+/// unquantized base.
+///
+/// CUDA 13 dropped Maxwell, Pascal and Volta, so compute capability below 7.5
+/// stays on cu128.
 async fn nvidia_pytorch_index_url() -> &'static str {
+    const CU130: &str = "https://download.pytorch.org/whl/cu130";
+    const CU128: &str = "https://download.pytorch.org/whl/cu128";
+
     let output = {
         let mut cmd = tokio::process::Command::new("nvidia-smi");
         cmd.args(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"]);
@@ -1038,19 +1057,30 @@ async fn nvidia_pytorch_index_url() -> &'static str {
     if let Ok(o) = output {
         if o.status.success() {
             let stdout = String::from_utf8_lossy(&o.stdout);
-            for line in stdout.lines() {
-                if let Some((major_str, _)) = line.trim().split_once('.') {
-                    if let Ok(major) = major_str.parse::<u32>() {
-                        if major >= 12 {
-                            log::info!("Blackwell GPU detected — using cu130 PyTorch index");
-                            return "https://download.pytorch.org/whl/cu130";
-                        }
-                    }
+            // One venv serves every worker, so the oldest card decides.
+            let oldest = stdout.lines().filter_map(parse_major_minor).min();
+            if let Some(cap) = oldest {
+                if cap < (7, 5) {
+                    log::info!(
+                        "Compute capability {}.{} predates CUDA 13 — using cu128 PyTorch index",
+                        cap.0,
+                        cap.1
+                    );
+                    return CU128;
                 }
+                log::info!(
+                    "Compute capability {}.{} — using cu130 PyTorch index",
+                    cap.0,
+                    cap.1
+                );
+                return CU130;
             }
         }
     }
-    "https://download.pytorch.org/whl/cu128"
+    // Without a compute capability to check, cu128 is the safer default: it
+    // supports strictly more hardware than cu130.
+    log::warn!("Could not read compute capability from nvidia-smi — using cu128 PyTorch index");
+    CU128
 }
 
 async fn step_install_pytorch(
@@ -1227,6 +1257,20 @@ async fn venv_torch_is_cuda(base: &Path) -> bool {
     matches!(cmd.output().await, Ok(out) if out.status.success())
 }
 
+/// The CUDA version the venv's torch was built against, e.g. `(13, 0)`.
+/// `None` when torch is missing, broken, or a CPU build.
+async fn venv_torch_cuda_version(base: &Path) -> Option<(u32, u32)> {
+    let mut cmd = tokio::process::Command::new(venv_python(base));
+    cmd.arg("-c")
+        .arg("import torch; print(torch.version.cuda or '')");
+    hide_window(&mut cmd);
+    let out = cmd.output().await.ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_major_minor(&String::from_utf8_lossy(&out.stdout))
+}
+
 /// Ensure `triton-windows` is present on Windows + CUDA installs.
 ///
 /// The convrot quantization kernels in `comfy-kitchen` (pinned by ComfyUI's own
@@ -1285,9 +1329,29 @@ async fn verify_quant_stack(app: &AppHandle, base: &Path) {
         ),
     }
 
-    // comfy-kitchen falls back to pure-PyTorch eager when no fast kernel backend
-    // loads, and an eager quantized model generates *slower* than its unquantized
-    // base. Installing triton-windows is not enough on its own: its JIT needs a
+    // comfy-kitchen enables its optimized CUDA and Triton backends only on a torch
+    // built against CUDA 13.0 or newer, and drops to eager below that — where a
+    // quantized checkpoint is slower than its unquantized base. New installs get
+    // cu130 (see `nvidia_pytorch_index_url`), but an existing venv keeps whatever
+    // build it was created with until PyTorch is reinstalled. Only advise re-running
+    // setup when setup would actually pick a newer build for this GPU; on hardware
+    // CUDA 13 dropped, cu128 is the best available and the advice would be a loop.
+    if let Some((major, minor)) = venv_torch_cuda_version(base).await {
+        if major < 13 && nvidia_pytorch_index_url().await.ends_with("cu130") {
+            emit_log(
+                app,
+                &format!(
+                    "Warning: this environment's PyTorch is built against CUDA {}.{}. Quantized \
+                     (convrot) models will still generate correctly, but comfy-kitchen needs CUDA \
+                     13.0 or newer for its fast kernels and falls back to slow eager ones below \
+                     that. Re-run setup to rebuild the environment on the CUDA 13 build.",
+                    major, minor
+                ),
+            );
+        }
+    }
+
+    // Installing triton-windows is not enough on its own: its JIT needs a
     // C compiler at runtime, so a package that pip-installed cleanly can still
     // fail to import. Check the import, not just the install.
     if cfg!(target_os = "windows") && venv_torch_is_cuda(base).await {


### PR DESCRIPTION
Found while diagnosing #520.

## The problem

`comfy-kitchen`, which provides the int4/int8 convrot kernels, enables its optimized CUDA and Triton backends only on a torch built against CUDA 13.0 or newer. On an older build it logs:

```
WARNING: You need pytorch with cu130 or higher to use optimized CUDA operations.
Found comfy_kitchen backend eager:  {'available': True, 'disabled': False, ...}
Found comfy_kitchen backend cuda:   {'available': True, 'disabled': True, ...}
Found comfy_kitchen backend triton: {'available': True, 'disabled': True, ...}
```

Only eager is left, and an eager quantized checkpoint generates slower than its unquantized base. That is exactly the report in #520: `anima-aesthetic-v1.1-int8convrot.safetensors` was taking roughly double the time of `anima-aesthetic-v1.1.safetensors`.

Setup was reserving cu130 for Blackwell (compute >= 12.0) and handing cu128 to every other NVIDIA GPU, so this hit most users with a quantized model. The reporter is on an RTX 4060 Laptop (8.9).

## Changes

- `nvidia_pytorch_index_url` now returns cu130 down to compute capability 7.5, which is where CUDA 13 support ends (it dropped Maxwell, Pascal and Volta). Below that, cu128. On multi-GPU the oldest card decides, since one venv serves all workers. No readable compute capability still falls back to cu128, which supports strictly more hardware.
- `verify_quant_stack` warns when an existing venv's torch predates CUDA 13, since a venv keeps its build until PyTorch is reinstalled. The warning is gated on setup actually being able to pick a newer build for that GPU, so hardware CUDA 13 dropped is not sent round a loop.
- The diagnostic report now stamps the ComfyUI log section with its age. That file is truncated only when MooshieUI spawns ComfyUI itself, so when it attached to an already-running server the log can be from a much earlier launch with a different ComfyUI and torch version and be read as current. The #520 report had a log two versions stale with nothing to indicate it.
- `Cargo.lock` picks up the 1.9.1 version bump that was missed at release.

## Compatibility

SageAttention v2 wheel resolution matches on the exact CUDA tag, so cu130 needs cu130 wheels upstream. Checked against the woct0rdho releases the resolver reads: cu130 assets exist for torch 2.9.0, 2.9.1 and a 2.10.0-and-higher line, so v2 keeps resolving on a cu130 venv.

## Validation

`cargo check` and `cargo fmt --check` pass. No new clippy warnings in the changed lines. No frontend changes.