### PR TITLE
v2.0.3: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v2.0.3
+
+### Fixes and maintenance
+- **Custom node installs could fail on the Linux AppImage build**: the bundled AppImage runtime leaks its own `LD_LIBRARY_PATH` and `LD_PRELOAD` into every child process, so `git clone` for a required custom node could link against the AppImage's bundled `libssl`/`libpcre2` instead of the system ones and abort with a version mismatch. Node installs now strip the AppImage-specific environment before spawning `git`, `pip`, and `uv`.
+- **Wrong Wayland library picked up on Fedora-based distros (Nobara, RHEL, etc.)**: the search order for the bundled Wayland compatibility library checked `/usr/lib/` before `/usr/lib64/`, which is backwards on Fedora-family systems where `/usr/lib/` holds 32-bit compat stubs. That could preload a 32-bit library into a 64-bit process and produce a "wrong ELF class" failure. The search now checks the 64-bit path first.
+
+---
+
 ## What's New in v2.0.2
 
 ### Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v2.0.3
+
+### Fixes and maintenance
+- **Custom node installs could fail on the Linux AppImage build**: the bundled AppImage runtime leaks its own `LD_LIBRARY_PATH` and `LD_PRELOAD` into every child process, so `git clone` for a required custom node could link against the AppImage's bundled `libssl`/`libpcre2` instead of the system ones and abort with a version mismatch. Node installs now strip the AppImage-specific environment before spawning `git`, `pip`, and `uv`.
+- **Wrong Wayland library picked up on Fedora-based distros (Nobara, RHEL, etc.)**: the search order for the bundled Wayland compatibility library checked `/usr/lib/` before `/usr/lib64/`, which is backwards on Fedora-family systems where `/usr/lib/` holds 32-bit compat stubs. That could preload a 32-bit library into a 64-bit process and produce a "wrong ELF class" failure. The search now checks the 64-bit path first.
+
+---
+
 ## What's New in v2.0.2
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -48,6 +48,13 @@ pub(crate) fn std_command_no_window(program: &str) -> std::process::Command {
 }
 
 /// `tokio::process::Command` that does not flash a console window on Windows.
