### PR TITLE
add Transparent BG toggle for NovelAI V5

### DIFF
--- a/docs/NOVELAI.md
+++ b/docs/NOVELAI.md
@@ -221,6 +221,42 @@ no-op. The flag itself is still sent, because NovelAI's own client sends it
 and request parity is worth more than the byte. The sliders keep showing the
 raw values the user set, which is also what the official client does.
 
+### 2.11 Transparent BG is a prompt tag, not a request field
+
+V5's custom VAE is the first NovelAI VAE with a real alpha channel, and their
+site exposes it as a "Transparent BG" button beside the prompt box. That button
+is a tag shortcut. There is no request field for transparency: the whole feature
+is the tag `2.1::transparent background::`, at the weight NovelAI's own release
+notes recommend, and the model does the rest.
+
+MooshieUI copies the behaviour but not the placement. The toggle lives in the
+NovelAI advanced section and the tag is appended by `payload::with_transparency`
+while the request body is built, so it never appears in the user's prompt box.
+That is the point of doing it in Rust: the toggle owns the tag, so turning the
+toggle off takes the tag away again cleanly, and a saved prompt does not carry a
+setting the user cannot see. Both copies of the prompt in the request body (the
+`v4_prompt` caption and the top-level `input`) get the same appended text,
+because NovelAI reads both.
+
+Three guards sit around the injection:
+
+- **`models.alpha` gates it.** Only the two V5 rows carry the flag. On V4.5 or
+  V4 the toggle is hidden by `supportsNovelAiTransparency`, and the tag is
+  dropped server side regardless, so a stale persisted setting cannot spend
+  Anlas on a picture of a checkerboard.
+- **A prompt that already says `transparent background` is left alone**, so a
+  user who typed the tag themselves does not get a second copy fighting the
+  first one's weight.
+- **The free local post-process is skipped while the toggle is on.** That pass
+  round-trips the image through ComfyUI's `LoadImage`, whose IMAGE output is RGB
+  (alpha goes to the MASK output), so the transparency just paid for would come
+  back flattened onto black. `transparency_requested()` in `novelai/mod.rs`
+  mirrors the payload's condition exactly, and the panel warns before the
+  request is sent rather than after the Anlas is gone.
+
+Nothing else in the output path needed changing. The PNG NovelAI returns is
+passed through byte for byte and the gallery encoders are RGBA already.
+
 ## 3. The free local post-process
 
 NovelAI has already been paid for the pixels it returns, so upscaling and face
@@ -255,6 +291,9 @@ ComfyUI prompt maps to one alias and one GPU worker, and the first terminal
 event finishes the queue entry. A multi-image NovelAI batch has no safe
 single-prompt handoff, so batches are delivered untouched and a warning is
 logged. Generating one image at a time is the way to get the free upscale today.
+
+**It is also skipped while Transparent BG is on**, for the reason in section
+2.11: the pass would flatten the alpha channel onto a solid background.
 
 ## 4. Prompt syntax
 
@@ -309,6 +348,14 @@ does not mistake them for verified behaviour.
    carry the remaining allowance are still unconfirmed, and a bar fed by a
    guessed field would read wrong rather than read empty. Anlas remaining and
    Opus status are shown instead.
+5. **Whether NovelAI's stealth PNG metadata survives a transparent
+   background.** NovelAI hides generation metadata in the low bits of the alpha
+   channel of images that have no meaningful alpha. A real cut-out uses that
+   channel for picture data, so the stealth payload is either omitted or written
+   somewhere the reader does not look. `novelaiPngMetadata.ts` also reads the
+   visible `Comment` chunk, which is what the app actually relies on, so a
+   missing stealth layer costs nothing here. It is listed because the
+   interaction is unverified, not because it is known to break.
 
 `Subscription.extra` captures any key the backend does not name, and
 `fetch_subscription` logs them at debug level, so a field NovelAI adds later
@@ -325,6 +372,48 @@ and the direction of `percent`, the streaming protocol, and that
 Nothing in this backend is covered by an automated test that touches NovelAI's
 servers, so every phase that ships is followed by a hand-test pass recorded
 here, newest first. Each entry says plainly whether testing is needed at all.
