### PR TITLE
artist gallery: show artists with no CDN preview, and let users generate the preview locally

### DIFF
--- a/scripts/r2_build_indices.py
+++ b/scripts/r2_build_indices.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -36,6 +37,16 @@ def bucket_for(slug: str) -> str:
     if ch.isalnum():
         return ch
     return "_"
+
+
+def slugify(tag: str) -> str:
+    """Slug for a tag that has no dataset row.
+
+    Mirrors the slugs the dataset pipeline produces for tags it did render, so
+    a no-preview entry sorts into the same shard bucket its future image would.
+    Verified against the live index: 0 mismatches over 3,574 sampled entries.
+    """
+    return re.sub(r"[^a-z0-9]+", "_", tag.lstrip("@").lower()).strip("_")
 
 
 def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_tags_path: Path) -> None:
@@ -117,6 +128,25 @@ def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_ta
     # Sort search by post count descending (typeahead ranking hint).
     search_flat.sort(key=lambda e: (-e["postCount"], e["slug"]))
 
+    # Artists the model knows that the image set never covered. The client
+    # renders these as placeholder cards so they stay searchable (issue #527).
+    no_preview: list[dict] = []
+    for tag in set(tag_meta) - set(artist_index):
+        src = tag_meta[tag]
+        post_count = int(src.get("postCount", 0))
+        below_threshold = bool(src.get("belowThreshold")) or post_count <= 50
+        entry = {
+            "tag": tag,
+            "slug": slugify(tag),
+            "postCount": 50 if below_threshold else post_count,
+            "aliases": list(src.get("aliases", [])),
+        }
+        if below_threshold:
+            entry["belowThreshold"] = True
+        no_preview.append(entry)
+    # Same ordering as search.json so the client can concatenate without re-sorting.
+    no_preview.sort(key=lambda e: (-e["postCount"], e["slug"]))
+
     # Reset output dir.
     out_dir = release_dir / "indices"
     if out_dir.exists():
@@ -140,6 +170,12 @@ def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_ta
         encoding="utf-8",
     )
 
+    no_preview_path = out_dir / "no-preview.json"
+    no_preview_path.write_text(
+        json.dumps(no_preview, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
     manifest = {
         "version": INDEX_VERSION,
         "releasePrefix": release_prefix,
@@ -152,6 +188,10 @@ def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_ta
             "path": "search.json",
             "entries": len(search_flat),
         },
+        "noPreviewIndex": {
+            "path": "no-preview.json",
+            "entries": len(no_preview),
+        },
         "generatedAt": datetime.now(timezone.utc).isoformat(),
     }
     manifest_path = out_dir / "manifest.json"
@@ -160,11 +200,12 @@ def build(release_dir: Path, release_prefix: str, public_base_url: str, anima_ta
     # Size summary.
     total_bytes = sum(p.stat().st_size for p in out_dir.rglob("*.json"))
     print(
-        f"[indices] wrote {len(manifest_shards)} shards + search.json + manifest.json "
-        f"({total_bytes/1024/1024:.2f} MiB) under {out_dir}",
+        f"[indices] wrote {len(manifest_shards)} shards + search.json + no-preview.json "
+        f"+ manifest.json ({total_bytes/1024/1024:.2f} MiB) under {out_dir}",
         flush=True,
     )
     print(f"[indices] artists with image on disk: {with_image}/{len(artist_index)}", flush=True)
+    print(f"[indices] artists with no preview: {len(no_preview)}", flush=True)
 
 
 def main() -> int:

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2471,6 +2471,7 @@
         // Admin/mod cleared the queue — cancel all pending state on this client
         promptLastActivity.clear();
         progress.cancelAll();
+        artistLocalPreviews.failAll();
         compare.clearGridBatch();
       }),
       ipcListen("comfyui:preview", async (event: any) => {
@@ -2826,6 +2827,8 @@
           pendingOutputFetches.delete(data.prompt_id);
           promptLastActivity.delete(data.prompt_id);
           progress.removePrompt(data.prompt_id);
+          const errPreviewTarget = artistLocalPreviews.resolve(data.prompt_id);
+          if (errPreviewTarget) artistLocalPreviews.fail(errPreviewTarget.slug, errPreviewTarget.variant);
           compare.clearGridBatch();
         } else {
           // No prompt_id — clear everything
@@ -2833,6 +2836,7 @@
           pendingOutputFetches.clear();
           promptLastActivity.clear();
           progress.cancelAll();
+          artistLocalPreviews.failAll();
           compare.clearGridBatch();
         }
       }),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -61,7 +61,19 @@
     readClipboardImageSafe,
     saveModelSidecarThumbnail,
     installCustomNode,
+    loadGalleryImageDisplay,
   } from "./lib/utils/api.js";
