### PR TITLE
v2.0.8: Fix model downloads freezing on a stalled connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v2.0.8
+
+### Fixes and maintenance
+- **Model downloads (e.g. the RDBT-Anima LoRA) could freeze mid-transfer with no error**: a connection that stalled after the server stopped sending bytes without closing the socket would hang forever, since the shared HTTP client had no read timeout, leaving the download progress bar stuck indefinitely. Chunk reads now time out after 30 seconds of silence, cleaning up the partial file and surfacing a clear error so the download can be retried.
+
+---
+
 ## What's New in v2.0.7
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v2.0.8
+
+### Fixes and maintenance
+- **Model downloads (e.g. the RDBT-Anima LoRA) could freeze mid-transfer with no error**: a connection that stalled after the server stopped sending bytes without closing the socket would hang forever, since the shared HTTP client had no read timeout, leaving the download progress bar stuck indefinitely. Chunk reads now time out after 30 seconds of silence, cleaning up the partial file and surfacing a clear error so the download can be retried.
+
+---
+
 ## What's New in v2.0.7
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.7"
+version = "2.0.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/comfyui/client.rs
+++ b/src-tauri/src/comfyui/client.rs
@@ -656,8 +656,40 @@ impl AppState {
         )
         .ok();
 
+        // A stalled connection (server stops sending bytes without closing the
+        // socket) leaves `resp.chunk().await` pending forever — reqwest's default
+        // client has no read timeout, so nothing else would ever surface this as
+        // an error. Bound each chunk read so a stall fails loudly instead of
+        // hanging the download (and the UI's downloading state) indefinitely.
+        const STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
         let mut resp = resp;
-        while let Some(chunk) = resp.chunk().await? {
+        loop {
+            let chunk = match tokio::time::timeout(STALL_TIMEOUT, resp.chunk()).await {
+                Ok(result) => result?,
+                Err(_) => {
+                    drop(file);
+                    let _ = std::fs::remove_file(&dest);
+                    app.emit(
+                        "download:progress",
+                        crate::setup::DownloadProgress {
+                            filename: filename.to_string(),
+                            downloaded,
+                            total,
+                            done: true,
+                        },
+                    )
+                    .ok();
+                    return Err(AppError::Other(format!(
+                        "Download stalled for '{}': no data received for {} seconds",
+                        filename,
+                        STALL_TIMEOUT.as_secs()
+                    )));
+                }
+            };
+            let Some(chunk) = chunk else {
+                break;
+            };
             use std::io::Write;
             // Abort cleanly if the user cancelled this download (#399).
             if self.is_download_cancelled(filename) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Model downloads (e.g. RDBT-Anima LoRA) could freeze mid-transfer with no error, since the shared HTTP client had no read timeout and a stalled connection would hang the chunk-read loop forever.
- Chunk reads now time out after 30 seconds of silence; on stall the partial file is cleaned up and a clear error surfaces to the UI so the download can be retried.
- Verified with a local stalling-TCP-server test reproducing the exact bug pattern (server sends partial body, then goes silent without closing the socket): confirmed the fix errors out in seconds instead of hanging, then removed the throwaway test. Full `cargo test` suite (202 tests) still green.

## Test plan
- [x] `cargo check` (desktop)
- [x] `cargo check` (server, no-default-features)
- [x] `cargo test` (202 passed)
- [x] Manual reproduction against a local stalling TCP server confirming the timeout fires instead of hanging