+
+### 2026-08-25 - Transparent BG for V5
+
+**Requested by:** the user: "add the transparent bg feature that NAI V5 should
+have", then "add a button that functionally does the same thing and not showing
+it in prompts either".
+
+**What changed.** A "Transparent BG" checkbox in the NovelAI advanced section,
+shown only when the selected model's VAE carries an alpha channel, which today
+means the two V5 rows. NovelAI ships this as a prompt tag rather than a request
+field, so the backend appends `2.1::transparent background::` while the request
+body is built and the user's prompt box is never touched. Section 2.11 has the
+reasoning and the three guards around the injection. The free local
+post-process is suppressed while the toggle is on, with an amber warning in the
+panel and a `log::warn!` on the Rust side, because ComfyUI's `LoadImage` would
+flatten the alpha onto black.
+
+**Testing needed:** waived by the user: "no need to verify, it's a tag, will
+work right out of the box." The checklist below is kept as a regression
+reference for anyone who touches the injection later. Steps 4 to 9 spend
+Anlas, one image each.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | Select NovelAI V4.5 or V4, open the NovelAI advanced section | No Transparent BG checkbox |
+| 2 | Switch to NovelAI V5 Full | Transparent BG appears under Variety+ |
+| 3 | Hover its info tip | Explains that V5's VAE is the first with a real alpha channel |
+| 4 | Tick it, generate a simple subject (`1girl, standing`) | Result is a cut-out, and the prompt box still shows exactly what you typed |
+| 5 | Open the result in something that shows transparency | Genuinely transparent, not white or black |
+| 6 | Untick it, generate again on the same seed | Normal background returns, nothing left behind in the prompt |
+| 7 | Type `transparent background` yourself, tick the toggle, generate | Only one copy of the tag is sent, output matches step 4 |
+| 8 | Tick Transparent BG and Local post-process together | Amber warning appears in the panel before you generate |
+| 9 | Generate with both on | Image arrives untouched with alpha intact, Rust log says the local pass was skipped |
+| 10 | Tick it on V5, switch to V4.5 without unticking, generate | Normal background, no Anlas spent on a checkerboard |
+| 11 | Reload the app | The toggle's state persisted |
+| 12 | Import the saved image's metadata back into the app | Transparent BG comes back ticked (`mooshie_novelai_transparent_background`) |
+| 13 | Repeat step 4 in browser mode (LAN URL) | Identical behaviour |
+| 14 | Switch UI language | Label, info tip and the local-pass warning are translated |
+
+**Do not skip:** 1, 4, 5, 8, 12. Those cover the capability gate, the happy
+path, the actual alpha channel, the post-process conflict and the metadata
+round trip. **Low-risk, skip if short on time:** 3, 14.
 
 ### 2026-08-24 - Director Tools (PR #618)
 

--- a/src-tauri/src/novelai/mod.rs
+++ b/src-tauri/src/novelai/mod.rs
@@ -97,6 +97,17 @@ fn resolve_model_id(params: &GenerationParams, nai: &params::NovelAiParams) -> S
     }
 }
 
+/// True when this generation asked for, and can get, a transparent background.
+///
+/// Mirrors the condition `payload::with_transparency` injects the tag under, so
+/// the two never disagree about whether the returned PNG carries alpha.
+fn transparency_requested(params: &GenerationParams) -> bool {
+    params.novelai.as_ref().is_some_and(|nai| {
+        nai.transparent_background
+            && models::find(&resolve_model_id(params, nai)).is_some_and(|m| m.alpha)
+    })
+}
+
 /// Vibe encodings already paid for during this run of the app.
 ///
 /// `/ai/encode-vibe` bills 2 Anlas every time it is handed an image it has
