### PR TITLE
v2.0.4: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v2.0.4
+
+### Fixes and maintenance
+- **AppImage env leakage still reached some spawned processes**: v2.0.3 stripped the AppImage's bundled `LD_LIBRARY_PATH`/`LD_PRELOAD` from custom-node `git`/`pip`/`uv` calls, but the rest of the setup wizard (venv creation and repair, `nvidia-smi`/`rocm-smi` GPU probes), the video export subprocess, and the prompt assistant's local `llama-server` process still inherited it. Every process the app spawns on Linux now goes through the same AppImage-safe path.
+- **Gallery picker could lag on open with a large gallery**: "Make video" and "Add reference" mounted every image in the grid at once, which stalled on galleries with thousands of images. It now renders a bounded window and loads more as you scroll, and thumbnails no longer eagerly start downloading before they scroll into view.
+
+---
+
 ## What's New in v2.0.3
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v2.0.4
+
+### Fixes and maintenance
+- **AppImage env leakage still reached some spawned processes**: v2.0.3 stripped the AppImage's bundled `LD_LIBRARY_PATH`/`LD_PRELOAD` from custom-node `git`/`pip`/`uv` calls, but the rest of the setup wizard (venv creation and repair, `nvidia-smi`/`rocm-smi` GPU probes), the video export subprocess, and the prompt assistant's local `llama-server` process still inherited it. Every process the app spawns on Linux now goes through the same AppImage-safe path.
+- **Gallery picker could lag on open with a large gallery**: "Make video" and "Add reference" mounted every image in the grid at once, which stalled on galleries with thousands of images. It now renders a bounded window and loads more as you scroll, and thumbnails no longer eagerly start downloading before they scroll into view.
+
+---
+
 ## What's New in v2.0.3
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -37,6 +37,8 @@ pub(crate) fn parse_netstat_listening_pid(line: &str, port: u16) -> Option<u32> 
 }
 
 /// `std::process::Command` that does not flash a console window on Windows.
+///
+/// On Linux, also strips AppImage env leakage — see [`tokio_command_no_window`].
 pub(crate) fn std_command_no_window(program: &str) -> std::process::Command {
     let mut cmd = std::process::Command::new(program);
     #[cfg(windows)]
@@ -44,6 +46,8 @@ pub(crate) fn std_command_no_window(program: &str) -> std::process::Command {
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     }
+    #[cfg(target_os = "linux")]
+    strip_appimage_env_std(&mut cmd);
     cmd
 }
 
