### PR TITLE
v2.1.2: Dependency maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v2.1.2
+
+### Fixes and maintenance
+- **Dependency maintenance**: routine updates across Rust crates (`base64`, `futures-util`, `serde`, `tauri-plugin-dialog`, `ort`), npm packages (`@tauri-apps/plugin-dialog`, `dompurify`, `svelte`, `svelte-check`, `marked`), and GitHub Actions (`dtolnay/rust-toolchain`, `swatinem/rust-cache`, `docker/login-action`). No user-facing changes; each Rust crate bump was verified with `cargo check` against both the desktop and server build targets before merge.
+
+---
+
 ## What's New in v2.1.1
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v2.1.2
+
+### Fixes and maintenance
+- **Dependency maintenance**: routine updates across Rust crates (`base64`, `futures-util`, `serde`, `tauri-plugin-dialog`, `ort`), npm packages (`@tauri-apps/plugin-dialog`, `dompurify`, `svelte`, `svelte-check`, `marked`), and GitHub Actions (`dtolnay/rust-toolchain`, `swatinem/rust-cache`, `docker/login-action`). No user-facing changes; each Rust crate bump was verified with `cargo check` against both the desktop and server build targets before merge.
+
+---
+
 ## What's New in v2.1.1
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Routine dependency maintenance release, no user-facing changes.

- 13 dependabot chore(deps) PRs merged: Rust crates (base64, futures-util, serde, tauri-plugin-dialog, ort), npm packages (@tauri-apps/plugin-dialog, dompurify, svelte, svelte-check, marked), and GitHub Actions (dtolnay/rust-toolchain, swatinem/rust-cache, docker/login-action)
- Each Rust crate bump was compile-verified with cargo check against both the desktop and server build targets before merge (PR CI does not run Rust builds)
- Version bumped to 2.1.2 across package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json
- RELEASE_NOTES.md and CHANGELOG.md updated

## Test plan
- [x] cargo check (desktop) passed
- [x] cargo check --no-default-features --features server passed
- [x] cargo test passed (202 passed, 0 failed)
- [x] npm run build passed