### PR TITLE
v2.0.5: video node pre-flight check and Linux release build isolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,36 @@ jobs:
         run: cargo install cargo-audit --locked && cd src-tauri && cargo audit
         continue-on-error: true
 
-      - name: Build Tauri app (Linux)
+      # Built as three separate `tauri build` invocations (one process per format)
+      # instead of one `--target ... ` call with `targets: "all"`. Tauri's bundler
+      # binary-patches a __TAURI_BUNDLE_TYPE marker into the compiled binary per
+      # package type (deb/rpm/appimage) so the updater plugin on the user's machine
+      # knows which installer to run; when all three formats are built in a single
+      # process/job (as before), that patch/restore cycle shares mutable on-disk
+      # state across formats. Isolating each build to its own process — mirroring
+      # how the Windows job already isolates to `--bundles nsis` — removes that
+      # shared state entirely. AppImage is built first since it's the only format
+      # our updater manifest (latest.json) actually distributes.
+      - name: Build Tauri app (Linux, AppImage)
         if: runner.os != 'Windows'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npx tauri build --target ${{ matrix.target }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles appimage
+
+      - name: Build Tauri app (Linux, deb)
+        if: runner.os != 'Windows'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles deb
+
+      - name: Build Tauri app (Linux, rpm)
+        if: runner.os != 'Windows'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles rpm
 
       - name: Build Tauri app (Windows, NSIS only)
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v2.0.5
+
+### Fixes and maintenance
+- **Video generation could fail with a raw ComfyUI error instead of an actionable one**: the pre-flight check for required MiniMax H3 nodes only ran when a timeline drove the graph (the vendored Director pack). The native, non-timeline video path (image-to-video and reference-to-video) had no equivalent check, so a ComfyUI install missing that node, or older than 0.30, surfaced a raw prompt-validation error. Both video paths are now checked before submission, on the desktop app and the LAN web server alike.
+- **Linux release builds now build AppImage, deb, and rpm as separate steps**: isolates Tauri's per-format binary patching to its own process for each package type, matching how the Windows build already isolates to NSIS only.
+
+---
+
 ## What's New in v2.0.4
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v2.0.5
+
+### Fixes and maintenance
+- **Video generation could fail with a raw ComfyUI error instead of an actionable one**: the pre-flight check for required MiniMax H3 nodes only ran when a timeline drove the graph (the vendored Director pack). The native, non-timeline video path (image-to-video and reference-to-video) had no equivalent check, so a ComfyUI install missing that node, or older than 0.30, surfaced a raw prompt-validation error. Both video paths are now checked before submission, on the desktop app and the LAN web server alike.
+- **Linux release builds now build AppImage, deb, and rpm as separate steps**: isolates Tauri's per-format binary patching to its own process for each package type, matching how the Windows build already isolates to NSIS only.
+
+---
+
 ## What's New in v2.0.4
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/nodes.rs
+++ b/src-tauri/src/comfyui/nodes.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use super::process::tokio_command_no_window;
+use super::types::GenerationParams;
 
 #[derive(Clone, Copy)]
 struct RequiredCustomNodePackage {
@@ -154,6 +155,9 @@ pub const MISSING_RIFE_NODES_MARKER: &str = "Required RIFE custom nodes failed t
 /// Substring present in [`verify_required_h3_director_nodes`] error output.
 pub const MISSING_H3_DIRECTOR_NODES_MARKER: &str =
     "Required MiniMax H3 Director custom nodes failed to load";
+
+/// Substring present in [`verify_required_h3_native_nodes`] error output.
+pub const MISSING_H3_NATIVE_NODES_MARKER: &str = "Required MiniMax H3 video node failed to load";
 
 const REQUIRED_MOOSHIE_NODE_CLASSES: &[&str] = &[
     "MooshieSaveImage",
@@ -1046,6 +1050,76 @@ pub async fn verify_required_h3_director_nodes(
     ))
 }
 
+/// Native ComfyUI-core node class the non-timeline video path builds into the
+/// workflow for a given `video_variant` (see `templates::video::build`).
+fn required_h3_native_node_class(video_variant: &str) -> &'static str {
+    if video_variant == "fl2va" {
+        "MiniMaxH3ImageToVideo"
+    } else {
+        "MiniMaxH3ReferenceToVideo"
+    }
+}
+
+/// Verify ComfyUI exposes the native MiniMax H3 node the non-timeline video
+/// path depends on for `video_variant`.
+///
+/// Unlike [`verify_required_h3_director_nodes`], this class ships inside
+/// ComfyUI core itself (`comfy_extras/nodes_minimax_h3`, ComfyUI >= 0.30), not
+/// a package MooshieUI deploys — so a missing class here means the fix is
+/// updating ComfyUI, not restarting it.
+pub async fn verify_required_h3_native_nodes(
+    http_client: &reqwest::Client,
+    base_url: &str,
+    video_variant: &str,
+) -> Result<(), String> {
+    let node_class = required_h3_native_node_class(video_variant);
+
+    for attempt in 0..5 {
+        if object_info_has_node_class(http_client, base_url, node_class).await? {
+            log::info!("Verified required MiniMax H3 video node class ({node_class})");
+            return Ok(());
+        }
+        if attempt < 4 {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    Err(format!(
+        "{}: {}. This node ships inside ComfyUI itself (it is not a MooshieUI custom node), and requires ComfyUI 0.30 or newer. Open Settings and run \"Update ComfyUI\", then try again.",
+        MISSING_H3_NATIVE_NODES_MARKER, node_class
+    ))
+}
+
+/// Verify the MiniMax H3 video node(s) a `generate` call actually needs are
+/// loaded, before the workflow is submitted to ComfyUI.
+///
+/// A no-op outside video mode. Video mode branches into either the vendored
+/// Director package (when a timeline drives the graph) or ComfyUI's native H3
+/// node for the selected variant — same 0.30-or-newer requirement either way,
+/// just two different sources for the class. Both the Tauri `generate`
+/// command and the LAN web server `generate` route call this so neither can
+/// drift out of sync with what `templates::video::build` actually emits.
+pub async fn verify_required_h3_nodes_for_generation(
+    http_client: &reqwest::Client,
+    base_url: &str,
+    params: &GenerationParams,
+) -> Result<(), String> {
+    if params.mode != "video" {
+        return Ok(());
+    }
+
+    let timeline_drives = params
+        .video_timeline_data
+        .as_deref()
+        .is_some_and(|data| !data.trim().is_empty());
+
+    if timeline_drives {
+        verify_required_h3_director_nodes(http_client, base_url).await
+    } else {
+        verify_required_h3_native_nodes(http_client, base_url, &params.video_variant).await
+    }
+}
+
 /// Verify that ComfyUI loaded the MooshieUI custom node classes required by
 /// every generated workflow. If ComfyUI was already running when nodes were
 /// deployed to disk, the files exist but /object_info will still be missing
@@ -1490,6 +1564,26 @@ mod tests {
         assert_eq!(payload["kind"], "missing_mooshie_nodes");
         assert_eq!(payload["port"], 8188);
         assert!(payload["missing_nodes"].as_array().unwrap().len() == 1);
+    }
+
+    #[test]
+    fn native_h3_node_class_matches_video_variant() {
+        assert_eq!(
+            required_h3_native_node_class("fl2va"),
+            "MiniMaxH3ImageToVideo"
+        );
+        assert_eq!(
+            required_h3_native_node_class("ref2va"),
+            "MiniMaxH3ReferenceToVideo"
+        );
+        // Any other/unknown variant falls back to the ref2va node, matching
+        // `templates::video::build`'s `else` branch (guarded upstream by
+        // `validate_generation_params`, which rejects anything but the two
+        // known variants before this is ever reached).
+        assert_eq!(
+            required_h3_native_node_class("unknown"),
+            "MiniMaxH3ReferenceToVideo"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -41,21 +41,23 @@ pub async fn generate(
         )?;
     }
 
-    // The MiniMax H3 Director pack is verified here rather than at startup: it is
-    // video-only and needs ComfyUI >= 0.30, so an older or external server can be
-    // perfectly healthy for image generation without it. Checking on the timeline
-    // path alone keeps every other generation free of the round trip, and turns
-    // what would otherwise be a ComfyUI prompt-validation error into an
-    // actionable message.
-    if params
-        .video_timeline_data
-        .as_deref()
-        .is_some_and(|data| !data.trim().is_empty())
-    {
+    // The MiniMax H3 nodes are verified here rather than at startup: they are
+    // video-only and need ComfyUI >= 0.30, so an older or external server can be
+    // perfectly healthy for image generation without them. Checking only in video
+    // mode keeps every other generation free of the round trip, and turns what
+    // would otherwise be a raw ComfyUI prompt-validation error into an actionable
+    // message. mode == "video" always uses one of these nodes (native or,
+    // when a timeline drives the graph, the vendored Director) — see
+    // `templates::video::build`.
+    if params.mode == "video" {
         let base_url = { state.config.read().await.server_url.clone() };
-        crate::comfyui::nodes::verify_required_h3_director_nodes(&state.http_client, &base_url)
-            .await
-            .map_err(AppError::InvalidWorkflow)?;
+        crate::comfyui::nodes::verify_required_h3_nodes_for_generation(
+            &state.http_client,
+            &base_url,
+            &params,
+        )
+        .await
+        .map_err(AppError::InvalidWorkflow)?;
     }
 
     let mut params = params;

--- a/src-tauri/src/webserver.rs
+++ b/src-tauri/src/webserver.rs
@@ -2805,6 +2805,18 @@ async fn dispatch_command(
                 )
                 .map_err(|e| e.to_string())?;
             }
+            // Mirrors the same check in the Tauri `generate` command: catches a
+            // missing MiniMax H3 node before submission instead of surfacing
+            // ComfyUI's raw `missing_node_type` prompt-validation error.
+            if params.mode == "video" {
+                let base_url = state.base_url().await;
+                crate::comfyui::nodes::verify_required_h3_nodes_for_generation(
+                    &state.http_client,
+                    &base_url,
+                    &params,
+                )
+                .await?;
+            }
             let seed = if params.seed < 0 {
                 (rand::random::<u64>() >> 1) as i64
             } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v2.0.5

### Fixes and maintenance
- **Video generation could fail with a raw ComfyUI error instead of an actionable one**: the pre-flight check for required MiniMax H3 nodes only ran when a timeline drove the graph (the vendored Director pack). The native, non-timeline video path (image-to-video and reference-to-video) had no equivalent check, so a ComfyUI install missing that node, or older than 0.30, surfaced a raw prompt-validation error. Both video paths are now checked before submission, on the desktop app and the LAN web server alike.
- **Linux release builds now build AppImage, deb, and rpm as separate steps**: isolates Tauri's per-format binary patching to its own process for each package type, matching how the Windows build already isolates to NSIS only.

## Repo hygiene / bot triage
- No open PRs are release-blocking (14 open PRs are all routine dependabot version bumps, none touched by this release).
- No late bot comments found on the previous release PR (#582).
- No stale `release/v*` branches existed prior to this one.

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` (189 passed)
- [x] `cd src-tauri && cargo fmt --check`
- [x] `npm run build`