### PR TITLE
fix: Intel Arc GPU single-GPU correctness (VRAM detection, kernel cache persistence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the [Wiki](https://github.com/Mooshieblob1/MooshieUI/wiki) for the full feat
 ### Desktop (Windows/Linux)
 
 1. Download a release from [Releases](https://github.com/Mooshieblob1/MooshieUI/releases).
-2. Run the app. The setup wizard downloads uv, Python, ComfyUI, and PyTorch (GPU auto-detected) and installs MooshieUI's custom nodes - no Python or pip setup required.
+2. Run the app. The setup wizard downloads uv, Python, ComfyUI, and PyTorch (NVIDIA, AMD, or Intel Arc GPU auto-detected) and installs MooshieUI's custom nodes - no Python or pip setup required.
 3. Start generating; ComfyUI launches automatically.
 
 > ~5–10 GB disk, 5–15 minutes on first launch. macOS, Docker, and remote/cloud ComfyUI setups are covered in [Installation](https://github.com/Mooshieblob1/MooshieUI/wiki/Installation).

--- a/src-tauri/src/comfyui/process.rs
+++ b/src-tauri/src/comfyui/process.rs
@@ -536,6 +536,22 @@ fn attention_package_present(venv_path: &str, backend: &str) -> bool {
     false
 }
 
+/// (env var, target directory) pairs for persisted GPU kernel/compiler
+/// caches, given the shared cache base directory. MIOpen vars are no-ops
+/// off ROCm, the inductor/Triton vars are harmless on platforms that don't
+/// use them, and SYCL_CACHE_DIR/NEO_CACHE_DIR are the Intel XPU equivalents.
+/// Callers skip entries the user has already set explicitly.
+fn kernel_cache_targets(cache_base: &std::path::Path) -> [(&'static str, std::path::PathBuf); 6] {
+    [
+        ("TORCHINDUCTOR_CACHE_DIR", cache_base.join("torchinductor")),
+        ("TRITON_CACHE_DIR", cache_base.join("triton")),
+        ("MIOPEN_USER_DB_PATH", cache_base.join("miopen")),
+        ("MIOPEN_CUSTOM_CACHE_DIR", cache_base.join("miopen")),
+        ("SYCL_CACHE_DIR", cache_base.join("sycl")),
+        ("NEO_CACHE_DIR", cache_base.join("neo")),
+    ]
+}
+
 /// Spawn the ComfyUI process (or detect an already-running one).
 /// Returns immediately — does NOT wait for the server to become ready.
 pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppError> {
@@ -1034,34 +1050,32 @@ pub async fn start_comfyui_process(state: &AppState) -> Result<StartResult, AppE
     // compiling and autotuning kernels. This is most severe on AMD RDNA4
     // (gfx120x) with bleeding-edge ROCm, where MIOpen has no prebuilt kernel db
     // and does an exhaustive search, but it also affects the torch.compile /
-    // Triton path on CUDA. Those caches default to per-process or /tmp locations,
-    // so the compile cost is re-paid on every restart. Point them at a stable
-    // directory under the app data dir (the parent of the ComfyUI install) so the
-    // cost is paid once. Any value the user already set in the environment wins.
+    // Triton path on CUDA and Intel XPU's SYCL/NEO compiler caches. Those
+    // caches default to per-process or /tmp locations, so the compile cost is
+    // re-paid on every restart. Point them at a stable directory under the app
+    // data dir (the parent of the ComfyUI install) so the cost is paid once.
+    // Any value the user already set in the environment wins.
     {
         let cache_base = std::path::Path::new(&config.comfyui_path)
             .parent()
             .map(|p| p.join("kernel-cache"))
             .unwrap_or_else(|| std::env::temp_dir().join("mooshieui-kernel-cache"));
-        // (env var, subdir). MIOpen vars are no-ops off ROCm; the inductor/Triton
-        // vars are harmless on platforms that don't use them.
-        let caches: [(&str, &str); 4] = [
-            ("TORCHINDUCTOR_CACHE_DIR", "torchinductor"),
-            ("TRITON_CACHE_DIR", "triton"),
-            ("MIOPEN_USER_DB_PATH", "miopen"),
-            ("MIOPEN_CUSTOM_CACHE_DIR", "miopen"),
-        ];
-        for (var, subdir) in caches {
+        for (var, dir) in kernel_cache_targets(&cache_base) {
             if std::env::var_os(var).is_some() {
                 continue; // respect an explicit user override
             }
-            let dir = cache_base.join(subdir);
             match std::fs::create_dir_all(&dir) {
                 Ok(()) => {
                     cmd.env(var, &dir);
                 }
                 Err(e) => log::warn!("Could not create kernel cache dir {:?}: {}", dir, e),
             }
+        }
+        // Unlike CUDA/ROCm, Intel's SYCL runtime ships with persistent kernel
+        // caching disabled by default (SYCL_CACHE_PERSISTENT=0) — without this,
+        // SYCL_CACHE_DIR above has nothing to persist into.
+        if std::env::var_os("SYCL_CACHE_PERSISTENT").is_none() {
+            cmd.env("SYCL_CACHE_PERSISTENT", "1");
         }
         log::info!("Persistent kernel cache dir: {}", cache_base.display());
     }
@@ -1620,23 +1634,19 @@ pub async fn start_worker_process(
             .map(|p| p.join("kernel-cache"))
             .unwrap_or_else(|| std::env::temp_dir().join("mooshieui-kernel-cache"))
             .join(format!("gpu{}", worker.gpu_index));
-        let caches: [(&str, &str); 4] = [
-            ("TORCHINDUCTOR_CACHE_DIR", "torchinductor"),
-            ("TRITON_CACHE_DIR", "triton"),
-            ("MIOPEN_USER_DB_PATH", "miopen"),
-            ("MIOPEN_CUSTOM_CACHE_DIR", "miopen"),
-        ];
-        for (var, subdir) in caches {
+        for (var, dir) in kernel_cache_targets(&cache_base) {
             if std::env::var_os(var).is_some() {
                 continue; // respect an explicit user override
             }
-            let dir = cache_base.join(subdir);
             match std::fs::create_dir_all(&dir) {
                 Ok(()) => {
                     cmd.env(var, &dir);
                 }
                 Err(e) => log::warn!("Could not create kernel cache dir {:?}: {}", dir, e),
             }
+        }
+        if std::env::var_os("SYCL_CACHE_PERSISTENT").is_none() {
+            cmd.env("SYCL_CACHE_PERSISTENT", "1");
         }
     }
 
@@ -1978,7 +1988,7 @@ pub fn stop_all_workers_blocking(state: &AppState) {
 
 #[cfg(test)]
 mod tests {
-    use super::uses_configured_gpu_workers;
+    use super::{kernel_cache_targets, uses_configured_gpu_workers};
     use crate::config::{AppConfig, GpuWorkerConfig};
 
     #[test]
@@ -2008,5 +2018,28 @@ mod tests {
         });
 
         assert!(uses_configured_gpu_workers(&config));
+    }
+
+    #[test]
+    fn kernel_cache_targets_covers_all_backends_including_intel() {
+        let base = std::path::Path::new("/tmp/mooshie-kernel-cache-test");
+        let targets = kernel_cache_targets(base);
+        assert_eq!(targets.len(), 6);
+
+        let find = |var: &str| {
+            targets
+                .iter()
+                .find(|(v, _)| *v == var)
+                .map(|(_, d)| d.clone())
+        };
+        assert_eq!(
+            find("TORCHINDUCTOR_CACHE_DIR"),
+            Some(base.join("torchinductor"))
+        );
+        assert_eq!(find("TRITON_CACHE_DIR"), Some(base.join("triton")));
+        assert_eq!(find("MIOPEN_USER_DB_PATH"), Some(base.join("miopen")));
+        assert_eq!(find("MIOPEN_CUSTOM_CACHE_DIR"), Some(base.join("miopen")));
+        assert_eq!(find("SYCL_CACHE_DIR"), Some(base.join("sycl")));
+        assert_eq!(find("NEO_CACHE_DIR"), Some(base.join("neo")));
     }
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1523,6 +1523,33 @@ async fn step_install_attention_backend(
     }
 }
 
+/// Max VRAM in MB reported under a `/sys/class/drm`-shaped root, across all
+/// `card*/device` entries. Checks `mem_info_vram_total` (i915, and AMD's
+/// `amdgpu`) first, falling back to `tile0/vram0/total_bytes` (Intel's newer
+/// `xe` driver, default for Battlemage and increasingly used for Alchemist).
+/// No vendor filtering -- both paths only exist for dedicated VRAM in
+/// practice, matching the pre-existing (also unfiltered) behavior here.
+// Only called from the #[cfg(target_os = "linux")] block; tests exercise it
+// cross-platform, so the function is ungated but unused on non-Linux.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_vram_from_drm_root(root: &std::path::Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    let mut max_vram: u64 = 0;
+    for entry in entries.flatten() {
+        let device_dir = entry.path().join("device");
+        let bytes = std::fs::read_to_string(device_dir.join("mem_info_vram_total"))
+            .ok()
+            .or_else(|| std::fs::read_to_string(device_dir.join("tile0/vram0/total_bytes")).ok())
+            .and_then(|s| s.trim().parse::<u64>().ok());
+        if let Some(bytes) = bytes {
+            max_vram = max_vram.max(bytes / (1024 * 1024));
+        }
+    }
+    max_vram
+}
+
 /// Detect total GPU VRAM in megabytes. Returns 0 if detection fails.
 async fn detect_vram_mb() -> u64 {
     // NVIDIA: nvidia-smi reports MiB
@@ -1545,24 +1572,13 @@ async fn detect_vram_mb() -> u64 {
         }
     }
 
-    // AMD: sysfs exposes VRAM in bytes (Linux only)
+    // AMD (mem_info_vram_total) and Intel Arc (i915: mem_info_vram_total,
+    // xe: tile0/vram0/total_bytes) both expose VRAM via sysfs (Linux only).
     #[cfg(target_os = "linux")]
     {
-        if let Ok(entries) = std::fs::read_dir("/sys/class/drm") {
-            let mut max_vram: u64 = 0;
-            for entry in entries.flatten() {
-                let path = entry.path().join("device/mem_info_vram_total");
-                if path.exists() {
-                    if let Ok(val) = std::fs::read_to_string(&path) {
-                        if let Ok(bytes) = val.trim().parse::<u64>() {
-                            max_vram = max_vram.max(bytes / (1024 * 1024));
-                        }
-                    }
-                }
-            }
-            if max_vram > 0 {
-                return max_vram;
-            }
+        let max_vram = parse_vram_from_drm_root(std::path::Path::new("/sys/class/drm"));
+        if max_vram > 0 {
+            return max_vram;
         }
     }
 
@@ -2553,4 +2569,83 @@ pub async fn update_comfyui(
         target_ref: COMFYUI_REF.to_string(),
         method,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_vram_from_drm_root;
+    use std::fs;
+
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mooshieui-test-{}-{}",
+            name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parses_i915_mem_info_vram_total_path() {
+        let root = unique_temp_dir("i915");
+        let device_dir = root.join("card0").join("device");
+        fs::create_dir_all(&device_dir).unwrap();
+        fs::write(device_dir.join("mem_info_vram_total"), "17179869184").unwrap(); // 16 GiB
+        assert_eq!(parse_vram_from_drm_root(&root), 16384);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn parses_xe_tile0_vram0_total_bytes_path_when_mem_info_absent() {
+        let root = unique_temp_dir("xe");
+        let device_dir = root.join("card0").join("device");
+        let tile_dir = device_dir.join("tile0").join("vram0");
+        fs::create_dir_all(&tile_dir).unwrap();
+        fs::write(tile_dir.join("total_bytes"), "17179869184").unwrap(); // 16 GiB
+        assert_eq!(parse_vram_from_drm_root(&root), 16384);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn prefers_mem_info_vram_total_when_both_paths_present() {
+        let root = unique_temp_dir("both");
+        let device_dir = root.join("card0").join("device");
+        let tile_dir = device_dir.join("tile0").join("vram0");
+        fs::create_dir_all(&tile_dir).unwrap();
+        fs::write(device_dir.join("mem_info_vram_total"), "8589934592").unwrap(); // 8 GiB
+        fs::write(tile_dir.join("total_bytes"), "17179869184").unwrap(); // 16 GiB
+        assert_eq!(parse_vram_from_drm_root(&root), 8192);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn takes_max_across_multiple_cards() {
+        let root = unique_temp_dir("multi");
+        let card0 = root.join("card0").join("device");
+        let card1 = root.join("card1").join("device");
+        fs::create_dir_all(&card0).unwrap();
+        fs::create_dir_all(&card1).unwrap();
+        fs::write(card0.join("mem_info_vram_total"), "8589934592").unwrap(); // 8 GiB
+        fs::write(card1.join("mem_info_vram_total"), "17179869184").unwrap(); // 16 GiB
+        assert_eq!(parse_vram_from_drm_root(&root), 16384);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn returns_zero_when_no_vram_files_present() {
+        let root = unique_temp_dir("empty");
+        fs::create_dir_all(root.join("card0").join("device")).unwrap();
+        assert_eq!(parse_vram_from_drm_root(&root), 0);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn returns_zero_when_root_does_not_exist() {
+        let root = std::env::temp_dir().join("mooshieui-test-nonexistent-drm-root");
+        assert_eq!(parse_vram_from_drm_root(&root), 0);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix VRAM detection on Intel Arc GPUs using the newer `xe` Linux kernel driver (default for Battlemage/B-series), which previously reported 0 VRAM and silently corrupted hardware-tier recommendations
- Fix Intel SYCL/DPC++ kernel cache persistence for ComfyUI XPU workers, which previously recompiled every kernel from scratch on each launch since `SYCL_CACHE_PERSISTENT` defaults to off
- Name NVIDIA, AMD, and Intel Arc explicitly in the README's GPU auto-detection line

Multi-GPU orchestration for Intel is explicitly out of scope (separate future track): `detect_gpus()` remains `nvidia-smi`-only, and per-worker device pinning (`ZE_AFFINITY_MASK`/`ONEAPI_DEVICE_SELECTOR`) is not addressed here.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 196 passed, 0 failed, 1 ignored
- [x] `cargo check` (desktop, default features) — clean
- [x] `cargo check --no-default-features --features server` — clean (pre-existing warnings only)
- [x] `npm run build` — clean
- [x] Per-task code review (3/3 approved, no Critical/Important findings) and final whole-branch review (opus, Ready to merge: Yes)