### PR TITLE
fix(video-export): raise Discord free attachment limit to 20 MB

### DIFF
--- a/src-tauri/src/commands/video_export.rs
+++ b/src-tauri/src/commands/video_export.rs
@@ -162,7 +162,7 @@ pub fn supports_audio(format: &str, loop_mode: &str) -> bool {
 /// An unrecognised or absent target never produces a hint.
 pub fn over_size_limit(bytes: u64, target: &str) -> bool {
     match target {
-        "discord" => bytes > 10 * 1024 * 1024,
+        "discord" => bytes > 20 * 1024 * 1024,
         "nitro" => bytes > 500 * 1024 * 1024,
         _ => false,
     }
@@ -812,10 +812,10 @@ mod tests {
 
     #[test]
     fn size_limits_follow_the_platform_table() {
-        let ten_mb = 10 * 1024 * 1024;
-        assert!(!over_size_limit(ten_mb, "discord"));
-        assert!(over_size_limit(ten_mb + 1, "discord"));
-        assert!(!over_size_limit(ten_mb + 1, "nitro"));
+        let twenty_mb = 20 * 1024 * 1024;
+        assert!(!over_size_limit(twenty_mb, "discord"));
+        assert!(over_size_limit(twenty_mb + 1, "discord"));
+        assert!(!over_size_limit(twenty_mb + 1, "nitro"));
         assert!(over_size_limit(500 * 1024 * 1024 + 1, "nitro"));
         // No target selected means no hint, ever.
         assert!(!over_size_limit(u64::MAX, "none"));

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1259,7 +1259,7 @@ const de: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1488,7 +1488,7 @@ const en: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1297,7 +1297,7 @@ const es: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1260,7 +1260,7 @@ const fr: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1238,7 +1238,7 @@ const it: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1260,7 +1260,7 @@ const ja: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1238,7 +1238,7 @@ const ko: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1486,7 +1486,7 @@ const pl: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1238,7 +1238,7 @@ const pt: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1238,7 +1238,7 @@ const ru: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1238,7 +1238,7 @@ const zhTw: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1238,7 +1238,7 @@ const zh: Record<string, string> = {
   "video.export.size_actual": "{size}",
   "video.export.frames": "{count} frames",
   "video.export.target_platform": "Size limit",
-  "video.export.target_discord": "Discord (free) 10 MB",
+  "video.export.target_discord": "Discord (free) 20 MB",
   "video.export.target_nitro": "Discord Nitro 500 MB",
   "video.export.target_none": "No limit",
   "video.export.over_limit": "Over the {target} limit. Try the next preset down.",

--- a/src/lib/utils/videoExport.ts
+++ b/src/lib/utils/videoExport.ts
@@ -236,7 +236,7 @@ export function resolveAuto(seamDelta: number): "trim" | "none" {
 
 /** Rust: `over_size_limit` */
 export function overSizeLimit(bytes: number, target: SizeTarget): boolean {
-  if (target === "discord") return bytes > 10 * 1024 * 1024;
+  if (target === "discord") return bytes > 20 * 1024 * 1024;
   if (target === "nitro") return bytes > 500 * 1024 * 1024;
   return false;
 }


### PR DESCRIPTION
## Summary

The video export popover's "Size limit" target for Discord's free tier was set to 10 MB, which is out of date. Discord raised the free attachment cap to 20 MB, so the over-limit hint fired on files that upload fine.

Four touchpoints, all the places the 10 MB figure lived:

- `src-tauri/src/commands/video_export.rs` — `over_size_limit` threshold for the `"discord"` target, 10 MB to 20 MB
- `src/lib/utils/videoExport.ts` — `overSizeLimit`, the TypeScript mirror of that function, kept in sync
- `src-tauri/src/commands/video_export.rs` (tests) — `size_limits_follow_the_platform_table`, with `ten_mb` renamed to `twenty_mb`
- `src/lib/locales/*.ts` — the `video.export.target_discord` label now reads "Discord (free) 20 MB"

The Nitro target (500 MB) and the "Discord-safe" GIF preset are unchanged.

All 12 locale files carried the same untranslated English string for this key, so the new value is identical across all of them.

Validation run locally: `npm run build` passes, `cargo test --no-default-features --features server` is green (191 passed, 1 ignored), `cargo fmt --check` is clean, and `npm run check` reports no new problems in the changed files (the 6 pre-existing errors are in unrelated components). The desktop-feature `cargo check` could not run in this environment because the GTK dev libraries (`gdk-3.0`) are not installed. The changed module compiles under both feature sets and touches no `tauri` symbols, so CI's desktop job is the remaining check.

## Linked issue

No linked issue.

## How this fits the project scope

SCOPE.md puts video on the same footing as images, including clip export. This is a correctness fix to the export size hint, not new surface area.

## Guideline checklist

- [x] i18n: any new user-facing strings are added to ALL files in `src/lib/locales/`, with matching `{placeholder}` names. (No new keys, an existing key's value updated in all 12 locale files.)
- [x] a11y: interactive elements are keyboard- and screen-reader-accessible. (No markup changed.)
- [x] I ran `npm run check` locally and addressed issues in the files I changed. (No issues reported in the changed files.)
- [x] This change is within the scope described in `SCOPE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013HoN6WAtxNfQLyg9ha9NPk)_