### PR TITLE
v2.0.9: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v2.0.9
+
+### New features
+- **Generation time is now tracked for video, not just images**: the video output pipeline never recorded how long a generation took, so videos never showed a duration anywhere in the UI. Video prompts now get the same timing capture images already had.
+- **"Show Generation Time" checkbox in the gallery**: a new toggle in the gallery toolbar displays how long each image or video took to generate directly on the grid and details view, instead of only on hover in the bottom panel.
+- **Generation time shown in the lightbox**: opening an image or video in the lightbox now shows its generation time alongside the rest of its metadata.
+
+### Fixes and maintenance
+- **The "Videos generated this session" gallery tab wasn't populating**: newly generated videos never got added to the in-memory session gallery list, so the tab stayed empty even right after generating a video.
+
+---
+
 ## What's New in v2.0.8
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v2.0.9
+
+### New features
+- **Generation time is now tracked for video, not just images**: the video output pipeline never recorded how long a generation took, so videos never showed a duration anywhere in the UI. Video prompts now get the same timing capture images already had.
+- **"Show Generation Time" checkbox in the gallery**: a new toggle in the gallery toolbar displays how long each image or video took to generate directly on the grid and details view, instead of only on hover in the bottom panel.
+- **Generation time shown in the lightbox**: opening an image or video in the lightbox now shows its generation time alongside the rest of its metadata.
+
+### Fixes and maintenance
+- **The "Videos generated this session" gallery tab wasn't populating**: newly generated videos never got added to the in-memory session gallery list, so the tab stayed empty even right after generating a video.
+
+---
+
 ## What's New in v2.0.8
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.8"
+version = "2.0.9"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -85,6 +85,7 @@
     checkStyleTransferNodesReady,
   } from "./lib/utils/styleTransferNodes.js";
   import { classifyGenerationError } from "./lib/utils/generationErrors.js";
