### PR TITLE
video: vendor MiniMax H3 Director custom nodes

### DIFF
--- a/comfyui-nodes/minimax_director/LICENSE
+++ b/comfyui-nodes/minimax_director/LICENSE
@@ -1,0 +1,674 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/comfyui-nodes/minimax_director/__init__.py
+++ b/comfyui-nodes/minimax_director/__init__.py
@@ -1,0 +1,49 @@
+# MiniMax H3 Director, vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5.
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director (GPL-3.0)
+# See LICENSE in this directory for the full GPL-3.0 text.
+#
+# This file is a MooshieUI rewrite of the upstream __init__.py. What differs:
+#
+#   * Only the two nodes MooshieUI drives are registered. MiniMaxH3EnhancePrompt and
+#     MiniMaxH3PreviewOverride are not vendored: MooshieUI has its own prompt assistant
+#     and its own generation preview, so both would be dead weight.
+#   * node_ids are namespaced "MooshieH3*" rather than upstream's "MiniMaxH3*CS", so
+#     this copy cannot collide if a user also installs the upstream pack via ComfyUI
+#     Manager. Both can coexist.
+#   * No WEB_DIRECTORY. The upstream js/ timeline editor (~540 KB) only runs on
+#     ComfyUI's graph canvas, which MooshieUI never renders. MooshieUI builds the
+#     timeline_data JSON itself and passes it as a plain widget value.
+#
+# MiniMaxH3DirectorChain is likewise not vendored. Upstream withdrew it because there
+# was no way to hand it a timeline from the canvas; that specific blocker does not apply
+# here, but its other tradeoffs (it swallows the sampler, losing live preview,
+# per-window progress and clean interruption) still do. Revisit for long-form video.
+
+from comfy_api.latest import ComfyExtension, io
+from typing_extensions import override
+
+from .minimax_director import MiniMaxH3Director
+from .minimax_retake import MiniMaxH3RetakeStitch
+
+
+class MooshieH3DirectorExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [MiniMaxH3Director, MiniMaxH3RetakeStitch]
+
+
+async def comfy_entrypoint() -> MooshieH3DirectorExtension:
+    return MooshieH3DirectorExtension()
+
+
+NODE_CLASS_MAPPINGS = {
+    "MooshieH3Director": MiniMaxH3Director,
+    "MooshieH3RetakeStitch": MiniMaxH3RetakeStitch,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "MooshieH3Director": "MiniMax H3 Director",
+    "MooshieH3RetakeStitch": "MiniMax H3 Retake Stitch",
+}
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/comfyui-nodes/minimax_director/minimax_core.py
+++ b/comfyui-nodes/minimax_director/minimax_core.py
@@ -1,0 +1,82 @@
+# Vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0).
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director
+# See LICENSE in this directory for the full GPL-3.0 text. Unmodified.
+"""Access to ComfyUI's built-in comfy_extras node modules.
+
+ComfyUI loads comfy_extras modules with `spec_from_file_location(<abs path minus
+extension>, ...)`, so they land in sys.modules under their full filesystem path and there
+is no importable `comfy_extras.nodes_minimax_h3` name. We look them up by path suffix
+first — reusing the already-loaded instance, so we stay bit for bit identical to the nodes
+the user sees in the menu — and only fall back to loading the file ourselves if that
+lookup fails.
+
+Delegating to those classes rather than reimplementing them means this pack tracks
+upstream behaviour instead of drifting from it.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+
+log = logging.getLogger(__name__)
+
+_CACHE = {}
+
+
+def _find_in_sys_modules(module_name, probe_attr):
+    suffix = "comfy_extras/" + module_name
+    for name, mod in list(sys.modules.items()):
+        if mod is None:
+            continue
+        if not str(name).replace("\\", "/").endswith(suffix):
+            continue
+        if probe_attr is None or hasattr(mod, probe_attr):
+            return mod
+    return None
+
+
+def _load_from_file(module_name):
+    # comfy_extras sits next to nodes.py, which is always importable while ComfyUI runs.
+    import nodes as _comfy_nodes
+
+    path = os.path.join(
+        os.path.dirname(os.path.realpath(_comfy_nodes.__file__)),
+        "comfy_extras", module_name + ".py",
+    )
+    if not os.path.exists(path):
+        raise ImportError(
+            "MiniMax H3 Director: comfy_extras/%s.py not found at %s. Update ComfyUI."
+            % (module_name, path)
+        )
+    spec = importlib.util.spec_from_file_location("_mmxdirector_" + module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def extra(module_name, probe_attr=None):
+    """Return a comfy_extras module by name, loading it on first use."""
+    if module_name not in _CACHE:
+        mod = _find_in_sys_modules(module_name, probe_attr)
+        if mod is None:
+            mod = _load_from_file(module_name)
+            log.info("[MiniMaxDirector] Loaded comfy_extras/%s from file (not in sys.modules yet).",
+                     module_name)
+        _CACHE[module_name] = mod
+    return _CACHE[module_name]
+
+
+def core():
+    """The MiniMax H3 core node module."""
+    return extra("nodes_minimax_h3", "MiniMaxH3ImageToVideo")
+
+
+def samplers():
+    """comfy_extras/nodes_custom_sampler.py — guiders, noise, SamplerCustomAdvanced."""
+    return extra("nodes_custom_sampler", "SamplerCustomAdvanced")
+
+
+def audio_nodes():
+    """comfy_extras/nodes_audio.py — VAEDecodeAudio and friends."""
+    return extra("nodes_audio", "VAEDecodeAudio")

--- a/comfyui-nodes/minimax_director/minimax_director.py
+++ b/comfyui-nodes/minimax_director/minimax_director.py
@@ -1,0 +1,585 @@
+# Vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0).
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director
+# See LICENSE in this directory for the full GPL-3.0 text.
+#
+# Modifications for MooshieUI, 2026:
+#   * node_id renamed to "MooshieH3Director" so this copy cannot collide with the
+#     upstream pack if a user also installs it through ComfyUI Manager.
+#   * The js/ timeline editor is not vendored. MooshieUI never renders the ComfyUI
+#     graph canvas; it builds timeline_data itself and passes it as a widget value.
+"""MiniMax H3 Director — a WYSIWYG timeline front-end for MiniMax H3.
+
+The timeline editor (js/minimax_director.js) is a modified version of the LTX Director
+editor by WhatDreamsCost (GPL-3.0, see LICENSE), by way of the CS fork by CGlide;
+modified in 2026 for MiniMax H3. What changed is everything below the UI, because H3
+conditions completely differently from LTX 2.3:
+
+* LTX 2.3 gets per-segment prompts through a Prompt-Relay cross-attention mask.
+  H3 is a single-stream packed DiT whose only attention is full self-attention with
+  `mask=None` hardcoded, and whose Qwen3-VL text encoder was trained on *storyboard*
+  prompts with explicit `[0s-1.5s]` shot markers. So timeline segments are compiled
+  into that storyboard form — the model's own native mechanism for timed control,
+  and exactly what the official H3 templates do.
+
+* Keyframes: H3's PackedLayout only accepts anchors at frame 0 and frame_count-1, so
+  timeline images resolve to first_frame / last_frame. Images in the middle become
+  <Picture i> references instead (ref2va), the closest thing H3 offers.
+
+* Audio: H3 generates native stereo audio jointly with the video, so there is no audio
+  latent to inpaint. Imported audio becomes an <Audio j> reference for voice/music
+  style, and is always also emitted on `combined_audio` for muxing.
+
+* The reference-video track (the old IC-LoRA track) feeds <Video k> references.
+
+Two conditioning paths, each with its own diffusion weights:
+  Refs OFF -> t2va / fl2va  (minimax_h3_fl2va_*)
+  Refs ON  -> ref2va        (minimax_h3_ref2va_*)
+
+All timeline interpretation lives in minimax_plan.py so the live prompt preview and the
+chain node cannot drift from what actually gets encoded.
+"""
+
+import json
+import logging
+
+import torch
+
+from comfy_api.latest import io
+
+from . import minimax_media as media
+from . import minimax_plan as plan
+from .minimax_core import core
+
+log = logging.getLogger(__name__)
+
+MODEL_FPS = plan.MODEL_FPS
+DEFAULT_W, DEFAULT_H = 1344, 768
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+
+def _unpack(out):
+    """Normalise an io.NodeOutput / tuple / list into a plain tuple."""
+    if out is None:
+        return ()
+    args = getattr(out, "args", None)
+    if isinstance(args, (tuple, list)):
+        return tuple(args)
+    result = getattr(out, "result", None)
+    if isinstance(result, (tuple, list)):
+        return tuple(result)
+    if isinstance(out, (tuple, list)):
+        return tuple(out)
+    if isinstance(out, dict) and isinstance(out.get("result"), (tuple, list)):
+        return tuple(out["result"])
+    return (out,)
+
+
+def _snap(value, multiple):
+    # Floor, not round — same as the LTX Director's snap() and media.resize_image(), so a
+    # derived edge never grows past the box. 16:9 at height 768 lands on 1344, H3's native
+    # canvas, instead of overshooting to 1376.
+    return max(multiple, (int(value) // multiple) * multiple)
+
+
+def resolve_canvas(mm, custom_width, custom_height, divisible_by, resize_method, first_image):
+    """Pick the output canvas.
+
+    With both dimensions set, the widgets are a *box*, not a verdict: the first timeline
+    image is run through the chosen resize_method and the canvas becomes whatever comes
+    out. That is what the LTX Director does, and it is why 'maintain aspect ratio' with a
+    1024x1024 box gives a 16:9 image 1024x576 instead of a squashed square. Every other
+    method returns the full box.
+    """
+    div = max(1, int(divisible_by))
+    if custom_width > 0 and custom_height > 0:
+        if first_image is not None:
+            fitted = media.resize_image(first_image[:1], custom_width, custom_height,
+                                        resize_method, div)
+            return int(fitted.shape[2]), int(fitted.shape[1])
+        return _snap(custom_width, div), _snap(custom_height, div)
+
+    if first_image is not None:
+        src_h, src_w = int(first_image.shape[1]), int(first_image.shape[2])
+    else:
+        src_w, src_h = DEFAULT_W, DEFAULT_H
+
+    if custom_width > 0:
+        w = _snap(custom_width, div)
+        return w, _snap(src_h * w / max(1, src_w), div)
+    if custom_height > 0:
+        h = _snap(custom_height, div)
+        return _snap(src_w * h / max(1, src_h), div), h
+
+    # H3's own canvas policy: 768 short edge, 768*1344 area cap, per-axis round to 32
+    return mm.adapt_canvas(src_w, src_h)
+
+
+def resolve_window(tdata, fps, start_frame, duration_frames,
+                   start=None, end=None, duration=None):
+    """Resolve the render window, honouring automation inputs and retake mode.
+
+    The automation sockets are the only route by which a nonsensical window reaches this
+    node: the widgets carry minimums, a connected input carries none. A `duration` of 0 —
+    what an upstream node hands over when its own value was never set — used to clamp to
+    one timeline frame and then render five, a fifth of a second, without a word. Refuse
+    it by name instead. Whatever breaks downstream on a window that short breaks a long
+    way from the wire that caused it, which is the expensive kind of bug to report.
+    """
+    if start is not None:
+        if float(start) < 0:
+            raise ValueError(
+                "MiniMax H3 Director: the connected 'start' is %.3gs. It is a position in "
+                "seconds and cannot be negative." % float(start))
+        start_frame = int(round(float(start) * fps))
+    if end is not None:
+        end_frame = int(round(float(end) * fps))
+        if duration is None:
+            if end_frame <= start_frame:
+                raise ValueError(
+                    "MiniMax H3 Director: the connected 'end' (%.3gs) is not after the "
+                    "window start (%.3gs), so there is nothing to render. Both are in "
+                    "seconds." % (float(end), start_frame / fps))
+            duration_frames = end_frame - start_frame
+    if duration is not None:
+        if float(duration) <= 0:
+            raise ValueError(
+                "MiniMax H3 Director: the connected 'duration' is %.3gs, so there is "
+                "nothing to render. It is a length in seconds — H3's trained range is "
+                "4-15s. Check the node feeding it; a value that was never set arrives "
+                "here as 0." % float(duration))
+        duration_frames = max(1, int(round(float(duration) * fps)))
+
+    retake = plan.retake_state(tdata)
+    if retake:
+        # the marked range replaces the panel window entirely
+        return int(retake["start"]), max(1, int(retake["length"]))
+    return int(start_frame), max(1, int(duration_frames))
+
+
+def _load_event_tensor(ev, fps, win_start):
+    """Decode the pixels behind one main-track segment, image or video."""
+    seg = ev["seg"]
+    if ev["kind"] == "video":
+        seg_start = float(seg.get("start", 0))
+        trim = float(seg.get("trimStart", 0)) + max(0.0, win_start - seg_start)
+        return media.load_video_tensor(seg.get("imageFile", ""), trim / fps,
+                                       float(seg.get("length", 1)) / fps)
+    return media.load_image_tensor(seg)
+
+
+class _Unconnected:
+    """Distinguishes an empty optional socket from a lazy one that is merely unevaluated.
+
+    ComfyUI passes None for both, so a plain `None` default cannot tell them apart.
+    """
+    def __repr__(self):
+        return "<unconnected>"
+
+
+_UNCONNECTED = _Unconnected()
+
+
+def pick_model(model_fl2va, model_ref2va, ref_mode_on):
+    """Choose the weights the toolbar switch calls for.
+
+    fl2va and ref2va are separate checkpoints, so the switch that changes the conditioning
+    path has to change the model too. Connect both and it is automatic; connect one and it
+    is used either way, with a warning when that is the wrong one for the current path.
+    """
+    wanted, other = (model_ref2va, model_fl2va) if ref_mode_on else (model_fl2va, model_ref2va)
+    label = "ref2va" if ref_mode_on else "fl2va"
+    if wanted is not None:
+        return wanted
+    if other is not None:
+        log.warning("[MiniMaxDirector] The toolbar is on '%s' but no %s model is connected — "
+                    "using the other one. Load minimax_h3_%s_* for correct results.",
+                    "Refs ON" if ref_mode_on else "Refs OFF", label, label)
+        return other
+    raise ValueError(
+        "MiniMax H3 Director: no model connected. Wire a UNETLoader into 'model (t2v/i2v)' "
+        "(minimax_h3_fl2va_*) and/or 'model (ref2v)' (minimax_h3_ref2va_*)."
+    )
+
+
+def _grab_base_frame(video_ref, frame_index, fps):
+    """One frame out of the retake base video, by timeline frame index."""
+    if frame_index < 0:
+        return None
+    frames = media.load_video_tensor(video_ref, frame_index / fps, 1.0 / MODEL_FPS)
+    if frames is None or frames.shape[0] == 0:
+        return None
+    return frames[:1]
+
+
+# --------------------------------------------------------------------------------------
+# node
+# --------------------------------------------------------------------------------------
+
+class MiniMaxH3Director(io.ComfyNode):
+    """Timeline editor -> MiniMax H3 storyboard conditioning + joint AV latent."""
+
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MooshieH3Director",
+            display_name="MiniMax H3 Director",
+            category="MiniMax H3",
+            description=(
+                "Visual timeline for MiniMax H3. Segments become a storyboard prompt with "
+                "[0s-1.5s] shot markers, timeline images become first/last keyframes (fl2va) "
+                "or <Picture i> references (ref2va), the reference-video track becomes "
+                "<Video k>, and audio clips become <Audio j> plus a muxable audio output. "
+                "Retake Mode regenerates a marked range of a base video between its own "
+                "surrounding frames."
+            ),
+            inputs=[
+                # lazy: only the checkpoint the toolbar actually calls for gets loaded.
+                # See check_lazy_status below — without it ComfyUI resolves both inputs
+                # before the node runs and reads ~42 GB of weights to use half of them.
+                io.Model.Input("model", display_name="model (t2v/i2v)", optional=True, lazy=True,
+                               tooltip="The fl2va weights (minimax_h3_fl2va_*), used when the "
+                                       "toolbar is on 'Refs OFF'. Connect both models and the "
+                                       "node loads whichever the toolbar switch calls for — "
+                                       "the other one is never read from disk."),
+                io.Model.Input("model_ref2va", display_name="model (ref2v)", optional=True, lazy=True,
+                               tooltip="The ref2va weights (minimax_h3_ref2va_*), used when the "
+                                       "toolbar is on 'Refs ON'. Optional — with only one model "
+                                       "connected that one is used either way."),
+                io.Clip.Input("clip", tooltip="Qwen3-VL-32B MiniMax text encoder (CLIPLoader type 'minimax')."),
+                io.Vae.Input("vae", tooltip="minimax_h3_video_vae — encodes keyframes and references."),
+                io.Vae.Input("audio_vae", optional=True,
+                             tooltip="minimax_h3_audio_vae. Only needed when audio references are used (ref2va)."),
+                io.String.Input(
+                    "global_prompt", multiline=True, default="", force_input=True, optional=True,
+                    tooltip="Conditions the whole video: style, scene, characters. Written above the storyboard.",
+                ),
+                io.Float.Input("start_second", default=0.0, min=0.0, max=1000.0, step=0.01,
+                               tooltip="Start of the render window, in seconds."),
+                io.Float.Input("end_second", default=5.0, min=0.0, max=1000.0, step=0.01,
+                               tooltip="End of the render window, in seconds."),
+                io.Float.Input("duration_seconds", default=5.0, min=0.1, max=1000.0, step=0.01,
+                               tooltip="Render length in seconds. Snapped up to H3's 17k+5 frame grid at 24 fps."),
+                io.Int.Input("start_frame", default=0, min=0, max=10000, step=1,
+                             tooltip="Start of the render window, in timeline frames."),
+                io.Int.Input("end_frame", default=120, min=1, max=10000, step=1,
+                             tooltip="End of the render window, in timeline frames."),
+                io.Int.Input("duration_frames", default=120, min=1, max=10000, step=1,
+                             tooltip="Render length in timeline frames (at the timeline's frame_rate)."),
+                io.String.Input("timeline_data", default="",
+                                tooltip="JSON state of the timeline editor (auto-managed; do not edit by hand)."),
+                io.Boolean.Input("use_custom_audio", default=False, optional=True,
+                                 tooltip="ON: timeline audio clips are used as <Audio j> references (ref2va). "
+                                         "The mixdown is always available on combined_audio regardless."),
+                io.Boolean.Input("use_custom_motion", default=True, optional=True,
+                                 tooltip="ON: the reference-video track feeds <Video k> references (ref2va)."),
+                io.Boolean.Input("inpaint_audio", default=True, optional=True,
+                                 tooltip="Unused on H3 — audio is generated jointly with the video and cannot be inpainted."),
+                io.String.Input("local_prompts", multiline=True, default="",
+                                tooltip="Auto-populated from the timeline editor."),
+                io.String.Input("segment_lengths", default="",
+                                tooltip="Auto-populated from the timeline editor (pixel-space frame counts)."),
+                io.Float.Input("frame_rate", default=24, min=1, max=240, step=1, optional=True,
+                               tooltip="Timeline editing rate. Output is always 24 fps; times are converted via seconds."),
+                io.Combo.Input("display_mode", options=["frames", "seconds"], default="seconds", optional=True,
+                               tooltip="Show the ruler and segment ranges in frames or seconds."),
+                io.String.Input("guide_strength", default="",
+                                tooltip="Auto-populated from the timeline editor. H3 has no per-keyframe strength, so it is ignored."),
+                io.Int.Input("custom_width", default=0, min=0, max=8192, step=1, optional=True,
+                             tooltip="Output width. With height set too this is a BOX: 'maintain aspect ratio' "
+                                     "keeps the first image's aspect inside it. 0 = derive from the image."),
+                io.Int.Input("custom_height", default=0, min=0, max=8192, step=1, optional=True,
+                             tooltip="Output height. See custom_width."),
+                io.Combo.Input("resize_method",
+                               options=["maintain aspect ratio", "stretch to fit", "pad", "pad green", "crop"],
+                               default="crop", optional=True,
+                               tooltip="How timeline images are fitted to the output canvas."),
+                io.Int.Input("divisible_by", default=32, min=1, max=256, step=1, optional=True,
+                             tooltip="Snap output dimensions to this multiple. H3 needs 32."),
+                io.Int.Input("img_compression", default=0, min=0, max=100, step=1, optional=True,
+                             tooltip="H.264 CRF baked into each keyframe. 0 = off (recommended for H3)."),
+                io.Boolean.Input("override_audio", default=False, optional=True,
+                                 tooltip="Use the reference video's own soundtrack as the timeline audio."),
+                io.Combo.Input("ref_image_size", options=["match", "max"], default="match", optional=True,
+                               tooltip="ref2va only. 'match' scales references to the output pixel area (fast); "
+                                       "'max' keeps a 2048 px short edge for identity, at real speed cost."),
+                io.Float.Input("shift_video", default=12.0, min=0.01, max=100.0, step=0.01, optional=True,
+                               tooltip="Video flow sigma shift (H3 default 12.0)."),
+                io.Float.Input("shift_audio", default=3.0, min=0.01, max=100.0, step=0.01, optional=True,
+                               tooltip="Audio flow sigma shift (H3 default 3.0)."),
+                io.Image.Input("ref_images", optional=True,
+                               tooltip="Extra <Picture i> references (single image or batch), appended after the "
+                                       "character slots. ref2va only."),
+                io.Float.Input("start", force_input=True, optional=True, default=0.0,
+                               tooltip="Automation (connection-only). Window start in SECONDS."),
+                io.Float.Input("end", force_input=True, optional=True, default=0.0,
+                               tooltip="Automation (connection-only). Window end in SECONDS."),
+                io.Float.Input("duration", force_input=True, optional=True, default=0.0,
+                               tooltip="Automation (connection-only). Render length in SECONDS."),
+            ],
+            outputs=[
+                io.Model.Output(display_name="model"),
+                io.Conditioning.Output(display_name="positive"),
+                io.Latent.Output(display_name="latent", tooltip="Joint video+audio latent. Wire to SamplerCustomAdvanced."),
+                io.Audio.Output(display_name="combined_audio",
+                                tooltip="Timeline audio mixdown. Wire into CreateVideo to replace the generated audio."),
+                io.Float.Output(display_name="fps", tooltip="Always 24.0 — H3's native output rate. Wire into CreateVideo."),
+                io.Int.Output(display_name="width"),
+                io.Int.Output(display_name="height"),
+                io.Int.Output(display_name="length", tooltip="Frame count actually generated (snapped to the 17k+5 grid)."),
+                io.String.Output(display_name="prompt", tooltip="The compiled storyboard prompt that was encoded."),
+                io.String.Output(display_name="retake_info",
+                                 tooltip="JSON describing the retake window. Wire into MiniMax H3 Retake Stitch "
+                                         "to splice the result back into the base video. Empty when retake is off."),
+            ],
+        )
+
+    # ------------------------------------------------------------ lazy models
+
+    @classmethod
+    def check_lazy_status(cls, timeline_data="", model=_UNCONNECTED,
+                          model_ref2va=_UNCONNECTED, **_):
+        """Ask for the one checkpoint the toolbar switch calls for, and only that one.
+
+        fl2va and ref2va are ~21 GB each. Without this, ComfyUI resolves both inputs
+        before execute() runs, so every render reads both from disk to throw one away —
+        which is what pushed a 32 GB machine into a page-file crash (issue #2).
+
+        `None` means *connected but not evaluated yet*, so it cannot be used to detect an
+        empty socket; that is what the _UNCONNECTED sentinel is for. Same trick core uses
+        in comfy_extras/nodes_logic.py.
+        """
+        ref_on = plan.ref_mode_from(plan.parse_timeline(timeline_data))
+        order = ("model_ref2va", "model") if ref_on else ("model", "model_ref2va")
+        have = {"model": model, "model_ref2va": model_ref2va}
+
+        for name in order:                       # preferred first, then the fallback
+            if have[name] is _UNCONNECTED:
+                continue                         # nothing wired here, try the other
+            return [name] if have[name] is None else []
+        return []                                # neither connected: execute() raises
+
+    # ---------------------------------------------------------------- execute
+
+    @classmethod
+    def execute(cls, clip, vae, start_second, end_second, duration_seconds,
+                start_frame, end_frame, duration_frames, timeline_data,
+                model=None, model_ref2va=None,
+                local_prompts="", segment_lengths="", global_prompt="", guide_strength="",
+                frame_rate=24, display_mode="seconds",
+                custom_width=0, custom_height=0, resize_method="crop",
+                divisible_by=32, img_compression=0, audio_vae=None,
+                use_custom_audio=False, inpaint_audio=True, use_custom_motion=True,
+                override_audio=False, ref_image_size="match",
+                shift_video=12.0, shift_audio=3.0, ref_images=None,
+                start=None, end=None, duration=None) -> io.NodeOutput:
+
+        mm = core()
+        tdata = plan.parse_timeline(timeline_data)
+        fps = float(frame_rate) if frame_rate else 24.0
+
+        win_start, duration_frames = resolve_window(
+            tdata, fps, start_frame, duration_frames, start, end, duration)
+
+        extra_refs = 0
+        if ref_images is not None:
+            try:
+                extra_refs = int(ref_images.shape[0])
+            except Exception:
+                extra_refs = 0
+
+        p = plan.plan_timeline(tdata, win_start, duration_frames, fps,
+                               global_prompt=global_prompt,
+                               use_custom_motion=use_custom_motion,
+                               use_custom_audio=use_custom_audio,
+                               override_audio=override_audio,
+                               extra_ref_image_count=extra_refs)
+
+        length = p["length"]
+        if length > plan.TRAINED_MAX_FRAMES:
+            log.warning("[MiniMaxDirector] %d frames (%.1fs) is past H3's trained range of "
+                        "~%d-%d frames (~4-15s). Expect drift, looping or a VRAM wall — "
+                        "shorten the timeline, or render it as several windows and splice "
+                        "them together.",
+                        length, p["actual_seconds"], plan.TRAINED_MIN_FRAMES,
+                        plan.TRAINED_MAX_FRAMES)
+        elif length < plan.TRAINED_MIN_FRAMES:
+            log.info("[MiniMaxDirector] %d frames (%.1fs) is below H3's trained range "
+                     "(~%d frames / 5s). Fine for tests, weaker motion than a full shot.",
+                     length, p["actual_seconds"], plan.TRAINED_MIN_FRAMES)
+        if p["prompt_is_fallback"]:
+            log.warning("[MiniMaxDirector] No prompt text on the timeline — falling back to 'video'.")
+        for warning in p.get("ref_warnings") or []:
+            log.warning("[MiniMaxDirector] %s", warning)
+
+        retake = p["retake"]
+
+        # --- load the pixels the plan calls for ------------------------------------
+        for ev in p["events"]:
+            ev["tensor"] = _load_event_tensor(ev, fps, win_start)
+
+        first_src = last_src = None
+        if retake:
+            # anchor on the base video's own frames either side of the marked range
+            first_src = _grab_base_frame(retake["video"], retake["start"] - 1, fps)
+            tail_index = retake["start"] + retake["length"]
+            if not retake["base_frames"] or tail_index < retake["base_frames"]:
+                last_src = _grab_base_frame(retake["video"], tail_index, fps)
+            if first_src is None and last_src is None:
+                log.warning("[MiniMaxDirector] Retake: could not read anchor frames from '%s' "
+                            "— falling back to a plain text-to-video window.", retake["video"])
+        else:
+            for ev in p["events"]:
+                if ev["role"] == plan.ROLE_FIRST:
+                    first_src = ev["tensor"][:1]
+                elif ev["role"] == plan.ROLE_LAST:
+                    last_src = ev["tensor"][-1:]
+
+        # --- canvas -----------------------------------------------------------------
+        canvas_src = first_src
+        if canvas_src is None:
+            canvas_src = p["events"][0]["tensor"] if p["events"] else None
+        width, height = resolve_canvas(mm, int(custom_width), int(custom_height),
+                                       int(divisible_by), resize_method, canvas_src)
+
+        def fit(tensor):
+            out = media.resize_image(tensor, width, height, resize_method, int(divisible_by))
+            if out.shape[1] != height or out.shape[2] != width:
+                # A later image with a different aspect than the one that set the canvas.
+                # The canvas is already fixed, so cover-crop it to match exactly — otherwise
+                # the core node would stretch the keyframe and distort it.
+                out = media.resize_image(out, width, height, "crop", int(divisible_by))
+            if int(img_compression) > 0:
+                out = media.compress_image(out, int(img_compression))
+            return out
+
+        first_frame = fit(first_src) if first_src is not None else None
+        last_frame = fit(last_src) if last_src is not None else None
+
+        # --- reference payloads ------------------------------------------------------
+        ref_image_tensors, ref_videos, ref_video_audios, ref_audios = [], {}, {}, {}
+        if p["ref_mode_on"]:
+            input_cursor = 0
+            for slot in p["ref_image_slots"]:
+                src = slot["source"]
+                if src == "char":
+                    img = slot["image"]
+                    ref_image_tensors.append(
+                        media.load_image_source(img.get("b64", ""), img.get("name", "")))
+                elif src == "input":
+                    ref_image_tensors.append(ref_images[input_cursor:input_cursor + 1])
+                    input_cursor += 1
+                else:
+                    ev = slot["event"]
+                    tensor = ev["tensor"]
+                    if slot.get("keyframe") == plan.ROLE_LAST:
+                        ref_image_tensors.append(fit(tensor[-1:]))
+                    elif slot.get("keyframe"):
+                        ref_image_tensors.append(fit(tensor[:1]))
+                    else:
+                        ref_image_tensors.append(tensor[:1])
+
+            for seg in p["ref_video_segs"]:
+                idx = len(ref_videos)
+                seg_start = float(seg.get("start", 0))
+                seg_len = float(seg.get("length", 1))
+                offset = max(0.0, win_start - seg_start)
+                trim = float(seg.get("trimStart", 0)) + offset
+                clip_sec = min(plan.REF_VIDEO_MAX_SEC,
+                               max(plan.REF_VIDEO_MIN_SEC, (seg_len - offset) / fps))
+                frames = media.load_video_tensor(seg["videoFile"], trim / fps, clip_sec)
+                if frames.shape[0] < 5:
+                    log.warning("[MiniMaxDirector] Reference video '%s' is shorter than 5 "
+                                "frames — skipped.", seg.get("fileName", seg["videoFile"]))
+                    continue
+                ref_videos["ref_video_%d" % idx] = frames
+                if override_audio:
+                    clip_audio = media.load_audio_segment(
+                        {"audioFile": seg["videoFile"], "trimStart": trim,
+                         "length": clip_sec * fps}, fps, file_key="audioFile")
+                    if clip_audio is not None:
+                        ref_video_audios["ref_video_audio_%d" % idx] = clip_audio
+
+            for seg in p["ref_audio_segs"]:
+                clip_audio = media.load_audio_segment(seg, fps)
+                if clip_audio is not None:
+                    ref_audios["ref_audio_%d" % len(ref_audios)] = clip_audio
+
+            if first_frame is not None or last_frame is not None:
+                log.info("[MiniMaxDirector] ref2va has no first/last keyframe slot — the "
+                         "timeline keyframes were added as <Picture i> references instead.")
+                first_frame = last_frame = None
+
+        prompt = p["prompt"]
+        log.info("[MiniMaxDirector] %s%s | %dx%d | %d frames (%.2fs @24fps) | %d shots | "
+                 "refs: %d img / %d vid / %d audio",
+                 p["mode"], " (retake)" if retake else "", width, height, length,
+                 p["actual_seconds"], len(p["shots"]),
+                 len(ref_image_tensors), len(ref_videos), len(ref_audios))
+        # The full storyboard is one to two screens of text; the node's `prompt` output and
+        # the COMPILED PROMPT panel both show it, so keep it out of the console by default.
+        log.debug("[MiniMaxDirector] prompt:\n%s", prompt)
+
+        # --- conditioning ------------------------------------------------------------
+        if p["ref_mode_on"]:
+            if (ref_audios or ref_video_audios) and audio_vae is None:
+                raise ValueError(
+                    "MiniMax H3 Director: audio references need the audio VAE. Connect "
+                    "minimax_h3_audio_vae to the Director's 'audio_vae' input (or turn off "
+                    "the audio track / Override Audio)."
+                )
+            out = mm.MiniMaxH3ReferenceToVideo.execute(
+                clip=clip, vae=vae, audio_vae=audio_vae, prompt=prompt,
+                width=width, height=height, length=length,
+                ref_image_size=ref_image_size,
+                ref_images={"ref_image_%d" % i: t for i, t in enumerate(ref_image_tensors)} or None,
+                ref_videos=ref_videos or None,
+                ref_video_audios=ref_video_audios or None,
+                ref_audios=ref_audios or None,
+            )
+        else:
+            middles = [e for e in p["events"] if e["role"] == plan.ROLE_MIDDLE]
+            if middles:
+                log.warning("[MiniMaxDirector] %d timeline image(s) sit in the middle of the "
+                            "window. H3 only anchors keyframes at the first and last frame, so "
+                            "they were ignored — switch the toolbar to 'Refs ON (ref2va)' to "
+                            "use them as <Picture i> references.", len(middles))
+            out = mm.MiniMaxH3ImageToVideo.execute(
+                clip=clip, vae=vae, prompt=prompt,
+                width=width, height=height, length=length,
+                first_frame=first_frame, last_frame=last_frame,
+            )
+
+        conditioning, latent = _unpack(out)[:2]
+
+        chosen_model = pick_model(model, model_ref2va, p["ref_mode_on"])
+        patched_model = _unpack(mm.MiniMaxH3SigmaShift.execute(
+            model=chosen_model, shift_video=float(shift_video),
+            shift_audio=float(shift_audio)))[0]
+
+        audio_out = media.build_combined_audio(
+            timeline_data, win_start,
+            max(1, int(round(p["actual_seconds"] * fps))), fps, override_audio=override_audio)
+
+        retake_info = ""
+        if retake:
+            retake_info = json.dumps({
+                "base_video": retake["video"],
+                "timeline_fps": fps,
+                "start_frame": retake["start"],
+                "length_frames": retake["length"],
+                "base_frames": retake["base_frames"],
+                "generated_frames": length,
+                "generated_fps": MODEL_FPS,
+                "width": int(width), "height": int(height),
+            })
+
+        return io.NodeOutput(patched_model, conditioning, latent, audio_out,
+                             MODEL_FPS, int(width), int(height), int(length), prompt,
+                             retake_info)
+
+
+NODE_CLASS_MAPPINGS = {"MiniMaxH3DirectorCS": MiniMaxH3Director}
+NODE_DISPLAY_NAME_MAPPINGS = {"MiniMaxH3DirectorCS": "MiniMax H3 Director"}

--- a/comfyui-nodes/minimax_director/minimax_media.py
+++ b/comfyui-nodes/minimax_director/minimax_media.py
@@ -1,0 +1,926 @@
+"""Media I/O + HTTP endpoints for the MiniMax H3 Director timeline editor.
+
+Contains code derived from the LTX Director node by WhatDreamsCost (GPL-3.0, see
+LICENSE), via the CS fork by CGlide; modified in 2026 for MiniMax H3. The timeline UI
+behaves identically on purpose: same chunked upload path, same waveform peaks, same
+workspace folder, same drag-and-drop handling. Route paths are namespaced under
+/minimax_director* so both nodes can be installed side by side.
+
+The upload workspace stays `input/whatdreamscost` on purpose — assets dropped into
+either Director are then visible to both.
+"""
+
+# Vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0).
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director
+# See LICENSE in this directory for the full GPL-3.0 text. Unmodified.
+#
+# The aiohttp routes below serve the upstream js/ timeline editor, which MooshieUI does
+# not vendor. They are left in place rather than stripped: they register inertly at
+# import time, and removing them would fork this file away from upstream for no gain.
+
+import asyncio
+import base64
+import io as _io
+import json
+import logging
+import math
+import os
+import platform
+import subprocess
+import wave
+
+import av
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+import folder_paths
+from aiohttp import web
+from server import PromptServer
+
+log = logging.getLogger(__name__)
+
+WORKSPACE_SUBDIR = "whatdreamscost"
+AUDIO_SR = 44100
+
+
+# --------------------------------------------------------------------------------------
+# path helpers
+# --------------------------------------------------------------------------------------
+
+def resolve_input_path(rel_name: str):
+    """Resolve a timeline file reference to an absolute path inside ComfyUI/input."""
+    if not rel_name:
+        return None
+    input_dir = folder_paths.get_input_directory()
+    candidates = [
+        os.path.join(input_dir, rel_name),
+        os.path.join(input_dir, WORKSPACE_SUBDIR, os.path.basename(rel_name)),
+        os.path.join(input_dir, os.path.basename(rel_name)),
+    ]
+    for path in candidates:
+        if os.path.exists(path) and os.path.isfile(path):
+            return path
+    return None
+
+
+# --------------------------------------------------------------------------------------
+# waveform peaks / audio extraction (timeline UI)
+# --------------------------------------------------------------------------------------
+
+def _peaks_from_int16(samples, num_peaks=200):
+    peaks = []
+    step = max(1, len(samples) // num_peaks)
+    for i in range(num_peaks):
+        chunk = samples[i * step:(i + 1) * step]
+        peaks.append(float(np.max(np.abs(chunk)) / 32767.0) if len(chunk) else 0.0)
+    return peaks
+
+
+def read_wav_peaks(wav_path):
+    with wave.open(wav_path, "rb") as w:
+        n_frames = w.getnframes()
+        if n_frames <= 0:
+            return [0.0] * 200
+        samples = np.frombuffer(w.readframes(n_frames), dtype=np.int16)
+    return _peaks_from_int16(samples)
+
+
+def _decode_to_int16_mono(container, rate):
+    stream = container.streams.audio[0]
+    resampler = av.AudioResampler(format="s16", layout="mono", rate=rate)
+    audio_bytes = bytearray()
+    for frame in container.decode(stream):
+        for out in resampler.resample(frame):
+            audio_bytes.extend(out.to_ndarray().tobytes())
+    for out in resampler.resample(None):
+        audio_bytes.extend(out.to_ndarray().tobytes())
+    return audio_bytes
+
+
+def extract_audio_from_video(video_path):
+    """Write a mono 44.1 kHz WAV next to the video and return (relative path, peaks)."""
+    try:
+        base, _ = os.path.splitext(video_path)
+        output_wav = base + "_extracted_audio.wav"
+
+        if os.path.exists(output_wav) and os.path.getsize(output_wav) > 44:
+            try:
+                with wave.open(output_wav, "rb") as w_check:
+                    if w_check.getframerate() == AUDIO_SR:
+                        peaks = read_wav_peaks(output_wav)
+                        rel = os.path.relpath(output_wav, folder_paths.get_input_directory())
+                        return rel.replace("\\", "/"), peaks
+            except Exception:
+                pass
+
+        with av.open(video_path) as container:
+            if not container.streams.audio:
+                return None, None
+            audio_bytes = _decode_to_int16_mono(container, AUDIO_SR)
+            if not audio_bytes:
+                return None, None
+            with wave.open(output_wav, "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(AUDIO_SR)
+                w.writeframes(audio_bytes)
+
+        peaks = _peaks_from_int16(np.frombuffer(audio_bytes, dtype=np.int16))
+        rel = os.path.relpath(output_wav, folder_paths.get_input_directory())
+        return rel.replace("\\", "/"), peaks
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Server audio extraction failed: %s", e)
+        return None, None
+
+
+def get_audio_peaks(audio_path):
+    if os.path.splitext(audio_path)[1].lower() == ".wav":
+        try:
+            return read_wav_peaks(audio_path)
+        except Exception:
+            pass
+    try:
+        with av.open(audio_path) as container:
+            if not container.streams.audio:
+                return None
+            audio_bytes = _decode_to_int16_mono(container, 8000)
+        if not audio_bytes:
+            return None
+        return _peaks_from_int16(np.frombuffer(audio_bytes, dtype=np.int16))
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Failed to get audio peaks via PyAV: %s", e)
+        return None
+
+
+# --------------------------------------------------------------------------------------
+# HTTP endpoints used by the timeline editor
+# --------------------------------------------------------------------------------------
+
+@PromptServer.instance.routes.get("/minimax_director_check_file")
+async def minimax_director_check_file(request):
+    """Dedupe uploads: report whether an identically named (and sized) file already exists."""
+    filename = request.query.get("filename", "")
+    file_size = request.query.get("size", "")
+    if not filename:
+        return web.json_response({"exists": False})
+
+    upload_dir = folder_paths.get_input_directory()
+    temp_dir = os.path.join(upload_dir, WORKSPACE_SUBDIR)
+
+    def _matches(path):
+        if not (os.path.exists(path) and os.path.isfile(path)):
+            return False
+        if not file_size:
+            return True
+        try:
+            return os.path.getsize(path) == int(file_size)
+        except ValueError:
+            return True
+
+    for path in (os.path.join(temp_dir, filename), os.path.join(upload_dir, filename)):
+        if _matches(path):
+            rel = os.path.relpath(path, upload_dir).replace("\\", "/")
+            return web.json_response({"exists": True, "name": rel})
+
+    base_name = os.path.basename(filename)
+    suffix = "_" + base_name
+    try:
+        for search_dir in (temp_dir, upload_dir):
+            if not os.path.exists(search_dir):
+                continue
+            for f_name in os.listdir(search_dir):
+                if f_name.endswith(suffix) or f_name == base_name:
+                    path = os.path.join(search_dir, f_name)
+                    if _matches(path):
+                        rel = os.path.relpath(path, upload_dir).replace("\\", "/")
+                        return web.json_response({"exists": True, "name": rel})
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Error listing input directory: %s", e)
+
+    return web.json_response({"exists": False})
+
+
+@PromptServer.instance.routes.post("/minimax_director/compile_prompt")
+async def compile_prompt_endpoint(request):
+    """Live prompt preview for the editor.
+
+    Runs the very same planner the Director runs, so what the panel shows is what the
+    model gets. Metadata only — no image, video or audio is decoded, so it stays instant
+    no matter how much is on the timeline.
+    """
+    from . import minimax_plan as plan
+    try:
+        data = await request.json()
+        fps = float(data.get("frame_rate") or 24.0) or 24.0
+        tdata = plan.parse_timeline(data.get("timeline_data") or "")
+
+        win_start = int(float(data.get("start_frame") or 0))
+        duration_frames = max(1, int(float(data.get("duration_frames") or 1)))
+        retake = plan.retake_state(tdata)
+        if retake:
+            win_start, duration_frames = retake["start"], retake["length"]
+
+        p = plan.plan_timeline(
+            tdata, win_start, duration_frames, fps,
+            global_prompt=data.get("global_prompt") or "",
+            use_custom_motion=bool(data.get("use_custom_motion", True)),
+            use_custom_audio=bool(data.get("use_custom_audio", False)),
+            override_audio=bool(data.get("override_audio", False)),
+            extra_ref_image_count=int(data.get("extra_ref_image_count") or 0),
+        )
+
+        warnings = []
+        if p["prompt_is_fallback"]:
+            warnings.append("No prompt text on the timeline — 'video' would be sent.")
+        if p["length"] > plan.TRAINED_MAX_FRAMES:
+            warnings.append("%.1fs is past H3's trained range (~4-15s). Expect drift or "
+                            "looping — shorten the window." % p["actual_seconds"])
+        if not p["ref_mode_on"]:
+            middles = sum(1 for e in p["events"] if e["role"] == plan.ROLE_MIDDLE)
+            if middles:
+                warnings.append("%d image(s) in the middle are ignored — H3 only anchors the "
+                                "first and last frame. Switch to 'Refs ON (ref2va)'." % middles)
+        if p["ref_mode_on"] and len(p["ref_image_slots"]) >= plan.MAX_REF_IMAGES:
+            warnings.append("Reference images are capped at %d." % plan.MAX_REF_IMAGES)
+        warnings.extend(p.get("ref_warnings") or [])
+
+        return web.json_response({
+            "status": "success",
+            "prompt": p["prompt"],
+            "mode": p["mode"] + (" (retake)" if retake else ""),
+            "format": p.get("prompt_format"),
+            "shots": len(p["shots"]),
+            "length": p["length"],
+            "seconds": round(p["actual_seconds"], 2),
+            "refs": {"images": len(p["ref_image_slots"]),
+                     "videos": len(p["ref_video_segs"]),
+                     "audios": len(p["ref_audio_segs"])},
+            "warnings": warnings,
+        })
+    except Exception as e:
+        log.warning("[MiniMaxDirector] compile_prompt failed: %s", e)
+        return web.json_response({"status": "error", "message": str(e)}, status=500)
+
+
+@PromptServer.instance.routes.get("/minimax_director_get_audio")
+async def minimax_director_get_audio(request):
+    filename = request.query.get("filename")
+    if not filename:
+        return web.json_response({"error": "Missing filename"}, status=400)
+
+    file_path = resolve_input_path(filename.replace("\\", "/"))
+    if not file_path:
+        return web.json_response({"error": "File not found"}, status=404)
+
+    upload_dir = folder_paths.get_input_directory()
+    if os.path.splitext(file_path)[1].lower() in (".wav", ".mp3", ".ogg", ".flac", ".m4a"):
+        peaks = None
+        try:
+            peaks = get_audio_peaks(file_path)
+        except Exception as e:
+            log.warning("[MiniMaxDirector] Failed to get audio peaks: %s", e)
+        rel = os.path.relpath(file_path, upload_dir).replace("\\", "/")
+        return web.json_response({"audio_file": rel, "peaks": peaks})
+
+    audio_file, peaks = None, None
+    try:
+        loop = asyncio.get_event_loop()
+        audio_file, peaks = await loop.run_in_executor(None, extract_audio_from_video, file_path)
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Error extracting audio: %s", e)
+    return web.json_response({"audio_file": audio_file, "peaks": peaks})
+
+
+@PromptServer.instance.routes.get("/minimax_director_open_folder")
+async def minimax_director_open_folder(request):
+    upload_dir = os.path.join(folder_paths.get_input_directory(), WORKSPACE_SUBDIR)
+    os.makedirs(upload_dir, exist_ok=True)
+    try:
+        system = platform.system()
+        if system == "Windows":
+            subprocess.Popen(["explorer", os.path.normpath(upload_dir)])
+        elif system == "Darwin":
+            subprocess.Popen(["open", upload_dir])
+        else:
+            subprocess.Popen(["xdg-open", upload_dir])
+        return web.json_response({"success": True})
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Failed to open workspace folder: %s", e)
+        return web.json_response({"success": False, "error": str(e)}, status=500)
+
+
+def _write_chunk(file, file_path, mode):
+    with open(file_path, mode) as f:
+        f.write(file.file.read())
+
+
+@PromptServer.instance.routes.post("/minimax_director_upload_chunk")
+async def minimax_director_upload_chunk(request):
+    """Chunked upload — sidesteps the 413 Payload Too Large limit on big videos."""
+    post = await request.post()
+    file = post.get("file")
+    filename = os.path.basename(post.get("filename"))
+    chunk_index = int(post.get("chunk_index"))
+    total_chunks = int(post.get("total_chunks"))
+
+    upload_dir = os.path.join(folder_paths.get_input_directory(), WORKSPACE_SUBDIR)
+    os.makedirs(upload_dir, exist_ok=True)
+    file_path = os.path.join(upload_dir, filename)
+
+    if not os.path.realpath(file_path).startswith(os.path.realpath(upload_dir)):
+        return web.json_response({"error": "Invalid filename"}, status=400)
+
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, _write_chunk, file, file_path, "ab" if chunk_index > 0 else "wb")
+
+    if chunk_index == total_chunks - 1:
+        audio_file, peaks = None, None
+        try:
+            audio_file, peaks = await loop.run_in_executor(None, extract_audio_from_video, file_path)
+        except Exception as e:
+            log.warning("[MiniMaxDirector] Error in final chunk audio extraction: %s", e)
+        return web.json_response({
+            "name": "%s/%s" % (WORKSPACE_SUBDIR, filename),
+            "audio_file": audio_file,
+            "peaks": peaks,
+        })
+    return web.json_response({"status": "ok"})
+
+
+# --------------------------------------------------------------------------------------
+# VLM character analysis (Ollama / LM Studio / OpenAI-compatible)
+# --------------------------------------------------------------------------------------
+
+_PROVIDER_DEFAULTS = {
+    # Any vision model Ollama can serve works; this one is only the pre-filled suggestion.
+    "ollama": {"url": "http://127.0.0.1:11434", "model": "qwen2.5vl:7b"},
+    "lmstudio": {"url": "http://127.0.0.1:1234", "model": ""},
+    "custom": {"url": "", "model": ""},
+}
+
+_ANALYZE_PROMPT = (
+    "Describe the character's physical appearance in two concise sentences. "
+    "Specify their hair color/style, face details, and their clothing type/color. "
+    "Keep the entire response very brief."
+)
+
+
+def normalize_base_url(url, fallback=""):
+    """Make a typed-in address usable.
+
+    "127.0.0.1:11434" is what people actually enter, and aiohttp rejects it outright with
+    NonHttpUrlClientError because it has no scheme. Assume http:// when none is given.
+    """
+    url = (url or "").strip().rstrip("/")
+    if not url:
+        return (fallback or "").strip().rstrip("/")
+    if "://" not in url:
+        url = "http://" + url
+    return url
+
+
+def _resolve_provider(data):
+    provider = (data.get("provider") or "ollama").lower()
+    defs = _PROVIDER_DEFAULTS.get(provider, _PROVIDER_DEFAULTS["ollama"])
+    base_url = normalize_base_url(data.get("base_url"), defs["url"])
+    model = data.get("model") or defs["model"]
+    return provider, base_url, model
+
+
+class VLMError(RuntimeError):
+    """A VLM round-trip that failed with a message worth showing the user verbatim."""
+
+
+def strip_thinking(text):
+    """Drop a reasoning preamble. Models with the `thinking` capability emit one even
+    when asked not to, and it must never reach the prompt."""
+    text = (text or "").strip()
+    if "</think>" in text:
+        text = text.split("</think>")[-1].strip()
+    elif text.startswith("<think>"):        # unterminated block: nothing usable survives
+        text = ""
+    return text
+
+
+async def vlm_generate(images_b64, prompt, provider, base_url, model,
+                       system_prompt=None, timeout=120, keep_alive=0, max_tokens=None):
+    """One vision-model round-trip, shared by the Analyze endpoint and the Enhance node.
+
+    Kept provider-shaped rather than generic on purpose: Ollama takes raw base64 in an
+    `images` array on /api/generate, everyone else takes data URLs in OpenAI message
+    content on /v1/chat/completions.
+
+    `keep_alive=0` makes Ollama drop the model right after answering, so it is not still
+    holding VRAM when H3 starts sampling.
+
+    Raises VLMError with a user-facing message; returns the answer with any thinking
+    preamble removed.
+    """
+    import aiohttp
+
+    if provider in ("lmstudio", "custom") and not model:
+        raise VLMError("No model name set for %s. Enter the name of the model you have "
+                       "loaded there." % provider)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            if provider == "ollama":
+                payload = {"model": model, "prompt": prompt, "images": images_b64,
+                           "stream": False, "keep_alive": keep_alive,
+                           # honoured by thinking-capable models; harmless on the rest
+                           "think": False}
+                if system_prompt:
+                    payload["system"] = system_prompt
+                if max_tokens:
+                    # the only thing that actually stops a small model from rambling;
+                    # asking for a word count in the prompt does not
+                    payload["options"] = {"num_predict": int(max_tokens)}
+                async with session.post("%s/api/generate" % base_url, json=payload,
+                                        timeout=timeout) as response:
+                    if response.status != 200:
+                        raise VLMError("Ollama HTTP %s: %s" % (response.status, await response.text()))
+                    body = await response.json()
+                    text = ((body.get("response") or "").strip()
+                            or (body.get("thinking") or "").strip())
+            else:
+                content = [{"type": "text", "text": prompt}]
+                for b64 in images_b64:
+                    content.append({"type": "image_url",
+                                    "image_url": {"url": "data:image/jpeg;base64,%s" % b64}})
+                messages = []
+                if system_prompt:
+                    messages.append({"role": "system", "content": system_prompt})
+                messages.append({"role": "user", "content": content})
+                payload = {"model": model, "messages": messages,
+                           "max_tokens": int(max_tokens) if max_tokens else 2048,
+                           "stream": False}
+                async with session.post("%s/v1/chat/completions" % base_url, json=payload,
+                                        timeout=timeout) as response:
+                    if response.status != 200:
+                        raise VLMError("%s HTTP %s: %s" % (provider, response.status, await response.text()))
+                    resp_json = await response.json()
+                    try:
+                        msg = resp_json["choices"][0]["message"]
+                        text = (msg.get("content") or "").strip()
+                        if not text:
+                            # thinking models leave content empty
+                            text = (msg.get("reasoning_content") or "").strip()
+                    except (KeyError, IndexError, TypeError):
+                        raise VLMError("Unexpected response shape from %s." % provider)
+    except aiohttp.ClientConnectorError:
+        raise VLMError("Could not connect to %s at %s. Make sure the server is running."
+                       % (provider, base_url))
+    except (aiohttp.ServerTimeoutError, asyncio.TimeoutError):
+        raise VLMError("%s did not answer within %ss." % (provider, timeout))
+    except aiohttp.InvalidURL:
+        raise VLMError("'%s' is not a usable address for %s." % (base_url, provider))
+    except VLMError:
+        raise
+    except Exception as e:
+        # Everything reaching a caller has to be a VLMError, or the node's passthrough
+        # guard cannot catch it and a typo in the URL takes the whole run down.
+        raise VLMError("%s: %s: %s" % (provider, type(e).__name__, e))
+
+    return strip_thinking(text)
+
+
+@PromptServer.instance.routes.post("/minimax_director/analyze_character")
+async def analyze_character_endpoint(request):
+    try:
+        data = await request.json()
+        image_b64 = data.get("image_b64", "")
+        char_index = int(data.get("char_index", 0))
+        provider, base_url, model_name = _resolve_provider(data)
+
+        if provider == "off":
+            return web.json_response({"status": "error", "message": "Analyze is set to Off / Manual."})
+        if not image_b64:
+            return web.json_response({"status": "error", "message": "No image provided for analysis."})
+
+        b64_list = image_b64 if isinstance(image_b64, list) else [image_b64]
+        cleaned = [b.split(",", 1)[1] if "," in b else b for b in b64_list]
+        if not cleaned:
+            return web.json_response({"status": "error", "message": "No valid base64 images decoded."})
+
+        log.info("[MiniMaxDirector] Analyzing Character %d via %s (%s, model '%s')...",
+                 char_index + 1, provider, base_url, model_name)
+        try:
+            generated_text = await vlm_generate(cleaned, _ANALYZE_PROMPT, provider,
+                                                base_url, model_name)
+        except VLMError as e:
+            return web.json_response({"status": "error", "message": str(e)})
+
+        log.info("[MiniMaxDirector] Analysis complete: %s", generated_text)
+        return web.json_response({"status": "success", "description": generated_text})
+    except Exception as e:
+        log.error("[MiniMaxDirector] Failed to analyze character: %s", e)
+        return web.json_response({"status": "error", "message": str(e)}, status=500)
+
+
+async def unload_model(provider, base_url, model):
+    """Evict the model from VRAM. Never raises — freeing memory must not fail a render.
+
+    `keep_alive: 0` on the generate call already asks for this, but a second, explicit
+    request is cheap and covers the cases where it did not take: a request that errored
+    before the option was honoured, or a server that keeps its own TTL.
+    Only Ollama exposes an unload API; LM Studio and OpenAI-compatible servers manage
+    residency themselves.
+    """
+    if provider != "ollama" or not model:
+        return False
+    try:
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.post("%s/api/generate" % base_url,
+                                    json={"model": model, "keep_alive": 0},
+                                    timeout=10) as response:
+                await response.text()
+        log.info("[MiniMaxDirector] asked Ollama to release '%s'.", model)
+        return True
+    except Exception as e:
+        log.debug("[MiniMaxDirector] could not unload '%s': %s", model, e)
+        return False
+
+
+@PromptServer.instance.routes.post("/minimax_director/unload_ollama")
+async def unload_ollama_endpoint(request):
+    """Evict the analysis VLM from VRAM right before a run so it doesn't fight H3 for memory."""
+    try:
+        import aiohttp
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        provider, base_url, model_name = _resolve_provider(data)
+
+        if provider == "ollama":
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post("%s/api/generate" % base_url,
+                                            json={"model": model_name, "keep_alive": 0},
+                                            timeout=8) as response:
+                        await response.text()
+                log.info("[MiniMaxDirector] Asked Ollama to release '%s' before the run.", model_name)
+            except Exception:
+                pass  # not running / unreachable -> nothing to free
+            return web.json_response({"status": "ok", "provider": provider})
+
+        return web.json_response({"status": "ok", "provider": provider,
+                                  "note": "no-op (set a JIT/TTL unload in your server)"})
+    except Exception as e:
+        return web.json_response({"status": "error", "message": str(e)})
+
+
+# --------------------------------------------------------------------------------------
+# tensor loading
+# --------------------------------------------------------------------------------------
+
+BLANK = lambda: torch.zeros((1, 512, 512, 3), dtype=torch.float32)
+
+
+def _pil_to_tensor(img):
+    arr = np.array(img.convert("RGB"), dtype=np.float32) / 255.0
+    return torch.from_numpy(arr).unsqueeze(0)
+
+
+def load_image_source(b64_or_url: str, filename: str = None) -> torch.Tensor:
+    """Load a reference image from base64, a Comfy /view URL, or an input-relative name."""
+    if not b64_or_url and not filename:
+        return BLANK()
+
+    if b64_or_url and "view?" in b64_or_url:
+        try:
+            from urllib.parse import urlparse, parse_qs
+            q = parse_qs(urlparse(b64_or_url).query)
+            fname = q.get("filename", [None])[0]
+            subfolder = q.get("subfolder", [""])[0]
+            if fname:
+                path = os.path.join(folder_paths.get_input_directory(), subfolder, fname)
+                if os.path.exists(path):
+                    return _pil_to_tensor(Image.open(path))
+        except Exception as e:
+            log.debug("[MiniMaxDirector] URL parsing failed for %s: %s", b64_or_url, e)
+
+    if filename:
+        path = resolve_input_path(filename)
+        if path:
+            return _pil_to_tensor(Image.open(path))
+
+    if b64_or_url:
+        try:
+            b64_str = b64_or_url.split(",", 1)[1] if "," in b64_or_url else b64_or_url
+            return _pil_to_tensor(Image.open(_io.BytesIO(base64.b64decode(b64_str))))
+        except Exception as e:
+            log.debug("[MiniMaxDirector] Base64 decoding failed: %s", e)
+
+    return BLANK()
+
+
+def load_image_tensor(seg: dict) -> torch.Tensor:
+    """Decode a timeline image segment to [1, H, W, 3] float32 in [0, 1]."""
+    if seg.get("imageFile"):
+        path = resolve_input_path(seg["imageFile"])
+        if path:
+            return _pil_to_tensor(Image.open(path))
+
+    b64_str = seg.get("imageB64", "")
+    if not b64_str or b64_str.startswith("/view?"):
+        return BLANK()
+    try:
+        if "," in b64_str:
+            b64_str = b64_str.split(",", 1)[1]
+        return _pil_to_tensor(Image.open(_io.BytesIO(base64.b64decode(b64_str))))
+    except Exception:
+        return BLANK()
+
+
+def _decode_target_size(width, height, max_short_edge, max_pixels):
+    """Aspect-preserving downscale bound: short edge <= max_short_edge and area <= max_pixels."""
+    scale = min(1.0, max_short_edge / max(1, min(width, height)))
+    if width * height * scale * scale > max_pixels:
+        scale = math.sqrt(max_pixels / float(width * height))
+    return max(16, int(round(width * scale)) // 2 * 2), max(16, int(round(height * scale)) // 2 * 2)
+
+
+def load_video_tensor(file_ref: str, trim_start_sec: float, duration_sec: float,
+                      out_fps: float = 24.0, max_short_edge: int = 768,
+                      max_pixels: int = 768 * 1344) -> torch.Tensor:
+    """Decode a clip and resample it to `out_fps`, returning [N, H, W, 3] float32.
+
+    Frames are downscaled while decoding — a few seconds of 4K at full resolution would
+    otherwise blow up RAM long before the VAE ever sees them.
+    """
+    path = resolve_input_path(file_ref)
+    if not path:
+        log.warning("[MiniMaxDirector] Video not found: %s", file_ref)
+        return BLANK()
+
+    n_out = max(1, int(round(duration_sec * out_fps)))
+    targets = [trim_start_sec + i / out_fps for i in range(n_out)]
+
+    frames = []
+    try:
+        with av.open(path) as container:
+            stream = container.streams.video[0]
+            stream.thread_type = "AUTO"
+            src_w = stream.width or stream.codec_context.width
+            src_h = stream.height or stream.codec_context.height
+            dst_w, dst_h = _decode_target_size(src_w, src_h, max_short_edge, max_pixels)
+
+            seek_target = max(0.0, trim_start_sec - 0.5)
+            if stream.time_base:
+                container.seek(int(seek_target / float(stream.time_base)), stream=stream, backward=True)
+            else:
+                container.seek(int(seek_target * av.time_base), stream=stream, backward=True)
+
+            idx = 0
+            prev = None
+            for frame in container.decode(stream):
+                ftime = frame.time
+                if ftime is None and frame.pts is not None and stream.time_base:
+                    ftime = float(frame.pts * stream.time_base)
+                if ftime is None:
+                    ftime = 0.0
+
+                # emit every target timestamp this frame is the closest match for
+                while idx < n_out and ftime >= targets[idx] - 1e-6:
+                    pick = frame
+                    if prev is not None and abs(prev[0] - targets[idx]) < abs(ftime - targets[idx]):
+                        pick = prev[1]
+                    frames.append(pick.reformat(width=dst_w, height=dst_h, format="rgb24").to_ndarray())
+                    idx += 1
+                prev = (ftime, frame)
+                if idx >= n_out:
+                    break
+
+            # source ended early: hold the last frame so the clip still has its full length
+            if frames and idx < n_out:
+                frames.extend([frames[-1]] * (n_out - idx))
+    except Exception as e:
+        log.warning("[MiniMaxDirector] Video extract error for %s: %s", file_ref, e)
+
+    if not frames:
+        return BLANK()
+    return torch.from_numpy(np.asarray(frames, dtype=np.float32) / 255.0)
+
+
+def _decode_audio_stereo(buffer_or_path, target_sr=AUDIO_SR):
+    """Decode anything PyAV reads into a [2, N] float32 tensor at target_sr."""
+    blocks = []
+    with av.open(buffer_or_path) as container:
+        if not container.streams.audio:
+            return None
+        stream = container.streams.audio[0]
+        resampler = av.AudioResampler(format="fltp", layout="stereo", rate=target_sr)
+        for frame in container.decode(stream):
+            for out in resampler.resample(frame):
+                blocks.append(torch.from_numpy(out.to_ndarray()))
+        for out in resampler.resample(None):
+            blocks.append(torch.from_numpy(out.to_ndarray()))
+    if not blocks:
+        return None
+    return torch.cat(blocks, dim=1)
+
+
+def load_audio_segment(seg: dict, frame_rate: float, file_key: str = "audioFile"):
+    """Load one timeline audio segment as a ComfyUI AUDIO dict, honouring its trim."""
+    waveform = None
+    if seg.get(file_key):
+        path = resolve_input_path(seg[file_key])
+        if path:
+            try:
+                waveform = _decode_audio_stereo(path)
+            except Exception as e:
+                log.warning("[MiniMaxDirector] Audio decode failed for %s: %s", seg.get(file_key), e)
+    if waveform is None and seg.get("audioB64"):
+        try:
+            b64 = seg["audioB64"]
+            if "," in b64:
+                b64 = b64.split(",", 1)[1]
+            waveform = _decode_audio_stereo(_io.BytesIO(base64.b64decode(b64)))
+        except Exception as e:
+            log.warning("[MiniMaxDirector] Audio base64 decode failed: %s", e)
+    if waveform is None:
+        return None
+
+    start = int(float(seg.get("trimStart", 0)) / frame_rate * AUDIO_SR)
+    length = int(float(seg.get("length", 1)) / frame_rate * AUDIO_SR)
+    clip = waveform[:, max(0, start):max(0, start) + max(1, length)]
+    if clip.shape[1] <= 0:
+        return None
+    return {"waveform": clip.unsqueeze(0), "sample_rate": AUDIO_SR}
+
+
+# --------------------------------------------------------------------------------------
+# image geometry
+# --------------------------------------------------------------------------------------
+
+def resize_image(tensor: torch.Tensor, target_w: int, target_h: int,
+                 method: str, divisible_by: int) -> torch.Tensor:
+    """Resize [N, H, W, 3] to the target, snapping the result to `divisible_by`."""
+    def snap(val, div):
+        return max(div, (int(val) // div) * div)
+
+    tw, th = snap(target_w, divisible_by), snap(target_h, divisible_by)
+    N, H, W, C = tensor.shape
+    if H == th and W == tw:
+        return tensor
+
+    t = tensor.permute(0, 3, 1, 2)
+
+    if method == "maintain aspect ratio":
+        ratio = min(tw / W, th / H)
+        out = F.interpolate(t, size=(snap(int(H * ratio), divisible_by), snap(int(W * ratio), divisible_by)),
+                            mode="bilinear", align_corners=False)
+    elif method in ("pad", "pad green"):
+        ratio = min(tw / W, th / H)
+        new_w, new_h = snap(int(W * ratio), divisible_by), snap(int(H * ratio), divisible_by)
+        inner = F.interpolate(t, size=(new_h, new_w), mode="bilinear", align_corners=False)
+        pad_l, pad_t = (tw - new_w) // 2, (th - new_h) // 2
+        if method == "pad green":
+            out = torch.zeros((N, C, th, tw), dtype=t.dtype, device=t.device)
+            out[:, 0], out[:, 1], out[:, 2] = 102 / 255.0, 1.0, 0.0
+            out[:, :, pad_t:pad_t + new_h, pad_l:pad_l + new_w] = inner
+        else:
+            out = F.pad(inner, (pad_l, tw - new_w - pad_l, pad_t, th - new_h - pad_t),
+                        mode="constant", value=0)
+    elif method == "crop":
+        ratio = max(tw / W, th / H)
+        new_w, new_h = int(W * ratio), int(H * ratio)
+        inner = F.interpolate(t, size=(new_h, new_w), mode="bilinear", align_corners=False)
+        left, top = (new_w - tw) // 2, (new_h - th) // 2
+        out = inner[:, :, top:top + th, left:left + tw]
+    else:  # "stretch to fit" and anything unknown
+        out = F.interpolate(t, size=(th, tw), mode="bilinear", align_corners=False)
+
+    return out.permute(0, 2, 3, 1)
+
+
+def compress_image(tensor: torch.Tensor, crf: int) -> torch.Tensor:
+    """Bake H.264 artefacts into [N, H, W, 3]; crf=0 is a no-op."""
+    if crf <= 0:
+        return tensor
+    N, H, W, C = tensor.shape
+    h, w = (H // 2) * 2, (W // 2) * 2
+    frames = (tensor[:, :h, :w, :] * 255.0).byte().cpu().numpy()
+    try:
+        buf = _io.BytesIO()
+        container = av.open(buf, mode="w", format="mp4")
+        stream = container.add_stream("libx264", rate=24)
+        stream.width, stream.height, stream.pix_fmt = w, h, "yuv420p"
+        stream.options = {"crf": str(crf), "preset": "ultrafast"}
+        for i in range(N):
+            for pkt in stream.encode(av.VideoFrame.from_ndarray(frames[i], format="rgb24")):
+                container.mux(pkt)
+        for pkt in stream.encode(None):
+            container.mux(pkt)
+        container.close()
+
+        buf.seek(0)
+        reader = av.open(buf, mode="r")
+        decoded = [f.to_ndarray(format="rgb24") for f in reader.decode(video=0)]
+        reader.close()
+        if not decoded:
+            return tensor
+
+        out = tensor.clone()
+        n = min(N, len(decoded))
+        out[:n, :h, :w] = torch.from_numpy(
+            np.stack(decoded).astype(np.float32) / 255.0)[:n].to(tensor.device, tensor.dtype)
+        return out
+    except Exception as e:
+        log.warning("[MiniMaxDirector] img_compression encode/decode failed: %s", e)
+        return tensor
+
+
+# --------------------------------------------------------------------------------------
+# timeline audio mixdown
+# --------------------------------------------------------------------------------------
+
+def build_combined_audio(timeline_data_str: str, start_frame: int, duration_frames: int,
+                         frame_rate: float, override_audio: bool = False) -> dict:
+    """Mix the timeline's audio track down to one AUDIO dict covering the render window."""
+    total_samples = max(1, int(math.ceil(duration_frames / frame_rate * AUDIO_SR)))
+    empty = {"waveform": torch.zeros((1, 2, total_samples), dtype=torch.float32),
+             "sample_rate": AUDIO_SR}
+
+    if not timeline_data_str:
+        return empty
+
+    try:
+        data = json.loads(timeline_data_str)
+        if data.get("retakeMode") and data.get("retakeVideo"):
+            rv = data["retakeVideo"]
+            name = rv.get("imageFile") or rv.get("fileName")
+            audio_segs = [{"videoFile": name, "audioFile": name, "start": 0,
+                           "length": rv.get("videoDurationFrames", duration_frames), "trimStart": 0}]
+            override_audio = True
+        elif override_audio:
+            audio_segs = data.get("motionSegments", [])
+        else:
+            audio_segs = data.get("audioSegments", [])
+    except Exception:
+        return empty
+
+    if not audio_segs:
+        return empty
+
+    out = torch.zeros((2, total_samples), dtype=torch.float32)
+    file_key = "videoFile" if override_audio else "audioFile"
+
+    for seg in audio_segs:
+        buffer = None
+        if seg.get(file_key):
+            path = resolve_input_path(seg[file_key])
+            if path:
+                with open(path, "rb") as f:
+                    buffer = _io.BytesIO(f.read())
+        if not override_audio and buffer is None and seg.get("audioB64"):
+            try:
+                b64 = seg["audioB64"]
+                if "," in b64:
+                    b64 = b64.split(",", 1)[1]
+                buffer = _io.BytesIO(base64.b64decode(b64))
+            except Exception:
+                pass
+        if buffer is None:
+            continue
+
+        try:
+            waveform = _decode_audio_stereo(buffer)
+            if waveform is None:
+                continue
+
+            trim_start = float(seg.get("trimStart", 0))
+            length = float(seg.get("length", 1))
+            seg_start = float(seg.get("start", 0))
+
+            if seg_start + length <= start_frame:
+                continue
+            offset = max(0, start_frame - seg_start)
+            trim_start += offset
+            length = max(1, length - offset)
+            seg_start = max(0, seg_start - start_frame)
+
+            src_a = max(0, int(trim_start / frame_rate * AUDIO_SR))
+            src_b = min(waveform.shape[1], src_a + int(length / frame_rate * AUDIO_SR))
+            n = src_b - src_a
+            if n <= 0:
+                continue
+
+            dst_a = int(seg_start / frame_rate * AUDIO_SR)
+            if dst_a >= out.shape[1]:
+                continue
+            n = min(n, out.shape[1] - dst_a)
+            if n <= 0:
+                continue
+
+            # additive mix so overlapping clips sum, matching the editor's preview
+            out[:, dst_a:dst_a + n] += waveform[:, src_a:src_a + n]
+        except Exception as e:
+            log.warning("[MiniMaxDirector] Audio process error for segment %s: %s", seg.get("fileName"), e)
+            continue
+
+    return {"waveform": out.unsqueeze(0), "sample_rate": AUDIO_SR}

--- a/comfyui-nodes/minimax_director/minimax_plan.py
+++ b/comfyui-nodes/minimax_director/minimax_plan.py
@@ -1,0 +1,633 @@
+"""Timeline -> MiniMax H3 plan, with no pixels touched.
+
+Everything that decides *what* a timeline means — which image is the opening frame,
+which becomes a <Picture i> reference, what the storyboard prompt reads like — lives
+here and works on metadata alone. Three callers share it:
+
+* the Director node, which then loads exactly the media the plan calls for,
+* the /minimax_director/compile_prompt endpoint behind the editor's live prompt
+  preview, which loads nothing at all,
+* the chain node, which plans one window per shot.
+
+Keeping it in one place is the point: a prompt preview that disagrees with what is
+actually sent would be worse than no preview.
+"""
+
+# Vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0).
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director
+# See LICENSE in this directory for the full GPL-3.0 text. Unmodified.
+
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+MODEL_FPS = 24.0
+
+# Limits straight from MiniMax's own model card (huggingface.co/MiniMaxAI/MiniMax-H3),
+# not from ComfyUI's node signatures — the two do not agree everywhere.
+MAX_REF_IMAGES = 9          # "<= 9 images"
+MAX_REF_VIDEOS = 3          # "<= 3 clips"
+MAX_REF_AUDIOS = 3          # "<= 3 clips"
+MAX_REF_FILES = 12          # "at most 12 files in total across all input types"
+REF_VIDEO_MIN_SEC = 2.0     # "each clip must be 2-15 seconds long"
+REF_VIDEO_MAX_SEC = 15.0
+REF_VIDEO_TOTAL_SEC = 15.0  # "total duration <= 15 seconds"
+# Output envelope: "4-15 seconds" at 24 fps
+TRAINED_MIN_FRAMES = 96
+TRAINED_MAX_FRAMES = 360
+
+ROLE_FIRST = "first"
+ROLE_LAST = "last"
+ROLE_MIDDLE = "middle"
+
+
+def align_frame_count(n):
+    """H3 only accepts frame counts on the 17k+5 grid."""
+    while n % 17 != 5:
+        n += 1
+    return n
+
+
+def fmt_seconds(value):
+    """0.0 -> '0s', 1.5 -> '1.5s' — the notation used in MiniMax's own templates."""
+    rounded = round(float(value), 1)
+    if abs(rounded - round(rounded)) < 1e-9:
+        return "%ds" % int(round(rounded))
+    return "%.1fs" % rounded
+
+
+def substitute_char_tags(text, replacements):
+    """Swap @character1/@char1 .. @character3/@char3 for their resolved text."""
+    if not text:
+        return text or ""
+    for slot in (1, 2, 3):
+        value = replacements.get(slot)
+        if not value:
+            continue
+        for tag in ("@character%d" % slot, "@char%d" % slot):
+            text = text.replace(tag, value)
+    return text
+
+
+def overlaps(seg, win_start, win_end):
+    start = float(seg.get("start", 0))
+    length = float(seg.get("length", 1))
+    return start < win_end and start + length > win_start
+
+
+def parse_timeline(timeline_data):
+    try:
+        return json.loads(timeline_data) if timeline_data else {}
+    except Exception as e:
+        log.error("[MiniMaxDirector] timeline_data parse error: %s", e)
+        return {}
+
+
+def ref_mode_from(tdata):
+    """Is the toolbar on 'Refs ON (ref2va)'?
+
+    Lives here rather than inline in the planner because the Director's lazy-input check
+    has to answer the same question *before* the plan is built — the two must not drift,
+    or the node would load one checkpoint and condition for the other.
+    """
+    return str(tdata.get("reference_mode", "OFF")).upper() != "OFF"
+
+
+def retake_state(tdata):
+    """The retake panel's state, or None when retake mode is off / has no base video."""
+    if not tdata.get("retakeMode"):
+        return None
+    video = tdata.get("retakeVideo") or {}
+    if not isinstance(video, dict):
+        return None
+    name = video.get("imageFile") or video.get("fileName")
+    if not name:
+        return None
+    return {
+        "video": name,
+        "start": int(float(tdata.get("retakeStart", 0) or 0)),
+        "length": max(1, int(float(tdata.get("retakeLength", 0) or 1))),
+        "base_frames": int(float(video.get("videoDurationFrames", 0) or 0)),
+        "prompt": tdata.get("retakePrompt", "") or "",
+    }
+
+
+FORMAT_MINIMAX = "minimax"
+FORMAT_COMFYUI = "comfyui"
+
+
+def fmt_timestamp(seconds):
+    """MM:SS.mmm — the cut-time format MiniMax's prompt guide uses."""
+    seconds = max(0.0, float(seconds))
+    minutes = int(seconds // 60)
+    rest = seconds - minutes * 60
+    return "%02d:%06.3f" % (minutes, rest)
+
+
+def build_subject_definitions(char_slots, ref_image_slots, ref_video_segs, ref_audio_segs):
+    """Bind <Subject N> names to the <Picture i> labels the tokenizer will emit.
+
+    The guide separates <Subject N> (reusable content: a person, a place, a style) from
+    <Picture N> (a concrete frame anchor). ComfyUI's tokenizer only ever labels images
+    <Picture i>, so a subject has to be *defined* in terms of those labels before shots
+    can refer to it — which is exactly what subject_definitions is for.
+    """
+    lines = []
+    subject_of_slot = {}
+    for slot_index, _slot in enumerate(char_slots):
+        ordinals = [i + 1 for i, s in enumerate(ref_image_slots)
+                    if s.get("source") == "char" and s.get("slot") == slot_index]
+        if not ordinals:
+            continue
+        subject = len(subject_of_slot) + 1
+        subject_of_slot[slot_index + 1] = subject
+        pictures = " and ".join("<Picture %d>" % o for o in ordinals)
+        lines.append("<Subject %d> is the character shown in %s." % (subject, pictures))
+
+    for i, _seg in enumerate(ref_video_segs):
+        lines.append("<Video %d> is a reference video: follow its motion and camera work."
+                     % (i + 1))
+    for i, _seg in enumerate(ref_audio_segs):
+        lines.append("<Audio %d> is a reference audio clip: follow its voice and timbre."
+                     % (i + 1))
+    return lines, subject_of_slot
+
+
+def alignment_instruction(has_first, has_last, shot_count, seconds):
+    """The image-alignment line the base guide requires as the very first line.
+
+    Quoted verbatim from VIDEO_PROMPT_WRITING_GUIDE_base_en.md, including its own
+    inconsistency: I2VA and L2VA bracket the tokens (`<Picture 1>`, `[Shot 1]`) while
+    FL2VA does not. The model was trained on that text, so it is reproduced as written
+    rather than tidied up.
+
+    T2VA has no instruction, and the reference guide does not ask for one at all, so this
+    only applies to the fl2va path.
+
+    S.SS is the *effective* duration — after snapping to the 17k+5 grid, so a 5s request
+    reports 5.16, not 5.00. It is floored to the hundredth rather than rounded, because
+    rounding can name a mark that is past the end of the video: 124 frames last
+    5.166667s, and "5.17" is outside the clip it is describing. Ten of the twenty-four
+    valid frame counts up to 16s round that way (issue #6). The multiply-round-then-floor
+    keeps binary noise from stealing a hundredth off an exact value like 12.25.
+    """
+    n = max(1, int(shot_count))
+    s = "%.2f" % (int(round(max(0.0, float(seconds)) * 10000)) // 100 / 100.0)
+    if has_first and has_last:
+        return ("How the reference pictures align with the target video — Picture 1 "
+                "(from Shot 1) aligns with the 0.00-second mark of the target video; "
+                "Picture 2 (from Shot %d) aligns with the %s-second mark of the target "
+                "video." % (n, s))
+    if has_first:
+        return ("For the target video, at 0.00 seconds into the target video, "
+                "<Picture 1> (from [Shot 1]) is fully referenced.")
+    if has_last:
+        return ("How the reference pictures align with the target video — <Picture 1> "
+                "(from [Shot %d]) aligns with the %s-second mark of the target video."
+                % (n, s))
+    return ""
+
+
+def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
+                               subject_lines=None, retention_lines=None,
+                               instruction=""):
+    """The notation MiniMax documents in VIDEO_PROMPT_WRITING_GUIDE_*.md.
+
+    `integrated_multimodal_description: [Shot 1] … [Shot 2] At 00:05.000, …`, with the
+    first shot carrying no timestamp and every later cut carrying a strictly increasing
+    one, followed by the soundscape fields. Sections are only emitted when there is
+    something real to put in them — an empty heading is worse than none.
+    """
+    parts = []
+
+    # the guide: "must be the first line of the final prompt, followed by one blank line
+    # before the core fields" — joining parts with a blank line gives exactly that
+    if (instruction or "").strip():
+        parts.append(instruction.strip())
+
+    if subject_lines:
+        parts.append("subject_definitions: " + " ".join(subject_lines))
+    if retention_lines:
+        parts.append("retention_analysis: " + " ".join(retention_lines))
+
+    written = [s for s in shots if (s["prompt"] or "").strip()]
+    body = []
+    gp = (global_prompt or "").strip()
+    if gp:
+        body.append(gp)
+    for index, shot in enumerate(written):
+        text = shot["prompt"].strip()
+        if index == 0:
+            body.append("[Shot 1] %s" % text)
+        else:
+            body.append("[Shot %d] At %s, %s"
+                        % (index + 1, fmt_timestamp(shot["start_sec"]), text))
+    if body:
+        parts.append(("detailed_description: " if subject_lines
+                      else "integrated_multimodal_description: ") + " ".join(body))
+
+    if (soundscape or "").strip():
+        parts.append("overall_soundscape: " + soundscape.strip())
+    if (music or "").strip():
+        parts.append("non_diegetic_music: " + music.strip())
+
+    return "\n\n".join(parts).strip()
+
+
+SOUND_PREFIXES = ("audio:", "sound:", "soundscape:", "sfx:")
+MUSIC_PREFIXES = ("music:", "score:", "soundtrack:")
+
+
+def split_audio_music(text):
+    """Lift `Audio: …` / `Music: …` lines out of a prompt into their own fields.
+
+    Everyone writes the soundtrack into the prompt as an "Audio:" line — MiniMax's own
+    ComfyUI templates do it too — while the guide wants it in overall_soundscape and
+    non_diegetic_music. Only a line that *starts* with one of these labels counts, so
+    prose that merely mentions sound is left where it is. Whatever follows such a line
+    without its own label belongs to it.
+    """
+    if not text:
+        return "", "", ""
+    kept, sound, music = [], [], []
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        low = stripped.lower()
+        if any(low.startswith(p) for p in SOUND_PREFIXES):
+            current = sound
+            stripped = stripped.split(":", 1)[1].strip()
+        elif any(low.startswith(p) for p in MUSIC_PREFIXES):
+            current = music
+            stripped = stripped.split(":", 1)[1].strip()
+        elif not stripped:
+            current = None            # a blank line ends the block
+            kept.append(line)
+            continue
+        elif current is None:
+            kept.append(line)
+            continue
+        if stripped:
+            current.append(stripped)
+    return "\n".join(kept).strip(), " ".join(sound).strip(), " ".join(music).strip()
+
+
+def compile_storyboard(global_prompt, shots, total_seconds):
+    """Global block, then timed shot lines in the ComfyUI templates' `[0s-1.5s]` notation."""
+    written = [s for s in shots if (s["prompt"] or "").strip()]
+
+    parts = []
+    gp = (global_prompt or "").strip()
+    if gp:
+        parts.append(gp)
+
+    if len(written) == 1 and written[0]["start_sec"] <= 0.01 and \
+            written[0]["end_sec"] >= total_seconds - 0.01:
+        # One shot covering the whole window is just a prompt — wrapping it in
+        # storyboard syntax would imply a cut that isn't there.
+        parts.append(written[0]["prompt"].strip())
+    elif written:
+        parts.append("Timeline:\n" + "\n".join(
+            "[%s-%s] %s" % (fmt_seconds(s["start_sec"]), fmt_seconds(s["end_sec"]),
+                            s["prompt"].strip())
+            for s in written))
+
+    return "\n\n".join(parts).strip()
+
+
+def classify_events(events, duration_frames, fps):
+    """Assign each main-track image/video segment its keyframe role.
+
+    H3's PackedLayout only anchors keyframes at frame 0 and frame_count-1, so a timeline
+    image is either the opening frame, the closing frame, or a reference.
+    """
+    head_window_f = max(1.0, fps * 0.5)
+    have_first = have_last = False
+    for ev in events:
+        starts_at_head = ev["rel_start_f"] <= head_window_f
+        reaches_tail = ev["rel_end_f"] >= duration_frames - 0.5
+
+        # An explicit "end frame" flag always wins. Otherwise an image that merely runs to
+        # the end of the window is only a closing frame if it did not also start at the
+        # head — one clip spanning the whole timeline is the classic i2v case and means
+        # "start from this image".
+        if ev["is_end"] or (reaches_tail and not starts_at_head):
+            if not have_last or ev["is_end"]:
+                ev["role"] = ROLE_LAST
+                have_last = True
+                continue
+        if starts_at_head and not have_first:
+            ev["role"] = ROLE_FIRST
+            have_first = True
+            continue
+        ev["role"] = ROLE_MIDDLE
+    return events
+
+
+def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
+                  use_custom_motion=True, use_custom_audio=False, override_audio=False,
+                  extra_ref_image_count=0, soundscape="", music="", prompt_format=None):
+    """Work out shots, keyframe roles, reference ordinals and the final prompt.
+
+    Returns a dict; `execute` uses it to decide what media to load, the endpoint just
+    reads `prompt`.
+    """
+    win_end = win_start + duration_frames
+    window_seconds = duration_frames / fps
+    retake = retake_state(tdata)
+
+    if not global_prompt:
+        global_prompt = tdata.get(
+            "retake_global_prompt" if retake else "global_prompt", "") or ""
+
+    # The editor's two soundscape boxes live in the timeline, so both consumers read them
+    # from the same place and no third copy can go stale. Unlike the global prompt these
+    # have no retake twin on purpose: re-rolling part of a shot does not change what the
+    # room sounds like. An explicit argument still wins, which is what lets a caller
+    # override them without touching the timeline.
+    if not (soundscape or "").strip():
+        soundscape = tdata.get("overall_soundscape", "") or ""
+    if not (music or "").strip():
+        music = tdata.get("non_diegetic_music", "") or ""
+
+    ref_mode_on = ref_mode_from(tdata)
+    if prompt_format is None:
+        prompt_format = str(tdata.get("prompt_format", FORMAT_MINIMAX)).lower()
+    if prompt_format not in (FORMAT_MINIMAX, FORMAT_COMFYUI):
+        prompt_format = FORMAT_MINIMAX
+
+    # --- character slots (metadata only) ---
+    char_slots = []          # [{"count": n, "images": [{"b64","name"}], "description": str}]
+    for char_info in tdata.get("characters", []) or []:
+        images_list = char_info.get("images", []) or []
+        legacy_b64 = char_info.get("imageB64", "")
+        if legacy_b64 and not images_list:
+            images_list = [{"b64": legacy_b64, "name": char_info.get("fileName", "")}]
+        char_slots.append({"images": images_list,
+                           "description": char_info.get("description", "") or ""})
+
+    # --- shots + image events ---
+    shots, events = [], []
+    if retake:
+        # Retake replaces the timeline window: one shot over the marked range, anchored on
+        # the base video's own frames either side of it.
+        text = retake["prompt"].strip()
+        if not text:
+            for seg in sorted(tdata.get("segments", []) or [],
+                              key=lambda s: float(s.get("start", 0))):
+                if overlaps(seg, win_start, win_end) and (seg.get("prompt") or "").strip():
+                    text = seg["prompt"]
+                    break
+        shots.append({"prompt": text, "start_sec": 0.0, "end_sec": window_seconds})
+    else:
+        segments = [s for s in (tdata.get("segments", []) or [])
+                    if overlaps(s, win_start, win_end)]
+        segments.sort(key=lambda s: float(s.get("start", 0)))
+        for seg in segments:
+            seg_start = float(seg.get("start", 0))
+            seg_len = float(seg.get("length", 1))
+            rel_start = max(0.0, seg_start - win_start)
+            rel_end = min(float(duration_frames), seg_start + seg_len - win_start)
+            shots.append({"prompt": seg.get("prompt", "") or "",
+                          "start_sec": rel_start / fps, "end_sec": rel_end / fps})
+
+            kind = seg.get("type", "image")
+            if kind not in ("image", "video"):
+                continue
+            if not (seg.get("imageFile") or seg.get("imageB64")):
+                continue
+            events.append({"seg": seg, "rel_start_f": rel_start, "rel_end_f": rel_end,
+                           "is_end": bool(seg.get("isEndFrame")), "kind": kind,
+                           "name": seg.get("fileName", "") or "", "role": ROLE_MIDDLE,
+                           # which shot this image belongs to, so a picture note can name
+                           # it the way the guide does. Resolved to the *written* shot
+                           # numbering below — the body only numbers shots that carry text.
+                           "shot_index": len(shots) - 1})
+        classify_events(events, duration_frames, fps)
+
+    # --- reference ordinals, in the order the tokenizer will present them ---
+    char_tag_values = {}
+    ref_notes = []
+    ref_image_slots = []     # {"source": "char"/"input"/"timeline", ...} in <Picture i> order
+
+    if ref_mode_on:
+        for slot_idx, slot in enumerate(char_slots):
+            if not slot["images"] or len(ref_image_slots) >= MAX_REF_IMAGES:
+                continue
+            char_tag_values[slot_idx + 1] = "<Picture %d>" % (len(ref_image_slots) + 1)
+            for img in slot["images"]:
+                if len(ref_image_slots) >= MAX_REF_IMAGES:
+                    break
+                ref_image_slots.append({"source": "char", "slot": slot_idx, "image": img})
+                ref_image_slots[-1]["slot"] = slot_idx
+
+        for _ in range(max(0, int(extra_ref_image_count))):
+            if len(ref_image_slots) >= MAX_REF_IMAGES:
+                break
+            ref_image_slots.append({"source": "input"})
+
+        # Timeline images in the order they appear on the timeline. `events` is already
+        # chronological, so <Picture n> counts up with time. Character slots and the
+        # ref_images input stay ahead of all of them, so a character's number never shifts
+        # when an image is dropped on the timeline.
+        #
+        # The wording is the reference guide's own, verbatim where it gives it:
+        # "the shot begins from <Picture 1>", "the shot's keyframe corresponds to
+        # <Picture 2>", "the shot ends on <Picture 3>". `<Picture N>` is precisely what
+        # that guide asks for when an image "serves as a shot's first frame, keyframe,
+        # last frame, edited keyframe, or composition anchor", so ref2va does have frame
+        # anchors in its notation — what it does not have is FL2VA's vocabulary. Calling
+        # these "opening frame" / "closing frame" borrowed from the wrong guide, and made
+        # the phrasing depend on where a segment happened to end: flush with the window it
+        # read as a closing frame, three frames shorter as something else entirely
+        # (issue #4).
+        #
+        # Shots are named the way the body names them, which counts only shots carrying
+        # text. An image whose own segment has no prompt gets the guide's shot-free
+        # phrasing rather than a number the reader cannot find.
+        #
+        # The role also lives on the slot, where it is not about wording at all: it picks
+        # which frame of a *video* segment becomes the reference (the last one for
+        # ROLE_LAST) and whether it is fitted to the canvas. See minimax_director.py.
+        written_shot_no = {}
+        counted = 0
+        for shot_i, shot in enumerate(shots):
+            if (shot["prompt"] or "").strip():
+                counted += 1
+                written_shot_no[shot_i] = counted
+
+        for ev in events:
+            if len(ref_image_slots) >= MAX_REF_IMAGES:
+                break
+            ordinal = len(ref_image_slots) + 1
+            slot = {"source": "timeline", "event": ev}
+            if ev["role"] in (ROLE_FIRST, ROLE_LAST):
+                slot["keyframe"] = ev["role"]
+            shot_no = written_shot_no.get(ev.get("shot_index"))
+            at = fmt_seconds(ev["rel_start_f"] / fps)
+            if ev["role"] == ROLE_FIRST:
+                ref_notes.append("[Shot %d] begins from <Picture %d>" % (shot_no, ordinal)
+                                 if shot_no else
+                                 "The video begins from <Picture %d>" % ordinal)
+            elif ev["role"] == ROLE_LAST:
+                ref_notes.append("[Shot %d] ends on <Picture %d>" % (shot_no, ordinal)
+                                 if shot_no else
+                                 "The video ends on <Picture %d>" % ordinal)
+            else:
+                ref_notes.append(
+                    "The keyframe of [Shot %d] corresponds to <Picture %d>, at %s"
+                    % (shot_no, ordinal, at) if shot_no else
+                    "<Picture %d> is a composition anchor at %s" % (ordinal, at))
+            ref_image_slots.append(slot)
+    else:
+        for slot_idx, slot in enumerate(char_slots):
+            if slot["description"]:
+                char_tag_values[slot_idx + 1] = slot["description"]
+
+    # --- reference video / audio tracks ---
+    ref_video_segs, ref_audio_segs = [], []
+    if ref_mode_on:
+        if use_custom_motion:
+            motion = [s for s in (tdata.get("motionSegments", []) or [])
+                      if s.get("videoFile") and overlaps(s, win_start, win_end)]
+            motion.sort(key=lambda s: float(s.get("start", 0)))
+            ref_video_segs = motion[:MAX_REF_VIDEOS]
+        if use_custom_audio:
+            audio = [s for s in (tdata.get("audioSegments", []) or [])
+                     if (s.get("audioFile") or s.get("audioB64"))
+                     and overlaps(s, win_start, win_end)]
+            audio.sort(key=lambda s: float(s.get("start", 0)))
+            ref_audio_segs = audio[:MAX_REF_AUDIOS]
+
+    # --- total file cap ---
+    # The per-type caps are not the whole story: H3 also takes at most 12 reference files
+    # across all types. Trim from the back so the earlier, more deliberate references win.
+    ref_warnings = []
+    total_files = len(ref_image_slots) + len(ref_video_segs) + len(ref_audio_segs)
+    if total_files > MAX_REF_FILES:
+        excess = total_files - MAX_REF_FILES
+        for bucket, label in ((ref_audio_segs, "audio"), (ref_video_segs, "video"),
+                              (ref_image_slots, "image")):
+            while excess > 0 and bucket:
+                bucket.pop()
+                excess -= 1
+        ref_warnings.append(
+            "H3 takes at most %d reference files in total; %d were dropped."
+            % (MAX_REF_FILES, total_files - MAX_REF_FILES))
+        # drop the notes for every picture that was trimmed, not just the first one
+        kept_pictures = len(ref_image_slots)
+        ref_notes = [n for n in ref_notes
+                     if not (n.startswith("<Picture ")
+                             and int(n[9:n.index(">")]) > kept_pictures)]
+
+    # reference videos: each 2-15s, and no more than 15s of them together
+    if ref_video_segs:
+        budget = REF_VIDEO_TOTAL_SEC
+        kept = []
+        for seg in ref_video_segs:
+            seconds = max(0.0, float(seg.get("length", 0)) / fps)
+            if seconds < REF_VIDEO_MIN_SEC:
+                ref_warnings.append(
+                    "Reference video '%s' is %.1fs; H3 wants 2-15s per clip."
+                    % (seg.get("fileName") or seg.get("videoFile"), seconds))
+            # what this clip would actually contribute, after the per-clip cap
+            usable = min(seconds, REF_VIDEO_MAX_SEC)
+            # the question is whether it FITS, not whether anything is left at all
+            if usable > budget + 1e-6:
+                ref_warnings.append(
+                    "Reference videos exceed the %.0fs total budget; '%s' was dropped."
+                    % (REF_VIDEO_TOTAL_SEC, seg.get("fileName") or seg.get("videoFile")))
+                continue
+            kept.append(seg)
+            budget -= usable
+        ref_video_segs = kept
+
+    # --- output length ---
+    # Computed before the prompt because the alignment instruction has to name the
+    # *effective* duration, i.e. after snapping to the 17k+5 grid, not the window length.
+    length = align_frame_count(max(5, int(round(window_seconds * MODEL_FPS))))
+    actual_seconds = length / MODEL_FPS
+
+    # --- prompt ---
+    subject_lines, subject_of_slot = [], {}
+    if ref_mode_on and prompt_format == FORMAT_MINIMAX:
+        subject_lines, subject_of_slot = build_subject_definitions(
+            char_slots, ref_image_slots, ref_video_segs, ref_audio_segs)
+        # a named subject beats a bare picture label: it survives across cuts
+        for slot, subject in subject_of_slot.items():
+            char_tag_values[slot] = "<Subject %d>" % subject
+
+    global_prompt = substitute_char_tags(global_prompt, char_tag_values)
+    for shot in shots:
+        shot["prompt"] = substitute_char_tags(shot["prompt"], char_tag_values)
+
+    if prompt_format == FORMAT_MINIMAX:
+        # the guide keeps the soundtrack out of the shot description
+        global_prompt, found_audio, found_music = split_audio_music(global_prompt)
+        # A filled box wins, but the lifted line is then thrown away — and it may be work
+        # the Enhance node's vision model just did. Say so rather than swallow it.
+        for label, box, found in (("overall_soundscape", soundscape, found_audio),
+                                  ("non_diegetic_music", music, found_music)):
+            if (box or "").strip() and found:
+                log.info("[MiniMaxDirector] %s came from the timeline box, so the %s line "
+                         "in the prompt text was dropped.", label,
+                         "Audio:" if label == "overall_soundscape" else "Music:")
+        soundscape = (soundscape or "").strip() or found_audio
+        music = (music or "").strip() or found_music
+        retention_lines = []
+        if subject_lines:
+            named = ", ".join("<Subject %d>" % s for s in sorted(subject_of_slot.values()))
+            if named:
+                retention_lines.append(
+                    "Keep the identity, face and clothing of %s consistent across every shot."
+                    % named)
+            if ref_video_segs:
+                retention_lines.append(
+                    "Follow the camera work and motion of %s."
+                    % ", ".join("<Video %d>" % (i + 1) for i in range(len(ref_video_segs))))
+            if ref_audio_segs:
+                retention_lines.append(
+                    "Keep the voice and timbre of %s."
+                    % ", ".join("<Audio %d>" % (i + 1) for i in range(len(ref_audio_segs))))
+        if ref_notes:
+            retention_lines.extend(n + "." for n in ref_notes)
+        # Only the fl2va path: ref2va has no keyframe slot and its guide asks for no
+        # instruction line. `written` mirrors the shot numbering the body will use.
+        instruction = ""
+        if not ref_mode_on:
+            written_shots = len([s for s in shots if (s["prompt"] or "").strip()])
+            instruction = alignment_instruction(
+                any(e["role"] == ROLE_FIRST for e in events),
+                any(e["role"] == ROLE_LAST for e in events),
+                written_shots, actual_seconds)
+        prompt = compile_storyboard_minimax(global_prompt, shots, soundscape, music,
+                                            subject_lines, retention_lines, instruction)
+    else:
+        prompt = compile_storyboard(global_prompt, shots, window_seconds)
+        if ref_notes:
+            prompt = (prompt + "\n\nReference notes: " + "; ".join(ref_notes) + ".").strip()
+        if (soundscape or "").strip():
+            prompt = (prompt + "\n\nAudio: " + soundscape.strip()).strip()
+        if (music or "").strip():
+            prompt = (prompt + "\n\nMusic: " + music.strip()).strip()
+
+    fallback = not prompt
+    if fallback:
+        prompt = "video"
+
+    has_keyframe = any(ev["role"] in (ROLE_FIRST, ROLE_LAST) for ev in events) or bool(retake)
+    mode = "ref2va" if ref_mode_on else ("fl2va" if has_keyframe else "t2va")
+
+    return {
+        "prompt": prompt, "prompt_is_fallback": fallback,
+        "shots": shots, "events": events, "retake": retake,
+        "ref_mode_on": ref_mode_on, "mode": mode,
+        "ref_image_slots": ref_image_slots, "ref_notes": ref_notes,
+        "ref_video_segs": ref_video_segs, "ref_audio_segs": ref_audio_segs,
+        "ref_warnings": ref_warnings, "prompt_format": prompt_format,
+        "char_tag_values": char_tag_values,
+        "win_start": win_start, "duration_frames": duration_frames, "fps": fps,
+        "window_seconds": window_seconds,
+        "length": length, "actual_seconds": actual_seconds,
+    }

--- a/comfyui-nodes/minimax_director/minimax_retake.py
+++ b/comfyui-nodes/minimax_director/minimax_retake.py
@@ -1,0 +1,206 @@
+# Vendored into MooshieUI from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0).
+# Upstream: https://github.com/seesee75-commits/ComfyUI-MiniMaxH3-Director
+# See LICENSE in this directory for the full GPL-3.0 text.
+#
+# Modifications for MooshieUI, 2026:
+#   * node_id renamed to "MooshieH3RetakeStitch" to avoid colliding with the
+#     upstream pack.
+"""Splice a retake back into its base video.
+
+The Director's Retake Mode regenerates only the marked range, anchored on the base
+video's own frames either side of it. This node puts the result back: head from the
+base video, the freshly generated middle, then the tail — video and audio both, all
+resampled onto H3's 24 fps output grid.
+
+It is driven entirely by the Director's `retake_info` output, so the range can never
+fall out of sync with what was actually generated.
+"""
+
+import json
+import logging
+
+import torch
+import torch.nn.functional as F
+
+from comfy_api.latest import io
+
+from . import minimax_media as media
+
+log = logging.getLogger(__name__)
+
+MODEL_FPS = 24.0
+AUDIO_SR = media.AUDIO_SR
+
+
+def _fit(frames, width, height):
+    """Cover-crop [N, H, W, 3] onto the generated canvas."""
+    if frames is None or frames.shape[0] == 0:
+        return None
+    if frames.shape[1] == height and frames.shape[2] == width:
+        return frames
+    return media.resize_image(frames, width, height, "crop", 1)
+
+
+def _silence(seconds):
+    return torch.zeros((2, max(1, int(round(seconds * AUDIO_SR)))), dtype=torch.float32)
+
+
+def _audio_slice(path, start_sec, dur_sec):
+    """Stereo 44.1 kHz slice of a file's soundtrack, silence-padded when short."""
+    want = max(1, int(round(dur_sec * AUDIO_SR)))
+    try:
+        waveform = media._decode_audio_stereo(path)
+    except Exception as e:
+        log.warning("[MiniMaxRetake] could not read audio from %s: %s", path, e)
+        waveform = None
+    if waveform is None:
+        return _silence(dur_sec)
+    a = max(0, int(round(start_sec * AUDIO_SR)))
+    clip = waveform[:, a:a + want]
+    if clip.shape[1] < want:
+        clip = torch.cat([clip, torch.zeros((2, want - clip.shape[1]), dtype=clip.dtype)], dim=1)
+    return clip
+
+
+def _as_stereo_44k(audio):
+    """Any ComfyUI AUDIO dict -> [2, N] float32 at 44.1 kHz."""
+    if audio is None:
+        return None
+    waveform = audio.get("waveform")
+    if waveform is None:
+        return None
+    if waveform.ndim == 3:
+        waveform = waveform[0]
+    waveform = waveform.to(torch.float32).cpu()
+    if waveform.shape[0] == 1:
+        waveform = waveform.repeat(2, 1)
+    elif waveform.shape[0] > 2:
+        waveform = waveform[:2]
+    sr = int(audio.get("sample_rate", AUDIO_SR))
+    if sr != AUDIO_SR:
+        try:
+            import torchaudio
+            waveform = torchaudio.functional.resample(waveform, sr, AUDIO_SR)
+        except Exception:
+            # linear fallback keeps the splice usable even without torchaudio
+            n = int(round(waveform.shape[1] * AUDIO_SR / max(1, sr)))
+            waveform = F.interpolate(waveform.unsqueeze(0), size=n,
+                                     mode="linear", align_corners=False)[0]
+    return waveform
+
+
+class MiniMaxH3RetakeStitch(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MooshieH3RetakeStitch",
+            display_name="MiniMax H3 Retake Stitch",
+            category="MiniMax H3",
+            description=(
+                "Splices a Retake Mode result back into its base video: base head + the "
+                "generated range + base tail, video and audio, all on H3's 24 fps grid. "
+                "Wire the Director's retake_info in; it carries the range that was rendered."
+            ),
+            inputs=[
+                io.String.Input("retake_info", force_input=True,
+                                tooltip="From the Director's retake_info output."),
+                io.Image.Input("images", tooltip="The decoded retake (VAEDecode output)."),
+                io.Audio.Input("audio", optional=True,
+                               tooltip="The retake's audio (VAEDecodeAudio output). "
+                                       "Left out, the base video's own audio is kept throughout."),
+                io.Boolean.Input("keep_base_audio", default=False, optional=True,
+                                 tooltip="Ignore the generated audio and keep the base video's "
+                                         "soundtrack across the whole result."),
+            ],
+            outputs=[
+                io.Image.Output(display_name="images", tooltip="Full-length video frames at 24 fps."),
+                io.Audio.Output(display_name="audio"),
+                io.Float.Output(display_name="fps"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, retake_info, images, audio=None, keep_base_audio=False) -> io.NodeOutput:
+        try:
+            info = json.loads(retake_info) if retake_info else {}
+        except Exception as e:
+            raise ValueError("MiniMax H3 Retake Stitch: retake_info is not valid JSON (%s). "
+                             "Wire it from the Director's retake_info output." % e)
+        if not info.get("base_video"):
+            # Pass through instead of raising. This node sits at the END of the graph, so
+            # raising here throws away a finished render — several minutes of sampling —
+            # for a node that simply had nothing to do. Leaving it wired while you work
+            # normally has to be harmless; it only splices when the Director actually ran
+            # a retake.
+            log.info("[MiniMaxRetake] no retake in this run (the Director was not in Retake "
+                     "Mode, or no base video was marked) — passing the %d frame(s) through "
+                     "unchanged.", int(images.shape[0]))
+            passthrough_audio = audio or {
+                "waveform": _silence(images.shape[0] / MODEL_FPS).unsqueeze(0),
+                "sample_rate": AUDIO_SR,
+            }
+            return io.NodeOutput(images, passthrough_audio, MODEL_FPS)
+
+        base = info["base_video"]
+        tl_fps = float(info.get("timeline_fps") or 24.0) or 24.0
+        start_f = int(info.get("start_frame") or 0)
+        length_f = int(info.get("length_frames") or 0)
+        base_frames = int(info.get("base_frames") or 0)
+        height, width = int(images.shape[1]), int(images.shape[2])
+
+        head_sec = max(0.0, start_f / tl_fps)
+        gap_start_sec = (start_f + length_f) / tl_fps
+        base_sec = base_frames / tl_fps if base_frames else 0.0
+        tail_sec = max(0.0, base_sec - gap_start_sec)
+
+        parts, audio_parts = [], []
+
+        if head_sec > 1e-3:
+            head = _fit(media.load_video_tensor(base, 0.0, head_sec, out_fps=MODEL_FPS,
+                                                max_short_edge=max(width, height),
+                                                max_pixels=width * height * 4), width, height)
+            if head is not None:
+                parts.append(head)
+                audio_parts.append(_audio_slice(base, 0.0, head.shape[0] / MODEL_FPS))
+
+        gen = images.to(torch.float32)
+        parts.append(gen)
+        gen_sec = gen.shape[0] / MODEL_FPS
+        gen_audio = None if keep_base_audio else _as_stereo_44k(audio)
+        if gen_audio is None:
+            gen_audio = _audio_slice(base, head_sec, gen_sec)
+        audio_parts.append(gen_audio)
+
+        if tail_sec > 1e-3:
+            tail = _fit(media.load_video_tensor(base, gap_start_sec, tail_sec, out_fps=MODEL_FPS,
+                                                max_short_edge=max(width, height),
+                                                max_pixels=width * height * 4), width, height)
+            if tail is not None:
+                parts.append(tail)
+                audio_parts.append(_audio_slice(base, gap_start_sec, tail.shape[0] / MODEL_FPS))
+
+        out_images = torch.cat(parts, dim=0)
+
+        # pad each audio piece to its own video piece so a short soundtrack cannot shift
+        # everything after it out of sync
+        fixed = []
+        for part, chunk in zip(parts, audio_parts):
+            want = max(1, int(round(part.shape[0] / MODEL_FPS * AUDIO_SR)))
+            if chunk.shape[1] < want:
+                chunk = torch.cat(
+                    [chunk, torch.zeros((2, want - chunk.shape[1]), dtype=chunk.dtype)], dim=1)
+            fixed.append(chunk[:, :want])
+        out_audio = torch.cat(fixed, dim=1)
+
+        log.info("[MiniMaxRetake] stitched %d + %d + %d frames (%.2fs) around the retake at %.2fs",
+                 parts[0].shape[0] if head_sec > 1e-3 else 0, gen.shape[0],
+                 parts[-1].shape[0] if tail_sec > 1e-3 else 0,
+                 out_images.shape[0] / MODEL_FPS, head_sec)
+
+        return io.NodeOutput(out_images,
+                             {"waveform": out_audio.unsqueeze(0), "sample_rate": AUDIO_SR},
+                             MODEL_FPS)
+
+
+NODE_CLASS_MAPPINGS = {"MiniMaxH3RetakeStitchCS": MiniMaxH3RetakeStitch}
+NODE_DISPLAY_NAME_MAPPINGS = {"MiniMaxH3RetakeStitchCS": "MiniMax H3 Retake Stitch"}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "comfyui-desktop",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "version": "1.9.2",
   "type": "module",
   "scripts": {

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -151,6 +151,10 @@ pub const MISSING_GGUF_NODES_MARKER: &str = "Required GGUF custom nodes failed t
 /// Substring present in [`verify_required_rife_nodes`] error output.
 pub const MISSING_RIFE_NODES_MARKER: &str = "Required RIFE custom nodes failed to load";
 
+/// Substring present in [`verify_required_h3_director_nodes`] error output.
+pub const MISSING_H3_DIRECTOR_NODES_MARKER: &str =
+    "Required MiniMax H3 Director custom nodes failed to load";
+
 const REQUIRED_MOOSHIE_NODE_CLASSES: &[&str] = &[
     "MooshieSaveImage",
     "MooshieSaveVideo",
@@ -187,6 +191,36 @@ const NANOSAUR_MODEL_PY: &str = include_str!("../../../comfyui-nodes/nanosaur_su
 const NANOSAUR_TEXT_ENCODER_PY: &str =
     include_str!("../../../comfyui-nodes/nanosaur_support/text_encoder.py");
 const NANOSAUR_VAE_PY: &str = include_str!("../../../comfyui-nodes/nanosaur_support/vae.py");
+
+// ── MiniMax H3 Director package (video mode) ─────────────────────────────────
+// Vendored from ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0); see
+// comfyui-nodes/minimax_director/LICENSE. Node classes are namespaced Mooshie* so
+// this copy coexists with the upstream pack if a user also installs it.
+//
+// Deliberately NOT in REQUIRED_MOOSHIE_NODE_CLASSES: that list gates every
+// generation, including image mode, and these nodes need ComfyUI >= 0.30's
+// comfy_extras/nodes_minimax_h3. A remote or older ComfyUI would otherwise fail
+// image generation over a video-only node. Video mode calls
+// verify_required_h3_director_nodes() instead.
+const MINIMAX_DIRECTOR_INIT_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/__init__.py");
+const MINIMAX_DIRECTOR_CORE_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/minimax_core.py");
+const MINIMAX_DIRECTOR_PLAN_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/minimax_plan.py");
+const MINIMAX_DIRECTOR_MEDIA_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/minimax_media.py");
+const MINIMAX_DIRECTOR_NODE_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/minimax_director.py");
+const MINIMAX_DIRECTOR_RETAKE_PY: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/minimax_retake.py");
+/// GPL-3.0 requires the licence text travel with the source, so it is deployed
+/// alongside the modules rather than left behind in the app bundle.
+const MINIMAX_DIRECTOR_LICENSE: &str =
+    include_str!("../../../comfyui-nodes/minimax_director/LICENSE");
+
+/// Node classes provided by the vendored MiniMax H3 Director package.
+const REQUIRED_H3_DIRECTOR_NODE_CLASSES: &[&str] = &["MooshieH3Director", "MooshieH3RetakeStitch"];
 
 /// Ensure all bundled MooshieUI custom nodes exist in ComfyUI's custom_nodes directory.
 /// Always overwrites to keep in sync with the app version.
@@ -291,6 +325,38 @@ pub fn ensure_mooshie_nodes(comfyui_path: &str) -> Result<(), String> {
         std::fs::write(&path, content).map_err(|e| {
             format!(
                 "Failed to write nanosaur_support/{} at '{}': {}",
+                name,
+                path.display(),
+                e
+            )
+        })?;
+    }
+
+    // ── MiniMax H3 Director package (video mode timeline) ────────────────────
+    // A package rather than a flat file: the modules import each other relatively
+    // (`from . import minimax_plan as plan`).
+    let director_dir = custom_nodes.join("minimax_director");
+    std::fs::create_dir_all(&director_dir).map_err(|e| {
+        format!(
+            "Failed to create minimax_director directory at '{}': {}",
+            director_dir.display(),
+            e
+        )
+    })?;
+
+    for (name, content) in [
+        ("__init__.py", MINIMAX_DIRECTOR_INIT_PY),
+        ("minimax_core.py", MINIMAX_DIRECTOR_CORE_PY),
+        ("minimax_plan.py", MINIMAX_DIRECTOR_PLAN_PY),
+        ("minimax_media.py", MINIMAX_DIRECTOR_MEDIA_PY),
+        ("minimax_director.py", MINIMAX_DIRECTOR_NODE_PY),
+        ("minimax_retake.py", MINIMAX_DIRECTOR_RETAKE_PY),
+        ("LICENSE", MINIMAX_DIRECTOR_LICENSE),
+    ] {
+        let path = director_dir.join(name);
+        std::fs::write(&path, content).map_err(|e| {
+            format!(
+                "Failed to write minimax_director/{} at '{}': {}",
                 name,
                 path.display(),
                 e
@@ -940,6 +1006,41 @@ pub async fn verify_required_style_transfer_nodes(
     Err(format!(
         "{}: {}. Check the ComfyUI log for custom-node import errors.",
         MISSING_STYLE_TRANSFER_NODES_MARKER,
+        missing.join(", ")
+    ))
+}
+
+/// Verify ComfyUI loaded the vendored MiniMax H3 Director node classes.
+///
+/// Video-mode only. The package needs ComfyUI >= 0.30 (it delegates to
+/// `comfy_extras/nodes_minimax_h3`), so an older or external server can be
+/// perfectly healthy for image generation while missing these.
+pub async fn verify_required_h3_director_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+) -> Result<(), String> {
+    let mut missing = Vec::new();
+
+    for attempt in 0..5 {
+        missing.clear();
+        for node_class in REQUIRED_H3_DIRECTOR_NODE_CLASSES {
+            if !object_info_has_node_class(http_client, base_url, node_class).await? {
+                missing.push((*node_class).to_string());
+            }
+        }
+        if missing.is_empty() {
+            log::info!("Verified MiniMax H3 Director custom node classes");
+            return Ok(());
+        }
+
+        if attempt < 4 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    Err(format!(
+        "{}: {}. MooshieUI deploys these on start; fully stop ComfyUI/python.exe and start MooshieUI again so they load. They require ComfyUI 0.30 or newer.",
+        MISSING_H3_DIRECTOR_NODES_MARKER,
         missing.join(", ")
     ))
 }


### PR DESCRIPTION
Vendors ComfyUI-MiniMaxH3-Director v0.1.5 (GPL-3.0) into `comfyui-nodes/minimax_director/` and deploys it through the existing `ensure_mooshie_nodes()` path, so the H3 timeline nodes ship with the app rather than being git-cloned at runtime. Same mechanism already used for `nodes_tiled_diffusion.py` and `nanosaur_support/`.

Groundwork only. Nothing calls these nodes yet; the video template still routes through the native `MiniMaxH3ImageToVideo` path.

## What is vendored

7 files, 151 KB. Full GPL-3.0 LICENSE text travels with the source, and every module carries a provenance header naming the upstream repo, version, and what was modified.

Not vendored, deliberately:

- `js/` (546 KB timeline editor) - MooshieUI never renders the ComfyUI graph canvas. It builds the `timeline_data` JSON itself and passes it as a plain widget value.
- `minimax_enhance.py` - MooshieUI has its own prompt assistant.
- `minimax_preview.py` - MooshieUI has its own generation preview.
- `minimax_chain.py` - withdrawn upstream. Its stated blocker (no way to hand it a timeline from the canvas) does not apply here, but it swallows the sampler, which costs live preview, per-window progress and clean interruption. Worth revisiting for long-form video.

Node ids are namespaced `MooshieH3Director` and `MooshieH3RetakeStitch` rather than upstream's `MiniMaxH3*CS`, so this copy cannot collide if a user also installs the upstream pack through ComfyUI Manager.

## Not added to REQUIRED_MOOSHIE_NODE_CLASSES

That list gates every generation, including image mode, and this package needs ComfyUI 0.30 or newer (it delegates to `comfy_extras/nodes_minimax_h3`). An older or remote ComfyUI would otherwise start failing image generation over a video-only node. Added `verify_required_h3_director_nodes()` instead, following the existing mode-scoped pattern used for controlnet, GGUF, RIFE and style transfer.

## No new pip dependencies

Upstream `pyproject.toml` declares `dependencies = []`. Verified against actual imports: av, numpy, torch, PIL, aiohttp, folder_paths and server all ship with ComfyUI. `MOOSHIE_NODES_REQUIREMENTS` is unchanged.

## Licensing

`package.json` said `MIT` while the repo LICENSE is AGPL-3.0. Corrected to `AGPL-3.0-only`. AGPL-3.0 and GPL-3.0 are compatible.

## Verification

- `cargo fmt` clean
- `cargo check` no errors
- `cargo clippy` exit 0, 26 warnings, all pre-existing baseline
- `python -m py_compile` on all 6 modules, exit 0
- `npm run build` succeeds
- No locale keys added, so parity is unchanged