### PR TITLE
v2.1.1: Resolution lock and LoRA trigger-word tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v2.1.1
+
+### New features
+- **Lock resolution across model swaps**: switching checkpoints normally resets width/height to that model's default resolution. A new lock toggle next to the resolution controls keeps your current width and height fixed through model swaps.
+- **LoRA trigger words tracked and highlighted in the prompt**: words added via a LoRA's trigger-word chip are now tracked per-LoRA, highlighted inline in the prompt, and automatically removed if you disable or remove that LoRA.
+- **Collapsible LoRA list**: the LoRA section in the model picker can now be collapsed, with the state remembered between sessions.
+
+---
+
 ## What's New in v2.1.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v2.1.1
+
+### New features
+- **Lock resolution across model swaps**: switching checkpoints normally resets width/height to that model's default resolution. A new lock toggle next to the resolution controls keeps your current width and height fixed through model swaps.
+- **LoRA trigger words tracked and highlighted in the prompt**: words added via a LoRA's trigger-word chip are now tracked per-LoRA, highlighted inline in the prompt, and automatically removed if you disable or remove that LoRA.
+- **Collapsible LoRA list**: the LoRA section in the model picker can now be collapsed, with the state remembered between sessions.
+
+---
+
 ## What's New in v2.1.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/DimensionControls.svelte
+++ b/src/lib/components/generation/DimensionControls.svelte
@@ -318,17 +318,38 @@
   <div>
     <div class="flex items-center justify-between mb-1.5">
       <label class="text-xs text-neutral-400">{locale.t('generation.dimensions.resolution')}<InfoTip text={locale.t('generation.dimensions.resolution_tip')} /></label>
-      <button
-        onclick={() => applySideLength(DEFAULT_SIDE)}
-        class="inline-flex items-center gap-1 text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
-        title={locale.t('generation.dimensions.reset', { res: DEFAULT_SIDE })}
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-          <path d="M3 3v5h5"/>
-        </svg>
-        {locale.t('generation.dimensions.reset', { res: DEFAULT_SIDE })}
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          onclick={() => { generation.resolutionLocked = !generation.resolutionLocked; generation.saveSettings(); }}
+          class="inline-flex items-center gap-1 text-[10px] transition-colors {generation.resolutionLocked ? 'text-indigo-400 hover:text-indigo-300' : 'text-neutral-400 hover:text-neutral-200'}"
+          title={locale.t('generation.dimensions.lock_tip')}
+          aria-pressed={generation.resolutionLocked}
+        >
+          {#if generation.resolutionLocked}
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2"/>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+          {:else}
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2"/>
+              <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+            </svg>
+          {/if}
+          {locale.t('generation.dimensions.lock')}
+        </button>
+        <button
+          onclick={() => applySideLength(DEFAULT_SIDE)}
+          class="inline-flex items-center gap-1 text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
+          title={locale.t('generation.dimensions.reset', { res: DEFAULT_SIDE })}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+            <path d="M3 3v5h5"/>
+          </svg>
+          {locale.t('generation.dimensions.reset', { res: DEFAULT_SIDE })}
+        </button>
+      </div>
     </div>
     <div class="flex items-center gap-1 flex-wrap mb-2">
       {#each sidePresets as side (side)}

--- a/src/lib/components/generation/LoraGallery.svelte
+++ b/src/lib/components/generation/LoraGallery.svelte
@@ -470,10 +470,11 @@
     }
   }
 
