### PR TITLE
video: stop timeline strip collapsing in director panel

### DIFF
--- a/src/lib/components/video/VideoTimelinePanel.svelte
+++ b/src/lib/components/video/VideoTimelinePanel.svelte
@@ -450,7 +450,7 @@
   {/if}
 
   <!-- Strip -->
-  <div class="overflow-x-auto pb-2 mb-4">
+  <div class="shrink-0 overflow-x-auto overflow-y-hidden pb-2 mb-4">
     <div class="min-w-max space-y-2">
       <!-- Ruler -->
       <div class="flex items-end gap-2">


### PR DESCRIPTION
The timeline strip (ruler plus shots/motion/audio tracks) is a direct flex item of the panel's `flex h-full flex-col` root and carried `overflow-x-auto`.

CSS promotes `overflow-y` from `visible` to `auto` when `overflow-x` is `auto`, and a scroll container's automatic minimum size is 0 rather than its content height. The strip therefore shrank to whatever space was left instead of holding its natural track height, and the promoted `overflow-y` rendered a tiny vertical scrollbar.

Adds `shrink-0` so the strip keeps full track height, and `overflow-y-hidden` so no stray vertical scrollbar appears. The panel root already has `overflow-y-auto`, so the section scrolls normally.

Verified with `npm run build` (passes).

 src/lib/components/video/VideoTimelinePanel.svelte | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)