### PR TITLE
v2.0.2: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v2.0.2
+
+### Fixes
+- **Video generation now has a seed control**: video mode shared the same seed as image generation but had no way to see or change it, so a seed pinned earlier (metadata import, "Use Last Seed", or just a saved session) silently stuck to every video afterwards. Video settings now has the same seed field, "Rng" toggle and "Last" button as image generation.
+- **Regenerating a video with unchanged settings could silently do nothing**: the video save node had no cache-bypass, so when every input matched the previous run (guaranteed by the seed bug above, or whenever a seed is pinned on purpose), ComfyUI's execution cache skipped the whole pipeline and the app was left showing the previous clip instead of a new one.
+
+---
+
 ## What's New in v2.0.1
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v2.0.2
+
+### Fixes
+- **Video generation now has a seed control**: video mode shared the same seed as image generation but had no way to see or change it, so a seed pinned earlier (metadata import, "Use Last Seed", or just a saved session) silently stuck to every video afterwards. Video settings now has the same seed field, "Rng" toggle and "Last" button as image generation.
+- **Regenerating a video with unchanged settings could silently do nothing**: the video save node had no cache-bypass, so when every input matched the previous run (guaranteed by the seed bug above, or whenever a seed is pinned on purpose), ComfyUI's execution cache skipped the whole pipeline and the app was left showing the previous clip instead of a new one.
+
+---
+
 ## What's New in v2.0.1
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/mooshie_nodes.py
+++ b/src-tauri/src/comfyui/mooshie_nodes.py
@@ -801,6 +801,14 @@ class MooshieSaveVideo:
         PromptServer.instance.send_sync(MOOSHIE_VIDEO_EVENT_TYPE, payload)
         return {"ui": {"images": []}}
 
+    @classmethod
+    def IS_CHANGED(cls, video, filename_prefix="mooshie_video", metadata_json=""):
+        # Always re-execute — output nodes should never be cached. Without this,
+        # a regenerate with identical inputs (e.g. a pinned seed) cache-hits the
+        # whole upstream chain: save_video() never runs, no new file or event is
+        # produced, and the UI is left showing the previous video.
+        return float("nan")
+
 
 _MODEL_EXTENSIONS = (".safetensors", ".sft", ".ckpt", ".pt", ".pth", ".bin")
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/video/VideoSettingsPanel.svelte
+++ b/src/lib/components/video/VideoSettingsPanel.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { generation } from "../../stores/generation.svelte.js";
   import { connection } from "../../stores/connection.svelte.js";
+  import { progress } from "../../stores/progress.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
   import { models } from "../../stores/models.svelte.js";
   import {
@@ -136,6 +137,7 @@
   const refSlotsFree = $derived(videoReferenceSlotsFree());
 
   const dimensions = $derived(generation.videoDimensions);
+  let randomSeed = $derived(generation.seed === "-1");
 
   /** Highest filled reference slot, so the list grows one empty slot at a time. */
   const visibleRefSlots = $derived(
@@ -908,6 +910,55 @@
         : locale.t("generation.video.aspect_ratio_auto_empty")}
     </p>
   {/if}
+
+  <!-- Seed. Video shares `generation.seed` with image generation, but had no
+       control here to see or reset it, so a fixed seed picked up elsewhere
+       (typed in, "Use Last", a PNG metadata import) silently stuck to every
+       video generated afterwards with no way to tell why (#minimal repro: any
+       non "-1" value in the store never surfaces in this panel). -->
+  <div>
+    <label class="flex items-center justify-between text-xs text-neutral-400 mb-1">
+      <span>{locale.t('generation.sampler.seed')}<InfoTip text={locale.t('generation.sampler.seed_tip')} /></span>
+      <div class="flex items-center gap-1">
+        {#if progress.lastCompletedSeed != null}
+          <button
+            class="text-[10px] px-1.5 py-0.5 rounded bg-neutral-700 text-neutral-300 hover:bg-neutral-600 transition-colors"
+            onclick={() => {
+              generation.seed = progress.lastCompletedSeed!;
+              generation.saveSettings();
+            }}
+            title={locale.t('generation.sampler.seed_use_last_tip')}
+          >
+            {locale.t('generation.sampler.seed_use_last')}
+          </button>
+        {/if}
+        <button
+          class="text-[10px] px-1.5 py-0.5 rounded {randomSeed
+            ? 'bg-indigo-600 text-white'
+            : 'bg-neutral-700 text-neutral-300'} transition-colors"
+          onclick={() => {
+            generation.seed = randomSeed ? (progress.lastCompletedSeed ?? "0") : "-1";
+            generation.saveSettings();
+          }}
+        >
+          {locale.t('generation.sampler.seed_random')}
+        </button>
+      </div>
+    </label>
+    <input
+      type="text"
+      inputmode="numeric"
+      value={randomSeed ? '' : generation.seed}
+      placeholder={locale.t('generation.sampler.random_display')}
+      oninput={(e) => {
+        const digits = e.currentTarget.value.replace(/\D/g, '');
+        if (e.currentTarget.value !== digits) e.currentTarget.value = digits;
+        generation.seed = digits === '' ? "-1" : digits;
+        generation.saveSettings();
+      }}
+      class="w-full bg-neutral-800 border border-neutral-700 rounded-lg px-2 py-1.5 text-xs text-neutral-100 focus:outline-none focus:border-indigo-500 transition-colors"
+    />
+  </div>
 
   <!-- VRAM assessment. Two tiers off one estimate: sky when the pass fits with
        little headroom left (slower, because weights start moving over PCIe),


### PR DESCRIPTION
## What's New in v2.0.2

### Fixes
- Video generation now has a seed control: video mode shared the same seed as image generation but had no way to see or change it, so a seed pinned earlier (metadata import, "Use Last Seed", or a saved session) silently stuck to every video afterwards. Video settings now has the same seed field, "Rng" toggle and "Last" button as image generation.
- Regenerating a video with unchanged settings could silently do nothing: the video save node had no cache-bypass, so when every input matched the previous run (guaranteed by the seed bug above, or whenever a seed is pinned on purpose), ComfyUI's execution cache skipped the whole pipeline and the app was left showing the previous clip instead of a new one.