+///
+/// On Linux, when running inside an AppImage, also strips the AppImage's
+/// bundled `LD_LIBRARY_PATH`/`LD_PRELOAD` (and the AppImage-internal `PATH`
+/// entries) so spawned tools like `git`, `pip`, and `uv` link against the
+/// system's native libraries instead of the bundle's — a mismatch otherwise
+/// breaks `git clone` (`git-remote-https` fails to resolve `libssl`/`libcurl`
+/// symbols) for every custom-node install.
 pub(crate) fn tokio_command_no_window(
     program: impl AsRef<std::ffi::OsStr>,
 ) -> tokio::process::Command {
@@ -60,7 +67,32 @@ pub(crate) fn tokio_command_no_window(
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
+    #[cfg(target_os = "linux")]
+    strip_appimage_env(&mut cmd);
     cmd
+}
+
+/// Remove AppImage-bundled library/env leakage from a child process's
+/// environment. See [`tokio_command_no_window`] for why this matters.
+#[cfg(target_os = "linux")]
+pub(crate) fn strip_appimage_env(cmd: &mut tokio::process::Command) {
+    if std::env::var("APPIMAGE").is_err() {
+        return;
+    }
+    cmd.env_remove("LD_LIBRARY_PATH");
+    cmd.env_remove("LD_PRELOAD");
+    cmd.env_remove("PYTHONHOME");
+    cmd.env_remove("PYTHONPATH");
+    cmd.env_remove("PYTHONDONTWRITEBYTECODE");
+    cmd.env_remove("GDK_BACKEND");
+    // Preserve the real PATH but remove AppImage-internal paths
+    if let Ok(path) = std::env::var("PATH") {
+        let filtered: Vec<&str> = path
+            .split(':')
+            .filter(|p| !p.contains("/tmp/.mount_"))
+            .collect();
+        cmd.env("PATH", filtered.join(":"));
+    }
 }
 
 /// Detect whether the system has a Blackwell (compute capability 12.x) NVIDIA GPU.
@@ -1015,24 +1047,7 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
     // can interfere with Python/PyTorch. Clear them for the child process so it
     // uses the system's native libraries (CUDA, ROCm, etc.).
     #[cfg(target_os = "linux")]
-    {
-        if std::env::var("APPIMAGE").is_ok() {
-            cmd.env_remove("LD_LIBRARY_PATH");
-            cmd.env_remove("LD_PRELOAD");
-            cmd.env_remove("PYTHONHOME");
-            cmd.env_remove("PYTHONPATH");
-            cmd.env_remove("PYTHONDONTWRITEBYTECODE");
-            cmd.env_remove("GDK_BACKEND");
-            // Preserve the real PATH but remove AppImage-internal paths
-            if let Ok(path) = std::env::var("PATH") {
-                let filtered: Vec<&str> = path
-                    .split(':')
-                    .filter(|p| !p.contains("/tmp/.mount_"))
-                    .collect();
-                cmd.env("PATH", filtered.join(":"));
-            }
-        }
-    }
+    strip_appimage_env(&mut cmd);
 
     // Hide the console window on Windows so ComfyUI doesn't pop up a terminal
     #[cfg(target_os = "windows")]
@@ -1604,23 +1619,7 @@ pub async fn start_worker_process(
 
     // AppImage cleanup on Linux
     #[cfg(target_os = "linux")]
-    {
-        if std::env::var("APPIMAGE").is_ok() {
-            cmd.env_remove("LD_LIBRARY_PATH");
-            cmd.env_remove("LD_PRELOAD");
-            cmd.env_remove("PYTHONHOME");
-            cmd.env_remove("PYTHONPATH");
-            cmd.env_remove("PYTHONDONTWRITEBYTECODE");
-            cmd.env_remove("GDK_BACKEND");
-            if let Ok(path) = std::env::var("PATH") {
-                let filtered: Vec<&str> = path
-                    .split(':')
-                    .filter(|p| !p.contains("/tmp/.mount_"))
-                    .collect();
-                cmd.env("PATH", filtered.join(":"));
-            }
-        }
-    }
+    strip_appimage_env(&mut cmd);
 
     #[cfg(target_os = "windows")]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,15 +53,17 @@ fn fix_wayland_appimage_env() {
 
     // Search common library paths for the versioned libwayland-client.
     // Arch/CachyOS uses /usr/lib/, Debian/Ubuntu uses the multiarch path,
-    // Fedora/RHEL uses /usr/lib64/.
+    // Fedora/RHEL/Nobara uses /usr/lib64/ for the real 64-bit libs and
+    // /usr/lib/ for 32-bit multilib compat stubs — check /usr/lib64/ first
+    // so Fedora-family systems don't pick up a wrong-ELF-class 32-bit lib.
     let search_paths = [
-        "/usr/lib/libwayland-client.so.0",
-        "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
         "/usr/lib64/libwayland-client.so.0",
+        "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+        "/usr/lib/libwayland-client.so.0",
         // Unversioned fallback
-        "/usr/lib/libwayland-client.so",
-        "/usr/lib/x86_64-linux-gnu/libwayland-client.so",
         "/usr/lib64/libwayland-client.so",
+        "/usr/lib/x86_64-linux-gnu/libwayland-client.so",
+        "/usr/lib/libwayland-client.so",
     ];
 
     let wayland_lib = match search_paths

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Fix custom node installs failing on the Linux AppImage build: the bundled AppImage runtime leaked LD_LIBRARY_PATH/LD_PRELOAD into git/pip/uv child processes, causing them to link against the AppImage's bundled libssl/libpcre2 and fail. These env vars are now stripped before spawning those processes.
- Fix wrong library picked up on Fedora-based distros (Nobara, RHEL, etc.): the Wayland compat library search checked /usr/lib/ before /usr/lib64/, which is backwards on Fedora-family systems, causing a wrong ELF class failure. Search order now checks the 64-bit path first.
- Version bump to 2.0.3 (package.json, Cargo.toml, tauri.conf.json, Cargo.lock) and changelog updates.

## Test plan
- [x] cargo check (desktop feature set)
- [x] cargo check --no-default-features --features server
- [x] cargo fmt (no unexpected diffs)
- [x] cargo clippy --all-targets (no new warnings)
- [x] cargo test (188 passed, 0 failed, 1 ignored)