@@ -76,23 +80,48 @@ pub(crate) fn tokio_command_no_window(
 /// environment. See [`tokio_command_no_window`] for why this matters.
 #[cfg(target_os = "linux")]
 pub(crate) fn strip_appimage_env(cmd: &mut tokio::process::Command) {
-    if std::env::var("APPIMAGE").is_err() {
+    let Some(filtered_path) = appimage_env_overrides() else {
         return;
-    }
+    };
     cmd.env_remove("LD_LIBRARY_PATH");
     cmd.env_remove("LD_PRELOAD");
     cmd.env_remove("PYTHONHOME");
     cmd.env_remove("PYTHONPATH");
     cmd.env_remove("PYTHONDONTWRITEBYTECODE");
     cmd.env_remove("GDK_BACKEND");
-    // Preserve the real PATH but remove AppImage-internal paths
-    if let Ok(path) = std::env::var("PATH") {
-        let filtered: Vec<&str> = path
-            .split(':')
-            .filter(|p| !p.contains("/tmp/.mount_"))
-            .collect();
-        cmd.env("PATH", filtered.join(":"));
+    cmd.env("PATH", filtered_path);
+}
+
+/// [`strip_appimage_env`] twin for `std::process::Command` — used by blocking
+/// spawns like `nvidia-smi`/`rocm-smi` probes.
+#[cfg(target_os = "linux")]
+fn strip_appimage_env_std(cmd: &mut std::process::Command) {
+    let Some(filtered_path) = appimage_env_overrides() else {
+        return;
+    };
+    cmd.env_remove("LD_LIBRARY_PATH");
+    cmd.env_remove("LD_PRELOAD");
+    cmd.env_remove("PYTHONHOME");
+    cmd.env_remove("PYTHONPATH");
+    cmd.env_remove("PYTHONDONTWRITEBYTECODE");
+    cmd.env_remove("GDK_BACKEND");
+    cmd.env("PATH", filtered_path);
+}
+
+/// `None` when not running under an AppImage; otherwise the current `PATH`
+/// with AppImage-internal mount entries filtered out.
+#[cfg(target_os = "linux")]
+fn appimage_env_overrides() -> Option<String> {
+    if std::env::var("APPIMAGE").is_err() {
+        return None;
     }
+    let path = std::env::var("PATH").unwrap_or_default();
+    Some(
+        path.split(':')
+            .filter(|p| !p.contains("/tmp/.mount_"))
+            .collect::<Vec<_>>()
+            .join(":"),
+    )
 }
 
 /// Detect whether the system has a Blackwell (compute capability 12.x) NVIDIA GPU.
@@ -725,18 +754,12 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
                         let python_dir_str = python_dir.to_string_lossy().to_string();
                         let venv_str = config.venv_path.clone();
                         let uv_str = uv.to_string_lossy().to_string();
-                        let mut repair = tokio::process::Command::new(&uv_str);
+                        let mut repair = tokio_command_no_window(&uv_str);
                         repair
                             .args(["venv", &venv_str, "--python", "3.11", "--allow-existing"])
                             .env("UV_PYTHON_INSTALL_DIR", &python_dir_str)
                             .stdout(std::process::Stdio::null())
                             .stderr(std::process::Stdio::null());
-                        #[cfg(target_os = "windows")]
-                        {
-                            #[allow(unused_imports)]
-                            use std::os::windows::process::CommandExt;
-                            repair.creation_flags(0x08000000); // CREATE_NO_WINDOW
-                        }
                         match repair.status().await {
                             Ok(s) if s.success() => {
                                 log::info!("Venv repair succeeded");

--- a/src-tauri/src/commands/video_export.rs
+++ b/src-tauri/src/commands/video_export.rs
@@ -283,15 +283,11 @@ pub(crate) async fn probe_export_inner(state: &AppState) -> ExportCapability {
             }
         }
     };
-    let mut cmd = tokio::process::Command::new(&python);
+    let mut cmd = crate::comfyui::process::tokio_command_no_window(&python);
     cmd.arg("-c")
         .arg(PROBE_SCRIPT)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    #[cfg(target_os = "windows")]
-    {
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
     match cmd.output().await {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
@@ -428,16 +424,12 @@ pub(crate) async fn run_export(
         "metadata_json": source_metadata_json(source),
     });
 
-    let mut cmd = tokio::process::Command::new(&python);
+    let mut cmd = crate::comfyui::process::tokio_command_no_window(&python);
     cmd.arg("-")
         .arg(job.to_string())
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    #[cfg(target_os = "windows")]
-    {
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
     let mut child = cmd
         .spawn()
         .map_err(|e| AppError::Other(format!("Could not start Python: {e}")))?;

--- a/src-tauri/src/prompt_assistant/server.rs
+++ b/src-tauri/src/prompt_assistant/server.rs
@@ -4,8 +4,9 @@ use std::time::{Duration, Instant};
 
 use serde_json::json;
 use tokio::io::AsyncWriteExt;
-use tokio::process::{Child, Command};
+use tokio::process::Child;
 
+use crate::comfyui::process::tokio_command_no_window;
 use crate::error::AppError;
 
 /// Pinned llama.cpp release. Update this constant to roll the binary forward.
@@ -225,7 +226,7 @@ impl LlamaServer {
         let log_path = self.log_path();
         let log_file = std::fs::File::create(&log_path)
             .map_err(|e| AppError::LlmError(format!("Failed to create llama-server log: {e}")))?;
-        let mut cmd = Command::new(self.server_path());
+        let mut cmd = tokio_command_no_window(self.server_path());
         cmd.arg("-m")
             .arg(model_path)
             .arg("--host")
@@ -239,10 +240,6 @@ impl LlamaServer {
             .stderr(Stdio::from(log_file))
             // Ensure the child dies with the app even if unload() is skipped.
             .kill_on_drop(true);
-        #[cfg(windows)]
-        {
-            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        }
         let child = cmd
             .spawn()
             .map_err(|e| AppError::LlmError(format!("Failed to spawn llama-server: {e}")))?;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -154,9 +154,19 @@ fn hide_window(cmd: &mut tokio::process::Command) -> &mut tokio::process::Comman
     cmd.creation_flags(0x08000000) // CREATE_NO_WINDOW
 }
 
-#[cfg(not(target_os = "windows"))]
+// On Linux, spawned setup tooling (`uv`, the venv's `python`, `nvidia-smi`, ...)
+// must not inherit the AppImage's bundled `LD_LIBRARY_PATH`/`LD_PRELOAD` — see
+// `crate::comfyui::process::strip_appimage_env` for why that breaks symbol
+// resolution against the system's native libraries.
+#[cfg(target_os = "linux")]
 fn hide_window(cmd: &mut tokio::process::Command) -> &mut tokio::process::Command {
-    cmd // no-op on non-Windows
+    crate::comfyui::process::strip_appimage_env(cmd);
+    cmd
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn hide_window(cmd: &mut tokio::process::Command) -> &mut tokio::process::Command {
+    cmd // no-op on macOS
 }
 
 /// Run a command with hidden window, capturing stdout/stderr and streaming

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/gallery/GalleryPickerModal.svelte
+++ b/src/lib/components/gallery/GalleryPickerModal.svelte
@@ -21,17 +21,34 @@
   let tab = $state<"session" | "gallery">("session");
   let search = $state("");
   let picked = $state<OutputImage[]>([]);
+  let renderLimit = $state(60);
 
   // Videos cannot be a frame or a reference, so they never reach the grid.
   const sessionStills = $derived(gallery.sessionImages.filter((image) => !isVideoImage(image)));
   const galleryStills = $derived(gallery.images.filter((image) => !isVideoImage(image)));
 
-  const visible = $derived.by(() => {
+  const filtered = $derived.by(() => {
     const source = tab === "session" ? sessionStills : galleryStills;
     const query = search.toLowerCase().trim();
     if (!query) return source;
     return source.filter((image) => image.filename.toLowerCase().includes(query));
   });
+
+  // Only mount a bounded window of grid cells at a time — a full gallery can
+  // be thousands of images, and rendering every <img> at once on open is what
+  // caused the lag spike.
+  const visible = $derived(filtered.slice(0, renderLimit));
+
+  function loadMore(node: HTMLElement) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) renderLimit += 60;
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(node);
+    return { destroy() { observer.disconnect(); } };
+  }
 
   // Reset on each opening only. The body is untracked so a gallery refresh
   // mid-selection cannot wipe what the user has already ticked.
@@ -41,7 +58,14 @@
       tab = gallery.sessionImages.some((image) => !isVideoImage(image)) ? "session" : "gallery";
       search = "";
       picked = [];
+      renderLimit = 60;
     });
+  });
+
+  $effect(() => {
+    void tab;
+    void search;
+    renderLimit = 60;
   });
 
   function isPicked(image: OutputImage): boolean {
@@ -72,6 +96,16 @@
     event.stopPropagation();
     onclose();
   }
+
+  /** Teleport element to document.body so it escapes overflow/transform containers (mobile panel slide). */
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        node.remove();
+      },
+    };
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -80,6 +114,7 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
+    use:portal
     class="fixed inset-0 z-[10000] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
     onclick={onclose}
   >
