### PR TITLE
v2.0.6: Intel Arc GPU fixes and local LLM auto-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v2.0.6
+
+### Fixes and maintenance
+- **Intel Arc GPUs on the newer `xe` kernel driver reported 0 VRAM**: Battlemage/B-series Arc GPUs default to the `xe` driver on Linux, which VRAM detection didn't account for, so it silently corrupted hardware-tier recommendations. Detection now covers both the legacy `i915` and newer `xe` drivers.
+- **Intel SYCL/DPC++ kernels recompiled from scratch on every ComfyUI XPU launch**: `SYCL_CACHE_PERSISTENT` defaults to off, so kernel cache persistence wasn't actually enabled for Intel Arc workers. It's now set explicitly, cutting repeat startup time.
+- **Enhance, Compose, and prompt rewrite could hang on a stopped local LLM server**: if the configured Ollama or LM Studio endpoint wasn't running, requests would just fail instead of trying to start it. The app now makes a best-effort attempt to wake the server (`ollama list` / `lms server start`, 20s timeout) before giving up, skipped automatically if the endpoint is already up or not local.
+
+---
+
 ## What's New in v2.0.5
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v2.0.6
+
+### Fixes and maintenance
+- **Intel Arc GPUs on the newer `xe` kernel driver reported 0 VRAM**: Battlemage/B-series Arc GPUs default to the `xe` driver on Linux, which VRAM detection didn't account for, so it silently corrupted hardware-tier recommendations. Detection now covers both the legacy `i915` and newer `xe` drivers.
+- **Intel SYCL/DPC++ kernels recompiled from scratch on every ComfyUI XPU launch**: `SYCL_CACHE_PERSISTENT` defaults to off, so kernel cache persistence wasn't actually enabled for Intel Arc workers. It's now set explicitly, cutting repeat startup time.
+- **Enhance, Compose, and prompt rewrite could hang on a stopped local LLM server**: if the configured Ollama or LM Studio endpoint wasn't running, requests would just fail instead of trying to start it. The app now makes a best-effort attempt to wake the server (`ollama list` / `lms server start`, 20s timeout) before giving up, skipped automatically if the endpoint is already up or not local.
+
+---
+
 ## What's New in v2.0.5
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v2.0.6

### Fixes and maintenance
- **Intel Arc GPUs on the newer `xe` kernel driver reported 0 VRAM**: Battlemage/B-series Arc GPUs default to the `xe` driver on Linux, which VRAM detection didn't account for, so it silently corrupted hardware-tier recommendations. Detection now covers both the legacy `i915` and newer `xe` drivers.
- **Intel SYCL/DPC++ kernels recompiled from scratch on every ComfyUI XPU launch**: `SYCL_CACHE_PERSISTENT` defaults to off, so kernel cache persistence wasn't actually enabled for Intel Arc workers. It's now set explicitly, cutting repeat startup time.
- **Enhance, Compose, and prompt rewrite could hang on a stopped local LLM server**: if the configured Ollama or LM Studio endpoint wasn't running, requests would just fail instead of trying to start it. The app now makes a best-effort attempt to wake the server (`ollama list` / `lms server start`, 20s timeout) before giving up, skipped automatically if the endpoint is already up or not local.

## Bot triage
No bot comments found on the two source PRs (#584, #585) merged since v2.0.5, and no release-blocking findings on other open PRs.

## Test plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features server`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 198 passed, 0 failed
- [x] `npm run build`