### PR TITLE
v2.1.0: Gallery expiry opt-out and ComfyUI v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v2.1.0
+
+### New features
+- **Option to disable gallery image auto-expiry**: gallery images auto-delete after 7 days as a disk-usage safety net for shared/public servers, but this left no way to opt out. Single-owner setups reached remotely (for example, a home PC over Tailscale) now have a **Never auto-delete gallery images** toggle in Settings > Gallery. ([#596](https://github.com/Mooshieblob1/MooshieUI/pull/596))
+
+### Fixes and maintenance
+- **Bumped pinned ComfyUI to v0.31.0**: the bundled custom nodes and the core node inputs MooshieUI's workflow builder emits were verified compatible with this release. ([#564](https://github.com/Mooshieblob1/MooshieUI/pull/564))
+
+---
+
 ## What's New in v2.0.9
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v2.1.0
+
+### New features
+- **Option to disable gallery image auto-expiry**: gallery images auto-delete after 7 days as a disk-usage safety net for shared/public servers, but this left no way to opt out. Single-owner setups reached remotely (for example, a home PC over Tailscale) now have a **Never auto-delete gallery images** toggle in Settings > Gallery. ([#596](https://github.com/Mooshieblob1/MooshieUI/pull/596))
+
+### Fixes and maintenance
+- **Bumped pinned ComfyUI to v0.31.0**: the bundled custom nodes and the core node inputs MooshieUI's workflow builder emits were verified compatible with this release. ([#564](https://github.com/Mooshieblob1/MooshieUI/pull/564))
+
+---
+
 ## What's New in v2.0.9
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.0.9"
+version = "2.1.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.0.9"
+version = "2.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v2.1.0

### New features
- Option to disable gallery image auto-expiry: a **Never auto-delete gallery images** toggle in Settings > Gallery for single-owner setups reached remotely (e.g. Tailscale). (#596)

### Fixes and maintenance
- Bumped pinned ComfyUI to v0.31.0, verified compatible via the automated node smoke test. (#564)

## Bot triage
No open bot review comments found on #596 or #564 as of this release.

## Test plan
- [x] `cargo check` (desktop features)
- [x] `cargo check --no-default-features --features server`
- [x] `cargo test` (202 passed)
- [x] `npm run build`