### PR TITLE
docs: cover video gen in SCOPE; fix the jxl round-trip test

### DIFF
--- a/.agents/rules/mooshie-core.md
+++ b/.agents/rules/mooshie-core.md
@@ -15,7 +15,7 @@ npm run tauri build                 # production
 cargo check   # in src-tauri/
 ```
 
-No automated tests (no vitest/jest, no Rust `#[test]`).
+No frontend tests (no vitest/jest). Rust has ~126 `#[test]` fns over pure logic: `cargo test --manifest-path src-tauri/Cargo.toml`. `jxl::tests::roundtrip_2x2_rgba8` is known-red, so the gate is "no new failures".
 
 ## Dual-mode (non-negotiable)
 

--- a/.agents/rules/mooshie-core.md
+++ b/.agents/rules/mooshie-core.md
@@ -15,7 +15,7 @@ npm run tauri build                 # production
 cargo check   # in src-tauri/
 ```
 
-No frontend tests (no vitest/jest). Rust has ~126 `#[test]` fns over pure logic: `cargo test --manifest-path src-tauri/Cargo.toml`. `jxl::tests::roundtrip_2x2_rgba8` is known-red, so the gate is "no new failures".
+No frontend tests (no vitest/jest). Rust has ~128 `#[test]` fns over pure logic: `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; any failure is a real regression.
 
 ## Dual-mode (non-negotiable)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ cargo fmt                # Format Rust code (run inside src-tauri/)
 cargo clippy             # Lint Rust code (run inside src-tauri/)
 ```
 
-> **No test framework exists yet.** There are no test scripts, no vitest/jest, no Rust test modules.
+> **No frontend test framework.** There are no test scripts and no vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic, run with `cargo test --manifest-path src-tauri/Cargo.toml`. `jxl::tests::roundtrip_2x2_rgba8` is known-red on main, so the gate is "no new failures".
 
 ## Architecture
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ cargo fmt                # Format Rust code (run inside src-tauri/)
 cargo clippy             # Lint Rust code (run inside src-tauri/)
 ```
 
-> **No frontend test framework.** There are no test scripts and no vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic, run with `cargo test --manifest-path src-tauri/Cargo.toml`. `jxl::tests::roundtrip_2x2_rgba8` is known-red on main, so the gate is "no new failures".
+> **No frontend test framework.** There are no test scripts and no vitest/jest. Rust does have tests: ~128 `#[test]` fns in `#[cfg(test)]` modules over pure logic, run with `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; treat any failure as a real regression.
 
 ## Architecture
 

--- a/.github/instructions/mooshieui.instructions.md
+++ b/.github/instructions/mooshieui.instructions.md
@@ -30,7 +30,7 @@ cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
 
-**No test framework exists.** No vitest/jest on frontend, no `#[test]` modules in Rust.
+**No frontend test framework.** No vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. One test is known-red on main (`jxl::tests::roundtrip_2x2_rgba8`), so the gate is "no new failures".
 
 ## Non-Negotiable Behavioral Rules
 

--- a/.github/instructions/mooshieui.instructions.md
+++ b/.github/instructions/mooshieui.instructions.md
@@ -30,7 +30,7 @@ cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
 
-**No frontend test framework.** No vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. One test is known-red on main (`jxl::tests::roundtrip_2x2_rgba8`), so the gate is "no new failures".
+**No frontend test framework.** No vitest/jest. Rust does have tests: ~128 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; treat any failure as a real regression.
 
 ## Non-Negotiable Behavioral Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
 
-**No test framework exists.** No vitest/jest on frontend, no `#[test]` modules in Rust.
+**No frontend test framework.** No vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. One test is known-red on main (`jxl::tests::roundtrip_2x2_rgba8`), so the gate is "no new failures".
 
 ## Critical Architecture (Non-Obvious)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
 
