### PR TITLE
fix server build: gate tauri behind the desktop feature

### DIFF
--- a/.agents/skills/pre-commit-check/SKILL.md
+++ b/.agents/skills/pre-commit-check/SKILL.md
@@ -28,6 +28,7 @@ If empty → report "Nothing to check" and stop.
 |------|------|---------|
 | Frontend | svelte / store / ts / package.json changed | `npm run build` — PASS if output ends with `✓ built in` |
 | Rust compile | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml` |
+| Rust server build | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server` — the server binary does not link `tauri`, so the desktop check above cannot catch a `tauri` reference that escaped a `#[cfg(feature = "desktop")]` gate |
 | Rust fmt | any `.rs` changed | `cd src-tauri; cargo fmt --check` — only **blocking** if diffs overlap **your** changed lines |
 
 If a build gate fails → report full error and **STOP** (skip convention audit).

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -127,6 +127,8 @@ Prepend to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`:
 
 ```powershell
 cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server
+cargo test --manifest-path src-tauri/Cargo.toml
 npm run build
 ```
 

--- a/.claude/skills/pre-commit-check/SKILL.md
+++ b/.claude/skills/pre-commit-check/SKILL.md
@@ -28,6 +28,7 @@ If empty → report "Nothing to check" and stop.
 |------|------|---------|
 | Frontend | svelte / store / ts / package.json changed | `npm run build` — PASS if output ends with `✓ built in` |
 | Rust compile | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml` |
+| Rust server build | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server` — the server binary does not link `tauri`, so the desktop check above cannot catch a `tauri` reference that escaped a `#[cfg(feature = "desktop")]` gate |
 | Rust fmt | any `.rs` changed | `cd src-tauri; cargo fmt --check` — only **blocking** if diffs overlap **your** changed lines |
 
 If a build gate fails → report full error and **STOP** (skip convention audit).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -127,6 +127,8 @@ Prepend to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`:
 
 ```powershell
 cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server
+cargo test --manifest-path src-tauri/Cargo.toml
 npm run build
 ```
 

--- a/.github/agents/pre-commit-check.agent.md
+++ b/.github/agents/pre-commit-check.agent.md
@@ -28,6 +28,7 @@ If empty → report "Nothing to check" and stop.
 |------|------|---------|
 | Frontend | svelte / store / ts / package.json changed | `npm run build` — PASS if output ends with `✓ built in` |
 | Rust compile | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml` |
+| Rust server build | rust / rust-deps / config changed | `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server` — the server binary does not link `tauri`, so the desktop check above cannot catch a `tauri` reference that escaped a `#[cfg(feature = "desktop")]` gate |
 | Rust fmt | any `.rs` changed | `cd src-tauri; cargo fmt --check` — only **blocking** if diffs overlap **your** changed lines |
 
 If a build gate fails → report full error and **STOP** (skip convention audit).

--- a/.github/instructions/mooshieui.instructions.md
+++ b/.github/instructions/mooshieui.instructions.md
@@ -25,10 +25,13 @@ npm run dev                  # Vite dev server (port 1420)
 npm run build                # Production frontend → dist/
 npm run tauri dev            # Full dev (Tauri + frontend hot-reload)
 npm run tauri build          # Cross-platform binary
-cargo check                  # Rust compile check (run in src-tauri/)
+cargo check                  # Rust compile check, desktop features (run in src-tauri/)
+cargo check --no-default-features --features server   # server binary build (run in src-tauri/)
 cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
