### PR TITLE
v2.1.3: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v2.1.3
+
+### Fixes and maintenance
+- **Fixed setup failing on Windows profiles with an apostrophe in the path**: the uv/uvx and ComfyUI archive extraction steps built PowerShell commands by interpolating file paths directly into single-quoted strings, so a path like `C:\Users\Cole's Computer\...` broke the quoting and corrupted the command, causing setup to fail. Paths are now properly escaped before being passed to PowerShell. ([#608](https://github.com/Mooshieblob1/MooshieUI/pull/608))
+
+---
+
 ## What's New in v2.1.2
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v2.1.3
+
+### Fixes and maintenance
+- **Fixed setup failing on Windows profiles with an apostrophe in the path**: the uv/uvx and ComfyUI archive extraction steps built PowerShell commands by interpolating file paths directly into single-quoted strings, so a path like `C:\Users\Cole's Computer\...` broke the quoting and corrupted the command, causing setup to fail. Paths are now properly escaped before being passed to PowerShell. ([#608](https://github.com/Mooshieblob1/MooshieUI/pull/608))
+
+---
+
 ## What's New in v2.1.2
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What's New in v2.1.3

### Fixes and maintenance
- Fixed setup failing on Windows profiles with an apostrophe in the path (uv/uvx and ComfyUI extraction PowerShell commands now properly escape paths). (#608)