### PR TITLE
video: MiniMax H3 workflow templates for fl2va and ref2va

### DIFF
--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -23,6 +23,79 @@ use crate::comfyui::types::{GenerationParams, PromptSegment};
 /// Both the Tauri `generate` command and the LAN web server `generate` route
 /// must call this before `build_workflow`.
 pub fn validate_generation_params(params: &GenerationParams) -> Result<(), String> {
+    // Video mode has its own parameter set; validate it and return early so
+    // image-only guards (input images, ControlNet, style transfer) never
+    // fire on stale image-mode state.
+    if params.mode == "video" {
+        if !matches!(params.video_variant.as_str(), "fl2va" | "ref2va") {
+            return Err(format!(
+                "Unknown video variant \"{}\" — expected \"fl2va\" or \"ref2va\".",
+                params.video_variant
+            ));
+        }
+        for (label, file) in [
+            ("diffusion model", params.video_diffusion_model.as_deref()),
+            ("text encoder", params.video_clip_model.as_deref()),
+            ("video VAE", params.video_vae_model.as_deref()),
+            ("audio VAE", params.video_audio_vae_model.as_deref()),
+        ] {
+            if file.map(str::trim).unwrap_or("").is_empty() {
+                return Err(format!(
+                    "Video generation requires a {} — open the model panel to download the MiniMax H3 files.",
+                    label
+                ));
+            }
+        }
+        let diffusion = params
+            .video_diffusion_model
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("");
+        let diffusion_lower = diffusion.to_lowercase();
+        if !video::H3_DIFFUSION_MARKERS
+            .iter()
+            .any(|marker| diffusion_lower.contains(marker))
+        {
+            return Err(format!(
+                "\"{}\" does not look like a MiniMax H3 model — only MiniMax H3 is supported for video in this version. If this file really is one, rename it to include \"minimax\" or \"h3\".",
+                diffusion
+            ));
+        }
+        let other_variant = if params.video_variant == "fl2va" {
+            "ref2va"
+        } else {
+            "fl2va"
+        };
+        if diffusion_lower.contains(other_variant) {
+            return Err(format!(
+                "\"{}\" is a {} model, but the {} variant is selected — pick the matching diffusion model or switch variants.",
+                diffusion, other_variant, params.video_variant
+            ));
+        }
+        if !(1.0..=15.0).contains(&params.video_duration_seconds) {
+            return Err(format!(
+                "Video duration must be between 1 and 15 seconds (got {}).",
+                params.video_duration_seconds
+            ));
+        }
+        if params.video_variant == "ref2va" {
+            let ref_count = params
+                .video_ref_images
+                .iter()
+                .filter(|s| !s.trim().is_empty())
+                .count();
+            if ref_count == 0 {
+                return Err(
+                    "Reference-to-video needs at least one reference image — please upload one before generating.".into(),
+                );
+            }
+            if ref_count > 9 {
+                return Err("Reference-to-video supports at most 9 reference images.".into());
+            }
+        }
+        return Ok(());
+    }
+
     let needs_input_image =
         matches!(params.mode.as_str(), "img2img" | "inpainting") || params.refine_only;
 
@@ -399,6 +472,12 @@ pub fn load_model_nodes(
 }
 
 pub fn build_workflow(params: &GenerationParams, seed: i64) -> Value {
+    // Video builds its own complete graph and must bypass finish_workflow
+    // (upscale/facefix/segment chains and MooshieSaveImage are image-only).
+    if params.mode == "video" {
+        return video::build(params, seed);
+    }
+
     if params.style_transfer_enabled && params.model_architecture == "anima" {
         let result = style_transfer::build(params, seed);
         return finish_workflow(result, params, seed);

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -7,6 +7,7 @@ pub mod segment_detail;
 pub mod style_transfer;
 pub mod txt2img;
 pub mod upscale;
+pub mod video;
 
 use serde_json::{json, Value};
 

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -34,14 +34,14 @@ pub fn validate_generation_params(params: &GenerationParams) -> Result<(), Strin
             ));
         }
         for (label, file) in [
-            ("diffusion model", params.video_diffusion_model.as_deref()),
-            ("text encoder", params.video_clip_model.as_deref()),
-            ("video VAE", params.video_vae_model.as_deref()),
-            ("audio VAE", params.video_audio_vae_model.as_deref()),
+            ("a diffusion model", params.video_diffusion_model.as_deref()),
+            ("a text encoder", params.video_clip_model.as_deref()),
+            ("a video VAE", params.video_vae_model.as_deref()),
+            ("an audio VAE", params.video_audio_vae_model.as_deref()),
         ] {
             if file.map(str::trim).unwrap_or("").is_empty() {
                 return Err(format!(
-                    "Video generation requires a {} — open the model panel to download the MiniMax H3 files.",
+                    "Video generation requires {} — open the model panel to download the MiniMax H3 files.",
                     label
                 ));
             }

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -547,4 +547,23 @@ mod tests {
         params.style_transfer_enabled = true;
         assert!(crate::templates::validate_generation_params(&params).is_ok());
     }
+
+    /// Dev utility for the manual structural probe (not part of the suite).
+    /// Writes ready-to-POST /prompt bodies for both variants to the system
+    /// temp dir. Run:
+    /// `cargo test --manifest-path src-tauri/Cargo.toml print_h3_workflow_json -- --ignored --nocapture`
+    #[test]
+    #[ignore = "dev utility for the manual ComfyUI structural probe"]
+    fn print_h3_workflow_json() {
+        for variant in ["fl2va", "ref2va"] {
+            let mut params = video_params(variant);
+            if variant == "ref2va" {
+                params.video_ref_images = vec!["ref_probe.png".to_string()];
+            }
+            let body = json!({ "prompt": build(&params, 42) });
+            let path = std::env::temp_dir().join(format!("h3_{variant}_workflow.json"));
+            std::fs::write(&path, serde_json::to_string_pretty(&body).unwrap()).unwrap();
+            println!("wrote {}", path.display());
+        }
+    }
 }

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -481,4 +481,70 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn build_workflow_dispatches_video_without_finish_workflow() {
+        let workflow = crate::templates::build_workflow(&video_params("fl2va"), 42);
+        assert_eq!(nodes_of_class(&workflow, "MooshieSaveVideo").len(), 1);
+        assert!(nodes_of_class(&workflow, "MooshieSaveImage").is_empty());
+    }
+
+    #[test]
+    fn validate_accepts_valid_video_params() {
+        assert!(crate::templates::validate_generation_params(&video_params("fl2va")).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_variant() {
+        let mut params = video_params("fl2va");
+        params.video_variant = "t2v".to_string();
+        assert!(crate::templates::validate_generation_params(&params).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_missing_model_files() {
+        let mut params = video_params("fl2va");
+        params.video_clip_model = None;
+        let err = crate::templates::validate_generation_params(&params).unwrap_err();
+        assert!(err.contains("text encoder"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_non_h3_diffusion_model() {
+        let mut params = video_params("fl2va");
+        params.video_diffusion_model = Some("wan2.2_t2v_fp8.safetensors".to_string());
+        assert!(crate::templates::validate_generation_params(&params).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_cross_variant_diffusion_model() {
+        let mut params = video_params("fl2va");
+        params.video_diffusion_model = Some("minimax_h3_ref2va_nvfp4.safetensors".to_string());
+        assert!(crate::templates::validate_generation_params(&params).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_duration() {
+        let mut params = video_params("fl2va");
+        params.video_duration_seconds = 0.5;
+        assert!(crate::templates::validate_generation_params(&params).is_err());
+        params.video_duration_seconds = 16.0;
+        assert!(crate::templates::validate_generation_params(&params).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_ref2va_without_references() {
+        let params = video_params("ref2va");
+        let err = crate::templates::validate_generation_params(&params).unwrap_err();
+        assert!(err.contains("reference image"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_video_ignores_stale_image_mode_flags() {
+        // Mode switches can leave image-only toggles set; they must not
+        // block video generation (the video arm early-returns).
+        let mut params = video_params("fl2va");
+        params.style_transfer_enabled = true;
+        assert!(crate::templates::validate_generation_params(&params).is_ok());
+    }
 }

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -43,9 +43,395 @@ pub fn compute_h3_dimensions(aspect_ratio: &str, megapixels: f64) -> (u32, u32) 
     (snap(width), snap(height))
 }
 
+/// Build the complete MiniMax H3 video workflow for either variant.
+///
+/// Returns the final workflow JSON directly — never routed through
+/// `finish_workflow`. The negative prompt is unused by design: `BasicGuider`
+/// has no negative conditioning input.
+pub fn build(params: &GenerationParams, seed: i64) -> Value {
+    let (width, height) =
+        compute_h3_dimensions(&params.video_aspect_ratio, params.video_megapixels);
+    let length = compute_h3_frame_length(params.video_duration_seconds);
+
+    let mut workflow = serde_json::Map::new();
+    let mut next_id: u32 = 1;
+
+    let unet_id = next_id.to_string();
+    workflow.insert(
+        unet_id.clone(),
+        json!({
+            "class_type": "UNETLoader",
+            "inputs": {
+                "unet_name": params.video_diffusion_model.as_deref().unwrap_or(""),
+                "weight_dtype": "default"
+            }
+        }),
+    );
+    next_id += 1;
+
+    let clip_id = next_id.to_string();
+    workflow.insert(
+        clip_id.clone(),
+        json!({
+            "class_type": "CLIPLoader",
+            "inputs": {
+                "clip_name": params.video_clip_model.as_deref().unwrap_or(""),
+                "type": "minimax"
+            }
+        }),
+    );
+    next_id += 1;
+
+    let vae_id = next_id.to_string();
+    workflow.insert(
+        vae_id.clone(),
+        json!({
+            "class_type": "VAELoader",
+            "inputs": { "vae_name": params.video_vae_model.as_deref().unwrap_or("") }
+        }),
+    );
+    next_id += 1;
+
+    let audio_vae_id = next_id.to_string();
+    workflow.insert(
+        audio_vae_id.clone(),
+        json!({
+            "class_type": "VAELoader",
+            "inputs": { "vae_name": params.video_audio_vae_model.as_deref().unwrap_or("") }
+        }),
+    );
+    next_id += 1;
+
+    let h3_id = if params.video_variant == "ref2va" {
+        let mut inputs = serde_json::Map::new();
+        inputs.insert("clip".to_string(), json!([clip_id.as_str(), 0]));
+        inputs.insert("vae".to_string(), json!([vae_id.as_str(), 0]));
+        inputs.insert("audio_vae".to_string(), json!([audio_vae_id.as_str(), 0]));
+        inputs.insert("prompt".to_string(), json!(params.positive_prompt));
+        inputs.insert("width".to_string(), json!(width));
+        inputs.insert("height".to_string(), json!(height));
+        inputs.insert("length".to_string(), json!(length));
+        inputs.insert("ref_image_size".to_string(), json!("match"));
+        for (i, filename) in params
+            .video_ref_images
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .take(9)
+            .enumerate()
+        {
+            let load_id = next_id.to_string();
+            workflow.insert(
+                load_id.clone(),
+                json!({ "class_type": "LoadImage", "inputs": { "image": filename } }),
+            );
+            next_id += 1;
+            inputs.insert(format!("ref_image_{}", i + 1), json!([load_id.as_str(), 0]));
+        }
+        let id = next_id.to_string();
+        workflow.insert(
+            id.clone(),
+            json!({ "class_type": "MiniMaxH3ReferenceToVideo", "inputs": inputs }),
+        );
+        next_id += 1;
+        id
+    } else {
+        let mut inputs = serde_json::Map::new();
+        inputs.insert("clip".to_string(), json!([clip_id.as_str(), 0]));
+        inputs.insert("vae".to_string(), json!([vae_id.as_str(), 0]));
+        inputs.insert("prompt".to_string(), json!(params.positive_prompt));
+        inputs.insert("width".to_string(), json!(width));
+        inputs.insert("height".to_string(), json!(height));
+        inputs.insert("length".to_string(), json!(length));
+        for (key, frame) in [
+            ("first_frame", params.video_first_frame.as_deref()),
+            ("last_frame", params.video_last_frame.as_deref()),
+        ] {
+            let filename = frame.map(str::trim).unwrap_or("");
+            if filename.is_empty() {
+                continue;
+            }
+            let load_id = next_id.to_string();
+            workflow.insert(
+                load_id.clone(),
+                json!({ "class_type": "LoadImage", "inputs": { "image": filename } }),
+            );
+            next_id += 1;
+            inputs.insert(key.to_string(), json!([load_id.as_str(), 0]));
+        }
+        let id = next_id.to_string();
+        workflow.insert(
+            id.clone(),
+            json!({ "class_type": "MiniMaxH3ImageToVideo", "inputs": inputs }),
+        );
+        next_id += 1;
+        id
+    };
+
+    let noise_id = next_id.to_string();
+    workflow.insert(
+        noise_id.clone(),
+        json!({ "class_type": "RandomNoise", "inputs": { "noise_seed": seed } }),
+    );
+    next_id += 1;
+
+    let sampler_select_id = next_id.to_string();
+    workflow.insert(
+        sampler_select_id.clone(),
+        json!({
+            "class_type": "KSamplerSelect",
+            "inputs": { "sampler_name": "res_multistep" }
+        }),
+    );
+    next_id += 1;
+
+    let scheduler_id = next_id.to_string();
+    workflow.insert(
+        scheduler_id.clone(),
+        json!({
+            "class_type": "BasicScheduler",
+            "inputs": {
+                "model": [unet_id.as_str(), 0],
+                "scheduler": "simple",
+                "steps": 20,
+                "denoise": 1.0
+            }
+        }),
+    );
+    next_id += 1;
+
+    let guider_id = next_id.to_string();
+    workflow.insert(
+        guider_id.clone(),
+        json!({
+            "class_type": "BasicGuider",
+            "inputs": {
+                "model": [unet_id.as_str(), 0],
+                "conditioning": [h3_id.as_str(), 0]
+            }
+        }),
+    );
+    next_id += 1;
+
+    let sampler_id = next_id.to_string();
+    workflow.insert(
+        sampler_id.clone(),
+        json!({
+            "class_type": "SamplerCustomAdvanced",
+            "inputs": {
+                "noise": [noise_id.as_str(), 0],
+                "guider": [guider_id.as_str(), 0],
+                "sampler": [sampler_select_id.as_str(), 0],
+                "sigmas": [scheduler_id.as_str(), 0],
+                "latent_image": [h3_id.as_str(), 1]
+            }
+        }),
+    );
+    next_id += 1;
+
+    let decode_id = next_id.to_string();
+    workflow.insert(
+        decode_id.clone(),
+        json!({
+            "class_type": "VAEDecode",
+            "inputs": {
+                "samples": [sampler_id.as_str(), 0],
+                "vae": [vae_id.as_str(), 0]
+            }
+        }),
+    );
+    next_id += 1;
+
+    let audio_decode_id = next_id.to_string();
+    workflow.insert(
+        audio_decode_id.clone(),
+        json!({
+            "class_type": "VAEDecodeAudio",
+            "inputs": {
+                "samples": [sampler_id.as_str(), 0],
+                "vae": [audio_vae_id.as_str(), 0]
+            }
+        }),
+    );
+    next_id += 1;
+
+    let create_video_id = next_id.to_string();
+    workflow.insert(
+        create_video_id.clone(),
+        json!({
+            "class_type": "CreateVideo",
+            "inputs": {
+                "images": [decode_id.as_str(), 0],
+                "audio": [audio_decode_id.as_str(), 0],
+                "fps": 24.0
+            }
+        }),
+    );
+    next_id += 1;
+
+    let save_id = next_id.to_string();
+    workflow.insert(
+        save_id,
+        json!({
+            "class_type": "MooshieSaveVideo",
+            "inputs": {
+                "video": [create_video_id.as_str(), 0],
+                "filename_prefix": "mooshie_video"
+            }
+        }),
+    );
+
+    Value::Object(workflow)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::comfyui::types::GenerationParams;
+
+    /// Minimal deserialization-based constructor — `GenerationParams` has
+    /// required fields and no `Default`, so tests build it from JSON. The
+    /// diffusion filename is derived from the variant so validation's
+    /// cross-variant guard (Task 3) accepts it.
+    fn video_params(variant: &str) -> GenerationParams {
+        serde_json::from_value(json!({
+            "mode": "video",
+            "positive_prompt": "a red fox running through snow",
+            "negative_prompt": "",
+            "checkpoint": "",
+            "loras": [],
+            "sampler_name": "euler",
+            "scheduler": "normal",
+            "steps": 28,
+            "cfg": 1.0,
+            "seed": "42",
+            "width": 0,
+            "height": 0,
+            "batch_size": 1,
+            "denoise": 1.0,
+            "upscale_enabled": false,
+            "upscale_method": "latent",
+            "upscale_scale": 1.0,
+            "upscale_denoise": 0.5,
+            "upscale_steps": 10,
+            "upscale_tile_size": 1024,
+            "upscale_tiling": false,
+            "video_variant": variant,
+            "video_duration_seconds": 5.0,
+            "video_megapixels": 0.4,
+            "video_aspect_ratio": "16:9",
+            "video_diffusion_model": format!("minimax_h3_{variant}_nvfp4.safetensors"),
+            "video_clip_model": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+            "video_vae_model": "minimax_h3_video_vae_fp16.safetensors",
+            "video_audio_vae_model": "minimax_h3_audio_vae_fp32.safetensors"
+        }))
+        .expect("valid test params")
+    }
+
+    fn nodes_of_class<'a>(workflow: &'a Value, class_type: &str) -> Vec<&'a Value> {
+        workflow
+            .as_object()
+            .expect("workflow is an object")
+            .values()
+            .filter(|node| node["class_type"] == class_type)
+            .collect()
+    }
+
+    #[test]
+    fn fl2va_graph_has_expected_shape() {
+        let workflow = build(&video_params("fl2va"), 42);
+        assert_eq!(nodes_of_class(&workflow, "MiniMaxH3ImageToVideo").len(), 1);
+        assert!(nodes_of_class(&workflow, "MiniMaxH3ReferenceToVideo").is_empty());
+        assert!(nodes_of_class(&workflow, "LoadImage").is_empty());
+        assert_eq!(nodes_of_class(&workflow, "UNETLoader").len(), 1);
+        assert_eq!(nodes_of_class(&workflow, "VAELoader").len(), 2);
+        assert_eq!(nodes_of_class(&workflow, "VAEDecode").len(), 1);
+        assert_eq!(nodes_of_class(&workflow, "VAEDecodeAudio").len(), 1);
+        assert_eq!(nodes_of_class(&workflow, "MooshieSaveVideo").len(), 1);
+        assert!(nodes_of_class(&workflow, "MooshieSaveImage").is_empty());
+
+        let h3 = nodes_of_class(&workflow, "MiniMaxH3ImageToVideo")[0];
+        assert_eq!(
+            h3["inputs"]["prompt"],
+            json!("a red fox running through snow")
+        );
+        assert_eq!(h3["inputs"]["width"], json!(832));
+        assert_eq!(h3["inputs"]["height"], json!(480));
+        assert_eq!(h3["inputs"]["length"], json!(124));
+        assert!(h3["inputs"].get("first_frame").is_none());
+        assert!(h3["inputs"].get("last_frame").is_none());
+
+        let clip = nodes_of_class(&workflow, "CLIPLoader")[0];
+        assert_eq!(clip["inputs"]["type"], json!("minimax"));
+
+        let noise = nodes_of_class(&workflow, "RandomNoise")[0];
+        assert_eq!(noise["inputs"]["noise_seed"], json!(42));
+
+        let sampler_select = nodes_of_class(&workflow, "KSamplerSelect")[0];
+        assert_eq!(
+            sampler_select["inputs"]["sampler_name"],
+            json!("res_multistep")
+        );
+
+        let scheduler = nodes_of_class(&workflow, "BasicScheduler")[0];
+        assert_eq!(scheduler["inputs"]["scheduler"], json!("simple"));
+        assert_eq!(scheduler["inputs"]["steps"], json!(20));
+        assert_eq!(scheduler["inputs"]["denoise"], json!(1.0));
+
+        let sampler = nodes_of_class(&workflow, "SamplerCustomAdvanced")[0];
+        assert_eq!(sampler["inputs"]["latent_image"][1], json!(1));
+
+        let create_video = nodes_of_class(&workflow, "CreateVideo")[0];
+        assert_eq!(create_video["inputs"]["fps"], json!(24.0));
+        assert!(create_video["inputs"]["audio"].is_array());
+
+        let save = nodes_of_class(&workflow, "MooshieSaveVideo")[0];
+        assert_eq!(save["inputs"]["filename_prefix"], json!("mooshie_video"));
+    }
+
+    #[test]
+    fn fl2va_wires_first_and_last_frames() {
+        let mut params = video_params("fl2va");
+        params.video_first_frame = Some("first.png".to_string());
+        params.video_last_frame = Some("last.png".to_string());
+        let workflow = build(&params, 1);
+        assert_eq!(nodes_of_class(&workflow, "LoadImage").len(), 2);
+        let h3 = nodes_of_class(&workflow, "MiniMaxH3ImageToVideo")[0];
+        assert!(h3["inputs"]["first_frame"].is_array());
+        assert!(h3["inputs"]["last_frame"].is_array());
+    }
+
+    #[test]
+    fn fl2va_ignores_blank_frame_entries() {
+        let mut params = video_params("fl2va");
+        params.video_first_frame = Some("  ".to_string());
+        let workflow = build(&params, 1);
+        assert!(nodes_of_class(&workflow, "LoadImage").is_empty());
+        let h3 = nodes_of_class(&workflow, "MiniMaxH3ImageToVideo")[0];
+        assert!(h3["inputs"].get("first_frame").is_none());
+    }
+
+    #[test]
+    fn ref2va_wires_reference_images_individually() {
+        let mut params = video_params("ref2va");
+        params.video_ref_images = vec![
+            "a.png".to_string(),
+            "b.png".to_string(),
+            "".to_string(),
+            "c.png".to_string(),
+        ];
+        let workflow = build(&params, 1);
+        assert!(nodes_of_class(&workflow, "MiniMaxH3ImageToVideo").is_empty());
+        let h3 = nodes_of_class(&workflow, "MiniMaxH3ReferenceToVideo")[0];
+        assert!(h3["inputs"]["audio_vae"].is_array());
+        assert_eq!(h3["inputs"]["ref_image_size"], json!("match"));
+        assert!(h3["inputs"]["ref_image_1"].is_array());
+        assert!(h3["inputs"]["ref_image_2"].is_array());
+        assert!(h3["inputs"]["ref_image_3"].is_array());
+        assert!(h3["inputs"].get("ref_image_4").is_none());
+        assert_eq!(nodes_of_class(&workflow, "LoadImage").len(), 3);
+    }
 
     #[test]
     fn frame_length_snaps_up_to_17n_plus_5() {

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -1,0 +1,98 @@
+//! MiniMax H3 video workflow builder (fl2va and ref2va variants).
+//!
+//! Unlike the image builders, `build` returns the final workflow JSON
+//! directly and never goes through `finish_workflow` — upscale, face fix,
+//! segment refinement, and `MooshieSaveImage` are all image-only concepts.
+//! The terminal node is `MooshieSaveVideo` (deployed by PR 2).
+
+use serde_json::{json, Value};
+
+use crate::comfyui::types::GenerationParams;
+
+/// Filename markers identifying MiniMax H3 model files (matched as lowercase
+/// substrings, any-match). Consumed by the video arm of
+/// `validate_generation_params`; PR 5's model onboarding reuses them to
+/// filter dropdown lists.
+pub const H3_DIFFUSION_MARKERS: [&str; 2] = ["minimax", "h3"];
+
+/// MiniMax H3 emits 24 fps and only accepts frame counts on the 17n+5 grid
+/// (widget: min 5, max 3600, step 17). Snaps the requested duration UP to
+/// the next valid count, clamped to the largest on-grid value <= 3600.
+pub fn compute_h3_frame_length(seconds: f64) -> u32 {
+    let base = ((seconds * 24.0).round() as i64).max(5);
+    let snapped = base + (5 - (base % 17)).rem_euclid(17);
+    snapped.min(3592) as u32
+}
+
+/// Width/height from a target megapixel budget and aspect ratio, snapped to
+/// multiples of 32 (the H3 width/height widget step). Replaces the official
+/// workflow's ResolutionSelector custom node. Unknown ratios fall back to
+/// 16:9.
+pub fn compute_h3_dimensions(aspect_ratio: &str, megapixels: f64) -> (u32, u32) {
+    let (rw, rh) = match aspect_ratio {
+        "9:16" => (9.0, 16.0),
+        "1:1" => (1.0, 1.0),
+        "4:3" => (4.0, 3.0),
+        "3:4" => (3.0, 4.0),
+        _ => (16.0, 9.0),
+    };
+    let pixels = megapixels.max(0.05) * 1_000_000.0;
+    let height = (pixels * rh / rw).sqrt();
+    let width = height * rw / rh;
+    let snap = |v: f64| ((v / 32.0).round() as u32).max(2) * 32;
+    (snap(width), snap(height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_length_snaps_up_to_17n_plus_5() {
+        assert_eq!(compute_h3_frame_length(5.0), 124);
+        assert_eq!(compute_h3_frame_length(1.0), 39);
+        assert_eq!(compute_h3_frame_length(15.0), 362);
+        // Robustness at the edges: never below the widget minimum,
+        // never above the largest on-grid value <= 3600.
+        assert_eq!(compute_h3_frame_length(0.0), 5);
+        assert_eq!(compute_h3_frame_length(500.0), 3592);
+    }
+
+    #[test]
+    fn frame_length_is_always_on_grid() {
+        for tenths in 10..=150 {
+            let length = compute_h3_frame_length(tenths as f64 / 10.0);
+            assert_eq!(
+                length % 17,
+                5,
+                "off-grid length {} for {} s",
+                length,
+                tenths as f64 / 10.0
+            );
+        }
+    }
+
+    #[test]
+    fn dimensions_hit_known_targets() {
+        assert_eq!(compute_h3_dimensions("16:9", 0.4), (832, 480));
+        assert_eq!(compute_h3_dimensions("9:16", 0.4), (480, 832));
+        assert_eq!(compute_h3_dimensions("1:1", 0.4), (640, 640));
+        assert_eq!(compute_h3_dimensions("4:3", 0.4), (736, 544));
+        assert_eq!(compute_h3_dimensions("3:4", 0.4), (544, 736));
+        assert_eq!(compute_h3_dimensions("16:9", 0.6), (1024, 576));
+        // Unknown ratios fall back to 16:9.
+        assert_eq!(compute_h3_dimensions("bogus", 0.4), (832, 480));
+    }
+
+    #[test]
+    fn dimensions_are_multiples_of_32() {
+        for ratio in ["16:9", "9:16", "1:1", "4:3", "3:4"] {
+            for mp in [0.2, 0.4, 0.6, 1.0] {
+                let (w, h) = compute_h3_dimensions(ratio, mp);
+                assert_eq!(w % 32, 0);
+                assert_eq!(h % 32, 0);
+                assert!(w >= 64 && h >= 64);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Workflow templates for MiniMax H3 video generation (PR 3 of the series). Backend only, no UI: this makes the generation pipeline emit a valid H3 ComfyUI graph when the mode is `video`. PR 1 (ComfyUI v0.30.2) and PR 2 (video params, MooshieSaveVideo node, event 102, gallery mp4 support) are already on main.

## What this adds

New `src-tauri/src/templates/video.rs`:

- **`compute_h3_frame_length(seconds)`.** H3 requires a frame count on the 17n+5 grid, so the requested duration is snapped up to the next valid value and clamped at 3592. 5 seconds at 24 fps gives `length: 124`.
- **`compute_h3_dimensions(aspect_ratio, megapixels)`.** Width and height derived from the megapixel budget and ratio, snapped to multiples of 32. The default 0.4 MP at 16:9 gives 832x480.
- **`build(params, seed)`.** Emits the complete graph for both variants. `fl2va` (MiniMaxH3ImageToVideo) takes optional first and last frames and doubles as text to video when neither is supplied. `ref2va` (MiniMaxH3ReferenceToVideo) takes up to 9 reference images through the autogrow `ref_image_1`..`ref_image_N` keys plus `ref_image_size: "match"`. Both run through RandomNoise, KSamplerSelect (res_multistep), BasicScheduler (simple, 20 steps), BasicGuider, and SamplerCustomAdvanced, then split into VAEDecode plus VAEDecodeAudio, into CreateVideo at 24 fps, into MooshieSaveVideo.

In `src-tauri/src/templates/mod.rs`:

- **Dispatch.** `build_workflow` returns `video::build(...)` early for video mode. Video deliberately does not call `finish_workflow`, because upscale, facefix, LoRA, and ControlNet chains are all image only, and neither is MooshieSaveImage wanted in a video graph.
- **Validation.** A video arm at the top of `validate_generation_params` checks the variant name, that all four model files are set, that the diffusion filename looks like an H3 model, that it is not the other variant's file, that the duration is 1 to 15 seconds, and that ref2va has between 1 and 9 reference images. It returns early, so the image-only guards below it are unreachable for video.

17 new unit tests cover the frame grid across the full duration range, all seven resolution targets, both graph shapes node by node, and every validation branch.

## Deliberate deviations from the design doc

1. The spec called for `detect_model_architecture()` to fingerprint H3 models. That function does not exist in this codebase. The H3 check instead follows the existing `KREA2_TEXT_ENCODER_MARKERS` precedent: an `H3_DIFFUSION_MARKERS` const matched against the lowercased filename, with the error message telling the user to rename the file to include "minimax" or "h3" if their copy is named something else.
2. A cross variant filename guard was added beyond the spec, so selecting the ref2va model file while the fl2va variant is active is rejected with a clear message instead of failing deep inside ComfyUI.

## Verification

`cargo fmt`, `cargo check`, `cargo clippy`, `cargo test`, and `npm run build` all pass. The only failing test is `jxl::tests::roundtrip_2x2_rgba8`, which is pre existing and unrelated.

Beyond the unit tests, both generated graphs were posted to a real ComfyUI v0.30.2 instance with no H3 model files installed. Both came back with `value_not_in_list` errors for exactly the four missing model filenames and nothing else: no unknown `class_type`, no unknown input key, no missing required input. ComfyUI validates every node in a graph rather than stopping at the first error, so that silence confirms the node class names, the input keys, and the wiring are all correct against the pinned version.

What this does not confirm: no generation has actually run. The models are a 33.7 GB download and none of them are installed here, so runtime behaviour, output quality, and the event 102 to gallery path are still unexercised. PR 4 adds the video UI and is the first change that can drive a real generation, so it carries the requirement that one complete H3 generation must succeed before it merges.