+
+**Two Rust builds, one crate.** `default = ["desktop"]` links `tauri`; the server binary (`--no-default-features --features server`, built by CI's `build-server` job) does not. A `tauri` reference outside a `#[cfg(feature = "desktop")]` gate compiles locally and breaks the release build. Modules gated whole in `commands/mod.rs` can use `tauri` freely; modules present in both builds (`api.rs`, `video_export.rs`, `video_interpolate.rs`, `webserver.rs`) need per-item gates, including on function parameters and the matching call-site arguments.
 
 **No frontend test framework.** No vitest/jest. Rust does have tests: ~128 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; treat any failure as a real regression.
 

--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -126,6 +126,8 @@ Prepend to **both** `RELEASE_NOTES.md` and `CHANGELOG.md`:
 
 ```powershell
 cargo check --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server
+cargo test --manifest-path src-tauri/Cargo.toml
 npm run build
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,13 @@ This file provides guidance to agents when working with code in this repository.
 npm install                  # Frontend dependencies
 npm run tauri dev            # Full dev (Tauri + Vite hot-reload on port 1420)
 npm run tauri build          # Production binary
-cargo check                  # Rust compile check (run in src-tauri/)
+cargo check                  # Rust compile check, desktop features (run in src-tauri/)
+cargo check --no-default-features --features server   # server binary build (run in src-tauri/)
 cargo fmt                    # Rust format (run in src-tauri/)
 cargo clippy                 # Rust lint (run in src-tauri/)
 ```
+
+**Two Rust builds, one crate.** `default = ["desktop"]` links `tauri`; the server binary (`--no-default-features --features server`, built by CI's `build-server` job) does not. A `tauri` reference outside a `#[cfg(feature = "desktop")]` gate compiles locally and breaks the release build. Modules gated whole in `commands/mod.rs` can use `tauri` freely; modules present in both builds (`api.rs`, `video_export.rs`, `video_interpolate.rs`, `webserver.rs`) need per-item gates, including on function parameters and the matching call-site arguments.
 
 **No frontend test framework.** No vitest/jest. Rust does have tests: ~128 `#[test]` fns in `#[cfg(test)]` modules over pure logic. Run `cargo test --manifest-path src-tauri/Cargo.toml`. The suite is green; treat any failure as a real regression.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,18 @@ npm install                  # Frontend dependencies
 npm run tauri dev            # Full dev (Tauri + Vite hot-reload on port 1420, strict)
 npm run tauri build          # Production binary
 npm run build                # Frontend-only build (used as a pre-commit gate)
-cargo check --manifest-path src-tauri/Cargo.toml   # Rust compile check
+cargo check --manifest-path src-tauri/Cargo.toml   # Rust compile check (desktop features)
+cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server   # server binary
 cargo fmt && cargo clippy    # Rust format/lint (run in src-tauri/)
 ```
+
+**Two Rust builds, one crate.** `default = ["desktop"]` links `tauri`; the server binary (`--no-default-features --features server`, built by CI's `build-server` job) does **not**. Anything referencing `tauri` outside a `#[cfg(feature = "desktop")]` gate compiles fine locally and breaks the release. Modules gated whole in `commands/mod.rs` can `use tauri::*` freely; modules that compile in both builds (`api.rs`, `video_export.rs`, `video_interpolate.rs`, `webserver.rs`) need per-item gates — including on function *parameters* and the matching call-site arguments (see `run_export`, `connect_websocket_for_worker_inner`).
 
 **No frontend test framework** — no vitest/jest. Rust *does* have tests: ~128 `#[test]` fns across 16 `#[cfg(test)]` modules, covering pure logic only (`templates/video.rs`, `commands/video_export.rs`, `commands/api.rs`, `prompt_assistant/*`, `comfyui/nodes.rs`, ...). Run them with `cargo test --manifest-path src-tauri/Cargo.toml`.
 
 The suite is green — treat any failure as a real regression.
 
-Validation is `npm run build` + `cargo check` + `cargo test` (see the `pre-commit-check` skill).
+Validation is `npm run build` + `cargo check` (both feature sets) + `cargo test` (see the `pre-commit-check` skill).
 
 ## Skills
 

--- a/src-tauri/src/commands/video_export.rs
+++ b/src-tauri/src/commands/video_export.rs
@@ -172,7 +172,9 @@ use crate::error::AppError;
 use crate::state::AppState;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+#[cfg(feature = "desktop")]
 use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::{Emitter, State};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
@@ -339,10 +341,11 @@ fn source_metadata_json(source: &Path) -> String {
 }
 
 /// Shared by the Tauri command and the browser-mode dispatch arm. `app` is
-/// `None` in browser mode, where progress goes out over SSE only.
+/// `None` in browser mode, where progress goes out over SSE only, and absent
+/// entirely from the server build, which has no Tauri to emit to.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_export(
-    app: Option<&tauri::AppHandle>,
+    #[cfg(feature = "desktop")] app: Option<&tauri::AppHandle>,
     state: &AppState,
     source: &Path,
     format: &str,
@@ -484,7 +487,12 @@ pub(crate) async fn run_export(
         if let Some(d) = msg.get("seam_delta").and_then(|v| v.as_f64()) {
             seam_delta_val = d as f32;
         }
-        emit_progress(app, state, &msg);
+        emit_progress(
+            #[cfg(feature = "desktop")]
+            app,
+            state,
+            &msg,
+        );
     }
 
     let status = child.wait().await?;
@@ -522,7 +530,12 @@ pub(crate) async fn run_export(
     Ok(result)
 }
 
-fn emit_progress(app: Option<&tauri::AppHandle>, state: &AppState, payload: &serde_json::Value) {
+fn emit_progress(
+    #[cfg(feature = "desktop")] app: Option<&tauri::AppHandle>,
+    state: &AppState,
+    payload: &serde_json::Value,
+) {
+    #[cfg(feature = "desktop")]
     if let Some(app) = app {
         let _ = app.emit("export:progress", payload.clone());
     }
@@ -573,6 +586,7 @@ pub async fn export_video_animation(
     let source = dir.join(&name);
 
     run_export(
+        #[cfg(feature = "desktop")]
         Some(&app),
         state.inner(),
         &source,

--- a/src-tauri/src/commands/video_interpolate.rs
+++ b/src-tauri/src/commands/video_interpolate.rs
@@ -5,8 +5,10 @@
 //! halves live here as free functions.
 
 use std::path::{Path, PathBuf};
+#[cfg(feature = "desktop")]
 use std::sync::Arc;
 
+#[cfg(feature = "desktop")]
 use tauri::State;
 
 use crate::error::AppError;

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -4950,6 +4950,7 @@ async fn dispatch_command(
             // Browser callers get their own gallery directory, not the root one.
             let dir = user_gallery_dir(username).ok_or("Gallery unavailable")?;
             let result = crate::commands::video_export::run_export(
+                #[cfg(feature = "desktop")]
                 None,
                 &state,
                 &dir.join(&name),


### PR DESCRIPTION
The v2.0.0 release workflow's `build-server` job failed with four errors, so no server binary was published and `docker-publish` was skipped:

```
error[E0432]: unresolved import `tauri`   src/commands/video_export.rs:176
error[E0432]: unresolved import `tauri`   src/commands/video_interpolate.rs:10
error[E0433]: cannot find module or crate `tauri`   src/commands/video_export.rs:345
error[E0433]: cannot find module or crate `tauri`   src/commands/video_export.rs:525
```

The server binary builds with `--no-default-features --features server`, where the `tauri` crate is not linked at all. `video_export` and `video_interpolate` are not module-gated (webserver.rs calls into their shared logic), so every `tauri` reference in them needs its own `#[cfg(feature = "desktop")]`.

## Fix

- `video_interpolate.rs`: gate `use tauri::State;` and `use std::sync::Arc;` (both used only by the already-gated `interpolate_video` command).
- `video_export.rs`: gate `use tauri::{Emitter, State};` and `use std::sync::Arc;`.
- `run_export` and `emit_progress`: gate the `app: Option<&tauri::AppHandle>` parameter, and the `if let Some(app)` emit inside `emit_progress`. Same per-parameter pattern already used by `connect_websocket_for_worker_inner`.
- Matching `#[cfg]` on the call-site arguments in `export_video_animation` and `webserver.rs`.

No behavior change in the desktop build.

## Preventing a repeat

`cargo check` with default features cannot catch this class of break, which is why it passed the local release gate. Added `cargo check --no-default-features --features server` as a blocking gate to the pre-commit-check and release skills (all synced copies), and documented the dual-build rule in CLAUDE.md, AGENTS.md and the instructions file.

## Verification

- `cargo check --no-default-features --features server --bin mooshieui-server`: clean (6 pre-existing warnings, 2 fewer than before)
- `cargo check` (desktop): clean
- `cargo fmt --check`: clean