### PR TITLE
chore: pin ComfyUI v0.34.0 and fix compat smoke test deploy list

### DIFF
--- a/scripts/comfyui-compat/smoke_test.py
+++ b/scripts/comfyui-compat/smoke_test.py
@@ -58,6 +58,7 @@ NODE_FILE_MAP = [
     ("src-tauri/src/comfyui/mooshie_nodes.py", "mooshie-nodes/__init__.py"),
     ("comfyui-nodes/nodes_tiled_diffusion.py", "nodes_tiled_diffusion.py"),
     ("comfyui-nodes/nodes_guidance.py", "nodes_guidance.py"),
+    ("comfyui-nodes/nodes_anima_teacache.py", "nodes_anima_teacache.py"),
     # Source name has the _combined suffix; deployed name drops it (see nodes.rs).
     ("comfyui-nodes/nodes_sdxl_flux2vae_combined.py", "nodes_sdxl_flux2vae.py"),
     ("comfyui-nodes/nanosaur_support/__init__.py", "nanosaur_support/__init__.py"),

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/src/comfyui_version.rs
+++ b/src-tauri/src/comfyui_version.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 /// whatever `master` happened to be at install time. The scheduled
 /// `comfyui-compat` workflow opens a bot PR bumping this constant once the
 /// custom-node smoke test passes against a newer ComfyUI release.
-pub const COMFYUI_REF: &str = "v0.31.0";
+pub const COMFYUI_REF: &str = "v0.34.0";
 
 /// Read the installed ComfyUI version from its `comfyui_version.py` file
 /// (`__version__ = "0.26.0"`). Returns `None` if the file is missing or


### PR DESCRIPTION
## What

- Add `comfyui-nodes/nodes_anima_teacache.py` to `NODE_FILE_MAP` in `scripts/comfyui-compat/smoke_test.py`.
- Bump `COMFYUI_REF` from `v0.31.0` to `v0.34.0`.

## Why

The scheduled `comfyui-compat` check has failed since 2026-08-17 with `FAIL: 1 required node class(es) did not register: MooshieAnimaTeaCache`, which is why the pin sat three releases behind.

The cause was in the smoke test, not the node. `MooshieAnimaTeaCache` is in the required-class list (parsed from `nodes.rs`) but `nodes_anima_teacache.py` was never in the deploy map, so it was never copied into `custom_nodes/` and could not register. The CI log confirms it: seven files deployed, that one absent, and no entry for it in ComfyUI's import-times table at all. The app's own deploy path (`ensure_mooshie_nodes`) has always written it, so nothing was broken for users.

With the deploy list correct, the pin can move. v0.34.0 also brings in core support for Anima tunes with extra blocks (added in v0.33.1), so Anima 2.9B checkpoints load natively with no custom loader patch (see #635).

## Validation

- `npm run build`
- `cargo check` (desktop and `--no-default-features --features server`)
- `cargo test` (400 passed, 0 failed)
- `comfyui-compat` against v0.34.0 is the real gate; it runs on this branch.