@@ -452,7 +463,15 @@ async fn run_inner(
     // any failure here falls back to delivering the image untouched rather
     // than surfacing an error the user would read as "my Anlas bought nothing".
     if crate::templates::upscale_standalone::is_requested(params) {
-        if let [png] = images.as_slice() {
+        if transparency_requested(params) {
+            // The local pass loads the image through ComfyUI's `LoadImage`,
+            // whose IMAGE output is RGB: the alpha the user paid V5 for would
+            // come back flattened onto black. Keeping the original is the only
+            // outcome that honours the toggle.
+            log::warn!(
+                "NovelAI {prompt_id}: local post-process skipped, it would flatten                  the transparent background"
+            );
+        } else if let [png] = images.as_slice() {
             match run_local_post_process(state, sink, prompt_id, params, png).await {
                 Ok(()) => return Ok(RunOutcome::HandedOff),
                 Err(err) => log::warn!(

--- a/src-tauri/src/novelai/models.rs
+++ b/src-tauri/src/novelai/models.rs
@@ -23,6 +23,12 @@ pub struct NovelAiModel {
     pub vibe_transfer: bool,
     /// Per-character negative prompts.
     pub character_negatives: bool,
+    /// The VAE emits a real alpha channel, so transparency can be asked for.
+    ///
+    /// V5's custom VAE is the first to carry one. There is no request field for
+    /// it: NovelAI ships the feature as a prompt tag, so this flag gates the
+    /// tag rather than a parameter.
+    pub alpha: bool,
 }
 
 /// Every NovelAI model MooshieUI offers.
@@ -39,6 +45,7 @@ pub const MODELS: &[NovelAiModel] = &[
         precise_reference: false,
         vibe_transfer: false,
         character_negatives: true,
+        alpha: true,
     },
     NovelAiModel {
         id: "nai-diffusion-5-curated",
@@ -48,6 +55,7 @@ pub const MODELS: &[NovelAiModel] = &[
         precise_reference: false,
         vibe_transfer: false,
         character_negatives: true,
+        alpha: true,
     },
     NovelAiModel {
         id: "nai-diffusion-4-5-full",
@@ -57,6 +65,7 @@ pub const MODELS: &[NovelAiModel] = &[
         precise_reference: true,
         vibe_transfer: true,
         character_negatives: true,
+        alpha: false,
     },
     NovelAiModel {
         id: "nai-diffusion-4-full",
@@ -66,6 +75,7 @@ pub const MODELS: &[NovelAiModel] = &[
         precise_reference: false,
         vibe_transfer: true,
         character_negatives: true,
+        alpha: false,
     },
 ];
 
@@ -126,6 +136,14 @@ mod tests {
         let v45 = find("nai-diffusion-4-5-full").unwrap();
         assert!(v45.precise_reference);
         assert!(v45.vibe_transfer);
+    }
+
+    #[test]
+    fn only_v5_carries_an_alpha_channel() {
+        assert!(find("nai-diffusion-5-full").unwrap().alpha);
+        assert!(find("nai-diffusion-5-curated").unwrap().alpha);
+        assert!(!find("nai-diffusion-4-5-full").unwrap().alpha);
+        assert!(!find("nai-diffusion-4-full").unwrap().alpha);
     }
 
     #[test]

--- a/src-tauri/src/novelai/params.rs
+++ b/src-tauri/src/novelai/params.rs
@@ -119,6 +119,13 @@ pub struct NovelAiParams {
     /// "Variety+" — suppresses CFG above a sigma threshold.
     #[serde(default)]
     pub variety_plus: bool,
+    /// "Transparent BG" — ask V5 for a real alpha channel.
+    ///
+    /// NovelAI has no request field for this. The feature is a prompt tag their
+    /// own UI inserts for you, so the toggle is honoured by appending the tag
+    /// while the request body is built. See `payload::with_transparency`.
+    #[serde(default)]
+    pub transparent_background: bool,
     #[serde(default = "default_true")]
     pub quality_toggle: bool,
     /// NovelAI's built-in undesired-content preset index.

--- a/src-tauri/src/novelai/payload.rs
+++ b/src-tauri/src/novelai/payload.rs
@@ -35,6 +35,7 @@ pub fn build(
     model: &NovelAiModel,
 ) -> Result<Value, String> {
     let action = normalise_action(&nai.action, input);
+    let positive_prompt = with_transparency(&input.positive_prompt, nai, model);
     let mut parameters = Map::new();
 
     parameters.insert("params_version".into(), json!(3));
@@ -80,7 +81,7 @@ pub fn build(
             "v4_prompt".into(),
             json!({
                 "caption": {
-                    "base_caption": input.positive_prompt,
+                    "base_caption": positive_prompt,
                     "char_captions": characters
                         .iter()
                         .map(|c| json!({
@@ -129,7 +130,7 @@ pub fn build(
     apply_image_action(&mut parameters, input, nai, &action)?;
 
     Ok(json!({
-        "input": input.positive_prompt,
+        "input": positive_prompt,
         "model": models::resolve_id(model, &action),
         "action": action,
         "parameters": Value::Object(parameters),
@@ -144,6 +145,34 @@ fn normalise_action(action: &str, input: &PayloadInput) -> String {
         "img2img" | "infill" if input.input_image.is_some() => "img2img".into(),
         _ => "generate".into(),
     }
+}
+
+/// The tag NovelAI's own "Transparent BG" button inserts, at the weight their
+/// release notes recommend for a clean cut-out.
+const TRANSPARENCY_TAG: &str = "2.1::transparent background::";
+
+/// Append the transparency tag when the toggle is on and the model can honour
+/// it.
+///
+/// NovelAI ships transparency as a prompt tag rather than a request field, and
+/// only the V5 VAE emits an alpha channel, so an older model would just spend
+/// Anlas on a picture of a checkerboard. The tag is kept out of the user's
+/// prompt box on purpose: the toggle owns it, so turning the toggle off takes
+/// it away again cleanly.
+fn with_transparency(prompt: &str, nai: &NovelAiParams, model: &NovelAiModel) -> String {
+    if !nai.transparent_background || !model.alpha {
+        return prompt.to_string();
+    }
+    // A user who typed the tag themselves already has what the toggle adds,
+    // and a second copy would only fight the first one's weight.
+    if prompt.to_lowercase().contains("transparent background") {
+        return prompt.to_string();
+    }
+    let trimmed = prompt.trim_end().trim_end_matches(',').trim_end();
+    if trimmed.is_empty() {
+        return TRANSPARENCY_TAG.to_string();
+    }
+    format!("{trimmed}, {TRANSPARENCY_TAG}")
 }
 
 /// NovelAI scales the Variety+ cutoff with the diagonal of the latent, so a
@@ -623,5 +652,68 @@ mod tests {
         n.variety_plus = true;
         let body = build(&input(), &n, v45()).unwrap();
         assert!(body["parameters"]["skip_cfg_above_sigma"].as_f64().unwrap() > 0.0);
+    }
+
+    fn v5() -> &'static NovelAiModel {
+        models::find("nai-diffusion-5-full").unwrap()
+    }
+
+    #[test]
+    fn transparency_appends_the_tag_to_both_prompt_copies() {
+        let mut n = nai();
+        n.transparent_background = true;
+        let body = build(&input(), &n, v5()).unwrap();
+        let expected = "1girl, solo, 2.1::transparent background::";
+        assert_eq!(body["input"], expected);
+        assert_eq!(
+            body["parameters"]["v4_prompt"]["caption"]["base_caption"],
+            expected
+        );
+        // The negative prompt is left alone.
+        assert_eq!(body["parameters"]["negative_prompt"], "lowres");
+    }
+
+    #[test]
+    fn transparency_is_off_by_default() {
+        let body = build(&input(), &nai(), v5()).unwrap();
+        assert_eq!(body["input"], "1girl, solo");
+    }
+
+    #[test]
+    fn transparency_is_ignored_by_models_without_an_alpha_channel() {
+        // V4.5's VAE has no alpha channel, so the tag would only cost Anlas
+        // for a picture of a checkerboard.
+        let mut n = nai();
+        n.transparent_background = true;
+        let body = build(&input(), &n, v45()).unwrap();
+        assert_eq!(body["input"], "1girl, solo");
+    }
+
+    #[test]
+    fn transparency_does_not_double_up_a_tag_the_user_typed() {
+        let mut n = nai();
+        n.transparent_background = true;
+        let mut i = input();
+        i.positive_prompt = "1girl, Transparent Background".into();
+        let body = build(&i, &n, v5()).unwrap();
+        assert_eq!(body["input"], "1girl, Transparent Background");
+    }
+
+    #[test]
+    fn transparency_tidies_the_join_and_survives_an_empty_prompt() {
+        let mut n = nai();
+        n.transparent_background = true;
+        let mut i = input();
+        i.positive_prompt = "1girl,  ".into();
+        assert_eq!(
+            build(&i, &n, v5()).unwrap()["input"],
+            "1girl, 2.1::transparent background::"
+        );
+
+        i.positive_prompt = String::new();
+        assert_eq!(
+            build(&i, &n, v5()).unwrap()["input"],
+            "2.1::transparent background::"
+        );
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1700,6 +1700,7 @@
       metadata.mooshie_novelai_uncond_scale = String(nai.uncond_scale);
       metadata.mooshie_novelai_dynamic_thresholding = String(nai.dynamic_thresholding);
       metadata.mooshie_novelai_variety_plus = String(nai.variety_plus);
+      metadata.mooshie_novelai_transparent_background = String(nai.transparent_background);
       metadata.mooshie_novelai_use_coords = String(nai.use_coords);
       metadata.mooshie_novelai_quality_toggle = String(nai.quality_toggle);
       metadata.mooshie_novelai_uc_preset = String(nai.uc_preset);

--- a/src/lib/components/generation/NovelAiSettings.svelte
+++ b/src/lib/components/generation/NovelAiSettings.svelte
@@ -21,6 +21,16 @@
   const postProcessArmed = $derived(generation.upscaleEnabled || generation.facefixEnabled);
 
   /**
+   * The local pass loads the image through ComfyUI's `LoadImage`, whose IMAGE
+   * output is RGB, so it would flatten the alpha the user paid V5 for. The
+   * backend skips the pass rather than destroy the transparency; this says so
+   * before the Anlas is spent.
+   */
+  const transparencyActive = $derived(
+    nai.transparent_background && generation.supportsNovelAiTransparency,
+  );
+
+  /**
    * The local model picker spans two folders, so the option value carries the
    * folder with it. A colon is safe as the separator: no filesystem this runs
    * on allows one in a file name, and only the first is split on so a
@@ -119,6 +129,20 @@
       {locale.t("generation.novelai.advanced.variety_plus")}
       <InfoTip text={locale.t("generation.novelai.advanced.variety_plus_desc")} />
     </label>
+
+    {#if generation.supportsNovelAiTransparency}
+      <label class="flex items-center gap-2 text-xs text-neutral-300">
+        <input
+          type="checkbox"
+          class="accent-indigo-500"
+          checked={nai.transparent_background}
+          onchange={(e) =>
+            generation.updateNovelAiSettings({ transparent_background: e.currentTarget.checked })}
+        />
+        {locale.t("generation.novelai.advanced.transparent_background")}
+        <InfoTip text={locale.t("generation.novelai.advanced.transparent_background_desc")} />
+      </label>
+    {/if}
 
     <label class="flex items-center gap-2 text-xs text-neutral-300">
       <input
@@ -288,6 +312,10 @@
       {:else if !postProcessArmed}
         <p class="text-[11px] text-amber-400/90">
           {locale.t("generation.novelai.local.nothing_to_do")}
+        </p>
+      {:else if transparencyActive}
+        <p class="text-[11px] text-amber-400/90">
+          {locale.t("generation.novelai.local.transparency_conflict")}
         </p>
       {/if}
     {/if}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -3106,6 +3106,8 @@ const de: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Verwendet die ältere Behandlung unerwünschter Inhalte. Lassen Sie dies aus, außer Sie bilden ein älteres Bild nach.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Fügt den ersten Schritten Variation hinzu, was lebendigere Kompositionen ergibt.",
+  "generation.novelai.advanced.transparent_background": "Transparenter HG",
+  "generation.novelai.advanced.transparent_background_desc": "Fordert von NovelAI V5 ein Freisteller-Bild auf transparentem Hintergrund an. Der VAE von V5 hat als erster einen echten Alphakanal, daher wird das PNG mit Transparenz gespeichert.",
   "generation.novelai.advanced.dynamic_thresholding": "Dynamisches Thresholding",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Bändigt übersättigte Farben bei hoher Guidance.",
   "generation.novelai.advanced.cfg_rescale": "Guidance-Reskalierung",
@@ -3127,6 +3129,7 @@ const de: Record<string, string> = {
   "generation.novelai.local.sampling": "Sampling: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Wählen Sie einen Checkpoint, damit der lokale Durchlauf startet.",
   "generation.novelai.local.nothing_to_do": "Aktivieren Sie Hochskalieren oder Gesichtskorrektur, damit der lokale Durchlauf etwas bewirkt.",
+  "generation.novelai.local.transparency_conflict": "Der lokale Durchlauf wird übersprungen, solange Transparenter HG aktiv ist: Er würde die Transparenz auf einen deckenden Hintergrund reduzieren.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Geschätzte Anlas-Kosten. NovelAI ist maßgeblich; prüfen Sie das Guthaben oben.",
 

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -3042,6 +3042,8 @@ const en: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Uses the older handling of undesired content. Leave this off unless you are matching an older image.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Adds variation to the first steps, which gives livelier compositions.",
+  "generation.novelai.advanced.transparent_background": "Transparent BG",
+  "generation.novelai.advanced.transparent_background_desc": "Asks NovelAI V5 for a cut-out on a transparent background. V5's VAE is the first with a real alpha channel, so the PNG is saved with transparency intact.",
   "generation.novelai.advanced.dynamic_thresholding": "Dynamic thresholding",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Reins in oversaturated colors at high guidance.",
   "generation.novelai.advanced.cfg_rescale": "Guidance rescale",
@@ -3063,6 +3065,7 @@ const en: Record<string, string> = {
   "generation.novelai.local.sampling": "Sampling: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Pick a checkpoint for the local pass to run.",
   "generation.novelai.local.nothing_to_do": "Turn on Upscale or Face Fix for the local pass to do anything.",
+  "generation.novelai.local.transparency_conflict": "The local pass is skipped while Transparent BG is on: it would flatten the transparency onto a solid background.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Estimated Anlas cost. NovelAI is the final authority; check the balance above.",
 

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -3133,6 +3133,8 @@ const es: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Usa el tratamiento antiguo del contenido no deseado. Déjalo desactivado salvo que quieras reproducir una imagen antigua.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Añade variación en los primeros pasos, lo que da composiciones más vivas.",
+  "generation.novelai.advanced.transparent_background": "Fondo transparente",
+  "generation.novelai.advanced.transparent_background_desc": "Pide a NovelAI V5 un recorte sobre fondo transparente. El VAE de V5 es el primero con un canal alfa real, así que el PNG se guarda con la transparencia intacta.",
   "generation.novelai.advanced.dynamic_thresholding": "Umbral dinámico",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Controla los colores sobresaturados cuando la guía es alta.",
   "generation.novelai.advanced.cfg_rescale": "Reescalado de guía",
@@ -3154,6 +3156,7 @@ const es: Record<string, string> = {
   "generation.novelai.local.sampling": "Muestreo: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Elige un checkpoint para que se ejecute la pasada local.",
   "generation.novelai.local.nothing_to_do": "Activa Escalar o Corregir caras para que la pasada local haga algo.",
+  "generation.novelai.local.transparency_conflict": "La pasada local se omite mientras Fondo transparente está activo: aplanaría la transparencia sobre un fondo sólido.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Coste estimado en Anlas. NovelAI es la autoridad final; comprueba el saldo de arriba.",
 

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -3130,6 +3130,8 @@ const fr: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Utilise l'ancien traitement du contenu indésirable. Laissez désactivé, sauf pour reproduire une image ancienne.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Ajoute de la variation aux premières étapes, ce qui donne des compositions plus vivantes.",
+  "generation.novelai.advanced.transparent_background": "Fond transparent",
+  "generation.novelai.advanced.transparent_background_desc": "Demande à NovelAI V5 un détourage sur fond transparent. Le VAE de V5 est le premier à avoir un vrai canal alpha, donc le PNG est enregistré avec sa transparence.",
   "generation.novelai.advanced.dynamic_thresholding": "Seuillage dynamique",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Limite les couleurs sursaturées quand la guidance est élevée.",
   "generation.novelai.advanced.cfg_rescale": "Rééchelonnage de la guidance",
@@ -3151,6 +3153,7 @@ const fr: Record<string, string> = {
   "generation.novelai.local.sampling": "Échantillonnage : {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Choisissez un checkpoint pour que la passe locale s'exécute.",
   "generation.novelai.local.nothing_to_do": "Activez Agrandir ou Correction des visages pour que la passe locale fasse quelque chose.",
+  "generation.novelai.local.transparency_conflict": "La passe locale est ignorée tant que Fond transparent est actif : elle aplatirait la transparence sur un fond opaque.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Coût estimé en Anlas. NovelAI fait foi ; vérifiez le solde ci-dessus.",
 

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -3104,6 +3104,8 @@ const it: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Usa la vecchia gestione dei contenuti indesiderati. Lascialo disattivato, a meno che tu non stia riproducendo un'immagine più vecchia.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Aggiunge variazione ai primi passi, per composizioni più vivaci.",
+  "generation.novelai.advanced.transparent_background": "Sfondo trasparente",
+  "generation.novelai.advanced.transparent_background_desc": "Chiede a NovelAI V5 un ritaglio su sfondo trasparente. Il VAE di V5 è il primo con un vero canale alfa, quindi il PNG viene salvato con la trasparenza intatta.",
   "generation.novelai.advanced.dynamic_thresholding": "Soglia dinamica",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Tiene a freno i colori sovrasaturi con guidance alta.",
   "generation.novelai.advanced.cfg_rescale": "Riscalatura della guidance",
@@ -3125,6 +3127,7 @@ const it: Record<string, string> = {
   "generation.novelai.local.sampling": "Campionamento: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Scegli un checkpoint per far partire la passata locale.",
   "generation.novelai.local.nothing_to_do": "Attiva Upscale o Correzione volti perché la passata locale faccia qualcosa.",
+  "generation.novelai.local.transparency_conflict": "La passata locale viene saltata finché Sfondo trasparente è attivo: appiattirebbe la trasparenza su uno sfondo pieno.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Costo stimato in Anlas. NovelAI ha l'ultima parola; controlla il saldo qui sopra.",
 

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -3129,6 +3129,8 @@ const ja: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "ネガティブの旧処理を使います。以前の画像を再現する場合を除き、オフのままにしてください。",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "最初のステップに変化を加え、構図が生き生きとします。",
+  "generation.novelai.advanced.transparent_background": "透過背景",
+  "generation.novelai.advanced.transparent_background_desc": "NovelAI V5 に透過背景の切り抜きを依頼します。V5 の VAE は初めて本物のアルファチャンネルを持つため、PNG は透過を保ったまま保存されます。",
   "generation.novelai.advanced.dynamic_thresholding": "ダイナミックしきい値",
   "generation.novelai.advanced.dynamic_thresholding_desc": "ガイダンスが高いときの色の飽和を抑えます。",
   "generation.novelai.advanced.cfg_rescale": "ガイダンス再スケール",
@@ -3150,6 +3152,7 @@ const ja: Record<string, string> = {
   "generation.novelai.local.sampling": "サンプリング: {sampler} / {scheduler}、CFG {cfg}。",
   "generation.novelai.local.checkpoint_required": "ローカル処理を実行するチェックポイントを選んでください。",
   "generation.novelai.local.nothing_to_do": "ローカル処理を動かすには、アップスケールか顔補正を有効にしてください。",
+  "generation.novelai.local.transparency_conflict": "透過背景がオンの間はローカル処理をスキップします。透過が不透明な背景に統合されてしまうためです。",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Anlas の概算コストです。最終的な判断は NovelAI 側になります。上の残高をご確認ください。",
 

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -3104,6 +3104,8 @@ const ko: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "예전 방식의 네거티브 처리를 사용합니다. 이전 이미지를 재현하는 경우가 아니라면 꺼 두세요.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "초반 스텝에 변화를 더해 구도가 더 생동감 있게 나옵니다.",
+  "generation.novelai.advanced.transparent_background": "투명 배경",
+  "generation.novelai.advanced.transparent_background_desc": "NovelAI V5 에 투명 배경 컷아웃을 요청합니다. V5 의 VAE 는 처음으로 실제 알파 채널을 갖고 있어 PNG 가 투명도를 유지한 채 저장됩니다.",
   "generation.novelai.advanced.dynamic_thresholding": "동적 임계값",
   "generation.novelai.advanced.dynamic_thresholding_desc": "가이던스가 높을 때 색이 과포화되는 것을 억제합니다.",
   "generation.novelai.advanced.cfg_rescale": "가이던스 리스케일",
@@ -3125,6 +3127,7 @@ const ko: Record<string, string> = {
   "generation.novelai.local.sampling": "샘플링: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "로컬 처리를 실행할 체크포인트를 선택하세요.",
   "generation.novelai.local.nothing_to_do": "로컬 처리가 동작하려면 업스케일 또는 얼굴 보정을 켜세요.",
+  "generation.novelai.local.transparency_conflict": "투명 배경이 켜져 있는 동안에는 로컬 처리를 건너뜁니다. 투명도가 단색 배경으로 합쳐지기 때문입니다.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "예상 Anlas 비용입니다. 최종 기준은 NovelAI이니 위의 잔액을 확인하세요.",
 

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -3143,6 +3143,8 @@ const pl: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Używa starszej obsługi treści niepożądanych. Zostaw wyłączone, chyba że odtwarzasz starszy obraz.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Dodaje zmienność w pierwszych krokach, co daje żywsze kompozycje.",
+  "generation.novelai.advanced.transparent_background": "Przezroczyste tło",
+  "generation.novelai.advanced.transparent_background_desc": "Prosi NovelAI V5 o wycinek na przezroczystym tle. VAE w V5 jako pierwszy ma prawdziwy kanał alfa, więc PNG zapisuje się z zachowaną przezroczystością.",
   "generation.novelai.advanced.dynamic_thresholding": "Dynamiczne progowanie",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Powstrzymuje przesycone kolory przy wysokim guidance.",
   "generation.novelai.advanced.cfg_rescale": "Przeskalowanie guidance",
@@ -3164,6 +3166,7 @@ const pl: Record<string, string> = {
   "generation.novelai.local.sampling": "Próbkowanie: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Wybierz checkpoint, aby uruchomić przebieg lokalny.",
   "generation.novelai.local.nothing_to_do": "Włącz Powiększanie lub Poprawianie twarzy, aby przebieg lokalny coś zrobił.",
+  "generation.novelai.local.transparency_conflict": "Przebieg lokalny jest pomijany, gdy Przezroczyste tło jest włączone: spłaszczyłby przezroczystość na jednolite tło.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Szacowany koszt w Anlas. Rozstrzygające jest NovelAI; sprawdź saldo powyżej.",
 

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -3105,6 +3105,8 @@ const pt: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Usa o tratamento antigo do conteúdo indesejado. Deixe desligado, a menos que esteja a reproduzir uma imagem antiga.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Acrescenta variação nos primeiros passos, o que dá composições mais vivas.",
+  "generation.novelai.advanced.transparent_background": "Fundo transparente",
+  "generation.novelai.advanced.transparent_background_desc": "Pede ao NovelAI V5 um recorte em fundo transparente. O VAE do V5 é o primeiro com um canal alfa real, por isso o PNG é guardado com a transparência intacta.",
   "generation.novelai.advanced.dynamic_thresholding": "Limiar dinâmico",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Contém as cores sobressaturadas quando a guidance é alta.",
   "generation.novelai.advanced.cfg_rescale": "Reescalonamento da guidance",
@@ -3126,6 +3128,7 @@ const pt: Record<string, string> = {
   "generation.novelai.local.sampling": "Amostragem: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Escolha um checkpoint para a passagem local correr.",
   "generation.novelai.local.nothing_to_do": "Ative Aumentar escala ou Corrigir rostos para a passagem local fazer alguma coisa.",
+  "generation.novelai.local.transparency_conflict": "A passagem local é ignorada enquanto Fundo transparente estiver ativo: achataria a transparência sobre um fundo sólido.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Custo estimado em Anlas. O NovelAI é a autoridade final; verifique o saldo acima.",
 

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -3104,6 +3104,8 @@ const ru: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "Использует прежнюю обработку нежелательного содержимого. Оставьте выключенным, если только не воспроизводите старое изображение.",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "Добавляет разнообразия на первых шагах, что даёт более живые композиции.",
+  "generation.novelai.advanced.transparent_background": "Прозрачный фон",
+  "generation.novelai.advanced.transparent_background_desc": "Просит NovelAI V5 сделать вырезку на прозрачном фоне. VAE у V5 первым получил настоящий альфа-канал, поэтому PNG сохраняется с прозрачностью.",
   "generation.novelai.advanced.dynamic_thresholding": "Динамический порог",
   "generation.novelai.advanced.dynamic_thresholding_desc": "Сдерживает пересыщенные цвета при высоком guidance.",
   "generation.novelai.advanced.cfg_rescale": "Пересчёт guidance",
@@ -3125,6 +3127,7 @@ const ru: Record<string, string> = {
   "generation.novelai.local.sampling": "Сэмплирование: {sampler} / {scheduler}, CFG {cfg}.",
   "generation.novelai.local.checkpoint_required": "Выберите чекпоинт, чтобы локальный проход запустился.",
   "generation.novelai.local.nothing_to_do": "Включите Апскейл или Исправление лиц, чтобы локальный проход что-то сделал.",
+  "generation.novelai.local.transparency_conflict": "Локальный проход пропускается, пока включён Прозрачный фон: он свёл бы прозрачность на сплошной фон.",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "Примерная стоимость в Anlas. Окончательное слово за NovelAI; проверьте баланс выше.",
 

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -3104,6 +3104,8 @@ const zhTw: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "使用舊的負面內容處理方式。除非要重現舊圖，否則請保持關閉。",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "在最初幾步加入變化，讓構圖更生動。",
+  "generation.novelai.advanced.transparent_background": "透明背景",
+  "generation.novelai.advanced.transparent_background_desc": "讓 NovelAI V5 產生透明背景的去背圖。V5 的 VAE 首次帶有真正的 Alpha 通道，因此 PNG 會保留透明度儲存。",
   "generation.novelai.advanced.dynamic_thresholding": "動態閾值",
   "generation.novelai.advanced.dynamic_thresholding_desc": "在高引導值下抑制過飽和的顏色。",
   "generation.novelai.advanced.cfg_rescale": "引導值重新縮放",
@@ -3125,6 +3127,7 @@ const zhTw: Record<string, string> = {
   "generation.novelai.local.sampling": "取樣：{sampler} / {scheduler}，CFG {cfg}。",
   "generation.novelai.local.checkpoint_required": "選擇一個模型檔，本機處理才能執行。",
   "generation.novelai.local.nothing_to_do": "啟用放大或臉部修復，本機處理才會有作用。",
+  "generation.novelai.local.transparency_conflict": "開啟透明背景時會略過本機處理，否則透明度會被合併到不透明背景上。",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "預估 Anlas 消耗。以 NovelAI 為準，請查看上方餘額。",
 

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -3105,6 +3105,8 @@ const zh: Record<string, string> = {
   "generation.novelai.advanced.legacy_uc_desc": "使用旧的负面内容处理方式。除非要复现旧图，否则请保持关闭。",
   "generation.novelai.advanced.variety_plus": "Variety+",
   "generation.novelai.advanced.variety_plus_desc": "在最初几步加入变化，让构图更生动。",
+  "generation.novelai.advanced.transparent_background": "透明背景",
+  "generation.novelai.advanced.transparent_background_desc": "让 NovelAI V5 生成透明背景的抠图。V5 的 VAE 首次带有真正的 Alpha 通道，因此 PNG 会保留透明度保存。",
   "generation.novelai.advanced.dynamic_thresholding": "动态阈值",
   "generation.novelai.advanced.dynamic_thresholding_desc": "在高引导值下抑制过饱和的颜色。",
   "generation.novelai.advanced.cfg_rescale": "引导值重缩放",
@@ -3126,6 +3128,7 @@ const zh: Record<string, string> = {
   "generation.novelai.local.sampling": "采样：{sampler} / {scheduler}，CFG {cfg}。",
   "generation.novelai.local.checkpoint_required": "选择一个模型文件，本地处理才能运行。",
   "generation.novelai.local.nothing_to_do": "启用放大或面部修复，本地处理才会起作用。",
+  "generation.novelai.local.transparency_conflict": "开启透明背景时会跳过本地处理，否则透明度会被合并到不透明背景上。",
   "generation.novelai.cost_badge": "~{anlas} Anlas",
   "generation.novelai.cost_tip": "预估 Anlas 消耗。以 NovelAI 为准，请查看上方余额。",
 

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -129,6 +129,7 @@ export function createDefaultNovelAiSettings(): NovelAiSettings {
     uncond_scale: 1.0,
     dynamic_thresholding: false,
     variety_plus: false,
+    transparent_background: false,
     quality_toggle: true,
     uc_preset: 0,
     legacy_uc: false,
@@ -1174,6 +1175,17 @@ class GenerationStore {
 
   get supportsNovelAiVibeTransfer(): boolean {
     return this.novelAiModel?.vibeTransfer ?? false;
+  }
+
+  /**
+   * True when the model can return a transparent background.
+   *
+   * Only V5's VAE carries an alpha channel, so on anything older the toggle
+   * would spend Anlas on a picture of a checkerboard. The Rust payload builder
+   * gates the tag on the same flag, so a stale setting cannot leak through.
+   */
+  get supportsNovelAiTransparency(): boolean {
+    return this.novelAiModel?.alpha ?? false;
   }
 
   /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -172,6 +172,13 @@ export interface NovelAiParams {
   dynamic_thresholding: boolean;
   /** "Variety+": suppresses CFG above a sigma threshold. */
   variety_plus: boolean;
+  /**
+   * "Transparent BG": ask V5 for a real alpha channel.
+   *
+   * NovelAI has no request field for it. The backend appends the prompt tag
+   * their own UI inserts, so the user's prompt box stays untouched.
+   */
+  transparent_background: boolean;
   quality_toggle: boolean;
   uc_preset: number;
   legacy_uc: boolean;

--- a/src/lib/utils/metadataImport.ts
+++ b/src/lib/utils/metadataImport.ts
@@ -224,6 +224,7 @@ function applyNovelAiSettings(meta: Record<string, string>, withCharacters = tru
   const booleans: [string, keyof NovelAiSettings][] = [
     ["mooshie_novelai_dynamic_thresholding", "dynamic_thresholding"],
     ["mooshie_novelai_variety_plus", "variety_plus"],
+    ["mooshie_novelai_transparent_background", "transparent_background"],
     ["mooshie_novelai_use_coords", "use_coords"],
     ["mooshie_novelai_quality_toggle", "quality_toggle"],
     ["mooshie_novelai_legacy_uc", "legacy_uc"],

--- a/src/lib/utils/novelaiModels.ts
+++ b/src/lib/utils/novelaiModels.ts
@@ -21,6 +21,11 @@ export interface NovelAiModelInfo {
   preciseReference: boolean;
   vibeTransfer: boolean;
   characterNegatives: boolean;
+  /**
+   * The VAE emits a real alpha channel, so a transparent background can be
+   * asked for. V5's custom VAE is the first to carry one.
+   */
+  alpha: boolean;
 }
 
 /**
@@ -38,6 +43,7 @@ export const NOVELAI_MODELS: readonly NovelAiModelInfo[] = [
     preciseReference: false,
     vibeTransfer: false,
     characterNegatives: true,
+    alpha: true,
   },
   {
     id: "nai-diffusion-5-curated",
@@ -47,6 +53,7 @@ export const NOVELAI_MODELS: readonly NovelAiModelInfo[] = [
     preciseReference: false,
     vibeTransfer: false,
     characterNegatives: true,
+    alpha: true,
   },
   {
     id: "nai-diffusion-4-5-full",
@@ -56,6 +63,7 @@ export const NOVELAI_MODELS: readonly NovelAiModelInfo[] = [
     preciseReference: true,
     vibeTransfer: true,
     characterNegatives: true,
+    alpha: false,
   },
   {
     id: "nai-diffusion-4-full",
@@ -65,6 +73,7 @@ export const NOVELAI_MODELS: readonly NovelAiModelInfo[] = [
     preciseReference: false,
     vibeTransfer: true,
     characterNegatives: true,
+    alpha: false,
   },
 ] as const;
 


### PR DESCRIPTION
NovelAI V5's VAE is the first with a real alpha channel, and their site exposes
it as a "Transparent BG" button. That button is a prompt tag shortcut, not a
request field, so this adds a toggle that does the same thing without touching
the user's prompt box.

## What it does

- Checkbox in the NovelAI advanced section, next to Variety+, shown only when
  the selected model's VAE carries alpha (the two V5 rows).
- `payload::with_transparency` appends `2.1::transparent background::` (the
  weight NovelAI's own release notes recommend) to both prompt copies in the
  request body while it is built. The prompt box is never modified, so turning
  the toggle off takes the tag away again cleanly.

## Guards

- `models.alpha` gates the injection, so a stale persisted setting on V4.5 or V4
  cannot spend Anlas on a picture of a checkerboard.
- A prompt that already contains "transparent background" is left alone rather
  than getting a second copy fighting the first one's weight.
- The free local post-process is skipped while the toggle is on: it round-trips
  through ComfyUI's `LoadImage`, whose IMAGE output is RGB, so the alpha would
  come back flattened onto black. `transparency_requested()` mirrors the
  payload's condition exactly, and the panel warns before the request is sent.

## Also

- Round-trips through PNG metadata as `mooshie_novelai_transparent_background`.
- All 12 locales at parity.
- docs/NOVELAI.md: new section 2.11, a Known Unknown on stealth metadata vs a
  real alpha channel, and a dated test entry.

## Validation

- cargo check desktop and `--no-default-features --features server`: pass
- cargo test: 360 passed, 0 failed (5 new transparency tests)
- cargo fmt, cargo clippy: clean
- npm run build: pass