### PR TITLE
v2.1.4: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## What's New in v2.1.4
+
+### Fixes and maintenance
+- **Fixed ComfyUI crashing on startup with "Torch not compiled with CUDA enabled"**: when the installed PyTorch build has no GPU accelerator support (for example CPU-only installs, or AMD GPUs on Windows where ROCm isn't available), ComfyUI was launched without the `--cpu` flag, and its own startup code assumes CUDA is present, crashing instead of falling back to CPU. MooshieUI now checks the installed torch build at launch and automatically passes `--cpu` when no accelerator is available. ([#610](https://github.com/Mooshieblob1/MooshieUI/pull/610))
+
+---
+
 ## What's New in v2.1.3
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## What's New in v2.1.4
+
+### Fixes and maintenance
+- **Fixed ComfyUI crashing on startup with "Torch not compiled with CUDA enabled"**: when the installed PyTorch build has no GPU accelerator support (for example CPU-only installs, or AMD GPUs on Windows where ROCm isn't available), ComfyUI was launched without the `--cpu` flag, and its own startup code assumes CUDA is present, crashing instead of falling back to CPU. MooshieUI now checks the installed torch build at launch and automatically passes `--cpu` when no accelerator is available. ([#610](https://github.com/Mooshieblob1/MooshieUI/pull/610))
+
+---
+
 ## What's New in v2.1.3
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
### Fixes and maintenance
- Fixed ComfyUI crashing on startup with "Torch not compiled with CUDA enabled" when the installed PyTorch build has no GPU accelerator support (CPU-only installs, or AMD GPUs on Windows where ROCm isn't available). MooshieUI now checks the installed torch build at launch and automatically passes --cpu when no accelerator is available. (#610)