### PR TITLE
v2.0.1: gallery video picker, Model Stack view, and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## What's New in v2.0.1
+
+### New features
+- **Pick video frames straight from the gallery**: "Make video" and "Add reference" now show up on the lightbox, the session hover bar, and the context menu for any still image, opening a gallery picker instead of requiring a file upload. A failed pick leaves whatever frame or reference was already set alone rather than clearing it.
+- **Model Stack shows the whole H3 tier**: the Models view now lists every file a tier can use, both DiT variants included, with a per-file download row, instead of only the variant currently selected.
+
+### Fixes
+- **Video first/last frame distortion**: a first or last frame image whose aspect ratio didn't match the output canvas is now pre-cropped to the canvas before generation, instead of being squashed or stretched to fit.
+- **Artist gallery: tags with no CDN preview are visible again**: 7,415 artist tags that exist in the vocabulary but never got a CDN preview image (15 percent of the total) were invisible in the style explorer. They now show as placeholder cards behind an opt-in toggle, with a "generate this preview yourself" action that renders the same recipe the CDN previews use, locally.
+- **Server build**: `video_export.rs` and `video_interpolate.rs` referenced `tauri` outside a `desktop`-feature gate, which broke the server-only binary build and skipped publishing it in v2.0.0's release CI. Fixed, and `cargo check --no-default-features --features server` is now a blocking gate in the pre-commit and release checks so it can't happen again silently.
+
+---
+
 ## What's New in v2.0.0
 
 MooshieUI generates video. That is the whole reason this is a 2.0 and not another point release: everything below is new surface area rather than a change to how images work, and image generation is untouched.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## What's New in v2.0.1
+
+### New features
+- **Pick video frames straight from the gallery**: "Make video" and "Add reference" now show up on the lightbox, the session hover bar, and the context menu for any still image, opening a gallery picker instead of requiring a file upload. A failed pick leaves whatever frame or reference was already set alone rather than clearing it.
+- **Model Stack shows the whole H3 tier**: the Models view now lists every file a tier can use, both DiT variants included, with a per-file download row, instead of only the variant currently selected.
+
+### Fixes
+- **Video first/last frame distortion**: a first or last frame image whose aspect ratio didn't match the output canvas is now pre-cropped to the canvas before generation, instead of being squashed or stretched to fit.
+- **Artist gallery: tags with no CDN preview are visible again**: 7,415 artist tags that exist in the vocabulary but never got a CDN preview image (15 percent of the total) were invisible in the style explorer. They now show as placeholder cards behind an opt-in toggle, with a "generate this preview yourself" action that renders the same recipe the CDN previews use, locally.
+- **Server build**: `video_export.rs` and `video_interpolate.rs` referenced `tauri` outside a `desktop`-feature gate, which broke the server-only binary build and skipped publishing it in v2.0.0's release CI. Fixed, and `cargo check --no-default-features --features server` is now a blocking gate in the pre-commit and release checks so it can't happen again silently.
+
+---
+
 ## What's New in v2.0.0
 
 MooshieUI generates video. That is the whole reason this is a 2.0 and not another point release: everything below is new surface area rather than a change to how images work, and image generation is untouched.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v2.0.1

### New features
- Gallery video picker: make-video/add-reference directly from the lightbox and hover bar, plus still-image context menu support
- Model Stack view: full tier listing (both DiT variants, text encoder, both VAEs) for the H3 video model stack

### Fixes
- Video generation no longer distorts the first/last frame; frames are pre-cropped to canvas before encoding
- Artist gallery now shows artists with no CDN preview (opt-in placeholder cards) and lets users generate the preview locally
- Server build (`--no-default-features --features server`) no longer fails to compile: `tauri` references are now gated behind the `desktop` feature in video export/interpolate

## Repo hygiene / bot triage (steps 1-2)
- No conflicting `release/v*` branches; one unrelated open PR (#564, ComfyUI bump) is out of scope for this patch and not blocking
- No unresolved bot review comments on the four PRs merged since v2.0.0 (#561, #562, #563, #565)

## Build validation
- `npm run build`, `cargo check` (desktop), `cargo check --no-default-features --features server`, and `cargo test` all pass with no new warnings or regressions