-**No frontend test framework.** No vitest/jest. Rust does have tests: ~126 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. One test is known-red on main (`jxl::tests::roundtrip_2x2_rgba8`), so the gate is "no new failures".
+**No frontend test framework.** No vitest/jest. Rust does have tests: ~128 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; treat any failure as a real regression.
 
 ## Critical Architecture (Non-Obvious)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ cargo check --manifest-path src-tauri/Cargo.toml   # Rust compile check
 cargo fmt && cargo clippy    # Rust format/lint (run in src-tauri/)
 ```
 
-**No frontend test framework** — no vitest/jest. Rust *does* have tests: ~126 `#[test]` fns across 12 `#[cfg(test)]` modules, covering pure logic only (`templates/video.rs`, `commands/video_export.rs`, `commands/api.rs`, `prompt_assistant/*`, `comfyui/nodes.rs`, ...). Run them with `cargo test --manifest-path src-tauri/Cargo.toml`.
+**No frontend test framework** — no vitest/jest. Rust *does* have tests: ~128 `#[test]` fns across 16 `#[cfg(test)]` modules, covering pure logic only (`templates/video.rs`, `commands/video_export.rs`, `commands/api.rs`, `prompt_assistant/*`, `comfyui/nodes.rs`, ...). Run them with `cargo test --manifest-path src-tauri/Cargo.toml`.
 
-One test is known-red on main: `jxl::tests::roundtrip_2x2_rgba8` asserts a byte-exact round-trip, but `encode_rgba8_lossless` is `LossyConfig::new(1.0)` (visually lossless, not mathematically lossless), so it fails by ~8/255 on a 2x2 image. Treat `cargo test` as "no *new* failures" until that test is corrected.
+The suite is green — treat any failure as a real regression.
 
 Validation is `npm run build` + `cargo check` + `cargo test` (see the `pre-commit-check` skill).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,11 @@ cargo check --manifest-path src-tauri/Cargo.toml   # Rust compile check
 cargo fmt && cargo clippy    # Rust format/lint (run in src-tauri/)
 ```
 
-**No test framework exists** — no vitest/jest on the frontend, no `#[test]` modules in Rust. Validation is `npm run build` + `cargo check` (see the `pre-commit-check` skill).
+**No frontend test framework** — no vitest/jest. Rust *does* have tests: ~126 `#[test]` fns across 12 `#[cfg(test)]` modules, covering pure logic only (`templates/video.rs`, `commands/video_export.rs`, `commands/api.rs`, `prompt_assistant/*`, `comfyui/nodes.rs`, ...). Run them with `cargo test --manifest-path src-tauri/Cargo.toml`.
+
+One test is known-red on main: `jxl::tests::roundtrip_2x2_rgba8` asserts a byte-exact round-trip, but `encode_rgba8_lossless` is `LossyConfig::new(1.0)` (visually lossless, not mathematically lossless), so it fails by ~8/255 on a 2x2 image. Treat `cargo test` as "no *new* failures" until that test is corrected.
+
+Validation is `npm run build` + `cargo check` + `cargo test` (see the `pre-commit-check` skill).
 
 ## Skills
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -6,10 +6,14 @@ open an issue with the feature template and ask.
 
 ## What MooshieUI is
 
-- A desktop (Tauri) and browser front-end for running local image generation
-  through ComfyUI, focused on a fast, friendly, single-user experience.
+- A desktop (Tauri) and browser front-end for running local image and video
+  generation through ComfyUI, focused on a fast, friendly, single-user
+  experience.
 - A polished UI over generation workflows: prompt building, generation
   settings, gallery management, model hub, and related in-app tooling.
+- Video generation on the same footing as images: shot planning through the
+  timeline director, playback, frame interpolation, and clip export. The
+  timeline is a shot list that feeds a ComfyUI graph, not a node editor.
 - Cross-platform (Windows, macOS, Linux) and dual-mode (native desktop app and
   an embedded browser server), sharing one codebase.
 - Localized (i18n across all supported locales) and accessible (a11y).
@@ -23,6 +27,9 @@ open an issue with the feature template and ask.
 - Not a model training or dataset-management tool.
 - Not a general-purpose image editor beyond the specific in-app editing features
   already shipped.
+- Not a video editor or non-linear editing suite. Clips are planned before
+  generation and exported afterwards; MooshieUI does not cut, composite, or
+  grade footage.
 - Not a plugin marketplace or arbitrary third-party extension host.
 
 ## How scope is enforced

