### PR TITLE
video backend pipeline: save node, event 102, gallery mp4 support

### DIFF
--- a/src-tauri/src/comfyui/mooshie_nodes.py
+++ b/src-tauri/src/comfyui/mooshie_nodes.py
@@ -685,6 +685,74 @@ class MooshieSaveImage:
         return float("nan")
 
 
+MOOSHIE_VIDEO_EVENT_TYPE = 102
+
+
+class MooshieSaveVideo:
+    """Save a VIDEO to ComfyUI's output directory and notify the Mooshie
+    backend over the client WebSocket (binary event 102) with absolute file
+    paths, so Rust can move the mp4 into the gallery without shuttling the
+    encoded bytes through the socket. Also writes a poster WebP of frame 0
+    next to the mp4 for thumbnail serving.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "video": ("VIDEO",),
+            },
+            "optional": {
+                "filename_prefix": ("STRING", {"default": "mooshie_video"}),
+            },
+        }
+
+    RETURN_TYPES = ()
+    OUTPUT_NODE = True
+    FUNCTION = "save_video"
+    CATEGORY = "mooshie"
+    DESCRIPTION = "Saves the video as mp4 with a poster frame and notifies MooshieUI over WebSocket."
+
+    def save_video(self, video, filename_prefix="mooshie_video"):
+        from PIL import Image
+        from comfy_api.latest import Types
+        from server import PromptServer
+
+        width, height = video.get_dimensions()
+        full_output_folder, filename, counter, _subfolder, _prefix = (
+            folder_paths.get_save_image_path(
+                filename_prefix, folder_paths.get_output_directory(), width, height
+            )
+        )
+        video_file = f"{filename}_{counter:05}_.mp4"
+        video_path = os.path.join(full_output_folder, video_file)
+        video.save_to(video_path, format=Types.VideoContainer("mp4"), codec="auto")
+
+        components = video.get_components()
+        frames = components.images
+        frame_count = int(frames.shape[0])
+        fps = float(components.frame_rate)
+
+        poster_path = os.path.splitext(video_path)[0] + "_poster.webp"
+        frame0 = (255.0 * frames[0].cpu().numpy()).clip(0, 255).astype(np.uint8)
+        Image.fromarray(frame0[:, :, :3], "RGB").save(
+            poster_path, format="WEBP", quality=90
+        )
+
+        payload = json.dumps(
+            {
+                "video_path": os.path.abspath(video_path),
+                "poster_path": os.path.abspath(poster_path),
+                "fps": fps,
+                "frame_count": frame_count,
+                "width": int(width),
+                "height": int(height),
+            }
+        ).encode("utf-8")
+        PromptServer.instance.send_sync(MOOSHIE_VIDEO_EVENT_TYPE, payload)
+        return {"ui": {"images": []}}
+
+
 _MODEL_EXTENSIONS = (".safetensors", ".sft", ".ckpt", ".pt", ".pth", ".bin")
 
 
@@ -788,6 +856,7 @@ NODE_CLASS_MAPPINGS = {
     "MooshieSaveImage": MooshieSaveImage,
     "MooshieCheckpointLoaderPath": MooshieCheckpointLoaderPath,
     "MooshieDiffusionLoaderPath": MooshieDiffusionLoaderPath,
+    "MooshieSaveVideo": MooshieSaveVideo,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -796,4 +865,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "MooshieSaveImage": "Mooshie Save Image",
     "MooshieCheckpointLoaderPath": "Mooshie Checkpoint Loader (path)",
     "MooshieDiffusionLoaderPath": "Mooshie Diffusion Model Loader (path)",
+    "MooshieSaveVideo": "Mooshie Save Video",
 }

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -70,6 +70,7 @@ pub const MISSING_GGUF_NODES_MARKER: &str = "Required GGUF custom nodes failed t
 
 const REQUIRED_MOOSHIE_NODE_CLASSES: &[&str] = &[
     "MooshieSaveImage",
+    "MooshieSaveVideo",
     "MooshieFaceDetailer",
     "MooshieSegmentDetailer",
     "MooshieSoftGuidance",

--- a/src-tauri/src/comfyui/types.rs
+++ b/src-tauri/src/comfyui/types.rs
@@ -219,6 +219,35 @@ pub struct GenerationParams {
     /// `model_source_category` is set. Never sent by the frontend.
     #[serde(default)]
     pub resolved_model_path: Option<String>,
+    // --- Video generation (MiniMax H3) ---
+    /// "fl2va" (first/last frame -> video+audio) or "ref2va" (reference images).
+    /// Empty string when the client predates video support.
+    #[serde(default)]
+    pub video_variant: String,
+    #[serde(default = "default_video_duration_seconds")]
+    pub video_duration_seconds: f64,
+    #[serde(default = "default_video_megapixels")]
+    pub video_megapixels: f64,
+    #[serde(default = "default_video_aspect_ratio")]
+    pub video_aspect_ratio: String,
+    /// First-frame image for fl2va, same encoding as `input_image`.
+    #[serde(default)]
+    pub video_first_frame: Option<String>,
+    #[serde(default)]
+    pub video_last_frame: Option<String>,
+    /// Up to 9 reference images for ref2va.
+    #[serde(default)]
+    pub video_ref_images: Vec<String>,
+    #[serde(default)]
+    pub video_rife_enabled: bool,
+    #[serde(default)]
+    pub video_diffusion_model: Option<String>,
+    #[serde(default)]
+    pub video_clip_model: Option<String>,
+    #[serde(default)]
+    pub video_vae_model: Option<String>,
+    #[serde(default)]
+    pub video_audio_vae_model: Option<String>,
     /// Optional ControlNet parameters
     #[serde(default)]
     pub controlnet: Option<ControlNetParam>,
@@ -356,6 +385,18 @@ fn default_style_transfer_blocks() -> String {
 
 fn default_region_strength() -> f64 {
     1.0
+}
+
+fn default_video_duration_seconds() -> f64 {
+    5.0
+}
+
+fn default_video_megapixels() -> f64 {
+    0.4
+}
+
+fn default_video_aspect_ratio() -> String {
+    "16:9".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -277,6 +277,89 @@ fn cache_temp_event(
     }
 }
 
+/// Handle a `MooshieSaveVideo` completion (binary WS event 102).
+///
+/// The payload after the 4-byte big-endian event id is UTF-8 JSON:
+/// `{"video_path","poster_path","fps","frame_count","width","height"}` with
+/// absolute paths inside ComfyUI's output directory. Moves the mp4 and its
+/// poster into the owning user's gallery directory, indexes them, and returns
+/// the payload to emit as `comfyui:output_video`. Any failure logs and
+/// returns None -- video output must never crash the WS loop.
+async fn handle_video_output(
+    state: &std::sync::Arc<crate::state::AppState>,
+    data: &[u8],
+    prompt_id: &str,
+) -> Option<serde_json::Value> {
+    let payload: serde_json::Value = match serde_json::from_slice(data.get(4..)?) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("[video] event 102 carried invalid JSON: {e}");
+            return None;
+        }
+    };
+    let video_path = std::path::PathBuf::from(payload.get("video_path")?.as_str()?);
+    let poster_path = payload
+        .get("poster_path")
+        .and_then(|v| v.as_str())
+        .map(std::path::PathBuf::from);
+    let fps = payload.get("fps").and_then(|v| v.as_f64()).unwrap_or(24.0);
+    let frame_count = payload
+        .get("frame_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let width = payload.get("width").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let height = payload.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+
+    // bind_alias copies ownership onto the ComfyUI-side prompt id, so the
+    // WS-side id resolves the owner directly. Desktop generations have no
+    // owner and land in the root gallery.
+    let owner = state.prompt_queue.owner_of(prompt_id);
+    let gallery_dir = crate::webserver::user_gallery_dir(owner.as_deref())?;
+
+    let prompt_id_owned = prompt_id.to_string();
+    let saved = tokio::task::spawn_blocking(move || {
+        crate::commands::api::save_video_to_gallery(
+            &video_path,
+            poster_path.as_deref(),
+            &gallery_dir,
+            &prompt_id_owned,
+            fps,
+            frame_count,
+            width,
+            height,
+        )
+    })
+    .await;
+    let saved = match saved {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            log::warn!("[video] failed to move video into gallery: {e}");
+            return None;
+        }
+        Err(e) => {
+            log::warn!("[video] gallery move task failed: {e}");
+            return None;
+        }
+    };
+
+    let duration_seconds = if fps > 0.0 {
+        frame_count as f64 / fps
+    } else {
+        0.0
+    };
+    Some(serde_json::json!({
+        "type": "video",
+        "prompt_id": prompt_id,
+        "video_filename": saved.video_filename,
+        "poster_filename": saved.poster_filename,
+        "duration_seconds": duration_seconds,
+        "fps": fps,
+        "frame_count": frame_count,
+        "width": width,
+        "height": height,
+    }))
+}
+
 #[cfg(feature = "desktop")]
 pub async fn connect_websocket(
     app_handle: AppHandle,
@@ -521,7 +604,7 @@ pub async fn connect_websocket(
                         // Skip binary events if we don't know which prompt they belong to
                         // (prevents cross-user event leaking via SSE)
                         if current_prompt_id.is_none()
-                            && matches!(event_type, 1 | 2 | 4 | 100 | 101)
+                            && matches!(event_type, 1 | 2 | 4 | 100 | 101 | 102)
                         {
                             continue;
                         }
@@ -706,6 +789,14 @@ pub async fn connect_websocket(
 
                                 emit_split(frontend_event, tauri_payload, sse_payload);
                             }
+                            102 => {
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                if let Some(payload) =
+                                    handle_video_output(&ws_state, &data, prompt_id_str).await
+                                {
+                                    emit("comfyui:output_video", payload);
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -858,7 +949,7 @@ pub async fn connect_websocket_headless(
                         let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
                         // Skip binary events if we don't know which prompt they belong to
                         if current_prompt_id.is_none()
-                            && matches!(event_type, 1 | 2 | 4 | 100 | 101)
+                            && matches!(event_type, 1 | 2 | 4 | 100 | 101 | 102)
                         {
                             continue;
                         }
@@ -923,6 +1014,14 @@ pub async fn connect_websocket_headless(
                                     "comfyui:output_image"
                                 };
                                 emit(frontend_event, payload);
+                            }
+                            102 => {
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                if let Some(payload) =
+                                    handle_video_output(&ws_state, &data, prompt_id_str).await
+                                {
+                                    emit("comfyui:output_video", payload);
+                                }
                             }
                             _ => {}
                         }
@@ -1128,7 +1227,7 @@ async fn connect_websocket_for_worker_inner(
                         }
                         let event_type = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
                         if current_prompt_id.is_none()
-                            && matches!(event_type, 1 | 2 | 4 | 100 | 101)
+                            && matches!(event_type, 1 | 2 | 4 | 100 | 101 | 102)
                         {
                             continue;
                         }
@@ -1192,6 +1291,14 @@ async fn connect_websocket_for_worker_inner(
                                     "comfyui:output_image"
                                 };
                                 emit(frontend_event, payload);
+                            }
+                            102 => {
+                                let prompt_id_str = current_prompt_id.as_deref().unwrap();
+                                if let Some(payload) =
+                                    handle_video_output(&ws_state, &data, prompt_id_str).await
+                                {
+                                    emit("comfyui:output_video", payload);
+                                }
                             }
                             _ => {}
                         }

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -314,7 +314,10 @@ async fn handle_video_output(
     // WS-side id resolves the owner directly. Desktop generations have no
     // owner and land in the root gallery.
     let owner = state.prompt_queue.owner_of(prompt_id);
-    let gallery_dir = crate::webserver::user_gallery_dir(owner.as_deref())?;
+    let Some(gallery_dir) = crate::webserver::user_gallery_dir(owner.as_deref()) else {
+        log::warn!("[video] gallery unavailable, dropping video output for prompt {prompt_id}");
+        return None;
+    };
 
     let prompt_id_owned = prompt_id.to_string();
     let saved = tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1968,9 +1968,17 @@ pub async fn rename_gallery_image(
         let old_poster = old_path.with_file_name(format!("{old_stem}_poster.webp"));
         if old_poster.is_file() {
             let new_poster = old_path.with_file_name(format!("{new_stem}_poster.webp"));
-            if std::fs::rename(&old_poster, &new_poster).is_ok() {
-                crate::gallery_index::rename(&old_poster, &new_poster);
-                crate::gallery_index::update_poster_path(&new_path, &new_poster);
+            match std::fs::rename(&old_poster, &new_poster) {
+                Ok(()) => {
+                    crate::gallery_index::rename(&old_poster, &new_poster);
+                    crate::gallery_index::update_poster_path(&new_path, &new_poster);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[gallery] poster rename failed ({} -> ...): {e}",
+                        old_poster.display()
+                    );
+                }
             }
         }
     }

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1831,6 +1831,14 @@ pub fn generate_thumbnail(
     filename: &str,
     max_size: u32,
 ) -> Result<Vec<u8>, String> {
+    // Videos can't be decoded by the image crate; their thumbnail is the
+    // poster sidecar written at save time.
+    let filename: String = if filename.to_ascii_lowercase().ends_with(".mp4") {
+        format!("{}_poster.webp", &filename[..filename.len() - 4])
+    } else {
+        filename.to_string()
+    };
+    let filename = filename.as_str();
     let path = resolve_gallery_image_path(gallery_dir, filename)
         .map_err(|e| format!("Read failed: {}", e))?;
     let bytes = std::fs::read(&path).map_err(|e| format!("Read failed: {}", e))?;

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1356,6 +1356,111 @@ pub fn save_to_gallery_inner(
     Ok(gallery_filename)
 }
 
+/// Result of moving a finished video (and its poster sidecar) into the gallery.
+pub struct SavedVideo {
+    pub video_filename: String,
+    pub poster_filename: Option<String>,
+}
+
+/// Rename where possible; fall back to copy+delete when ComfyUI's output dir
+/// and the gallery live on different filesystems.
+fn move_gallery_file(src: &std::path::Path, dst: &std::path::Path) -> Result<(), AppError> {
+    if std::fs::rename(src, dst).is_ok() {
+        return Ok(());
+    }
+    std::fs::copy(src, dst)?;
+    let _ = std::fs::remove_file(src);
+    Ok(())
+}
+
+/// Move a fresh mp4 (and optional poster) out of ComfyUI's output directory
+/// into `gallery_dir`, applying the user's output-filename template, then
+/// index it. Rust-side counterpart of the frontend-initiated image save path:
+/// the video is already encoded on disk, so files are moved instead of
+/// shuttling bytes through the WebSocket.
+#[allow(clippy::too_many_arguments)]
+pub fn save_video_to_gallery(
+    video_path: &std::path::Path,
+    poster_path: Option<&std::path::Path>,
+    gallery_dir: &std::path::Path,
+    prompt_id: &str,
+    fps: f64,
+    frame_count: u64,
+    width: u32,
+    height: u32,
+) -> Result<SavedVideo, AppError> {
+    if !video_path.is_file() {
+        return Err(AppError::from(format!(
+            "Video not found at {}",
+            video_path.display()
+        )));
+    }
+    std::fs::create_dir_all(gallery_dir)?;
+
+    let cfg = crate::config::load_persisted_config();
+    let stem = video_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("video");
+    let rendered = render_output_filename_base(
+        cfg.output_filename_template.as_deref(),
+        prompt_id,
+        "video",
+        stem,
+        None,
+    );
+
+    // The template can collapse distinct outputs onto one name; never
+    // overwrite an existing gallery file.
+    let mut video_filename = format!("{rendered}.mp4");
+    let mut n = 1;
+    while gallery_dir.join(&video_filename).exists() {
+        video_filename = format!("{rendered}_{n}.mp4");
+        n += 1;
+    }
+    let dest_video = gallery_dir.join(&video_filename);
+    move_gallery_file(video_path, &dest_video)?;
+
+    let video_stem = video_filename.trim_end_matches(".mp4").to_string();
+    let mut poster_filename = None;
+    let mut poster_dest_str = None;
+    if let Some(src_poster) = poster_path {
+        if src_poster.is_file() {
+            let name = format!("{video_stem}_poster.webp");
+            let dest_poster = gallery_dir.join(&name);
+            match move_gallery_file(src_poster, &dest_poster) {
+                Ok(()) => {
+                    poster_dest_str = Some(dest_poster.to_string_lossy().to_string());
+                    poster_filename = Some(name);
+                }
+                Err(e) => log::warn!("[video] poster move failed: {e}"),
+            }
+        }
+    }
+
+    let file_size = std::fs::metadata(&dest_video).map(|m| m.len()).unwrap_or(0);
+    let duration_seconds = if fps > 0.0 {
+        frame_count as f64 / fps
+    } else {
+        0.0
+    };
+    crate::gallery_index::upsert_video(
+        &dest_video,
+        file_size,
+        &crate::gallery_index::VideoIndexMeta {
+            duration_seconds,
+            fps,
+            width,
+            height,
+            poster_path: poster_dest_str,
+        },
+    );
+    Ok(SavedVideo {
+        video_filename,
+        poster_filename,
+    })
+}
+
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn read_image_metadata(
@@ -1386,6 +1491,23 @@ pub async fn read_image_metadata_path(
     crate::metadata::read_image_metadata(&bytes).map_err(AppError::Other)
 }
 
+/// Whether a gallery directory entry should appear in gallery listings and
+/// count toward storage quotas/expiry. Poster sidecars (`{stem}_poster.webp`)
+/// are internal to their video and never listed. Must stay in sync with the
+/// formats the save pipeline can write (images + mp4 video).
+pub(crate) fn is_listable_gallery_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if lower.ends_with("_poster.webp") {
+        return false;
+    }
+    lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".webp")
+        || lower.ends_with(".jxl")
+        || lower.ends_with(".mp4")
+}
+
 #[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn list_gallery_images() -> Result<Vec<String>, AppError> {
@@ -1398,12 +1520,7 @@ pub async fn list_gallery_images() -> Result<Vec<String>, AppError> {
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let name = entry.file_name().to_string_lossy().into_owned();
-            if name.ends_with(".png")
-                || name.ends_with(".jpg")
-                || name.ends_with(".jpeg")
-                || name.ends_with(".webp")
-                || name.ends_with(".jxl")
-            {
+            if is_listable_gallery_file(&name) {
                 Some((entry.metadata().ok()?.modified().ok()?, name))
             } else {
                 None
@@ -1427,12 +1544,7 @@ pub async fn list_gallery_image_entries() -> Result<Vec<GalleryImageEntry>, AppE
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let name = entry.file_name().to_string_lossy().into_owned();
-            if !(name.ends_with(".png")
-                || name.ends_with(".jpg")
-                || name.ends_with(".jpeg")
-                || name.ends_with(".webp")
-                || name.ends_with(".jxl"))
-            {
+            if !is_listable_gallery_file(&name) {
                 return None;
             }
 
@@ -1779,6 +1891,15 @@ pub async fn delete_gallery_image(filename: String) -> Result<(), AppError> {
         Ok(path) => {
             std::fs::remove_file(&path)?;
             crate::gallery_index::remove(&path);
+            // Videos own a poster sidecar that listings never surface; delete it
+            // together with its mp4.
+            if let Some(stem) = filename.strip_suffix(".mp4") {
+                let poster = path.with_file_name(format!("{stem}_poster.webp"));
+                if poster.is_file() {
+                    let _ = std::fs::remove_file(&poster);
+                    crate::gallery_index::remove(&poster);
+                }
+            }
         }
         Err(GalleryPathResolveError::NotFound) => {}
         Err(e) => return Err(AppError::Other(format!("{}: {}", e, filename))),
@@ -1812,6 +1933,13 @@ pub async fn rename_gallery_image(
         )));
     }
 
+    let old_is_video = old_filename.to_ascii_lowercase().ends_with(".mp4");
+    if old_is_video && !new_filename.to_ascii_lowercase().ends_with(".mp4") {
+        return Err(AppError::from(
+            "Videos must keep the .mp4 extension".to_string(),
+        ));
+    }
+
     let new_path = old_path
         .parent()
         .ok_or_else(|| AppError::Other("Invalid gallery path".into()))?
@@ -1825,6 +1953,20 @@ pub async fn rename_gallery_image(
 
     std::fs::rename(&old_path, &new_path)?;
     crate::gallery_index::rename(&old_path, &new_path);
+
+    if old_is_video {
+        let old_stem = old_filename.strip_suffix(".mp4").unwrap_or(&old_filename);
+        let new_stem = new_filename.strip_suffix(".mp4").unwrap_or(&new_filename);
+        let old_poster = old_path.with_file_name(format!("{old_stem}_poster.webp"));
+        if old_poster.is_file() {
+            let new_poster = old_path.with_file_name(format!("{new_stem}_poster.webp"));
+            if std::fs::rename(&old_poster, &new_poster).is_ok() {
+                crate::gallery_index::rename(&old_poster, &new_poster);
+                crate::gallery_index::update_poster_path(&new_path, &new_poster);
+            }
+        }
+    }
+
     Ok(new_filename)
 }
 

--- a/src-tauri/src/commands/api.rs
+++ b/src-tauri/src/commands/api.rs
@@ -1344,6 +1344,7 @@ pub fn save_to_gallery_inner(
                     }
                 }
             }
+            crate::metadata::ImageFormat::Mp4 => bytes.to_vec(),
             crate::metadata::ImageFormat::Unknown => bytes.to_vec(),
         }
     } else {

--- a/src-tauri/src/gallery_index.rs
+++ b/src-tauri/src/gallery_index.rs
@@ -103,7 +103,28 @@ fn init_schema(c: &Connection) -> rusqlite::Result<()> {
             VALUES (new.id, new.prompt, new.negative_prompt, new.checkpoint);
         END;
         "#,
-    )
+    )?;
+    apply_migrations(c);
+    Ok(())
+}
+
+/// Additive, idempotent column migrations. SQLite has no ADD COLUMN IF NOT
+/// EXISTS, so a re-run fails with "duplicate column name" — that exact error
+/// is expected and swallowed; anything else is logged.
+fn apply_migrations(c: &Connection) {
+    for ddl in [
+        "ALTER TABLE images ADD COLUMN media_type TEXT NOT NULL DEFAULT 'image'",
+        "ALTER TABLE images ADD COLUMN duration_seconds REAL",
+        "ALTER TABLE images ADD COLUMN fps REAL",
+        "ALTER TABLE images ADD COLUMN poster_path TEXT",
+    ] {
+        if let Err(e) = c.execute_batch(ddl) {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column name") {
+                log::warn!("gallery_index: migration failed ({ddl}): {msg}");
+            }
+        }
+    }
 }
 
 fn format_label(fmt: ImageFormat) -> &'static str {
@@ -111,6 +132,7 @@ fn format_label(fmt: ImageFormat) -> &'static str {
         ImageFormat::Png => "png",
         ImageFormat::Jxl => "jxl",
         ImageFormat::WebP => "webp",
+        ImageFormat::Mp4 => "mp4",
         ImageFormat::Unknown => "unknown",
     }
 }
@@ -264,6 +286,84 @@ pub fn upsert(
 
     if let Err(e) = res {
         log::warn!("gallery_index: upsert failed for {}: {e}", path_str);
+    }
+}
+
+/// Metadata for an indexed video, computed by the save pipeline.
+pub struct VideoIndexMeta {
+    pub duration_seconds: f64,
+    pub fps: f64,
+    pub width: u32,
+    pub height: u32,
+    /// Absolute path of the `{stem}_poster.webp` sidecar, if one was saved.
+    pub poster_path: Option<String>,
+}
+
+/// Upsert a gallery video into the index. Best-effort: errors are logged, not
+/// returned. Videos carry no embedded generation metadata in v1, so
+/// prompt/seed/checkpoint stay NULL (enrichment is a later PR).
+pub fn upsert_video(path: &Path, file_size: u64, meta: &VideoIndexMeta) {
+    let guard = conn().lock();
+    let Ok(mut guard) = guard else {
+        log::warn!("gallery_index: mutex poisoned, skipping video upsert");
+        return;
+    };
+    let Some(ref mut c) = *guard else {
+        return; // DB disabled
+    };
+
+    let path_str = path.to_string_lossy().to_string();
+    let res = c.execute(
+        r#"
+        INSERT INTO images (
+            path, format, file_size, width, height, created_at,
+            media_type, duration_seconds, fps, poster_path
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'video', ?7, ?8, ?9)
+        ON CONFLICT(path) DO UPDATE SET
+            format           = excluded.format,
+            file_size        = excluded.file_size,
+            width            = excluded.width,
+            height           = excluded.height,
+            media_type       = excluded.media_type,
+            duration_seconds = excluded.duration_seconds,
+            fps              = excluded.fps,
+            poster_path      = excluded.poster_path
+        "#,
+        params![
+            path_str,
+            format_label(ImageFormat::Mp4),
+            file_size as i64,
+            meta.width as i64,
+            meta.height as i64,
+            now_ms(),
+            meta.duration_seconds,
+            meta.fps,
+            meta.poster_path,
+        ],
+    );
+
+    if let Err(e) = res {
+        log::warn!("gallery_index: video upsert failed for {}: {e}", path_str);
+    }
+}
+
+/// Point a video row at a new poster path after a rename. Best-effort.
+pub fn update_poster_path(video_path: &Path, poster_path: &Path) {
+    let guard = conn().lock();
+    let Ok(guard) = guard else {
+        return;
+    };
+    let Some(ref c) = *guard else {
+        return;
+    };
+    let video_str = video_path.to_string_lossy().to_string();
+    let poster_str = poster_path.to_string_lossy().to_string();
+    if let Err(e) = c.execute(
+        "UPDATE images SET poster_path = ?1 WHERE path = ?2",
+        params![poster_str, video_str],
+    ) {
+        log::warn!("gallery_index: poster update failed for {video_str}: {e}");
     }
 }
 

--- a/src-tauri/src/http_range.rs
+++ b/src-tauri/src/http_range.rs
@@ -1,0 +1,89 @@
+//! Minimal single-range `Range: bytes=...` parsing for mp4 serving.
+//! Multi-range requests and non-byte units return None (caller sends 200).
+
+/// Cap for open-ended ranges (`bytes=N-`): a 15 s H3 mp4 can be hundreds of
+/// MB, and players re-request as they play, so never slurp the remainder.
+pub const OPEN_END_CHUNK: u64 = 8 * 1024 * 1024;
+
+/// Parse a `Range` header against a resource of `len` bytes into an inclusive
+/// `(start, end)` pair, per RFC 7233 (single range only).
+pub fn parse(header: &str, len: u64) -> Option<(u64, u64)> {
+    if len == 0 {
+        return None;
+    }
+    let spec = header.trim().strip_prefix("bytes=")?;
+    if spec.contains(',') {
+        return None;
+    }
+    let (start_s, end_s) = spec.split_once('-')?;
+    let (start_s, end_s) = (start_s.trim(), end_s.trim());
+    if start_s.is_empty() {
+        // Suffix range: last N bytes.
+        let n: u64 = end_s.parse().ok()?;
+        if n == 0 {
+            return None;
+        }
+        return Some((len.saturating_sub(n), len - 1));
+    }
+    let start: u64 = start_s.parse().ok()?;
+    if start >= len {
+        return None;
+    }
+    let end = if end_s.is_empty() {
+        (start + OPEN_END_CHUNK - 1).min(len - 1)
+    } else {
+        end_s.parse::<u64>().ok()?.min(len - 1)
+    };
+    if end < start {
+        return None;
+    }
+    Some((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closed_range() {
+        assert_eq!(parse("bytes=0-1023", 4096), Some((0, 1023)));
+    }
+
+    #[test]
+    fn open_range_is_capped() {
+        assert_eq!(
+            parse("bytes=100-", 1_000_000_000),
+            Some((100, 99 + OPEN_END_CHUNK))
+        );
+    }
+
+    #[test]
+    fn open_range_clamps_to_len() {
+        assert_eq!(parse("bytes=10-", 20), Some((10, 19)));
+    }
+
+    #[test]
+    fn end_clamps_to_len() {
+        assert_eq!(parse("bytes=0-999999", 100), Some((0, 99)));
+    }
+
+    #[test]
+    fn suffix_range() {
+        assert_eq!(parse("bytes=-500", 4096), Some((3596, 4095)));
+    }
+
+    #[test]
+    fn rejects_start_past_eof() {
+        assert_eq!(parse("bytes=4096-", 4096), None);
+    }
+
+    #[test]
+    fn rejects_multi_range_and_garbage() {
+        assert_eq!(parse("bytes=0-1,5-9", 4096), None);
+        assert_eq!(parse("items=0-1", 4096), None);
+        assert_eq!(parse("bytes=a-b", 4096), None);
+        assert_eq!(parse("bytes=5-2", 4096), None);
+        assert_eq!(parse("bytes=-0", 4096), None);
+        assert_eq!(parse("bytes=0-", 0), None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod gallery_index;
+pub mod http_range;
 #[cfg(any(feature = "desktop", feature = "server"))]
 pub mod interrogator;
 pub mod jxl;
@@ -274,6 +275,11 @@ pub fn run() {
         })
         .register_asynchronous_uri_scheme_protocol("gallery", |ctx, request, responder| {
             let _app_handle = ctx.app_handle().clone();
+            let range_header = request
+                .headers()
+                .get("range")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
             std::thread::spawn(move || {
                 let uri = request.uri().to_string();
                 // URL format varies by platform:
@@ -328,6 +334,69 @@ pub fn run() {
                             return;
                         }
                     };
+                if filename.to_ascii_lowercase().ends_with(".mp4") {
+                    let mut file = match std::fs::File::open(&file_path) {
+                        Ok(f) => f,
+                        Err(_) => {
+                            responder.respond(
+                                tauri::http::Response::builder()
+                                    .status(404)
+                                    .body(Vec::new())
+                                    .unwrap(),
+                            );
+                            return;
+                        }
+                    };
+                    let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+                    match range_header
+                        .as_deref()
+                        .and_then(|h| crate::http_range::parse(h, len))
+                    {
+                        Some((start, end)) => {
+                            use std::io::{Read, Seek, SeekFrom};
+                            let mut buf = vec![0u8; (end - start + 1) as usize];
+                            let ok = file.seek(SeekFrom::Start(start)).is_ok()
+                                && file.read_exact(&mut buf).is_ok();
+                            if !ok {
+                                responder.respond(
+                                    tauri::http::Response::builder()
+                                        .status(500)
+                                        .body(Vec::new())
+                                        .unwrap(),
+                                );
+                                return;
+                            }
+                            responder.respond(
+                                tauri::http::Response::builder()
+                                    .status(206)
+                                    .header("Content-Type", "video/mp4")
+                                    .header("Accept-Ranges", "bytes")
+                                    .header("Content-Range", format!("bytes {start}-{end}/{len}"))
+                                    .header("Cache-Control", "no-cache")
+                                    .body(buf)
+                                    .unwrap(),
+                            );
+                        }
+                        None => match std::fs::read(&file_path) {
+                            Ok(bytes) => responder.respond(
+                                tauri::http::Response::builder()
+                                    .status(200)
+                                    .header("Content-Type", "video/mp4")
+                                    .header("Accept-Ranges", "bytes")
+                                    .header("Cache-Control", "no-cache")
+                                    .body(bytes)
+                                    .unwrap(),
+                            ),
+                            Err(_) => responder.respond(
+                                tauri::http::Response::builder()
+                                    .status(404)
+                                    .body(Vec::new())
+                                    .unwrap(),
+                            ),
+                        },
+                    }
+                    return;
+                }
                 match std::fs::read(&file_path) {
                     Ok(data) => {
                         // Detect content type from extension

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -377,23 +377,27 @@ pub fn run() {
                                     .unwrap(),
                             );
                         }
-                        None => match std::fs::read(&file_path) {
-                            Ok(bytes) => responder.respond(
-                                tauri::http::Response::builder()
-                                    .status(200)
-                                    .header("Content-Type", "video/mp4")
-                                    .header("Accept-Ranges", "bytes")
-                                    .header("Cache-Control", "no-cache")
-                                    .body(bytes)
-                                    .unwrap(),
-                            ),
-                            Err(_) => responder.respond(
-                                tauri::http::Response::builder()
-                                    .status(404)
-                                    .body(Vec::new())
-                                    .unwrap(),
-                            ),
-                        },
+                        None => {
+                            use std::io::Read;
+                            let mut bytes = Vec::new();
+                            match file.read_to_end(&mut bytes) {
+                                Ok(_) => responder.respond(
+                                    tauri::http::Response::builder()
+                                        .status(200)
+                                        .header("Content-Type", "video/mp4")
+                                        .header("Accept-Ranges", "bytes")
+                                        .header("Cache-Control", "no-cache")
+                                        .body(bytes)
+                                        .unwrap(),
+                                ),
+                                Err(_) => responder.respond(
+                                    tauri::http::Response::builder()
+                                        .status(404)
+                                        .body(Vec::new())
+                                        .unwrap(),
+                                ),
+                            }
+                        }
                     }
                     return;
                 }

--- a/src-tauri/src/metadata.rs
+++ b/src-tauri/src/metadata.rs
@@ -36,6 +36,7 @@ pub enum ImageFormat {
     Png,
     Jxl,
     WebP,
+    Mp4,
     Unknown,
 }
 
@@ -55,6 +56,9 @@ pub fn detect_format(bytes: &[u8]) -> ImageFormat {
     } else if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0x0A {
         // Naked JXL codestream
         ImageFormat::Jxl
+    } else if bytes.len() >= 12 && &bytes[4..8] == b"ftyp" {
+        // ISO BMFF (mp4): size box then "ftyp" brand at offset 4.
+        ImageFormat::Mp4
     } else {
         ImageFormat::Unknown
     }
@@ -84,6 +88,7 @@ pub fn read_image_metadata(bytes: &[u8]) -> Result<Option<HashMap<String, String
         ImageFormat::Png => read_png_metadata(bytes),
         ImageFormat::Jxl => read_jxl_metadata(bytes),
         ImageFormat::WebP => read_webp_metadata(bytes),
+        ImageFormat::Mp4 => Ok(None),
         ImageFormat::Unknown => Ok(None),
     }
 }
@@ -103,6 +108,7 @@ pub fn embed_image_metadata(
         ImageFormat::Png => embed_png_metadata(image_bytes, params, mode),
         ImageFormat::Jxl => embed_jxl_metadata(image_bytes, params),
         ImageFormat::WebP => embed_webp_metadata(image_bytes, params, mode),
+        ImageFormat::Mp4 => Err("Metadata embedding is not supported for mp4 video".to_string()),
         ImageFormat::Unknown => Err("Unsupported image format for metadata embedding".to_string()),
     }
 }
@@ -1598,6 +1604,14 @@ mod tests {
         }
 
         assert_params_match(&read_image_metadata(&png).unwrap().expect("png metadata"));
+    }
+
+    #[test]
+    fn detects_mp4() {
+        let mut bytes = vec![0x00, 0x00, 0x00, 0x20];
+        bytes.extend_from_slice(b"ftypisom");
+        bytes.extend_from_slice(&[0u8; 8]);
+        assert_eq!(detect_format(&bytes), ImageFormat::Mp4);
     }
 
     /// ASCII/Latin-1 payloads must keep using `tEXt`, which is the chunk

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -221,15 +221,10 @@ fn is_staff_only_event(event: &str) -> bool {
         || event == "custom_node:installed"
 }
 
-/// Gallery files we list, count against storage quotas, and expire — must stay
-/// in sync with the formats `save_to_gallery` can write (JXL included).
+/// Which gallery files the browser-mode endpoints list, quota-count, and
+/// expire. Delegates to the canonical filter next to the save pipeline.
 fn is_gallery_image_filename(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    lower.ends_with(".png")
-        || lower.ends_with(".jpg")
-        || lower.ends_with(".jpeg")
-        || lower.ends_with(".webp")
-        || lower.ends_with(".jxl")
+    crate::commands::api::is_listable_gallery_file(name)
 }
 
 /// Commands that moderators (and admins) can execute.
@@ -5879,9 +5874,20 @@ fn cleanup_expired_images(auth: &AuthState) {
                     if let Ok(age) = now.duration_since(modified) {
                         if age > expiry {
                             let size = meta.len();
-                            if std::fs::remove_file(file_entry.path()).is_ok() {
+                            let path = file_entry.path();
+                            if std::fs::remove_file(&path).is_ok() {
                                 expired_count += 1;
                                 expired_bytes += size;
+                                crate::gallery_index::remove(&path);
+                                // Videos own a poster sidecar that listings
+                                // never surface; expire it with its mp4.
+                                if let Some(stem) = name.strip_suffix(".mp4") {
+                                    let poster = user_dir.join(format!("{stem}_poster.webp"));
+                                    if poster.is_file() {
+                                        let _ = std::fs::remove_file(&poster);
+                                        crate::gallery_index::remove(&poster);
+                                    }
+                                }
                             }
                         }
                     }

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -5430,7 +5430,7 @@ fn get_lan_ips() -> Vec<String> {
 /// Resolve the gallery directory for a given user.
 /// Admin/localhost (username=None) uses the root gallery dir.
 /// LAN users get a per-user subdirectory: `gallery/users/{username}/`.
-fn user_gallery_dir(username: Option<&str>) -> Option<std::path::PathBuf> {
+pub(crate) fn user_gallery_dir(username: Option<&str>) -> Option<std::path::PathBuf> {
     let base = config::gallery_dir()?;
     match username {
         Some(name) => {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -5614,6 +5614,7 @@ fn save_to_gallery_in_dir(
                 crate::metadata::embed_webp_metadata(bytes, meta, embed_mode)
                     .unwrap_or_else(|_| bytes.to_vec())
             }
+            crate::metadata::ImageFormat::Mp4 => bytes.to_vec(),
             crate::metadata::ImageFormat::Unknown => bytes.to_vec(),
         }
     } else {

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -1519,6 +1519,9 @@ async fn gallery_image_handler(
     };
 
     let file_path = gallery_dir.join(&filename);
+    if filename.to_ascii_lowercase().ends_with(".mp4") {
+        return serve_video_file(&file_path, headers.get(axum::http::header::RANGE)).await;
+    }
     match tokio::fs::read(&file_path).await {
         Ok(data) => {
             let lower = filename.to_ascii_lowercase();
@@ -1586,6 +1589,63 @@ async fn gallery_image_handler(
                 .into_response()
         }
         Err(_) => (StatusCode::NOT_FOUND, "Image not found").into_response(),
+    }
+}
+
+/// Serve an mp4 with single-range support so `<video>` seeking works.
+/// Open-ended ranges are capped (see `http_range::OPEN_END_CHUNK`) — players
+/// re-request as they play, so the server never reads a whole multi-hundred-MB
+/// file for one request.
+async fn serve_video_file(
+    path: &std::path::Path,
+    range: Option<&axum::http::HeaderValue>,
+) -> Response {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    let mut file = match tokio::fs::File::open(path).await {
+        Ok(f) => f,
+        Err(_) => return (StatusCode::NOT_FOUND, "Video not found").into_response(),
+    };
+    let len = match file.metadata().await {
+        Ok(m) => m.len(),
+        Err(_) => 0,
+    };
+    match range
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| crate::http_range::parse(h, len))
+    {
+        Some((start, end)) => {
+            if file.seek(std::io::SeekFrom::Start(start)).await.is_err() {
+                return (StatusCode::INTERNAL_SERVER_ERROR, "Seek failed").into_response();
+            }
+            let mut buf = vec![0u8; (end - start + 1) as usize];
+            if file.read_exact(&mut buf).await.is_err() {
+                return (StatusCode::INTERNAL_SERVER_ERROR, "Read failed").into_response();
+            }
+            (
+                StatusCode::PARTIAL_CONTENT,
+                [
+                    ("content-type", "video/mp4".to_string()),
+                    ("accept-ranges", "bytes".to_string()),
+                    ("content-range", format!("bytes {start}-{end}/{len}")),
+                    ("cache-control", "no-cache".to_string()),
+                ],
+                buf,
+            )
+                .into_response()
+        }
+        None => match tokio::fs::read(path).await {
+            Ok(bytes) => (
+                StatusCode::OK,
+                [
+                    ("content-type", "video/mp4".to_string()),
+                    ("accept-ranges", "bytes".to_string()),
+                    ("cache-control", "no-cache".to_string()),
+                ],
+                bytes,
+            )
+                .into_response(),
+            Err(_) => (StatusCode::NOT_FOUND, "Video not found").into_response(),
+        },
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: thumbnail: gallery: http://asset.localhost https://asset.localhost http://thumbnail.localhost https://thumbnail.localhost http://gallery.localhost https://gallery.localhost https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://blobs.animadex.net; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://animadex.net https://thetacursed.github.io https://raw.githubusercontent.com; font-src 'self' data:; media-src 'self' blob: data:; frame-src https://www.photopea.com"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: thumbnail: gallery: http://asset.localhost https://asset.localhost http://thumbnail.localhost https://thumbnail.localhost http://gallery.localhost https://gallery.localhost https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://blobs.animadex.net; connect-src 'self' ipc: http://ipc.localhost https://ipc.localhost http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:* https://api.github.com https://cdn.mooshieblob.com https://civitai.com https://*.civitai.com https://animadex.net https://thetacursed.github.io https://raw.githubusercontent.com; font-src 'self' data:; media-src 'self' blob: data: gallery: http://gallery.localhost https://gallery.localhost; frame-src https://www.photopea.com"
     }
   },
   "bundle": {


### PR DESCRIPTION
Backend-only groundwork for video generation (PR 2 of the MiniMax H3 series). No UI, no user-visible behavior change yet: this lands everything the frontend and the workflow templates will need. PR 1 (ComfyUI v0.30.2) is already on main.

## What this adds

- **Video generation params.** Twelve `video_*` fields on `GenerationParams`, all `#[serde(default)]` so older clients keep deserializing.
- **`MooshieSaveVideo` ComfyUI node.** Takes a VIDEO input from `CreateVideo`, saves the mp4, extracts frame 0 as a `{stem}_poster.webp` sidecar, and pushes a binary WebSocket event (id 102) carrying the paths plus fps, frame count, and dimensions. Registered in the required-node list so it deploys with the rest of the Mooshie nodes.
- **Event 102 handling.** All three WebSocket handlers (desktop, headless, worker) route the event through `handle_video_output`, which resolves the owning user via `prompt_queue.owner_of` and saves into the right gallery directory. Emits `comfyui:output_video` to both Tauri and SSE.
- **Gallery support for video.** Save, list, delete, rename, and storage-expiry all understand mp4 plus its poster sidecar. A single `is_listable_gallery_file` filter keeps posters out of every listing. The SQLite index gains `media_type`, `duration_seconds`, `fps`, and `poster_path` via additive idempotent migrations, so existing databases upgrade in place and existing rows are labelled `image`.
- **Range serving.** New `http_range` module (with unit tests) behind both the desktop `gallery://` scheme and the axum handler, so `<video>` seeking works. Open-ended ranges are capped at 8 MB per response. Thumbnail requests for an mp4 transparently serve its poster.
- **CSP.** `media-src` now allows the gallery scheme in both platform forms.

No new Rust crates and no new Python packages.

## Deliberate deviations from the design doc

1. The Python node calls `PromptServer.instance.send_sync(102, payload)` rather than `send_bytes_sync`, which does not exist in ComfyUI v0.30.2. The encoder prepends the event id itself, so the wire format is unchanged.
2. Duration comes from `frame_count / fps` sent by the node, instead of parsing the mp4 `mvhd` box. Simpler, and it avoids a box-parsing dependency for a number the node already has.
3. The gallery save happens Rust-side inside the WebSocket handler, routed per user via `prompt_queue.owner_of(prompt_id)`, so browser mode with multiple users works the same as desktop.
4. The storage-expiry sweep was extended to cover videos and their posters, otherwise posters would have been orphaned on cleanup.

## Known limitation

Video rows are indexed with NULL `prompt`, `seed`, and `checkpoint`. Metadata capture for video is deferred; mp4 has no equivalent of the PNG text chunks the image path uses.

## Verification

`cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`, and `npm run build` all pass. The only failing test is `jxl::tests::roundtrip_2x2_rgba8`, which is pre-existing and unrelated (jxl.rs is untouched here).

Runtime verification is partial, and worth stating plainly. A real ComfyUI v0.30.2 instance did execute a hand-built `EmptyImage -> CreateVideo -> MooshieSaveVideo` graph and produced a correct mp4 and poster in its output directory, which confirms the Python node and the `send_sync(102, ...)` call work against the shipped ComfyUI version. The Rust half (event receipt, gallery move, SQLite row, range serving, gallery listing) has not been exercised at runtime, because the app running on this machine is the released v1.9.2 build rather than this branch. That half closely mirrors the proven image path for events 100/101, and it merges on code review alone. PR 3 adds the workflow templates and is the first change that drives this pipeline end to end; the full path should be validated there before PR 3 merges.