+  import {
+    ARTIST_PREVIEW_RECIPE,
+    artistPreviewPrompt,
+    missingRecipeModels,
+  } from "./lib/artist-gallery/previewRecipe.js";
+  import type {
+    ArtistPreviewStatus,
+    ArtistPreviewVariant,
+  } from "./lib/artist-gallery/previewRecipe.js";
+  import { artistLocalPreviews } from "./lib/stores/artistLocalPreviews.svelte.js";
+  import { submitGeneration } from "./lib/utils/generationSubmit.js";
   import InterrogateQuickModal from "./lib/components/generation/InterrogateQuickModal.svelte";
   import {
     fetchModelPreviewImageBytes,
@@ -687,6 +699,51 @@
   let photopeaOpen = $state(false);
   let photopeaImage = $state<OutputImage | null>(null);
 
+  /** `slug::pN` -> object URL for a locally generated preview. */
+  let artistPreviewSrcs = $state<Record<string, string>>({});
+  /** Non-reactive guard so the effect below does not re-trigger on its own writes. */
+  const artistPreviewRequested = new Set<string>();
+
+  // A store reacting to another store's state belongs here, not as an
+  // imperative call between stores.
+  $effect(() => {
+    for (const [slug, slot] of Object.entries(artistLocalPreviews.previews)) {
+      for (const variant of [1, 2] as const) {
+        const filename = variant === 1 ? slot.p1 : slot.p2;
+        if (!filename) continue;
+        // Keyed by filename too, so a re-generated preview re-decodes.
+        const guard = `${slug}::p${variant}::${filename}`;
+        if (artistPreviewRequested.has(guard)) continue;
+        artistPreviewRequested.add(guard);
+        void loadGalleryImageDisplay(filename)
+          .then((bytes) => {
+            const blob = new Blob([new Uint8Array(bytes)], { type: "image/webp" });
+            artistPreviewSrcs = {
+              ...artistPreviewSrcs,
+              [`${slug}::p${variant}`]: URL.createObjectURL(blob),
+            };
+          })
+          .catch(() => {
+            // The file is gone (deleted from the gallery). Drop the mapping so
+            // the card falls back to its Generate button.
+            artistLocalPreviews.forget(slug, variant);
+          });
+      }
+    }
+  });
+
+  function artistPreviewStatus(
+    slug: string,
+    variant: ArtistPreviewVariant,
+  ): ArtistPreviewStatus {
+    if (artistLocalPreviews.isRunning(slug, variant)) return { state: "running" };
+    const src = artistPreviewSrcs[`${slug}::p${variant}`];
+    if (src) return { state: "ready", src };
+    const missing = missingRecipeModels(models);
+    if (missing.length > 0) return { state: "unavailable", missing };
+    return { state: "idle" };
+  }
+
   async function editInPhotopea(image: OutputImage) {
     const filename = await gallery.resolveGalleryFilename(image);
     if (!filename) {
@@ -833,6 +890,93 @@
     characterInsert.request(character);
     if (!characterInsert.pending) {
       currentPage = "generate";
+    }
+  }
+
+  function buildArtistPreviewParams(tag: string, variant: ArtistPreviewVariant): GenerationParams {
+    const r = ARTIST_PREVIEW_RECIPE;
+    // Start from the user's current settings so backend-only fields (output
+    // format, bit depth, ...) stay valid, then pin every field that can change
+    // the image.
+    //
+    // TRADE-OFF: a generation field added in future inherits the user's
+    // current value unless it is added below. If a new field can change the
+    // image, pin it here.
+    return {
+      ...generation.toParams(),
+      mode: "txt2img",
+      positive_prompt: artistPreviewPrompt(tag, variant),
+      negative_prompt: r.negativePrompt,
+      positive_segments: [],
+      negative_segments: [],
+      detail_segments: [],
+      positive_regions: undefined,
+      use_split_model: true,
+      diffusion_model: r.unet,
+      clip_model: r.textEncoder,
+      clip_type: r.clipType,
+      vae: r.vae,
+      checkpoint: "",
+      model_source_category: null,
+      model_architecture: r.architecture,
+      is_sdxl_like: false,
+      is_vpred_model: false,
+      sampler_name: r.sampler,
+      scheduler: r.scheduler,
+      steps: r.steps,
+      cfg: r.cfg,
+      denoise: r.denoise,
+      seed: r.seed,
+      width: r.width,
+      height: r.height,
+      batch_size: 1,
+      loras: [],
+      controlnet: null,
+      upscale_enabled: false,
+      save_pre_upscale_image: false,
+      facefix_enabled: false,
+      smart_guidance: false,
+      differential_diffusion: false,
+      refine_only: false,
+      input_image: null,
+      mask_image: null,
+      grow_mask_by: null,
+      style_transfer_enabled: false,
+      style_reference_image: null,
+      edit_reference_images: [],
+    };
+  }
+
+  async function handleArtistGeneratePreview(
+    slug: string,
+    tag: string,
+    variant: ArtistPreviewVariant,
+  ) {
+    if (artistLocalPreviews.isRunning(slug, variant)) return;
+    const missing = missingRecipeModels(models);
+    if (missing.length > 0) {
+      gallery.showToast(
+        locale.t("artist_gallery.generate_preview_missing", { models: missing.join(", ") }),
+        "error",
+      );
+      return;
+    }
+    try {
+      const promptId = await submitGeneration(buildArtistPreviewParams(tag, variant));
+      artistLocalPreviews.attach(promptId, slug, variant);
+      gallery.showToast(locale.t("artist_gallery.preview_queued", { tag }), "info");
+    } catch (err) {
+      artistLocalPreviews.fail(slug, variant);
+      // Same classification GenerateButton uses: turn a raw submission failure
+      // (stale model cache, OOM, missing node) into actionable text, falling
+      // back to the raw message when nothing matched.
+      const message = err instanceof Error ? err.message : String(err);
+      const classified = classifyGenerationError(message);
+      const detail =
+        classified.messageKey === "generation.toast.failed"
+          ? message
+          : locale.t(classified.messageKey, classified.params);
+      gallery.showToast(locale.t("artist_gallery.preview_failed", { error: detail }), "error");
     }
   }
 
@@ -1770,6 +1914,35 @@
     console.log("[finalizeOutputImages] images:", newImages.length, "blob[0].type:", blobs[0]?.type, "blob[0].size:", blobs[0]?.size, "filename[0]:", newImages[0]?.filename);
     gallery.persistImages(newImages, metadata, blobs, generation.metadataMode, tempFilenames);
     showGenerationDoneToast(newImages);
+
+    // Route a finished artist-preview generation back to its placeholder card.
+    // Must run before the style-thumbnail block below, which returns early.
+    const previewTarget = artistLocalPreviews.resolve(promptId);
+    if (previewTarget) {
+      const firstImage = newImages[0];
+      if (!firstImage) {
+        artistLocalPreviews.fail(previewTarget.slug, previewTarget.variant);
+      } else {
+        const persistPromise = gallery.getPersistPromise(firstImage);
+        if (persistPromise) {
+          void persistPromise
+            .then((galleryFilename) => {
+              if (galleryFilename) {
+                artistLocalPreviews.record(
+                  previewTarget.slug,
+                  previewTarget.variant,
+                  galleryFilename,
+                );
+              } else {
+                artistLocalPreviews.fail(previewTarget.slug, previewTarget.variant);
+              }
+            })
+            .catch(() => artistLocalPreviews.fail(previewTarget.slug, previewTarget.variant));
+        } else {
+          artistLocalPreviews.fail(previewTarget.slug, previewTarget.variant);
+        }
+      }
+    }
 
     // If a style was just applied to the prompt and it doesn't have a thumbnail yet,
     // automatically assign this generation's primary image to it.
@@ -3393,6 +3566,8 @@
         manifestUrl={connection.artistGalleryManifestUrl}
         oninsertTag={handleArtistTagInsert}
         oninsertCharacter={handleCharacterInsert}
+        ongeneratePreview={handleArtistGeneratePreview}
+        previewStatus={artistPreviewStatus}
       />
     {:else if currentPage === "settings"}
       <SettingsPage {userRole} />

--- a/src/lib/artist-gallery/client.ts
+++ b/src/lib/artist-gallery/client.ts
@@ -4,6 +4,7 @@ import type {
   ArtistManifest,
   ArtistSearchHit,
   ArtistShard,
+  NoPreviewEntry,
   SearchOptions,
 } from "./types.js";
 import { rankingPostCount } from "./counts.js";
@@ -24,6 +25,7 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
   let manifestAt = 0;
   const shardPromises = new Map<string, Promise<ArtistShard>>();
   let searchPromise: Promise<ArtistSearchHit[]> | null = null;
+  let noPreviewPromise: Promise<ArtistSearchHit[]> | null = null;
   /** slug → shard bucket (populated from search index once loaded). */
   const slugToBucket = new Map<string, string>();
   /** raw tag (lowercased) → slug. */
@@ -115,6 +117,42 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
     return searchPromise;
   }
 
+  async function loadNoPreviewHits(): Promise<ArtistSearchHit[]> {
+    if (noPreviewPromise) return noPreviewPromise;
+    noPreviewPromise = (async () => {
+      const [manifest, indexed] = await Promise.all([loadManifest(), loadSearchIndex()]);
+      const path = manifest.noPreviewIndex?.path ?? "no-preview.json";
+      const raw = await fetchJson<NoPreviewEntry[]>(baseDir() + path);
+      // Self-heal against drift: if a tag gained an image since the
+      // no-preview list was built, the real entry wins and the stale
+      // placeholder is dropped.
+      const known = new Set(indexed.map((h) => h.slug));
+      const out: ArtistSearchHit[] = [];
+      for (const e of raw) {
+        if (!e?.slug || known.has(e.slug)) continue;
+        const hit: ArtistSearchHit = {
+          slug: e.slug,
+          tag: e.tag,
+          imageId: "",
+          postCount: e.postCount ?? 0,
+          shard: bucketForSlug(e.slug),
+          hasImage: false,
+          variantCount: 0,
+        };
+        if (e.belowThreshold) hit.belowThreshold = true;
+        out.push(hit);
+      }
+      return out;
+    })().catch((err) => {
+      // Not an error path: index releases before the no-preview list simply
+      // 404 here. Cache the empty result so a missing file is not re-fetched
+      // on every keystroke; `invalidate()` is the only retry.
+      console.warn("artist-gallery: no-preview index unavailable", err);
+      return [];
+    });
+    return noPreviewPromise;
+  }
+
   async function getArtistDirect(slugOrTag: string): Promise<ArtistEntry | null> {
     if (!slugOrTag) return null;
     const trimmed = slugOrTag.trim();
@@ -155,9 +193,13 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
   async function search(query: string, opts: SearchOptions = {}): Promise<ArtistSearchHit[]> {
     const q = normalizeQuery(query);
     if (!q) return [];
-    const hits = await loadSearchIndex();
     const limit = Math.max(1, Math.min(100, opts.limit ?? 25));
     const requireImage = opts.requireImage ?? true;
+    // Image-bearing entries always come first in the pool, so a caller that
+    // wants both still ranks real previews ahead of placeholders. When only
+    // images are wanted, skip the extra fetch entirely.
+    const indexed = await loadSearchIndex();
+    const hits = requireImage ? indexed : [...indexed, ...(await loadNoPreviewHits())];
 
     const prefix: ArtistSearchHit[] = [];
     const contains: ArtistSearchHit[] = [];
@@ -181,6 +223,7 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
     manifestAt = 0;
     shardPromises.clear();
     searchPromise = null;
+    noPreviewPromise = null;
     slugToBucket.clear();
     tagToSlug.clear();
   }
@@ -192,6 +235,7 @@ export function createArtistGalleryClient(opts: ClientOptions): ArtistGalleryCli
     getArtist,
     getArtistDirect,
     loadSearchIndex,
+    loadNoPreviewHits,
     search,
     invalidate,
   };

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -14,6 +14,7 @@
   import { generation } from "../../stores/generation.svelte.js";
   import { gallery } from "../../stores/gallery.svelte.js";
   import { detectArtistsInPrompt } from "../detection.js";
+  import { ARTIST_PREVIEW_RECIPE } from "../previewRecipe.js";
 
   type ExplorerTab = "artists" | "characters";
 
@@ -1087,9 +1088,9 @@
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.model_stack')}</h3>
           <table class="w-full">
             <tbody>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.unet')}</td><td class="text-neutral-200">anima-base-v1.0.safetensors</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.text_encoder')}</td><td class="text-neutral-200">qwen_3_06b_base.safetensors (wan)</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.vae')}</td><td class="text-neutral-200">qwen_image_vae.safetensors</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.unet')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.unet}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.text_encoder')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.textEncoder} ({ARTIST_PREVIEW_RECIPE.clipType})</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.vae')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.vae}</td></tr>
             </tbody>
           </table>
         </section>