-  function addTriggerWord(word: string) {
+  function addTriggerWord(loraName: string, word: string) {
     const current = generation.positivePrompt.trim();
     if (current.includes(word)) return;
     generation.positivePrompt = current ? `${current}, ${word}` : word;
+    generation.recordInsertedLoraWord(loraName, word);
     generation.saveSettings();
   }
 
@@ -828,7 +829,7 @@
                   {#each info.civitai_trigger_words as word}
                     <button
                       class="px-1.5 py-0.5 text-[10px] rounded bg-indigo-500/10 border border-indigo-500/30 text-indigo-300 hover:bg-indigo-500/20 hover:border-indigo-400/50 transition-colors"
-                      onclick={(e) => { e.stopPropagation(); addTriggerWord(word); }}
+                      onclick={(e) => { e.stopPropagation(); addTriggerWord(loraName, word); }}
                       title={locale.t('lora.add_to_prompt', { word })}
                     >
                       {word}
@@ -838,7 +839,7 @@
                   {#each info.modelspec_trigger_phrase.split(",").map((s) => s.trim()).filter(Boolean) as word}
                     <button
                       class="px-1.5 py-0.5 text-[10px] rounded bg-indigo-500/10 border border-indigo-500/30 text-indigo-300 hover:bg-indigo-500/20 hover:border-indigo-400/50 transition-colors"
-                      onclick={(e) => { e.stopPropagation(); addTriggerWord(word); }}
+                      onclick={(e) => { e.stopPropagation(); addTriggerWord(loraName, word); }}
                       title={locale.t('lora.add_to_prompt', { word })}
                     >
                       {word}

--- a/src/lib/components/generation/ModelSelector.svelte
+++ b/src/lib/components/generation/ModelSelector.svelte
@@ -733,6 +733,17 @@
     generation.loras.filter((l) => l.enabled && l.name).length
   );
 
+  const LORAS_COLLAPSE_KEY = "mooshieui.generation.lorasCollapsed.v1";
+  let lorasOpen = $state(localStorage.getItem(LORAS_COLLAPSE_KEY) !== "true");
+  let lorasSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  $effect(() => {
+    const collapsed = String(!lorasOpen);
+    if (lorasSaveTimer) clearTimeout(lorasSaveTimer);
+    lorasSaveTimer = setTimeout(() => {
+      try { localStorage.setItem(LORAS_COLLAPSE_KEY, collapsed); } catch {}
+    }, 300);
+  });
+
   function filteredLorasForIndex(index: number) {
     const search = loraSearches[index] ?? "";
     return models.loras.filter((l) =>
@@ -1525,16 +1536,29 @@
           </span>
         {/if}
       </div>
-      <button
-        onclick={() => {
-          generation.addLora();
-          generation.saveSettings();
-        }}
-        class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
-      >
-        {locale.t('generation.model.add_lora')}
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          onclick={() => {
+            generation.addLora();
+            generation.saveSettings();
+          }}
+          class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
+          {locale.t('generation.model.add_lora')}
+        </button>
+        {#if generation.loras.length > 0}
+          <button
+            class="text-neutral-400 hover:text-neutral-200 focus:outline-none"
+            onclick={() => (lorasOpen = !lorasOpen)}
+            title={lorasOpen ? locale.t('common.collapse', { section: locale.t('generation.model.lora_title') }) : locale.t('common.expand', { section: locale.t('generation.model.lora_title') })}
+            aria-label={lorasOpen ? locale.t('common.collapse', { section: locale.t('generation.model.lora_title') }) : locale.t('common.expand', { section: locale.t('generation.model.lora_title') })}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 transition-transform {lorasOpen ? '' : '-rotate-90'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </button>
+        {/if}
+      </div>
     </div>
+    {#if lorasOpen}
     {#each generation.loras as lora, i}
       <div
         class="mb-2 rounded-lg border p-2.5 transition-opacity {lora.enabled
@@ -1646,5 +1670,6 @@
         {/if}
       </div>
     {/each}
+    {/if}
   </div>
 </div>

--- a/src/lib/components/generation/PromptInputs.svelte
+++ b/src/lib/components/generation/PromptInputs.svelte
@@ -422,6 +422,7 @@
       minHeight="min-h-25"
       storageKey="mooshieui.promptHeight.positive"
       tagAssist={!isVideoMode}
+      highlightLoraWords={true}
     />
     {#if !isVideoMode && hasRegionalPrompting && !regionalPromptingSupported}
       <p class="mt-1 text-[10px] text-amber-300">

--- a/src/lib/components/generation/PromptTextarea.svelte
+++ b/src/lib/components/generation/PromptTextarea.svelte
@@ -9,6 +9,7 @@
     renderHighlightedPrompt,
     hasSchedulingTags,
     hasPresetTokens,
+    hasLoraWordInPrompt,
     findPromptInertRangeContaining,
   } from "../../utils/promptSchedule.js";
   import {
@@ -39,6 +40,15 @@
      * completing, underlining and linking them all misfire together.
      */
     tagAssist?: boolean;
+    /**
+     * Highlight prompt words inserted via a LoRA's trigger-word chip
+     * (tracked per-LoRA in `generation.loras[].insertedWords`). Only the
+     * positive-prompt instance should set this — trigger words are only
+     * ever inserted into `generation.positivePrompt`, so lighting up the
+     * same literal text in the negative prompt or region boxes would be
+     * a false positive.
+     */
+    highlightLoraWords?: boolean;
   }
 
   let {
@@ -48,6 +58,7 @@
     minHeight = "min-h-25",
     storageKey,
     tagAssist = true,
+    highlightLoraWords = false,
   }: Props = $props();
 
   // Restored height is applied as inline style (set in $effect on mount).
@@ -537,11 +548,29 @@
     }, 200);
   }
 
-  // Reactive: detect if current value has scheduling tags or inline preset tokens
-  const showBackdrop = $derived(hasSchedulingTags(value) || hasPresetTokens(value));
+  // Words inserted into the prompt via an enabled LoRA's trigger-word chip,
+  // lowercased for case-insensitive matching against the raw prompt text.
+  const activeLoraWords = $derived(
+    highlightLoraWords
+      ? new Set(
+          generation.loras
+            .filter((l) => l.enabled && l.name)
+            .flatMap((l) => l.insertedWords ?? [])
+            .map((w) => w.trim().toLowerCase())
+            .filter(Boolean),
+        )
+      : new Set<string>(),
+  );
+
+  // Reactive: detect if current value has scheduling tags, inline preset tokens, or LoRA trigger words
+  const showBackdrop = $derived(
+    hasSchedulingTags(value) || hasPresetTokens(value) || hasLoraWordInPrompt(value, activeLoraWords),
+  );
 
   // Reactive: render highlighted HTML for the backdrop overlay
-  const highlightedHtml = $derived(showBackdrop ? renderHighlightedPrompt(value, promptPresets.slugs) : "");
+  const highlightedHtml = $derived(
+    showBackdrop ? renderHighlightedPrompt(value, promptPresets.slugs, activeLoraWords) : "",
+  );
   const clickableSegments = $derived(
     tagAssist && autocomplete.clickableOverlayEnabled ? getPromptClickableSegments(value) : [],
   );

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -605,6 +605,8 @@ class GenerationStore {
    *  The first-ever preset application (while `modelPresetAppliedKey` is still unset) is
    *  exempt so a fresh profile still gets sane defaults; every later swap preserves. */
   advancedMode = $state(false);
+  /** When true, checkpoint/model swaps never overwrite width/height, regardless of advancedMode. */
+  resolutionLocked = $state(false);
   regionalPrompts = $state<RegionalPromptSelection[]>([]);
   /** SDXL/Illustrious: conditioning areas vs sequential inpaint. Anima always uses inpaint chain. */
   regionalPromptStrategy = $state<RegionalPromptStrategy>("conditioning");
@@ -1528,7 +1530,7 @@ class GenerationStore {
     this.cfg = preset.cfg;
     this.samplerName = this.resolveAvailableOption(models.samplers, preset.samplerName, preset.samplerFallback ?? "euler");
     this.scheduler = this.resolveAvailableOption(models.schedulers, preset.scheduler, "normal");
-    if (!this.hasAuthoritativeEditSource) {
+    if (!this.hasAuthoritativeEditSource && !this.resolutionLocked) {
       this.width = preset.width;
       this.height = preset.height;
     }
@@ -2040,6 +2042,7 @@ class GenerationStore {
         }
         if (saved.manualSaveMode !== undefined) this.manualSaveMode = saved.manualSaveMode;
         if (saved.advancedMode !== undefined) this.advancedMode = saved.advancedMode;
+        if (saved.resolutionLocked !== undefined) this.resolutionLocked = saved.resolutionLocked;
         if (Array.isArray(saved.autoSaveDirs)) this.autoSaveDirs = saved.autoSaveDirs;
         if (saved.regionalPromptStrategy === "conditioning" || saved.regionalPromptStrategy === "inpaint_chain") {
           this.regionalPromptStrategy = saved.regionalPromptStrategy;
@@ -2184,6 +2187,7 @@ class GenerationStore {
         modelFamilyOverrides: this.modelFamilyOverrides,
         manualSaveMode: this.manualSaveMode,
         advancedMode: this.advancedMode,
+        resolutionLocked: this.resolutionLocked,
         autoSaveDirs: this.autoSaveDirs,
         regionalPrompts: this.regionalPrompts,
         regionalPromptStrategy: this.regionalPromptStrategy,
@@ -2310,6 +2314,7 @@ class GenerationStore {
       customNanosaurNegativeQuality: this.customNanosaurNegativeQuality,
       manualSaveMode: this.manualSaveMode,
       advancedMode: this.advancedMode,
+      resolutionLocked: this.resolutionLocked,
       autoSaveDirs: this.autoSaveDirs,
       regionalPrompts: this.regionalPrompts,
       regionalPromptStrategy: this.regionalPromptStrategy,
@@ -2764,13 +2769,48 @@ class GenerationStore {
   }
 
   removeLora(index: number) {
+    const removed = this.loras[index];
     this.loras = this.loras.filter((_, i) => i !== index);
+    if (removed?.insertedWords?.length) {
+      this.removeInsertedWordsFromPrompt(removed.insertedWords);
+    }
   }
 
   toggleLora(index: number) {
+    const target = this.loras[index];
+    const disabling = !!target?.enabled;
     this.loras = this.loras.map((l, i) =>
       i === index ? { ...l, enabled: !l.enabled } : l
     );
+    if (disabling && target?.insertedWords?.length) {
+      this.removeInsertedWordsFromPrompt(target.insertedWords);
+    }
+  }
+
+  /** Record a trigger word inserted into the prompt via a LoRA's trigger-word chip, so it can be removed on deselect. */
+  recordInsertedLoraWord(loraName: string, word: string) {
+    this.loras = this.loras.map((l) =>
+      l.name === loraName && !(l.insertedWords ?? []).includes(word)
+        ? { ...l, insertedWords: [...(l.insertedWords ?? []), word] }
+        : l
+    );
+  }
+
+  /** Strip trigger words previously inserted via addTriggerWord/recordInsertedLoraWord, removing each as its own comma-delimited segment so surrounding text is untouched. */
+  private removeInsertedWordsFromPrompt(words: string[]) {
+    let text = this.positivePrompt;
+    for (const word of words) {
+      const trimmed = word.trim();
+      if (!trimmed) continue;
+      const segments = text.split(",");
+      const idx = segments.findIndex((s) => s.trim() === trimmed);
+      if (idx === -1) continue;
+      segments.splice(idx, 1);
+      text = segments.join(",").replace(/^\s*,\s*/, "").replace(/,\s*$/, "").trim();
+    }
+    if (text !== this.positivePrompt) {
+      this.positivePrompt = text;
+    }
   }
 
   /** Apply defaults if no checkpoint is selected yet (first run). */

--- a/src/lib/utils/promptSchedule.ts
+++ b/src/lib/utils/promptSchedule.ts
@@ -214,7 +214,11 @@ function highlightPill(colors: { bg: string; border: string; glow: string }): st
  * Render prompt text as HTML with styled highlights for scheduling blocks.
  * Used by the backdrop overlay behind the textarea.
  */
-export function renderHighlightedPrompt(raw: string, knownPresetSlugs?: ReadonlySet<string>): string {
+export function renderHighlightedPrompt(
+  raw: string,
+  knownPresetSlugs?: ReadonlySet<string>,
+  loraWords?: ReadonlySet<string>,
+): string {
   let html = "";
   let lastIndex = 0;
 
@@ -225,7 +229,7 @@ export function renderHighlightedPrompt(raw: string, knownPresetSlugs?: Readonly
     const fullMatch = match[0];
     const matchStart = match.index;
 
-    html += renderSegmentAwareText(raw.slice(lastIndex, matchStart), knownPresetSlugs);
+    html += renderSegmentAwareText(raw.slice(lastIndex, matchStart), knownPresetSlugs, loraWords);
     lastIndex = matchStart + fullMatch.length;
 
     let isValid = false;
@@ -261,7 +265,7 @@ export function renderHighlightedPrompt(raw: string, knownPresetSlugs?: Readonly
     html += `</span>`;
   }
 
-  html += renderSegmentAwareText(raw.slice(lastIndex), knownPresetSlugs);
+  html += renderSegmentAwareText(raw.slice(lastIndex), knownPresetSlugs, loraWords);
   return html;
 }
 
@@ -274,15 +278,19 @@ const PRESET_TOKEN_REGEX = PROMPT_PRESET_TOKEN_REGEX;
  * feedback for typos. Returns escaped HTML so it can be concatenated into the
  * larger highlight string.
  */
-function renderPresetSegment(text: string, knownPresetSlugs?: ReadonlySet<string>): string {
+function renderPresetSegment(
+  text: string,
+  knownPresetSlugs?: ReadonlySet<string>,
+  loraWords?: ReadonlySet<string>,
+): string {
   if (!text) return "";
-  if (!text.includes("@preset:")) return escapeHtml(text);
+  if (!text.includes("@preset:")) return renderLoraWordsInPlainText(text, loraWords);
   let html = "";
   let lastIndex = 0;
   PRESET_TOKEN_REGEX.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = PRESET_TOKEN_REGEX.exec(text)) !== null) {
-    html += escapeHtml(text.slice(lastIndex, match.index));
+    html += renderLoraWordsInPlainText(text.slice(lastIndex, match.index), loraWords);
     lastIndex = match.index + match[0].length;
     const slug = match[1].toLowerCase();
     const known = knownPresetSlugs?.has(slug) ?? false;
@@ -295,7 +303,7 @@ function renderPresetSegment(text: string, knownPresetSlugs?: ReadonlySet<string
     html += escapeHtml(match[0]);
     html += `</span>`;
   }
-  html += escapeHtml(text.slice(lastIndex));
+  html += renderLoraWordsInPlainText(text.slice(lastIndex), loraWords);
   return html;
 }
 
@@ -305,6 +313,56 @@ const SEGMENT_TAG_COLOR = {
   border: "rgba(45, 212, 191, 0.45)",
   glow: "0 0 10px rgba(45, 212, 191, 0.25), 0 0 4px rgba(45, 212, 191, 0.12)",
 };
+
+/** Sky-blue pill for prompt words inserted via a LoRA's trigger-word chip. */
+const LORA_WORD_COLOR = {
+  bg: "rgba(56, 189, 248, 0.14)",
+  border: "rgba(56, 189, 248, 0.50)",
+  glow: "0 0 8px rgba(56, 189, 248, 0.30), 0 0 4px rgba(56, 189, 248, 0.15)",
+};
+
+/**
+ * Highlight comma-delimited segments of `text` that exactly match a known
+ * LoRA-inserted trigger word (case-insensitive). Only whole segments match —
+ * the same "own comma segment" rule `removeInsertedWordsFromPrompt` uses —
+ * so a word that merely appears inside a longer hand-written phrase is left
+ * alone. Escapes and emits the plain (non-matching) HTML itself, so callers
+ * can use this in place of a bare `escapeHtml()` on leaf text runs.
+ */
+function renderLoraWordsInPlainText(text: string, loraWords?: ReadonlySet<string>): string {
+  if (!text) return "";
+  if (!loraWords || loraWords.size === 0) return escapeHtml(text);
+  const parts = text.split(/(,)/);
+  let html = "";
+  for (const part of parts) {
+    if (part === ",") {
+      html += ",";
+      continue;
+    }
+    const trimmed = part.trim();
+    if (trimmed && loraWords.has(trimmed.toLowerCase())) {
+      const start = part.indexOf(trimmed);
+      html += escapeHtml(part.slice(0, start));
+      html += highlightPill(LORA_WORD_COLOR);
+      html += escapeHtml(trimmed);
+      html += `</span>`;
+      html += escapeHtml(part.slice(start + trimmed.length));
+    } else {
+      html += escapeHtml(part);
+    }
+  }
+  return html;
+}
+
+/**
+ * Check whether the prompt has any comma-delimited segment matching a known
+ * LoRA-inserted trigger word. Cheap guard so the backdrop overlay only
+ * mounts when there's actually something to highlight.
+ */
+export function hasLoraWordInPrompt(raw: string, loraWords?: ReadonlySet<string>): boolean {
+  if (!raw || !loraWords || loraWords.size === 0) return false;
+  return raw.split(",").some((segment) => loraWords.has(segment.trim().toLowerCase()));
+}
 
 /**
  * Highlight <segment:...> regions within a plain-text run, delegating the
@@ -318,22 +376,23 @@ const SEGMENT_TAG_COLOR = {
 function renderSegmentAwareText(
   text: string,
   knownPresetSlugs?: ReadonlySet<string>,
+  loraWords?: ReadonlySet<string>,
 ): string {
   if (!text) return "";
   if (!text.toLowerCase().includes("<segment:")) {
-    return renderPresetSegment(text, knownPresetSlugs);
+    return renderPresetSegment(text, knownPresetSlugs, loraWords);
   }
   const { ranges } = parseSegmentDetailPrompt(text);
   let html = "";
   let lastIndex = 0;
   for (const range of ranges) {
-    html += renderPresetSegment(text.slice(lastIndex, range.start), knownPresetSlugs);
+    html += renderPresetSegment(text.slice(lastIndex, range.start), knownPresetSlugs, loraWords);
     html += highlightPill(SEGMENT_TAG_COLOR);
     html += escapeHtml(text.slice(range.start, range.end));
     html += `</span>`;
     lastIndex = range.end;
   }
-  html += renderPresetSegment(text.slice(lastIndex), knownPresetSlugs);
+  html += renderPresetSegment(text.slice(lastIndex), knownPresetSlugs, loraWords);
   return html;
 }
 


### PR DESCRIPTION
### New features
- **Lock resolution across model swaps**: switching checkpoints normally resets width/height to that model's default resolution. A new lock toggle next to the resolution controls keeps your current width and height fixed through model swaps.
- **LoRA trigger words tracked and highlighted in the prompt**: words added via a LoRA's trigger-word chip are now tracked per-LoRA, highlighted inline in the prompt, and automatically removed if you disable or remove that LoRA.
- **Collapsible LoRA list**: the LoRA section in the model picker can now be collapsed, with the state remembered between sessions.

Follow-up to v2.1.0: these changes were finished and validated alongside the gallery-expiry work but were left uncommitted when v2.1.0 was cut. Shipping now as a quick patch release rather than amending the already-tagged v2.1.0.