### PR TITLE
fix: don't arm the heartbeat watchdog in LAN browser mode

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -155,9 +155,12 @@ pub async fn switch_to_browser_mode(
         port = actual_port;
     }
 
-    // Always start a new heartbeat watchdog — the previous one exits when
+    // Start a new heartbeat watchdog — the previous one exits when
     // app_mode_active is set, so we need a fresh one for the new browser session.
-    {
+    // Only in single-user browser mode: with LAN access enabled, multiple users
+    // may connect (often from phones that suspend background tab timers), and we
+    // must NOT shut down and cancel a running generation when one tab goes quiet.
+    if !lan_enabled {
         let shared_state: Arc<AppState> = state.inner().clone();
         // 120s: browsers throttle background setInterval to ~1 min;
         // we need a timeout well above that to avoid killing the


### PR DESCRIPTION
Fixes #612.

`switch_to_browser_mode` in `commands/config.rs` started the heartbeat watchdog unconditionally, while the startup path in `lib.rs` correctly guards it with `if !lan_enabled`. Since the web server only binds beyond 127.0.0.1 when LAN is enabled, every remote setup made through the in-app switch to browser mode had a watchdog armed against it.

After 120s without a heartbeat the watchdog interrupts the running generation and calls `process::exit(0)`. Mobile browsers suspend background tab timers well inside that window, so locking the phone screen during a long job killed the job and the app.

This adds the same `if !lan_enabled` guard to the second call site. `lan_enabled` was already snapshotted at the top of the function for `start_server`, so there is no new state read.

Validation: cargo fmt, cargo check on both feature sets, cargo test (209 passed). No frontend files touched.