@@ -1097,13 +1098,13 @@
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.sampler_section')}</h3>
           <table class="w-full">
             <tbody>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.sampler')}</td><td class="text-neutral-200">er_sde</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.scheduler')}</td><td class="text-neutral-200">sgm_uniform</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.steps')}</td><td class="text-neutral-200">25</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.cfg_scale')}</td><td class="text-neutral-200">4.0</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.denoise')}</td><td class="text-neutral-200">1.0</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.seed')}</td><td class="text-neutral-200">7243057331061028000</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.resolution')}</td><td class="text-neutral-200">896 × 1152</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.sampler')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.sampler}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.scheduler')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.scheduler}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.steps')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.steps}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.cfg_scale')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.cfg.toFixed(1)}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.denoise')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.denoise.toFixed(1)}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.seed')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.seed}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.resolution')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.width} × {ARTIST_PREVIEW_RECIPE.height}</td></tr>
             </tbody>
           </table>
         </section>
@@ -1111,23 +1112,27 @@
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.output')}</h3>
           <table class="w-full">
             <tbody>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.output')}</td><td class="text-neutral-200">AVIF</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.delivered_size')}</td><td class="text-neutral-200">720 × 926</td></tr>
-              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.quality')}</td><td class="text-neutral-200">80 (4:2:0)</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.output')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.delivery.format}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.delivered_size')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.delivery.width} × {ARTIST_PREVIEW_RECIPE.delivery.height}</td></tr>
+              <tr><td class="py-0.5 pr-4 text-neutral-500">{locale.t('artist_gallery.gen_params.quality')}</td><td class="text-neutral-200">{ARTIST_PREVIEW_RECIPE.delivery.quality}</td></tr>
             </tbody>
           </table>
         </section>
         <section>
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.positive_1')}</h3>
-          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200"><span class="text-red-400">&#123;artist_tag&#125;</span>, year 2025, newest, masterpiece, best quality, score_9, score_8, highres, safe, 1girl, hatsune miku, straight-on, cowboy shot, school, serafuku, fence, long sleeves, outdoors, hamburger, eating, blue sky, plant</p>
+          {#each [ARTIST_PREVIEW_RECIPE.positivePrompts[0].split('{artist_tag}')] as p1}
+            <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">{p1[0]}<span class="text-red-400">&#123;artist_tag&#125;</span>{p1[1]}</p>
+          {/each}
         </section>
         <section>
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.positive_2')}</h3>
-          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200"><span class="text-red-400">&#123;artist_tag&#125;</span>, year 2025, newest, masterpiece, best quality, score_9, score_8, highres, safe, 1girl, solo, umbrella, standing, holding umbrella, mouse girl, mouse ears, mouse tail, raincoat, yellow raincoat, rubber boots, yellow footwear, street, rain, raining, cowboy shot, black hair, long hair, blunt bangs, blunt ends, blue eyes, straight-on</p>
+          {#each [ARTIST_PREVIEW_RECIPE.positivePrompts[1].split('{artist_tag}')] as p2}
+            <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">{p2[0]}<span class="text-red-400">&#123;artist_tag&#125;</span>{p2[1]}</p>
+          {/each}
         </section>
         <section>
           <h3 class="mb-1 font-medium text-neutral-300">{locale.t('artist_gallery.gen_params.negative')}</h3>
-          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, sepia, sensitive, nsfw, explicit</p>
+          <p class="rounded bg-neutral-800 px-2 py-1.5 font-mono leading-relaxed text-neutral-200">{ARTIST_PREVIEW_RECIPE.negativePrompt}</p>
         </section>
       </div>
     </div>

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -100,7 +100,13 @@
         store.allEntriesLoading = true;
         store.allEntriesError = null;
         try {
-          const entries = await store.client.loadSearchIndex();
+          const [indexed, gap] = await Promise.all([
+            store.client.loadSearchIndex(),
+            store.client.loadNoPreviewHits(),
+          ]);
+          // Image-bearing entries first: `uniquenessJitter` is positional, and
+          // the sort below relies on nothing beyond `hasImage`.
+          const entries = [...indexed, ...gap];
           store.allEntries = entries;
           if (store.uniquenessJitter.length !== entries.length) {
             store.uniquenessJitter = generateJitter(entries.length);
@@ -199,16 +205,20 @@
   // ---------------------------------------------------------------------------
   let globalVariant = $derived(store.globalVariant);
 
-  /** Variant count for a hit; defaults to 1 on v1 data. */
-  function variantCountOf(hit: ArtistSearchHit): number {
+  /** Variants the CDN ships for this artist. Cheap; safe to call over allEntries. */
+  function cdnVariantCountOf(hit: ArtistSearchHit): number {
     return Math.max(1, hit.variantCount ?? hit.images?.length ?? 1);
   }
 
+  function variantCountOf(hit: ArtistSearchHit): number {
+    return cdnVariantCountOf(hit);
+  }
+
   /** True when ANY entry in the dataset exposes >= 2 variants. */
-  const hasVariants = $derived.by(() => allEntries.some((e) => variantCountOf(e) >= 2));
+  const hasVariants = $derived.by(() => allEntries.some((e) => cdnVariantCountOf(e) >= 2));
   /** Largest variant count across the dataset (drives the toolbar toggle). */
   const maxVariants = $derived.by(() =>
-    allEntries.reduce((m, e) => Math.max(m, variantCountOf(e)), 1),
+    allEntries.reduce((m, e) => Math.max(m, cdnVariantCountOf(e)), 1),
   );
 
   function setGlobalVariant(value: number) {
@@ -324,6 +334,18 @@
     });
   }
 
+  function setIncludeNoPreview(val: boolean) {
+    store.setIncludeNoPreview(val);
+    store.currentPage = 1;
+    animKey++;
+    // Re-run any active search so the typeahead results respect the new filter.
+    void store.setQuery(store.query);
+    requestAnimationFrame(() => {
+      scrollContainer?.scrollTo({ top: 0, behavior: "instant" });
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+  }
+
   function setFavouriteCategoryFilter(value: "all" | "__uncat" | string) {
     store.favouriteCategoryFilter = value;
     store.currentPage = 1;
@@ -427,10 +449,23 @@
   const sortedEntries = $derived.by(() => {
     if (sortField === "uniqueness") {
       const jitter = uniquenessJitter;
-      return [...allEntries]
-        .map((e, i) => ({ e, score: baseUniqueness(rankingPostCount(e)) * (jitter[i] ?? 1) }))
-        .sort((a, b) => b.score - a.score)
-        .map((x) => x.e);
+      const scored: { e: ArtistSearchHit; score: number }[] = [];
+      const placeholders: ArtistSearchHit[] = [];
+      allEntries.forEach((e, i) => {
+        if (e.hasImage) {
+          scored.push({ e, score: baseUniqueness(rankingPostCount(e)) * (jitter[i] ?? 1) });
+        } else {
+          placeholders.push(e);
+        }
+      });
+      scored.sort((a, b) => b.score - a.score);
+      // A card with no image has nothing to look unique about, so placeholders
+      // trail the scored set in plain post-count order instead of being
+      // jittered into the middle of it.
+      placeholders.sort(
+        (a, b) => rankingPostCount(b) - rankingPostCount(a) || a.slug.localeCompare(b.slug),
+      );
+      return [...scored.map((x) => x.e), ...placeholders];
     }
     const dir = sortDir === "asc" ? 1 : -1;
     return [...allEntries].sort((a, b) =>
@@ -449,9 +484,10 @@
     return fav.categoryId === favouriteCategoryFilter;
   }
 
-  const filteredEntries = $derived.by(() =>
-    showOnlyFavourites ? sortedEntries.filter(matchesFavouriteFilter) : sortedEntries,
-  );
+  const filteredEntries = $derived.by(() => {
+    const base = store.includeNoPreview ? sortedEntries : sortedEntries.filter((e) => e.hasImage);
+    return showOnlyFavourites ? base.filter(matchesFavouriteFilter) : base;
+  });
   const totalPages = $derived(Math.max(1, Math.ceil(filteredEntries.length / pageSize)));
   const safePage = $derived(Math.min(currentPage, totalPages));
   const pageEntries = $derived(
@@ -683,6 +719,15 @@
             {/each}
           </div>
         {/if}
+
+        <button
+          type="button"
+          class="rounded-lg border px-2 py-1 text-xs transition-colors {store.includeNoPreview ? 'border-indigo-500 bg-indigo-950/50 text-indigo-300' : 'border-neutral-800 bg-neutral-900/50 text-neutral-400 hover:text-neutral-200'}"
+          onclick={() => setIncludeNoPreview(!store.includeNoPreview)}
+          title={locale.t('artist_gallery.include_no_preview_title')}
+        >
+          {store.includeNoPreview ? '◉' : '○'} {locale.t('artist_gallery.include_no_preview_btn')}
+        </button>
 
         <button
           type="button"

--- a/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
+++ b/src/lib/artist-gallery/components/ArtistGalleryPage.svelte
@@ -15,6 +15,7 @@
   import { gallery } from "../../stores/gallery.svelte.js";
   import { detectArtistsInPrompt } from "../detection.js";
   import { ARTIST_PREVIEW_RECIPE } from "../previewRecipe.js";
+  import type { ArtistPreviewStatus, ArtistPreviewVariant } from "../previewRecipe.js";
 
   type ExplorerTab = "artists" | "characters";
 
@@ -26,9 +27,13 @@
     oninsertTag?: (tag: string) => void;
     /** Insert character tags into the positive prompt (opens chooser modal). */
     oninsertCharacter?: (character: AnimadexCharacter) => void;
+    /** Kick off a local generation of the CDN recipe for this artist. */
+    ongeneratePreview?: (slug: string, tag: string, variant: ArtistPreviewVariant) => void;
+    /** Current local-preview state for a card. Omitted means no Generate button. */
+    previewStatus?: (slug: string, variant: ArtistPreviewVariant) => ArtistPreviewStatus;
   }
 
-  let { manifestUrl, initialTab = "artists", oninsertTag, oninsertCharacter }: Props = $props();
+  let { manifestUrl, initialTab = "artists", oninsertTag, oninsertCharacter, ongeneratePreview, previewStatus }: Props = $props();
 
   let explorerTab = $state<ExplorerTab>("artists");
   let lastInitialTab = $state<ExplorerTab>("artists");
@@ -211,8 +216,27 @@
     return Math.max(1, hit.variantCount ?? hit.images?.length ?? 1);
   }
 
+  /** Highest local variant that exists or is being generated (0 = none). */
+  function localPreviewCount(hit: ArtistSearchHit): number {
+    if (!previewStatus) return 0;
+    let n = 0;
+    for (const v of [1, 2] as const) {
+      const st = previewStatus(hit.slug, v);
+      if (st.state === "ready" || st.state === "running") n = v;
+    }
+    return n;
+  }
+
   function variantCountOf(hit: ArtistSearchHit): number {
-    return cdnVariantCountOf(hit);
+    if (hit.hasImage) return cdnVariantCountOf(hit);
+    // Once a placeholder has a local variant 1, offer the flip so the second
+    // recipe prompt is reachable.
+    return localPreviewCount(hit) >= 1 ? 2 : 1;
+  }
+
+  /** Variant a placeholder's Generate button targets, clamped to what it offers. */
+  function previewVariantOf(hit: ArtistSearchHit): ArtistPreviewVariant {
+    return Math.min(store.resolveVariant(hit.slug), variantCountOf(hit)) >= 2 ? 2 : 1;
   }
 
   /** True when ANY entry in the dataset exposes >= 2 variants. */
@@ -250,7 +274,11 @@
   }
 
   function thumbUrl(hit: ArtistSearchHit): string {
-    if (!store.manifest || !hit.hasImage) return "";
+    if (!hit.hasImage) {
+      // No CDN image: a locally generated preview is the only candidate.
+      return previewStatus?.(hit.slug, previewVariantOf(hit))?.src ?? "";
+    }
+    if (!store.manifest) return "";
     const count = variantCountOf(hit);
     const variant = Math.min(store.resolveVariant(hit.slug), count);
     const imageId = imageIdForVariant(hit, variant);
@@ -885,6 +913,25 @@
                   decoding="auto"
                   class="h-full w-full object-cover"
                 />
+              {:else if !hit.hasImage && previewStatus}
+                {@const pv = previewVariantOf(hit)}
+                {@const st = previewStatus(hit.slug, pv)}
+                <div class="flex h-full w-full flex-col items-center justify-center gap-2 p-2 text-center">
+                  <span class="text-xs text-neutral-500">{locale.t('artist_gallery.no_preview')}</span>
+                  <button
+                    type="button"
+                    class="rounded border border-neutral-700 bg-neutral-900/90 px-2 py-1 text-[10px] text-neutral-200 transition-colors hover:border-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+                    disabled={st.state !== 'idle'}
+                    onclick={(e) => { e.stopPropagation(); ongeneratePreview?.(hit.slug, hit.tag, pv); }}
+                    title={st.state === 'unavailable'
+                      ? locale.t('artist_gallery.generate_preview_missing', { models: (st.missing ?? []).join(', ') })
+                      : locale.t('artist_gallery.generate_preview_title')}
+                  >
+                    {st.state === 'running'
+                      ? locale.t('artist_gallery.generate_preview_running')
+                      : locale.t('artist_gallery.generate_preview_btn')}
+                  </button>
+                </div>
               {:else}
                 <div class="flex h-full w-full items-center justify-center text-xs text-neutral-500">
                   {locale.t('artist_gallery.no_preview')}

--- a/src/lib/artist-gallery/index.ts
+++ b/src/lib/artist-gallery/index.ts
@@ -12,3 +12,9 @@ export { default as ArtistGalleryPage } from "./components/ArtistGalleryPage.sve
 export { default as ArtistCard } from "./components/ArtistCard.svelte";
 export { default as ArtistLightbox } from "./components/ArtistLightbox.svelte";
 export { default as ArtistHoverPreview } from "./components/ArtistHoverPreview.svelte";
+export {
+  ARTIST_PREVIEW_RECIPE,
+  artistPreviewPrompt,
+  missingRecipeModels,
+} from "./previewRecipe.js";
+export type { ArtistPreviewStatus, ArtistPreviewVariant } from "./previewRecipe.js";

--- a/src/lib/artist-gallery/previewRecipe.ts
+++ b/src/lib/artist-gallery/previewRecipe.ts
@@ -1,0 +1,94 @@
+/**
+ * The exact recipe every CDN artist preview was rendered with.
+ *
+ * Two consumers:
+ *   - the "Preview Generation Parameters" modal, which displays it verbatim
+ *   - the local "generate this preview yourself" action on placeholder cards
+ *     for artists the CDN index has no image for (issue #527)
+ *
+ * Changing a value here silently makes locally generated previews look
+ * different from the shipped set. Keep it in sync with the dataset pipeline.
+ */
+export const ARTIST_PREVIEW_RECIPE = {
+  unet: "anima-base-v1.0.safetensors",
+  textEncoder: "qwen_3_06b_base.safetensors",
+  clipType: "wan",
+  vae: "qwen_image_vae.safetensors",
+  /** Matches `generation.modelFamily` for Anima; the backend picks the workflow from it. */
+  architecture: "anima",
+  sampler: "er_sde",
+  scheduler: "sgm_uniform",
+  steps: 25,
+  cfg: 4.0,
+  denoise: 1.0,
+  /** Fixed across the whole set. Decimal string: 63-bit seeds exceed JS's safe-integer range. */
+  seed: "7243057331061028000",
+  width: 896,
+  height: 1152,
+  negativePrompt:
+    "worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, sepia, sensitive, nsfw, explicit",
+  /** One positive prompt per variant. `{artist_tag}` is the substitution marker. */
+  positivePrompts: [
+    "{artist_tag}, year 2025, newest, masterpiece, best quality, score_9, score_8, highres, safe, 1girl, hatsune miku, straight-on, cowboy shot, school, serafuku, fence, long sleeves, outdoors, hamburger, eating, blue sky, plant",
+    "{artist_tag}, year 2025, newest, masterpiece, best quality, score_9, score_8, highres, safe, 1girl, solo, umbrella, standing, holding umbrella, mouse girl, mouse ears, mouse tail, raincoat, yellow raincoat, rubber boots, yellow footwear, street, rain, raining, cowboy shot, black hair, long hair, blunt bangs, blunt ends, blue eyes, straight-on",
+  ],
+  /**
+   * How the CDN copy is encoded for delivery. Display-only: a locally
+   * generated preview is saved at full `width` x `height` in the user's
+   * configured output format.
+   */
+  delivery: { format: "AVIF", width: 720, height: 926, quality: "80 (4:2:0)" },
+} as const;
+
+export type ArtistPreviewVariant = 1 | 2;
+
+export interface ArtistPreviewStatus {
+  state: "idle" | "running" | "ready" | "unavailable";
+  /** Displayable object URL. Set only when `state === "ready"`. */
+  src?: string;
+  /** Recipe model filenames that are not installed. Set only when `state === "unavailable"`. */
+  missing?: string[];
+}
+
+/**
+ * Substitute the artist tag into a variant's positive prompt.
+ *
+ * Uses the RAW underscored tag with any leading "@" stripped, NOT
+ * `artistInsert.normalizeArtistTag()`, which turns underscores into spaces.
+ * The CDN previews were rendered with underscores; spaces tokenise
+ * differently and would produce a different image.
+ */
+export function artistPreviewPrompt(tag: string, variant: ArtistPreviewVariant): string {
+  const raw = tag.replace(/^@+/, "");
+  return ARTIST_PREVIEW_RECIPE.positivePrompts[variant - 1].replace("{artist_tag}", raw);
+}
+
+function basename(filename: string): string {
+  const normalized = filename.replace(/\\/g, "/");
+  const slash = normalized.lastIndexOf("/");
+  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
+}
+
+/**
+ * Recipe model files that are not installed, matched on basename because the
+ * model lists carry a folder prefix (`diffusion_models/...`, `unet/...`).
+ * An empty array means the recipe can run.
+ */
+export function missingRecipeModels(available: {
+  diffusionModels: string[];
+  textEncoders: string[];
+  vaes: string[];
+}): string[] {
+  const has = (list: string[], want: string) => list.some((f) => basename(f) === want);
+  const missing: string[] = [];
+  if (!has(available.diffusionModels, ARTIST_PREVIEW_RECIPE.unet)) {
+    missing.push(ARTIST_PREVIEW_RECIPE.unet);
+  }
+  if (!has(available.textEncoders, ARTIST_PREVIEW_RECIPE.textEncoder)) {
+    missing.push(ARTIST_PREVIEW_RECIPE.textEncoder);
+  }
+  if (!has(available.vaes, ARTIST_PREVIEW_RECIPE.vae)) {
+    missing.push(ARTIST_PREVIEW_RECIPE.vae);
+  }
+  return missing;
+}

--- a/src/lib/artist-gallery/store.svelte.ts
+++ b/src/lib/artist-gallery/store.svelte.ts
@@ -50,6 +50,11 @@ export class ArtistGalleryStore {
 
   showOnlyFavourites = $state(false);
   favouriteCategoryFilter = $state<"all" | "__uncat" | string>("all");
+  /**
+   * Show artists the model knows that have no CDN preview yet (issue #527).
+   * On by default: hiding them is what made them unfindable in the first place.
+   */
+  includeNoPreview = $state(true);
 
   /** Active lightbox entry, if any. */
   lightboxEntry = $state<ArtistEntry | null>(null);
@@ -74,10 +79,12 @@ export class ArtistGalleryStore {
 
   private static readonly GLOBAL_VARIANT_KEY = "artist-gallery-global-variant";
   private static readonly VARIANT_OVERRIDES_KEY = "artist-gallery-variant-overrides";
+  private static readonly INCLUDE_NO_PREVIEW_KEY = "artist-gallery-include-no-preview";
 
   constructor(manifestUrl: string) {
     this.client = createArtistGalleryClient({ manifestUrl, fetchImpl: cdnFetch });
     this.loadVariants();
+    this.loadIncludeNoPreview();
   }
 
   private loadVariants(): void {
@@ -110,6 +117,24 @@ export class ArtistGalleryStore {
         ArtistGalleryStore.VARIANT_OVERRIDES_KEY,
         JSON.stringify(this.variantOverrides),
       );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private loadIncludeNoPreview(): void {
+    try {
+      const raw = localStorage.getItem(ArtistGalleryStore.INCLUDE_NO_PREVIEW_KEY);
+      if (raw !== null) this.includeNoPreview = raw === "true";
+    } catch {
+      /* localStorage unavailable; the default (on) is fine */
+    }
+  }
+
+  setIncludeNoPreview(value: boolean): void {
+    this.includeNoPreview = value;
+    try {
+      localStorage.setItem(ArtistGalleryStore.INCLUDE_NO_PREVIEW_KEY, String(value));
     } catch {
       /* ignore */
     }
@@ -183,7 +208,10 @@ export class ArtistGalleryStore {
     }
     this.searchLoading = true;
     try {
-      const hits = await this.client.search(text, { limit: 50 });
+      const hits = await this.client.search(text, {
+        limit: 50,
+        requireImage: !this.includeNoPreview,
+      });
       if (seq === this.searchSeq) {
         this.results = hits;
       }

--- a/src/lib/artist-gallery/types.ts
+++ b/src/lib/artist-gallery/types.ts
@@ -57,6 +57,8 @@ export interface ArtistManifest {
   artistsWithImage: number;
   shards: ArtistManifestShardMeta[];
   searchIndex: { path: string; entries: number };
+  /** Present only on index releases that ship the no-preview fallback list. */
+  noPreviewIndex?: { path: string; entries: number };
   generatedAt: string;
 }
 
@@ -81,6 +83,19 @@ export interface ArtistSearchHit {
   images?: ArtistImage[];
 }
 
+/**
+ * A raw row of `no-preview.json`: an artist the model knows that the image
+ * set never covered. The client synthesises an `ArtistSearchHit` from this
+ * with `hasImage: false`.
+ */
+export interface NoPreviewEntry {
+  tag: string;
+  slug: string;
+  postCount: number;
+  belowThreshold?: boolean;
+  aliases?: string[];
+}
+
 export interface SearchOptions {
   limit?: number;
   /** Only return entries where `hasImage === true`. Default: true. */
@@ -96,6 +111,11 @@ export interface ArtistGalleryClient {
   /** Resolve only by direct shard lookup. Does not load the large search index fallback. */
   getArtistDirect(slugOrTag: string): Promise<ArtistEntry | null>;
   loadSearchIndex(): Promise<ArtistSearchHit[]>;
+  /**
+   * Artists with no CDN image, as synthesised hits (`hasImage: false`).
+   * Resolves to `[]` when the release predates the no-preview index.
+   */
+  loadNoPreviewHits(): Promise<ArtistSearchHit[]>;
   /** Prefix + contains + alias ranking mirrors src/lib/stores/autocomplete.svelte.ts. */
   search(query: string, opts?: SearchOptions): Promise<ArtistSearchHit[]>;
   /** Clear all in-memory caches (next call will re-fetch). */

--- a/src/lib/components/generation/GenerateButton.svelte
+++ b/src/lib/components/generation/GenerateButton.svelte
@@ -25,6 +25,7 @@
   import { checkStyleTransferNodesReady } from "../../utils/styleTransferNodes.js";
   import { classifyGenerationError } from "../../utils/generationErrors.js";
   import { parseSegmentDetailPrompt, yoloTargetFilename } from "../../utils/promptSegmentDetail.js";
+  import { requestGeneration, trackGeneration, submitGeneration } from "../../utils/generationSubmit.js";
 
   interface Props {
     canvasEditorRef?: { getRasterComposite: () => HTMLCanvasElement | null; getMaskCanvas: () => HTMLCanvasElement | null };
@@ -55,24 +56,6 @@
     }
     return locale.t("generation.generate_tip");
   });
-
-  async function requestGeneration(params: GenerationParams) {
-    const result = await generate(params);
-    params.seed = result.seed;
-    return result;
-  }
-
-  function trackGeneration(params: GenerationParams, result: Awaited<ReturnType<typeof requestGeneration>>): string {
-    progress.enqueue(result.prompt_id, params.upscale_enabled, params.mode, params);
-    if (result.queue_position != null && result.queue_total != null) {
-      progress.updateQueuePosition(result.prompt_id, result.queue_position, result.queue_total);
-    }
-    return result.prompt_id;
-  }
-
-  async function submitGeneration(params: GenerationParams): Promise<string> {
-    return trackGeneration(params, await requestGeneration(params));
-  }
 
   async function ensureFacefixPythonDependency() {
     if (isBrowserMode) return;

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1838,6 +1838,8 @@ const de: Record<string, string> = {
   "artist_gallery.size_label": "Größe:",
   "artist_gallery.favourites_btn": "Favoriten",
   "artist_gallery.favourites_title": "Favoritenfilter ein-/ausblenden",
+  "artist_gallery.include_no_preview_btn": "Ohne Vorschau",
+  "artist_gallery.include_no_preview_title": "Künstler anzeigen, die das Modell kennt, für die es aber noch keine CDN-Vorschau gibt",
   "artist_gallery.manage_btn": "⚙ Verwalten",
   "artist_gallery.manage_title": "Kategorien verwalten, Favoriten importieren/exportieren",
   "artist_gallery.category_label": "Kategorie:",

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -2634,6 +2634,12 @@ const de: Record<string, string> = {
   "artist_gallery.variant_n": "Bild {n}",
 
   "artist_gallery.flip_variant_aria": "Bildvariante wechseln",
+  "artist_gallery.generate_preview_btn": "⚡ Erzeugen",
+  "artist_gallery.generate_preview_running": "Wird erzeugt…",
+  "artist_gallery.generate_preview_title": "Diese Vorschau lokal mit denselben Parametern wie die CDN-Vorschauen erzeugen",
+  "artist_gallery.generate_preview_missing": "Fehlende Modelle: {models}",
+  "artist_gallery.preview_queued": "Vorschau für {tag} in der Warteschlange",
+  "artist_gallery.preview_failed": "Vorschau-Erzeugung fehlgeschlagen: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Bild {n}",
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1956,6 +1956,8 @@ const en: Record<string, string> = {
   "artist_gallery.size_label": "Size:",
   "artist_gallery.favourites_btn": "Favourites",
   "artist_gallery.favourites_title": "Toggle favourites filter",
+  "artist_gallery.include_no_preview_btn": "No-preview",
+  "artist_gallery.include_no_preview_title": "Show artists the model knows that have no CDN preview yet",
   "artist_gallery.manage_btn": "⚙ Manage",
   "artist_gallery.manage_title": "Manage categories, import/export favourites",
   "artist_gallery.category_label": "Category:",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1995,6 +1995,12 @@ const en: Record<string, string> = {
   "artist_gallery.variant_label": "Variant",
   "artist_gallery.variant_n": "Image {n}",
   "artist_gallery.flip_variant_aria": "Flip image variant",
+  "artist_gallery.generate_preview_btn": "⚡ Generate",
+  "artist_gallery.generate_preview_running": "Generating…",
+  "artist_gallery.generate_preview_title": "Generate this preview locally with the same parameters the CDN previews used",
+  "artist_gallery.generate_preview_missing": "Missing models: {models}",
+  "artist_gallery.preview_queued": "Preview queued for {tag}",
+  "artist_gallery.preview_failed": "Preview generation failed: {error}",
 
   // Gen params modal
   "artist_gallery.gen_params.title": "Preview Generation Parameters",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1880,6 +1880,8 @@ const es: Record<string, string> = {
   "artist_gallery.size_label": "Tamaño:",
   "artist_gallery.favourites_btn": "Favoritos",
   "artist_gallery.favourites_title": "Alternar filtro de favoritos",
+  "artist_gallery.include_no_preview_btn": "Sin vista previa",
+  "artist_gallery.include_no_preview_title": "Mostrar artistas que el modelo conoce pero que aún no tienen vista previa en la CDN",
   "artist_gallery.manage_btn": "⚙ Gestionar",
   "artist_gallery.manage_title": "Gestionar categorías, importar/exportar favoritos",
   "artist_gallery.category_label": "Categoría:",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -2660,6 +2660,12 @@ const es: Record<string, string> = {
   "artist_gallery.variant_n": "Imagen {n}",
 
   "artist_gallery.flip_variant_aria": "Cambiar variante de imagen",
+  "artist_gallery.generate_preview_btn": "⚡ Generar",
+  "artist_gallery.generate_preview_running": "Generando…",
+  "artist_gallery.generate_preview_title": "Generar esta vista previa localmente con los mismos parámetros que las vistas previas de la CDN",
+  "artist_gallery.generate_preview_missing": "Modelos faltantes: {models}",
+  "artist_gallery.preview_queued": "Vista previa en cola para {tag}",
+  "artist_gallery.preview_failed": "Error al generar la vista previa: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Imagen {n}",
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -2657,6 +2657,12 @@ const fr: Record<string, string> = {
   "artist_gallery.variant_n": "Image {n}",
 
   "artist_gallery.flip_variant_aria": "Changer de variante d'image",
+  "artist_gallery.generate_preview_btn": "⚡ Générer",
+  "artist_gallery.generate_preview_running": "Génération…",
+  "artist_gallery.generate_preview_title": "Générer cet aperçu en local avec les mêmes paramètres que les aperçus du CDN",
+  "artist_gallery.generate_preview_missing": "Modèles manquants : {models}",
+  "artist_gallery.preview_queued": "Aperçu mis en file d'attente pour {tag}",
+  "artist_gallery.preview_failed": "Échec de la génération de l'aperçu : {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Image {n}",
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1842,6 +1842,8 @@ const fr: Record<string, string> = {
   "artist_gallery.size_label": "Taille :",
   "artist_gallery.favourites_btn": "Favoris",
   "artist_gallery.favourites_title": "Activer/désactiver le filtre favoris",
+  "artist_gallery.include_no_preview_btn": "Sans aperçu",
+  "artist_gallery.include_no_preview_title": "Afficher les artistes connus du modèle qui n'ont pas encore d'aperçu CDN",
   "artist_gallery.manage_btn": "⚙ Gérer",
   "artist_gallery.manage_title": "Gérer les catégories, importer/exporter les favoris",
   "artist_gallery.category_label": "Catégorie :",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -2631,6 +2631,12 @@ const it: Record<string, string> = {
   "artist_gallery.variant_n": "Immagine {n}",
 
   "artist_gallery.flip_variant_aria": "Cambia variante immagine",
+  "artist_gallery.generate_preview_btn": "⚡ Genera",
+  "artist_gallery.generate_preview_running": "Generazione…",
+  "artist_gallery.generate_preview_title": "Genera questa anteprima in locale con gli stessi parametri delle anteprime della CDN",
+  "artist_gallery.generate_preview_missing": "Modelli mancanti: {models}",
+  "artist_gallery.preview_queued": "Anteprima in coda per {tag}",
+  "artist_gallery.preview_failed": "Generazione dell'anteprima non riuscita: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Immagine {n}",
 

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1818,6 +1818,8 @@ const it: Record<string, string> = {
   "artist_gallery.size_label": "Dimensione:",
   "artist_gallery.favourites_btn": "Preferiti",
   "artist_gallery.favourites_title": "Attiva/disattiva filtro preferiti",
+  "artist_gallery.include_no_preview_btn": "Senza anteprima",
+  "artist_gallery.include_no_preview_title": "Mostra gli artisti noti al modello che non hanno ancora un'anteprima CDN",
   "artist_gallery.manage_btn": "⚙ Gestisci",
   "artist_gallery.manage_title": "Gestisci categorie, importa/esporta preferiti",
   "artist_gallery.category_label": "Categoria:",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -2656,6 +2656,12 @@ const ja: Record<string, string> = {
   "artist_gallery.variant_n": "画像{n}",
 
   "artist_gallery.flip_variant_aria": "画像バリエーションを切り替え",
+  "artist_gallery.generate_preview_btn": "⚡ 生成",
+  "artist_gallery.generate_preview_running": "生成中…",
+  "artist_gallery.generate_preview_title": "CDN プレビューと同じパラメータでこのプレビューをローカル生成します",
+  "artist_gallery.generate_preview_missing": "不足しているモデル: {models}",
+  "artist_gallery.preview_queued": "{tag} のプレビューをキューに追加しました",
+  "artist_gallery.preview_failed": "プレビューの生成に失敗しました: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ 画像{n}",
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1843,6 +1843,8 @@ const ja: Record<string, string> = {
   "artist_gallery.size_label": "サイズ:",
   "artist_gallery.favourites_btn": "お気に入り",
   "artist_gallery.favourites_title": "お気に入りフィルターの切り替え",
+  "artist_gallery.include_no_preview_btn": "プレビューなし",
+  "artist_gallery.include_no_preview_title": "モデルが認識しているが CDN プレビューがまだないアーティストを表示",
   "artist_gallery.manage_btn": "⚙ 管理",
   "artist_gallery.manage_title": "カテゴリの管理、お気に入りのインポート/エクスポート",
   "artist_gallery.category_label": "カテゴリ:",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1818,6 +1818,8 @@ const ko: Record<string, string> = {
   "artist_gallery.size_label": "크기:",
   "artist_gallery.favourites_btn": "즐겨찾기",
   "artist_gallery.favourites_title": "즐겨찾기 필터 토글",
+  "artist_gallery.include_no_preview_btn": "미리보기 없음",
+  "artist_gallery.include_no_preview_title": "모델이 알고 있지만 아직 CDN 미리보기가 없는 작가 표시",
   "artist_gallery.manage_btn": "⚙ 관리",
   "artist_gallery.manage_title": "카테고리 관리, 즐겨찾기 가져오기/보내기",
   "artist_gallery.category_label": "카테고리:",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -2631,6 +2631,12 @@ const ko: Record<string, string> = {
   "artist_gallery.variant_n": "이미지 {n}",
 
   "artist_gallery.flip_variant_aria": "이미지 변형 전환",
+  "artist_gallery.generate_preview_btn": "⚡ 생성",
+  "artist_gallery.generate_preview_running": "생성 중…",
+  "artist_gallery.generate_preview_title": "CDN 미리보기와 동일한 매개변수로 이 미리보기를 로컬에서 생성합니다",
+  "artist_gallery.generate_preview_missing": "누락된 모델: {models}",
+  "artist_gallery.preview_queued": "{tag} 미리보기를 대기열에 추가했습니다",
+  "artist_gallery.preview_failed": "미리보기 생성 실패: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ 이미지 {n}",
 

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1954,6 +1954,8 @@ const pl: Record<string, string> = {
   "artist_gallery.size_label": "Rozmiar:",
   "artist_gallery.favourites_btn": "Ulubione",
   "artist_gallery.favourites_title": "Przełącz filtr ulubionych",
+  "artist_gallery.include_no_preview_btn": "Bez podglądu",
+  "artist_gallery.include_no_preview_title": "Pokaż artystów znanych modelowi, którzy nie mają jeszcze podglądu w CDN",
   "artist_gallery.manage_btn": "⚙ Zarządzaj",
   "artist_gallery.manage_title": "Zarządzaj kategoriami, importuj/eksportuj ulubione",
   "artist_gallery.category_label": "Kategoria:",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1993,6 +1993,12 @@ const pl: Record<string, string> = {
   "artist_gallery.variant_label": "Wariant",
   "artist_gallery.variant_n": "Obraz {n}",
   "artist_gallery.flip_variant_aria": "Przełącz wariant obrazu",
+  "artist_gallery.generate_preview_btn": "⚡ Generuj",
+  "artist_gallery.generate_preview_running": "Generowanie…",
+  "artist_gallery.generate_preview_title": "Wygeneruj ten podgląd lokalnie z tymi samymi parametrami co podglądy w CDN",
+  "artist_gallery.generate_preview_missing": "Brakujące modele: {models}",
+  "artist_gallery.preview_queued": "Podgląd dla {tag} dodany do kolejki",
+  "artist_gallery.preview_failed": "Generowanie podglądu nie powiodło się: {error}",
 
   // Gen params modal
   "artist_gallery.gen_params.title": "Parametry generowania podglądu",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1817,6 +1817,8 @@ const pt: Record<string, string> = {
   "artist_gallery.size_label": "Tamanho:",
   "artist_gallery.favourites_btn": "Favoritos",
   "artist_gallery.favourites_title": "Alternar filtro de favoritos",
+  "artist_gallery.include_no_preview_btn": "Sem pré-visualização",
+  "artist_gallery.include_no_preview_title": "Mostrar artistas que o modelo conhece mas que ainda não têm pré-visualização na CDN",
   "artist_gallery.manage_btn": "⚙ Gerir",
   "artist_gallery.manage_title": "Gerir categorias, importar/exportar favoritos",
   "artist_gallery.category_label": "Categoria:",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -2632,6 +2632,12 @@ const pt: Record<string, string> = {
   "artist_gallery.variant_n": "Imagem {n}",
 
   "artist_gallery.flip_variant_aria": "Alternar variante de imagem",
+  "artist_gallery.generate_preview_btn": "⚡ Gerar",
+  "artist_gallery.generate_preview_running": "A gerar…",
+  "artist_gallery.generate_preview_title": "Gerar esta pré-visualização localmente com os mesmos parâmetros das pré-visualizações da CDN",
+  "artist_gallery.generate_preview_missing": "Modelos em falta: {models}",
+  "artist_gallery.preview_queued": "Pré-visualização em fila para {tag}",
+  "artist_gallery.preview_failed": "Falha ao gerar a pré-visualização: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Imagem {n}",
 

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1818,6 +1818,8 @@ const ru: Record<string, string> = {
   "artist_gallery.size_label": "Размер:",
   "artist_gallery.favourites_btn": "Избранное",
   "artist_gallery.favourites_title": "Переключить фильтр избранного",
+  "artist_gallery.include_no_preview_btn": "Без превью",
+  "artist_gallery.include_no_preview_title": "Показывать художников, известных модели, но пока без превью в CDN",
   "artist_gallery.manage_btn": "⚙ Управление",
   "artist_gallery.manage_title": "Управление категориями, импорт/экспорт избранного",
   "artist_gallery.category_label": "Категория:",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -2631,6 +2631,12 @@ const ru: Record<string, string> = {
   "artist_gallery.variant_n": "Изображение {n}",
 
   "artist_gallery.flip_variant_aria": "Сменить вариант изображения",
+  "artist_gallery.generate_preview_btn": "⚡ Создать",
+  "artist_gallery.generate_preview_running": "Создание…",
+  "artist_gallery.generate_preview_title": "Создать это превью локально с теми же параметрами, что и превью в CDN",
+  "artist_gallery.generate_preview_missing": "Отсутствуют модели: {models}",
+  "artist_gallery.preview_queued": "Превью для {tag} добавлено в очередь",
+  "artist_gallery.preview_failed": "Не удалось создать превью: {error}",
 
   "artist_gallery.lightbox.flip": "⇄ Изображение {n}",
 

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1818,6 +1818,8 @@ const zhTw: Record<string, string> = {
   "artist_gallery.size_label": "大小：",
   "artist_gallery.favourites_btn": "收藏",
   "artist_gallery.favourites_title": "切換收藏篩選",
+  "artist_gallery.include_no_preview_btn": "無預覽",
+  "artist_gallery.include_no_preview_title": "顯示模型認識但 CDN 尚無預覽圖的繪師",
   "artist_gallery.manage_btn": "⚙ 管理",
   "artist_gallery.manage_title": "管理分類，匯入/匯出收藏",
   "artist_gallery.category_label": "分類：",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -2631,6 +2631,12 @@ const zhTw: Record<string, string> = {
   "artist_gallery.variant_n": "圖片 {n}",
 
   "artist_gallery.flip_variant_aria": "切換圖片變體",
+  "artist_gallery.generate_preview_btn": "⚡ 產生",
+  "artist_gallery.generate_preview_running": "產生中…",
+  "artist_gallery.generate_preview_title": "使用與 CDN 預覽圖相同的參數在本機產生此預覽圖",
+  "artist_gallery.generate_preview_missing": "缺少模型：{models}",
+  "artist_gallery.preview_queued": "已將 {tag} 的預覽圖加入佇列",
+  "artist_gallery.preview_failed": "預覽圖產生失敗：{error}",
 
   "artist_gallery.lightbox.flip": "⇄ 圖片 {n}",
 

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1859,6 +1859,8 @@ const zh: Record<string, string> = {
   "artist_gallery.size_label": "大小：",
   "artist_gallery.favourites_btn": "收藏",
   "artist_gallery.favourites_title": "切换收藏筛选",
+  "artist_gallery.include_no_preview_btn": "无预览",
+  "artist_gallery.include_no_preview_title": "显示模型认识但 CDN 尚无预览图的画师",
   "artist_gallery.manage_btn": "⚙ 管理",
   "artist_gallery.manage_title": "管理分类，导入/导出收藏",
   "artist_gallery.category_label": "分类：",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -2632,6 +2632,12 @@ const zh: Record<string, string> = {
   "artist_gallery.variant_n": "图片 {n}",
 
   "artist_gallery.flip_variant_aria": "切换图片变体",
+  "artist_gallery.generate_preview_btn": "⚡ 生成",
+  "artist_gallery.generate_preview_running": "生成中…",
+  "artist_gallery.generate_preview_title": "使用与 CDN 预览图相同的参数在本地生成此预览图",
+  "artist_gallery.generate_preview_missing": "缺少模型：{models}",
+  "artist_gallery.preview_queued": "已将 {tag} 的预览图加入队列",
+  "artist_gallery.preview_failed": "预览图生成失败：{error}",
 
   "artist_gallery.lightbox.flip": "⇄ 图片 {n}",
 

--- a/src/lib/stores/artistLocalPreviews.svelte.ts
+++ b/src/lib/stores/artistLocalPreviews.svelte.ts
@@ -1,0 +1,125 @@
+import type { ArtistPreviewVariant } from "../artist-gallery/previewRecipe.js";
+
+/**
+ * Locally generated artist previews.
+ *
+ * The CDN index ships a preview for ~42k artist tags; ~7.4k tags the model
+ * knows have none (issue #527). Those render as placeholder cards with a
+ * "generate this preview yourself" action, and the result is recorded here so
+ * the card shows the local image on later visits.
+ *
+ * Only the gallery filename is stored: gallery images live on disk as JXL and
+ * are resolved for display through `loadGalleryImageDisplay()`.
+ */
+
+interface LocalPreviewSlot {
+  p1?: string;
+  p2?: string;
+}
+
+const STORAGE_KEY = "artist-gallery-local-previews";
+
+function slotKey(variant: ArtistPreviewVariant): "p1" | "p2" {
+  return variant === 2 ? "p2" : "p1";
+}
+
+function runKey(slug: string, variant: ArtistPreviewVariant): string {
+  return `${slug}::p${variant}`;
+}
+
+class ArtistLocalPreviewsStore {
+  /** slug -> gallery filenames, one per variant. Persisted. */
+  previews = $state<Record<string, LocalPreviewSlot>>({});
+  /** `slug::pN` -> true while a generation is in flight. Not persisted. */
+  running = $state<Record<string, boolean>>({});
+
+  /** prompt_id -> target card. In-memory only: a queued job dies with the app. */
+  private pending = new Map<string, { slug: string; variant: ArtistPreviewVariant }>();
+
+  constructor() {
+    this.load();
+  }
+
+  private load(): void {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") return;
+      const clean: Record<string, LocalPreviewSlot> = {};
+      for (const [slug, slot] of Object.entries(parsed)) {
+        if (!slot || typeof slot !== "object") continue;
+        const s = slot as LocalPreviewSlot;
+        const next: LocalPreviewSlot = {};
+        if (typeof s.p1 === "string" && s.p1) next.p1 = s.p1;
+        if (typeof s.p2 === "string" && s.p2) next.p2 = s.p2;
+        if (next.p1 || next.p2) clean[slug] = next;
+      }
+      this.previews = clean;
+    } catch {
+      /* localStorage unavailable or corrupt; start empty */
+    }
+  }
+
+  private persist(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.previews));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  isRunning(slug: string, variant: ArtistPreviewVariant): boolean {
+    return this.running[runKey(slug, variant)] === true;
+  }
+
+  /** Mark a submitted generation so its finished images can be routed back. */
+  attach(promptId: string, slug: string, variant: ArtistPreviewVariant): void {
+    this.pending.set(promptId, { slug, variant });
+    this.running = { ...this.running, [runKey(slug, variant)]: true };
+  }
+
+  /** Claim the target for a finished prompt. Consumes the mapping. */
+  resolve(promptId: string): { slug: string; variant: ArtistPreviewVariant } | null {
+    const target = this.pending.get(promptId);
+    if (!target) return null;
+    this.pending.delete(promptId);
+    return target;
+  }
+
+  record(slug: string, variant: ArtistPreviewVariant, filename: string): void {
+    const slot = { ...(this.previews[slug] ?? {}), [slotKey(variant)]: filename };
+    this.previews = { ...this.previews, [slug]: slot };
+    this.clearRunning(slug, variant);
+    this.persist();
+  }
+
+  /** Drop a mapping whose file no longer loads (deleted from the gallery). */
+  forget(slug: string, variant: ArtistPreviewVariant): void {
+    const existing = this.previews[slug];
+    if (!existing) return;
+    const slot = { ...existing };
+    delete slot[slotKey(variant)];
+    const next = { ...this.previews };
+    if (slot.p1 || slot.p2) next[slug] = slot;
+    else delete next[slug];
+    this.previews = next;
+    this.clearRunning(slug, variant);
+    this.persist();
+  }
+
+  /** Generation failed or was cancelled: stop showing the spinner. */
+  fail(slug: string, variant: ArtistPreviewVariant): void {
+    this.clearRunning(slug, variant);
+  }
+
+  private clearRunning(slug: string, variant: ArtistPreviewVariant): void {
+    const key = runKey(slug, variant);
+    if (!(key in this.running)) return;
+    const next = { ...this.running };
+    delete next[key];
+    this.running = next;
+  }
+}
+
+export const artistLocalPreviews = new ArtistLocalPreviewsStore();

--- a/src/lib/stores/artistLocalPreviews.svelte.ts
+++ b/src/lib/stores/artistLocalPreviews.svelte.ts
@@ -113,6 +113,17 @@ class ArtistLocalPreviewsStore {
     this.clearRunning(slug, variant);
   }
 
+  /**
+   * Cancel all in-flight previews at once (queue cleared, execution error with
+   * no prompt_id). Drains `pending` and clears every `running` entry.
+   */
+  failAll(): void {
+    for (const { slug, variant } of this.pending.values()) {
+      this.clearRunning(slug, variant);
+    }
+    this.pending.clear();
+  }
+
   private clearRunning(slug: string, variant: ArtistPreviewVariant): void {
     const key = runKey(slug, variant);
     if (!(key in this.running)) return;

--- a/src/lib/utils/generationSubmit.ts
+++ b/src/lib/utils/generationSubmit.ts
@@ -1,0 +1,33 @@
+import { generate, type GenerateResponse } from "./api.js";
+import { progress } from "../stores/progress.svelte.js";
+import type { GenerationParams } from "../types/index.js";
+
+/**
+ * Submit + queue-tracking helpers shared by the main Generate button and any
+ * other caller that needs a generation to run through the normal progress
+ * queue (currently the artist gallery's local preview action).
+ *
+ * This lives in utils rather than a store: it only orchestrates an existing
+ * API wrapper and an existing store, and a store importing it would create a
+ * cycle with `progress`.
+ */
+
+export async function requestGeneration(params: GenerationParams): Promise<GenerateResponse> {
+  const result = await generate(params);
+  // The backend resolves seed "-1" to a concrete value; write it back so a
+  // caller reusing the same params object keeps the resolved seed.
+  params.seed = result.seed;
+  return result;
+}
+
+export function trackGeneration(params: GenerationParams, result: GenerateResponse): string {
+  progress.enqueue(result.prompt_id, params.upscale_enabled, params.mode, params);
+  if (result.queue_position != null && result.queue_total != null) {
+    progress.updateQueuePosition(result.prompt_id, result.queue_position, result.queue_total);
+  }
+  return result.prompt_id;
+}
+
+export async function submitGeneration(params: GenerationParams): Promise<string> {
+  return trackGeneration(params, await requestGeneration(params));
+}


### PR DESCRIPTION
## Summary

Artist tags that exist in the Anima vocabulary but never got a CDN preview image were completely invisible in the style explorer. `anima-tags.json` carries 49,623 artist tags at p >= 50, the CDN preview index carries 42,197, so 7,415 tags (15 percent) had no way to be found. `search()` read only `search.json` with `requireImage` defaulting to true and no fallback, so those tags returned nothing even on an exact-name search.

This branch does two things:

1. Makes the missing tags visible and searchable as placeholder cards, behind an opt-in toggle that persists in the store.
2. Adds a per-card "generate this preview yourself" action that reproduces the exact parameters the CDN previews were made with, runs the generation locally, and renders the result on the card.

The recipe is pinned in one module (`src/lib/artist-gallery/previewRecipe.ts`) and is the same source of truth the existing "generation parameters" modal reads from, so the local render and the CDN render cannot drift apart. If the recipe's models are not installed, the button surfaces which ones are missing instead of failing at submit time.

Changes by area:

- `scripts/r2_build_indices.py` emits `indices/no-preview.json` alongside `search.json` (the upload script already globs the indices directory, so no upload change was needed).
- `src/lib/artist-gallery/` gains the no-preview loader and merge, the store toggle, the placeholder cards, the shared recipe module, and the Generate button.
- `src/lib/utils/generationSubmit.ts` is a behaviour-preserving extraction of the submit helpers out of `GenerateButton.svelte` so the gallery can reuse them.
- `src/lib/stores/artistLocalPreviews.svelte.ts` tracks locally generated previews. It stores gallery filenames, not blob URLs, and defers decoding to `loadGalleryImageDisplay()`.
- `src/App.svelte` wires the lifecycle and clears in-flight state on execution errors and queue cancellation.

One deployment note: the live CDN has no `no-preview.json` yet, so this is a no-op on production data (one console warning, result cached, fetched once per session) until the index is rebuilt with the updated script.

On the three tags from the report: `nuri Kazuya` and `iwamoto tatsurou` become visible with this change. `hagakure kurage` is a true negative, it is not in the Anima vocabulary at all, so no amount of index work will surface it.

## Linked issue

Closes #527

## How this fits the project scope

Straightforward fix to an existing feature (the built-in artist style explorer) plus a local-generation action that reuses the app's own generation pipeline. No new subsystems, no new dependencies, no new remote origins.

## Guideline checklist

- [x] i18n: any new user-facing strings are added to ALL files in `src/lib/locales/`, with matching `{placeholder}` names.
- [x] a11y: interactive elements are keyboard- and screen-reader-accessible.
- [x] I ran `npm run check` locally and addressed issues in the files I changed.
- [x] This change is within the scope described in `SCOPE.md`.

Verification: `npm run build` clean, `npm run check` at the pre-existing 6-error baseline with zero new errors in any touched file, `cargo test` 187 passed / 0 failed (no Rust changes in this branch), i18n parity confirmed for all 8 new keys across all 12 locale files.
