### PR TITLE
video: snap export fps in Rust, fix video.rs test build

### DIFF
--- a/src-tauri/src/commands/video_export.rs
+++ b/src-tauri/src/commands/video_export.rs
@@ -370,6 +370,27 @@ pub(crate) async fn run_export(
         (width & !1, 0)
     };
 
+    // Every other mirrored function is re-derived from the raw request below,
+    // so a drifted `videoExport.ts` only mislabels the popover. `fps` was the
+    // exception: the picker chooses it and it reached the encoder verbatim, and
+    // a rate that does not divide the source resamples on an uneven cadence and
+    // visibly judders. Snapping it here makes Rust authoritative for the fps
+    // math too. A correct request passes through untouched.
+    let fps = match source_fps(source) {
+        Some(src_fps) => {
+            let snapped = snap_fps(fps, src_fps);
+            if snapped != fps {
+                log::warn!(
+                    "[export] {fps} fps does not divide the {src_fps} fps source; encoding at {snapped}"
+                );
+            }
+            snapped
+        }
+        // Nothing to check against - no indexed rate for this clip. Let the
+        // request through rather than guessing at a source rate.
+        None => fps,
+    };
+
     let dir = export_temp_dir();
     std::fs::create_dir_all(&dir)?;
     let stem = source
@@ -513,6 +534,14 @@ fn emit_progress(app: Option<&tauri::AppHandle>, state: &AppState, payload: &ser
 fn source_dimensions(source: &Path) -> (u32, u32) {
     let path_str = source.to_string_lossy().to_string();
     crate::gallery_index::video_dimensions(&path_str).unwrap_or((0, 0))
+}
+
+/// Source frame rate from the gallery index, rounded to whole frames. `None`
+/// when the row is unknown or carries no rate, in which case the requested fps
+/// is not second-guessed.
+fn source_fps(source: &Path) -> Option<u32> {
+    let path_str = source.to_string_lossy().to_string();
+    crate::gallery_index::video_fps(&path_str).map(|f| f.round() as u32)
 }
 
 #[cfg(feature = "desktop")]
@@ -707,6 +736,24 @@ mod tests {
         assert_eq!(snap_fps(60, 24), 24);
         // A target below everything offered lands on the lowest offered.
         assert_eq!(snap_fps(2, 24), 6);
+    }
+
+    #[test]
+    fn snapping_an_already_offered_rate_is_a_no_op() {
+        // `run_export` runs every incoming rate through `snap_fps` so a drifted
+        // `videoExport.ts` cannot hand the encoder a non-divisor. That guard is
+        // only safe if it leaves a correct request completely alone.
+        for src in [8u32, 12, 16, 24, 30, 48, 60] {
+            for offered in offered_fps(src) {
+                assert_eq!(snap_fps(offered, src), offered, "src={src} rate={offered}");
+            }
+        }
+        // A drifted mirror gets corrected downward, never upward.
+        assert_eq!(snap_fps(16, 24), 12);
+        assert_eq!(snap_fps(30, 24), 24);
+        // A missing or zero rate lands on the floor rather than reaching the
+        // encoder as 0.
+        assert_eq!(snap_fps(0, 24), MIN_OFFERED_FPS);
     }
 
     #[test]

--- a/src-tauri/src/gallery_index.rs
+++ b/src-tauri/src/gallery_index.rs
@@ -392,6 +392,22 @@ pub fn video_dimensions(path: &str) -> Option<(u32, u32)> {
     .filter(|(w, h)| *w > 0 && *h > 0)
 }
 
+/// Source frame rate for one indexed video, by gallery path.
+///
+/// `None` when the row is unknown, predates the `fps` column, or stored a rate
+/// the encoder never reported. Callers treat that as "unverifiable" rather than
+/// substituting a default, because a wrong assumed rate is worse than no check.
+pub fn video_fps(path: &str) -> Option<f64> {
+    let guard = conn().lock().ok()?;
+    let c = guard.as_ref()?;
+    c.query_row("SELECT fps FROM images WHERE path = ?1", [path], |row| {
+        row.get::<_, Option<f64>>(0)
+    })
+    .ok()
+    .flatten()
+    .filter(|v| *v > 0.0)
+}
+
 /// One query for the whole video table, keyed by gallery path.
 ///
 /// This is the first **reader** on the index. The gallery listing needs a

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -827,7 +827,7 @@ mod tests {
             let mut params = video_params("fl2va");
             params.video_rife_enabled = true;
             params.video_rife_multiplier = multiplier;
-            let workflow = build(&params, 1);
+            let workflow = build(&params, 1, false);
 
             let rife = nodes_of_class(&workflow, "RIFE VFI")[0];
             assert_eq!(rife["inputs"]["multiplier"], json!(multiplier));
@@ -843,7 +843,7 @@ mod tests {
         params.video_rife_scale_factor = 0.5;
         params.video_rife_fast_mode = false;
         params.video_rife_ensemble = false;
-        let workflow = build(&params, 1);
+        let workflow = build(&params, 1, false);
 
         let rife = nodes_of_class(&workflow, "RIFE VFI")[0];
         assert_eq!(rife["inputs"]["scale_factor"], json!(0.5));
@@ -856,7 +856,7 @@ mod tests {
         let mut params = video_params("fl2va");
         params.video_rife_enabled = true;
         params.video_rife_multiplier = 32;
-        let workflow = build(&params, 1);
+        let workflow = build(&params, 1, false);
 
         let rife = nodes_of_class(&workflow, "RIFE VFI")[0];
         assert_eq!(rife["inputs"]["multiplier"], json!(4));

--- a/src/lib/utils/videoExport.ts
+++ b/src/lib/utils/videoExport.ts
@@ -6,6 +6,13 @@
  * these values synchronously as the user drags a slider, and an IPC round-trip
  * per frame of interaction is not viable. Each function names its Rust
  * counterpart. Change one, change the other.
+ *
+ * Drift here is contained but not harmless. `run_export` re-derives dimensions,
+ * extension, audio gating and CRF from the raw request, so a wrong value in
+ * those only mislabels the popover. The fps math is the one the encoder acts on
+ * directly, so Rust snaps the incoming rate through its own `snap_fps` as a
+ * backstop - a correct value passes through untouched, a drifted one is
+ * corrected and logged.
  */
 
 /** Rust: `MIN_OFFERED_FPS` */


### PR DESCRIPTION
`src/lib/utils/videoExport.ts` mirrors the pure functions in `src-tauri/src/commands/video_export.rs` by hand, because the export popover needs those values synchronously as the user drags a slider. The two agree today (checked function by function against the Rust tests), but nothing enforces it.

Most of that mirror is low risk. `run_export` re-derives dimensions, extension, audio gating and CRF from the raw request, so a drifted value there only mislabels the popover and cannot reach the encoder.

The fps math was the exception. The picker chooses the rate and it was passed straight through, and Rust's own `snap_fps` was never called on the export path. A rate that does not divide the source resamples on an uneven cadence and visibly judders, silently.

## Changes

- `run_export` now snaps the incoming fps through `snap_fps` against the source rate from the gallery index. A correct request passes through untouched; a drifted one is corrected and logged. Rust is now authoritative for every mirrored function, not ten of eleven.
- New `gallery_index::video_fps(path)`, matching the shape of `video_dimensions`. Returns `None` for an unknown row, a row predating the `fps` column, or a stored zero, and the guard then leaves the request alone rather than assuming a source rate.
- Snapping happens before the output filename is built, so `{stem}_{w}w_{fps}fps_{mode}` keeps naming what was actually encoded.
- Header comment in `videoExport.ts` records which half of the mirror is cosmetic and which is backstopped.

## Unrelated fix in the same commit

The Rust test suite did not compile on main. #551 added the `include_metadata` parameter to `templates::video::build`, and #555 landed three RIFE tests written against the old two-argument signature. Git merged both cleanly because they touch different lines. `cargo check` does not build `#[cfg(test)]`, so the pre-commit gate and CI both passed it.

Fixed the three call sites to pass `false`, matching the other seventeen. Worth noting the gap: `cargo check` alone cannot catch this class of break, only `cargo test` can.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml` passes: 187 passed, 0 failed, 1 ignored. It did not build at all before this branch.
- New test `snapping_an_already_offered_rate_is_a_no_op` covers the guard's contract: every rate the picker offers survives snapping unchanged across seven source rates, a non-divisor is corrected downward, and a zero lands on the floor instead of reaching the encoder.
- `cargo fmt --check` clean, `cargo clippy` reports nothing new in the touched files.
- `npm run build` passes.