@@ -130,7 +165,7 @@
       </div>
 
       <div class="flex-1 min-h-0 overflow-y-auto p-3">
-        {#if visible.length === 0}
+        {#if filtered.length === 0}
           <p class="py-8 text-center text-xs text-neutral-500">
             {locale.t("gallery.picker.empty")}
           </p>
@@ -165,6 +200,9 @@
               </button>
             {/each}
           </div>
+          {#if renderLimit < filtered.length}
+            <div use:loadMore class="h-4 w-full"></div>
+          {/if}
         {/if}
       </div>
 

--- a/src/lib/utils/lazyThumbnail.ts
+++ b/src/lib/utils/lazyThumbnail.ts
@@ -18,6 +18,7 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
   let current = opts;
   let retryCount = 0;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let hasEnteredView = false;
 
   function getSrc(): string | undefined {
     const img = current.image;
@@ -55,10 +56,14 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
 
   node.addEventListener("error", onError);
 
+  // Only sets src once the element actually scrolls into view (or already is,
+  // which IntersectionObserver reports on the first callback) — a grid full of
+  // off-screen thumbnails must not all start downloading on mount.
   const observer = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
         if (entry.isIntersecting) {
+          hasEnteredView = true;
           applySrc();
           observer.unobserve(node);
         }
@@ -67,8 +72,6 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
     { rootMargin: "100px" },
   );
 
-  // Session images already have url — apply immediately if visible
-  applySrc();
   observer.observe(node);
 
   return {
@@ -79,7 +82,8 @@ export function lazyThumbnail(node: HTMLImageElement, opts: LazyThumbnailOpts) {
         clearTimeout(retryTimer);
         retryTimer = null;
       }
-      applySrc();
+      // Off-screen elements stay unloaded until the observer reports intersection.
+      if (hasEnteredView) applySrc();
     },
     destroy() {
       observer.disconnect();


### PR DESCRIPTION
## What's New in v2.0.4

### Fixes and maintenance
- AppImage env leakage still reached some spawned processes: v2.0.3 stripped the AppImage's bundled LD_LIBRARY_PATH/LD_PRELOAD from custom-node git/pip/uv calls, but the rest of the setup wizard (venv creation and repair, nvidia-smi/rocm-smi GPU probes), the video export subprocess, and the prompt assistant's local llama-server process still inherited it. Every process the app spawns on Linux now goes through the same AppImage-safe path.
- Gallery picker could lag on open with a large gallery: "Make video" and "Add reference" mounted every image in the grid at once, which stalled on galleries with thousands of images. It now renders a bounded window and loads more as you scroll, and thumbnails no longer eagerly start downloading before they scroll into view.