+  import { formatGenerationTime } from "./lib/utils/localeFormat.js";
   import {
     parseComfyServerError,
     type ComfyServerErrorPayload,
@@ -2770,11 +2771,13 @@
         const durationSeconds =
           typeof data.duration_seconds === "number" ? data.duration_seconds : undefined;
         const videoFps = typeof data.fps === "number" && data.fps > 0 ? data.fps : undefined;
+        const generationTimeMs = data.prompt_id ? progress.peekDurationMs(data.prompt_id) : undefined;
 
-        await gallery.addPersistedImage(videoFilename, {
-          duration_seconds: durationSeconds,
-          fps: videoFps,
-        });
+        await gallery.addPersistedImage(
+          videoFilename,
+          { duration_seconds: durationSeconds, fps: videoFps, generationTimeMs },
+          true,
+        );
 
         // Play it in the progress preview. The gallery URL is Range-served, so
         // the preview never buffers the whole clip.
@@ -3668,6 +3671,13 @@
                 {/each}
               </select>
             </div>
+
+            {#if gallery.selectedImage.generationTimeMs != null}
+              <div class="mb-3 flex justify-between gap-2">
+                <span class="text-[10px] text-neutral-500 uppercase tracking-wider">{locale.t("gallery.generation_time")}</span>
+                <span class="text-neutral-200">{formatGenerationTime(gallery.selectedImage.generationTimeMs, locale.current)}</span>
+              </div>
+            {/if}
 
             {#if lightboxMetadata}
               {@const promptKeys = ["positive_prompt", "negative_prompt"]}

--- a/src/lib/components/gallery/GalleryPage.svelte
+++ b/src/lib/components/gallery/GalleryPage.svelte
@@ -9,6 +9,7 @@
   import { uploadOutputImageForGenerationInput } from "../../utils/galleryActions.js";
   import { prepareOutputImageForEditMode } from "../../utils/editImagePreparation.js";
   import { uploadImageBytes } from "../../utils/api.js";
+  import { formatGenerationTime } from "../../utils/localeFormat.js";
   import type { OutputImage } from "../../types/index.js";
 
   interface Props {
@@ -393,6 +394,15 @@
             <button onclick={() => (galleryView = "details")} class="px-3 py-1.5 text-xs rounded border transition-colors {galleryView === 'details' ? 'border-indigo-500 bg-indigo-500/10 text-indigo-300' : 'border-neutral-700 text-neutral-300 hover:border-neutral-500'}">{locale.t("gallery.detailed_view")}</button>
             <button onclick={rescanGalleryMetadata} class="px-3 py-1.5 text-xs rounded border transition-colors border-amber-700/70 text-amber-300 hover:border-amber-500 hover:text-amber-200">{locale.t("gallery.rescan_metadata")}</button>
             <button onclick={sortGalleryByArtist} disabled={gallery.autoSorting} class="px-3 py-1.5 text-xs rounded border transition-colors border-indigo-700/70 text-indigo-300 hover:border-indigo-500 hover:text-indigo-200 disabled:opacity-50">{gallery.autoSorting ? locale.t("gallery.sort_by_artist_running") : locale.t("gallery.sort_by_artist")}</button>
+            <label class="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded border border-neutral-700 text-neutral-300 cursor-pointer hover:border-neutral-500">
+              <input
+                type="checkbox"
+                class="accent-indigo-500"
+                checked={gallery.showGenerationTime}
+                onchange={(e) => gallery.setShowGenerationTime((e.target as HTMLInputElement).checked)}
+              />
+              {locale.t("gallery.show_generation_time")}
+            </label>
           </div>
         </div>
       </div>
@@ -413,7 +423,12 @@
                     <img use:lazyThumbnail={{ image, size: thumbSize }} alt={image.filename} class="w-full h-full object-cover" />
                   </button>
                   <div class="text-sm text-neutral-200 truncate" title={image.filename}>{image.filename}</div>
-                  <div class="text-xs text-neutral-400">{formatDate(image.generated_at_ms)}</div>
+                  <div class="text-xs text-neutral-400">
+                    {formatDate(image.generated_at_ms)}
+                    {#if gallery.showGenerationTime && image.generationTimeMs != null}
+                      <span class="text-amber-300/80">· {formatGenerationTime(image.generationTimeMs, locale.current)}</span>
+                    {/if}
+                  </div>
                   <div class="text-xs text-neutral-400">{formatBytes(image.file_size_bytes)}</div>
                   <div class="flex flex-wrap gap-1">
                     <select class="px-2 py-1 text-[11px] rounded bg-neutral-800 border border-neutral-700 text-neutral-200" value={boardLabel(image)} onchange={(e) => assignBoard(image, (e.target as HTMLSelectElement).value)}>
@@ -464,6 +479,11 @@
                         {formatDuration(image.duration_seconds)}
                       </div>
                     {/if}
+                  {/if}
+                  {#if gallery.showGenerationTime && image.generationTimeMs != null}
+                    <div class="absolute {isVideoImage(image) && image.duration_seconds != null ? 'top-7' : 'top-1'} right-1 px-1.5 py-0.5 rounded bg-black/70 text-amber-300 text-[10px] font-mono pointer-events-none">
+                      {formatGenerationTime(image.generationTimeMs, locale.current)}
+                    </div>
                   {/if}
                   <div class="absolute top-1 left-1 px-1.5 py-0.5 rounded bg-black/70 text-[10px] text-neutral-200 pointer-events-none">{boardLabel(image)}</div>
                   {#if generation.manualSaveMode && !image.gallery_filename}

--- a/src/lib/components/generation/BottomPanel.svelte
+++ b/src/lib/components/generation/BottomPanel.svelte
@@ -572,7 +572,7 @@
                       </div>
                     </div>
                   {/if}
-                  {#if hoveredImage === image && image.generationTimeMs != null}
+                  {#if (hoveredImage === image || gallery.showGenerationTime) && image.generationTimeMs != null}
                     <div
                       class="absolute top-1.5 left-1.5 flex items-center gap-1 bg-black/65 text-white text-[10px] font-medium px-1.5 py-0.5 rounded backdrop-blur-sm pointer-events-none"
                       title={locale.t("generation.gen_time_label")}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1367,6 +1367,8 @@ const de: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Bilder automatisch Boards zuordnen basierend auf erkannten Künstler-Tags in ihren Prompts",
   "gallery.sort_by_artist_done": "{sorted} Bild(er) in {boards} Künstler-Board(s) sortiert",
   "gallery.sort_by_artist_none": "Keine Künstler-Tags in deiner Galerie erkannt",
+  "gallery.show_generation_time": "Generierungszeit anzeigen",
+  "gallery.generation_time": "Generierungszeit",
   "gallery.artist_detected": "Künstler-Tag erkannt: {tag}",
   "gallery.col_preview": "Vorschau",
   "gallery.col_name": "Name",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1598,6 +1598,8 @@ const en: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Auto-assign images to boards based on detected artist tags in their prompts",
   "gallery.sort_by_artist_done": "Sorted {sorted} image(s) into {boards} artist board(s)",
   "gallery.sort_by_artist_none": "No artist tags detected in your gallery",
+  "gallery.show_generation_time": "Show Generation Time",
+  "gallery.generation_time": "Generation Time",
   "gallery.artist_detected": "Artist tag detected: {tag}",
   "gallery.col_preview": "Preview",
   "gallery.col_name": "Name",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1405,6 +1405,8 @@ const es: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Asignar automáticamente imágenes a tableros según las etiquetas de artista detectadas en sus prompts",
   "gallery.sort_by_artist_done": "{sorted} imagen(es) ordenadas en {boards} tablero(s) de artista",
   "gallery.sort_by_artist_none": "No se detectaron etiquetas de artista en tu galería",
+  "gallery.show_generation_time": "Mostrar tiempo de generación",
+  "gallery.generation_time": "Tiempo de generación",
   "gallery.artist_detected": "Etiqueta de artista detectada: {tag}",
   "gallery.col_preview": "Vista previa",
   "gallery.col_name": "Nombre",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1368,6 +1368,8 @@ const fr: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Attribuer automatiquement les images à des tableaux selon les tags d'artiste détectés dans leurs prompts",
   "gallery.sort_by_artist_done": "{sorted} image(s) triée(s) dans {boards} tableau(x) d'artiste",
   "gallery.sort_by_artist_none": "Aucun tag d'artiste détecté dans votre galerie",
+  "gallery.show_generation_time": "Afficher le temps de génération",
+  "gallery.generation_time": "Temps de génération",
   "gallery.artist_detected": "Tag d'artiste détecté : {tag}",
   "gallery.col_preview": "Aperçu",
   "gallery.col_name": "Nom",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1346,6 +1346,8 @@ const it: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Assegna automaticamente le immagini alle bacheche in base ai tag artista rilevati nei prompt",
   "gallery.sort_by_artist_done": "{sorted} immagine/i ordinate in {boards} bacheca/e artista",
   "gallery.sort_by_artist_none": "Nessun tag artista rilevato nella tua galleria",
+  "gallery.show_generation_time": "Mostra tempo di generazione",
+  "gallery.generation_time": "Tempo di generazione",
   "gallery.artist_detected": "Tag artista rilevato: {tag}",
   "gallery.col_preview": "Anteprima",
   "gallery.col_name": "Nome",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1368,6 +1368,8 @@ const ja: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "プロンプトから検出されたアーティストタグに基づいて画像を自動でボードに振り分けます",
   "gallery.sort_by_artist_done": "{sorted} 枚の画像を {boards} 個のアーティストボードに整理しました",
   "gallery.sort_by_artist_none": "ギャラリーからアーティストタグが見つかりませんでした",
+  "gallery.show_generation_time": "生成時間を表示",
+  "gallery.generation_time": "生成時間",
   "gallery.artist_detected": "アーティストタグを検出: {tag}",
   "gallery.col_preview": "プレビュー",
   "gallery.col_name": "名前",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1346,6 +1346,8 @@ const ko: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "프롬프트에서 감지된 아티스트 태그를 기준으로 이미지를 보드에 자동 할당합니다",
   "gallery.sort_by_artist_done": "{sorted}개의 이미지를 {boards}개의 아티스트 보드로 정렬했습니다",
   "gallery.sort_by_artist_none": "갤러리에서 아티스트 태그를 찾을 수 없습니다",
+  "gallery.show_generation_time": "생성 시간 표시",
+  "gallery.generation_time": "생성 시간",
   "gallery.artist_detected": "아티스트 태그 감지됨: {tag}",
   "gallery.col_preview": "미리보기",
   "gallery.col_name": "이름",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1596,6 +1596,8 @@ const pl: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Automatycznie przypisuj obrazy do tablic na podstawie wykrytych tagów artystów w ich promptach",
   "gallery.sort_by_artist_done": "Posortowano {sorted} obraz(y) do {boards} tablicy/tablic artystów",
   "gallery.sort_by_artist_none": "Nie wykryto tagów artystów w galerii",
+  "gallery.show_generation_time": "Pokaż czas generowania",
+  "gallery.generation_time": "Czas generowania",
   "gallery.artist_detected": "Wykryto tag artysty: {tag}",
   "gallery.col_preview": "Podgląd",
   "gallery.col_name": "Nazwa",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1346,6 +1346,8 @@ const pt: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Atribuir imagens automaticamente a quadros com base nas tags de artista detectadas em seus prompts",
   "gallery.sort_by_artist_done": "{sorted} imagem(ns) ordenada(s) em {boards} quadro(s) de artista",
   "gallery.sort_by_artist_none": "Nenhuma tag de artista detectada na sua galeria",
+  "gallery.show_generation_time": "Mostrar tempo de geração",
+  "gallery.generation_time": "Tempo de geração",
   "gallery.artist_detected": "Tag de artista detectada: {tag}",
   "gallery.col_preview": "Prévia",
   "gallery.col_name": "Nome",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1346,6 +1346,8 @@ const ru: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "Автоматически распределять изображения по доскам на основе обнаруженных тегов художников в их промптах",
   "gallery.sort_by_artist_done": "Отсортировано {sorted} изображений в {boards} досок художников",
   "gallery.sort_by_artist_none": "Теги художников в галерее не найдены",
+  "gallery.show_generation_time": "Показывать время генерации",
+  "gallery.generation_time": "Время генерации",
   "gallery.artist_detected": "Обнаружен тег художника: {tag}",
   "gallery.col_preview": "Превью",
   "gallery.col_name": "Имя",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1346,6 +1346,8 @@ const zhTw: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "根據提示詞中偵測到的畫師標籤自動將圖片分配到看板",
   "gallery.sort_by_artist_done": "已將 {sorted} 張圖片排序到 {boards} 個畫師看板",
   "gallery.sort_by_artist_none": "您的圖庫中未偵測到任何畫師標籤",
+  "gallery.show_generation_time": "顯示產生時間",
+  "gallery.generation_time": "產生時間",
   "gallery.artist_detected": "偵測到畫師標籤：{tag}",
   "gallery.col_preview": "預覽",
   "gallery.col_name": "名稱",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1346,6 +1346,8 @@ const zh: Record<string, string> = {
   "gallery.sort_by_artist_tooltip": "根据提示词中检测到的画师标签自动将图片分配到看板",
   "gallery.sort_by_artist_done": "已将 {sorted} 张图片排序到 {boards} 个画师看板",
   "gallery.sort_by_artist_none": "您的图库中未检测到任何画师标签",
+  "gallery.show_generation_time": "显示生成时间",
+  "gallery.generation_time": "生成时间",
   "gallery.artist_detected": "检测到画师标签：{tag}",
   "gallery.col_preview": "预览",
   "gallery.col_name": "名称",

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -178,6 +178,7 @@ function isWebpGalleryFile(filename: string | undefined): boolean {
 
 const GALLERY_BOARDS_KEY = "mooshieui.gallery.boards.v1";
 const GALLERY_BOARD_NAMES_KEY = "mooshieui.gallery.boardNames.v1";
+const GALLERY_SHOW_GEN_TIME_KEY = "mooshieui.gallery.showGenerationTime.v1";
 
 type ToastType = "success" | "error" | "info" | "warning";
 type ToastOptions = {
@@ -212,6 +213,8 @@ class GalleryStore {
   toast = $state<GalleryToast | null>(null);
   boardAssignments = $state<Record<string, string>>({});
   customBoards = $state<string[]>([]);
+  /** Shown as a badge on thumbnails and the lightbox when true; persisted across sessions. */
+  showGenerationTime = $state(false);
   /** Storage info from the server (browser mode only). */
   storageInfo = $state<StorageInfo | null>(null);
   /** Lookup map for artist-tag detection.  Populated by loadArtistIndex(). */
@@ -257,6 +260,24 @@ class GalleryStore {
   constructor() {
     this.loadBoardAssignments();
     this.loadCustomBoards();
+    this.loadShowGenerationTime();
+  }
+
+  private loadShowGenerationTime() {
+    try {
+      this.showGenerationTime = localStorage.getItem(GALLERY_SHOW_GEN_TIME_KEY) === "true";
+    } catch (e) {
+      console.error("Failed to load showGenerationTime pref:", e);
+    }
+  }
+
+  setShowGenerationTime(value: boolean) {
+    this.showGenerationTime = value;
+    try {
+      localStorage.setItem(GALLERY_SHOW_GEN_TIME_KEY, String(value));
+    } catch (e) {
+      console.error("Failed to save showGenerationTime pref:", e);
+    }
   }
 
   private loadBoardAssignments() {
@@ -543,7 +564,8 @@ class GalleryStore {
    */
   async addPersistedImage(
     galleryFilename: string,
-    videoMeta?: { duration_seconds?: number; fps?: number },
+    videoMeta?: { duration_seconds?: number; fps?: number; generationTimeMs?: number },
+    addToSession = false,
   ) {
     // Mirror loadFromDisk's modern-format parse: {promptId}__{mode}__{origFilename}.
     let promptId = "";
@@ -572,8 +594,16 @@ class GalleryStore {
       generated_at_ms: Date.now(),
       duration_seconds: videoMeta?.duration_seconds,
       fps: videoMeta?.fps,
+      generationTimeMs: videoMeta?.generationTimeMs,
     };
     this.images = [entry, ...this.images];
+    // The "generated this session" tabs (e.g. BottomPanel's Videos tab) read
+    // sessionImages, not images — videos land here instead of addImages()
+    // because they're saved server-side rather than streamed as blobs, so
+    // they need to be added to both to show up while the app is still open.
+    if (addToSession) {
+      this.sessionImages = [entry, ...this.sessionImages];
+    }
     // Pull in the embedded metadata (artist detection etc.) in the background.
     void this.hydrateMetadataInBackground();
   }

--- a/src/lib/stores/progress.svelte.ts
+++ b/src/lib/stores/progress.svelte.ts
@@ -344,6 +344,18 @@ class ProgressStore {
    * frame is then discarded instead of being promoted to lastOutputImage —
    * promoting it first risks the blurry progress frame sticking around if the
    * final image swap fails. */
+  /**
+   * Non-destructive elapsed-time lookup for a still-pending prompt. Used by
+   * the video output handler, which fires before `completePrompt()` closes
+   * the prompt out, so it needs the same startedAt/generationStartTime
+   * fallback without removing the prompt from the queue.
+   */
+  peekDurationMs(promptId: string): number | undefined {
+    const item = this.pendingPrompts.find((p) => p.promptId === promptId);
+    const startedAt = item?.startedAt ?? this.generationStartTime;
+    return startedAt != null ? Date.now() - startedAt : undefined;
+  }
+
   completePrompt(promptId: string, hasFinalImage = false): QueuedPrompt | undefined {
     const item = this.pendingPrompts.find((p) => p.promptId === promptId);
 


### PR DESCRIPTION
## What's New in v2.0.9

### New features
- Generation time is now tracked for video, not just images.
- "Show Generation Time" checkbox in the gallery toolbar, showing duration on the grid and details view.
- Generation time shown in the lightbox metadata panel.

### Fixes and maintenance
- The "Videos generated this session" gallery tab wasn't populating: newly generated videos never got added to the in-memory session gallery list.