--- a/push-instructions.md
+++ b/push-instructions.md
@@ -44,14 +44,17 @@ This enables `.githooks/pre-commit` (Unicode steganography, tampered git dates, 
 
 ## 3. Validate before you open a PR
 
-There is no automated test suite (no Vitest/Jest, no Rust `#[test]`). Run the checks that match your changes:
+There is no frontend test suite (no Vitest/Jest). Rust has ~126 `#[test]` fns covering pure logic. Run the checks that match your changes:
 
 | If you changed… | Run |
 |-----------------|-----|
 | Svelte, stores, TypeScript, `package.json` | `npm run build` (expect `✓ built in` at the end) |
 | Rust (`src-tauri/`) | `cargo check --manifest-path src-tauri/Cargo.toml` |
+| Rust logic with test coverage | `cargo test --manifest-path src-tauri/Cargo.toml` (see note below) |
 | Rust formatting | `cd src-tauri && cargo fmt --check` |
 | Locale files (`src/lib/locales/*.ts`) | Ensure every locale has the same keys and `{placeholders}` as `en.ts` |
+
+One test is known-red on main: `jxl::tests::roundtrip_2x2_rgba8` asserts a byte-exact round-trip, but the encoder is distance 1.0 (visually lossless, not mathematically lossless). Until that is corrected, the gate is "no new failures", not a clean run.
 
 ### Conventions (high-signal)
 

--- a/push-instructions.md
+++ b/push-instructions.md
@@ -44,7 +44,7 @@ This enables `.githooks/pre-commit` (Unicode steganography, tampered git dates, 
 
 ## 3. Validate before you open a PR
 
-There is no frontend test suite (no Vitest/Jest). Rust has ~126 `#[test]` fns covering pure logic. Run the checks that match your changes:
+There is no frontend test suite (no Vitest/Jest). Rust has ~128 `#[test]` fns covering pure logic. Run the checks that match your changes:
 
 | If you changed… | Run |
 |-----------------|-----|
@@ -54,7 +54,7 @@ There is no frontend test suite (no Vitest/Jest). Rust has ~126 `#[test]` fns co
 | Rust formatting | `cd src-tauri && cargo fmt --check` |
 | Locale files (`src/lib/locales/*.ts`) | Ensure every locale has the same keys and `{placeholders}` as `en.ts` |
 
-One test is known-red on main: `jxl::tests::roundtrip_2x2_rgba8` asserts a byte-exact round-trip, but the encoder is distance 1.0 (visually lossless, not mathematically lossless). Until that is corrected, the gate is "no new failures", not a clean run.
+The Rust suite is green on `main`. If `cargo test` fails, treat it as a regression from your change, not a known issue.
 
 ### Conventions (high-signal)
 

--- a/src-tauri/src/comfyui/websocket.rs
+++ b/src-tauri/src/comfyui/websocket.rs
@@ -82,9 +82,9 @@ async fn process_output_image(data: &[u8]) -> Option<ProcessedOutputImage> {
             let is_16 = depth == 16;
             let result = tokio::task::spawn_blocking(move || {
                 let jxl = if is_16 {
-                    crate::jxl::encode_rgba16_lossless(&pixels, w, h)
+                    crate::jxl::encode_rgba16_visually_lossless(&pixels, w, h)
                 } else {
-                    crate::jxl::encode_rgba8_lossless(&pixels, w, h)
+                    crate::jxl::encode_rgba8_visually_lossless(&pixels, w, h)
                 };
                 let (display, display_fmt): (Option<Vec<u8>>, &'static str) =
                     match crate::jxl::encode_rgba8_webp_from_raw(&pixels, w, h, is_16) {

--- a/src-tauri/src/jxl.rs
+++ b/src-tauri/src/jxl.rs
@@ -44,7 +44,14 @@ fn is_codestream(bytes: &[u8]) -> bool {
 }
 
 /// Encode an 8-bit RGBA image as a visually-lossless JXL (distance 1.0).
-pub fn encode_rgba8_lossless(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, AppError> {
+///
+/// Visually lossless, **not** mathematically lossless: decoded pixels come back
+/// close to the originals, not byte-identical. Do not rely on byte equality.
+pub fn encode_rgba8_visually_lossless(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, AppError> {
     use jxl_encoder::{LossyConfig, PixelLayout};
     LossyConfig::new(1.0)
         .encode(rgba, width, height, PixelLayout::Rgba8)
@@ -52,7 +59,14 @@ pub fn encode_rgba8_lossless(rgba: &[u8], width: u32, height: u32) -> Result<Vec
 }
 
 /// Encode a 16-bit RGBA image (native-endian `u16` pairs) as a visually-lossless JXL (distance 1.0).
-pub fn encode_rgba16_lossless(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, AppError> {
+///
+/// Visually lossless, **not** mathematically lossless: decoded pixels come back
+/// close to the originals, not byte-identical. Do not rely on byte equality.
+pub fn encode_rgba16_visually_lossless(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, AppError> {
     use jxl_encoder::{LossyConfig, PixelLayout};
     // jxl-encoder expects &[u8] with native-endian u16 pairs — same layout Python sends
     LossyConfig::new(1.0)
@@ -172,7 +186,7 @@ pub fn read_xmp_box(jxl: &[u8]) -> Option<String> {
 
 /// Return a JXL container with the given XMP string embedded in an `xml ` box.
 ///
-/// Accepts either a naked codestream (from `encode_*_lossless`) or an existing
+/// Accepts either a naked codestream (from `encode_*_visually_lossless`) or an existing
 /// container. In the container case, any existing `xml ` boxes are replaced
 /// with the new one; all other boxes are preserved in original order, and the
 /// `xml ` box is placed before the codestream (`jxlc`/`jxlp`) box.
@@ -343,30 +357,94 @@ pub fn encode_rgba8_webp_from_raw(
 mod tests {
     use super::*;
 
+    /// Build a `width` x `height` RGBA8 smooth gradient — a stand-in for the
+    /// kind of image the gallery actually stores.
+    fn gradient_rgba8(width: u32, height: u32) -> Vec<u8> {
+        let mut px = Vec::with_capacity((width * height * 4) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                px.push((x * 4) as u8);
+                px.push((y * 4) as u8);
+                px.push(((x + y) * 2) as u8);
+                px.push(255);
+            }
+        }
+        px
+    }
+
+    /// Max and mean absolute per-byte difference between two equal-length buffers.
+    fn abs_error(a: &[u8], b: &[u8]) -> (u32, f64) {
+        assert_eq!(a.len(), b.len(), "buffers must be the same length");
+        let max = a
+            .iter()
+            .zip(b)
+            .map(|(&x, &y)| x.abs_diff(y) as u32)
+            .max()
+            .unwrap_or(0);
+        let mean = a
+            .iter()
+            .zip(b)
+            .map(|(&x, &y)| x.abs_diff(y) as f64)
+            .sum::<f64>()
+            / a.len() as f64;
+        (max, mean)
+    }
+
     #[test]
-    fn roundtrip_2x2_rgba8() {
+    fn roundtrip_2x2_preserves_shape_and_alpha() {
         let rgba = [
             255, 0, 0, 255, //
             0, 255, 0, 255, //
             0, 0, 255, 255, //
             255, 255, 255, 128, //
         ];
-        let encoded = encode_rgba8_lossless(&rgba, 2, 2).expect("encode");
+        let encoded = encode_rgba8_visually_lossless(&rgba, 2, 2).expect("encode");
         let decoded = decode_to_rgba8(&encoded).expect("decode");
         assert_eq!(decoded.width, 2);
         assert_eq!(decoded.height, 2);
         assert_eq!(decoded.rgba.len(), 16);
-        // Lossless round-trip: RGB channels should match exactly.
-        // Alpha round-trip through float is also exact for 8-bit values.
-        for (i, (&a, &b)) in rgba.iter().zip(decoded.rgba.iter()).enumerate() {
-            assert!(a.abs_diff(b) <= 1, "pixel {} mismatch: {} vs {}", i, a, b);
+        // Alpha survives the float pipeline exactly for 8-bit values.
+        for i in (3..16).step_by(4) {
+            assert_eq!(rgba[i], decoded.rgba[i], "alpha at byte {} changed", i);
         }
+        // Colour is deliberately not asserted here. A 2x2 of saturated primaries
+        // gives the encoder no spatial context, so a distance-1.0 encode can move
+        // a channel by ~96/255. Fidelity is pinned on realistic images below.
+    }
+
+    #[test]
+    fn roundtrip_gradient_stays_within_visually_lossless_envelope() {
+        let (w, h) = (64, 64);
+        let rgba = gradient_rgba8(w, h);
+        let encoded = encode_rgba8_visually_lossless(&rgba, w, h).expect("encode");
+        let decoded = decode_to_rgba8(&encoded).expect("decode");
+        assert_eq!(decoded.width, w);
+        assert_eq!(decoded.height, h);
+        assert_eq!(decoded.rgba.len(), rgba.len());
+
+        let (max, mean) = abs_error(&rgba, &decoded.rgba);
+        // Observed on jxl-encoder at distance 1.0: max 17, mean 0.553. These are
+        // envelopes, not exact expectations — tighten only if the encoder improves.
+        assert!(mean < 2.0, "mean abs error {mean:.3} exceeds envelope");
+        assert!(max <= 32, "max abs error {max} exceeds envelope");
+    }
+
+    #[test]
+    fn roundtrip_flat_image_is_effectively_exact() {
+        let (w, h) = (64, 64);
+        let rgba = vec![128u8; (w * h * 4) as usize];
+        let encoded = encode_rgba8_visually_lossless(&rgba, w, h).expect("encode");
+        let decoded = decode_to_rgba8(&encoded).expect("decode");
+
+        let (max, _) = abs_error(&rgba, &decoded.rgba);
+        // A constant image has nothing to lose: distance 1.0 reproduces it exactly.
+        assert!(max <= 1, "flat image drifted by {max}");
     }
 
     #[test]
     fn xmp_box_roundtrip() {
         let rgba = [10u8; 16];
-        let encoded = encode_rgba8_lossless(&rgba, 2, 2).expect("encode");
+        let encoded = encode_rgba8_visually_lossless(&rgba, 2, 2).expect("encode");
         let xmp = r#"{"sui_image_params":"{\"prompt\":\"test\"}"}"#;
         let wrapped = wrap_with_xmp(&encoded, xmp).expect("wrap");
         assert!(is_container(&wrapped), "wrapped output must be container");
@@ -401,7 +479,7 @@ mod tests {
     #[test]
     fn xmp_replace_existing() {
         let rgba = [10u8; 16];
-        let encoded = encode_rgba8_lossless(&rgba, 2, 2).expect("encode");
+        let encoded = encode_rgba8_visually_lossless(&rgba, 2, 2).expect("encode");
         let first = wrap_with_xmp(&encoded, "first").expect("wrap1");
         let second = wrap_with_xmp(&first, "second").expect("wrap2");
         assert_eq!(read_xmp_box(&second).as_deref(), Some("second"));


### PR DESCRIPTION
SCOPE.md did not mention video generation at all, so the charter read as image-only. Six instruction files still said the repo has no Rust `#[test]` modules. And the one test that was red on main was red because the test was wrong, not the code.

## SCOPE.md

- `What MooshieUI is` now lists video generation on the same footing as images: timeline shot planning, playback, frame interpolation, clip export. Notes the timeline is a shot list feeding a ComfyUI graph, not a node editor.
- `What MooshieUI is not` gains a line ruling out a video editor or NLE. Clips are planned before generation and exported afterwards; no cutting, compositing, or grading.

## jxl round-trip test

`jxl::tests::roundtrip_2x2_rgba8` asserted every byte survived encode/decode within 1/255, and failed. The encoder is `LossyConfig::new(1.0)`: visually lossless at distance 1.0, not mathematically lossless. The assertion was never achievable.

Measured actual error before rewriting the test:

| Input | Max abs error | Mean abs error |
|---|---|---|
| 2x2 saturated primaries | 96 / 255 | - |
| 64x64 smooth gradient | 17 / 255 | 0.553 |
| 64x64 flat | 0 | 0 |

A 2x2 gives the encoder no spatial context, so it is the worst possible fidelity probe. Replaced with three tests that pin what the encoder actually guarantees:

- `roundtrip_2x2_preserves_shape_and_alpha` keeps the structural claims (dimensions, buffer length) and asserts alpha survives exactly, which it does. Colour is explicitly not asserted, with a comment saying why.
- `roundtrip_gradient_stays_within_visually_lossless_envelope` uses a 64x64 gradient, representative of real gallery images, and asserts mean error under 2.0 and max under 32.
- `roundtrip_flat_image_is_effectively_exact` asserts a constant image comes back unchanged.

## Encoder rename

`encode_rgba8_lossless` and `encode_rgba16_lossless` promised something they do not deliver, which is how the bad test got written in the first place. Renamed to `encode_rgba8_visually_lossless` and `encode_rgba16_visually_lossless`, with doc comments saying not to rely on byte equality. One call site updated in `comfyui/websocket.rs`.

## Instruction files

CLAUDE.md, AGENTS.md, .agents/rules/mooshie-core.md, .github/copilot-instructions.md, .github/instructions/mooshieui.instructions.md and push-instructions.md all claimed there were no Rust tests. Each now points at `cargo test --manifest-path src-tauri/Cargo.toml`, gives the real count (~128 fns across 16 modules), and states the suite is green so any failure is a real regression.

## Checks

- `cargo test`: 128 passed, 0 failed, 1 ignored
- `cargo fmt --check`: clean
- `cargo clippy`: 26 warnings, all pre-existing, none in the touched files
- No frontend, locale, or dependency changes