### PR TITLE
v2.2.1: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## What's New in v2.2.1
+
+### Fixes and maintenance
+- **ComfyUI updated to v0.34.0**: the bundled ComfyUI pin moves from v0.31.0 to v0.34.0, so fresh installs and the in-app Update ComfyUI action both target the current release. This also picks up ComfyUI's native support for Anima tunes with extra blocks, which means community checkpoints like Anima 2.9B load without any extra custom node. ([#638](https://github.com/Mooshieblob1/MooshieUI/pull/638))
+- **Fixed the weekly ComfyUI compatibility check**: the check required the Anima TeaCache node but never deployed it into its test ComfyUI, so it had been failing since mid-August and holding the ComfyUI pin back. The app itself always installed the node correctly, so nothing was broken for users. ([#638](https://github.com/Mooshieblob1/MooshieUI/pull/638))
+
+---
+
 ## What's New in v2.2.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## What's New in v2.2.1
+
+### Fixes and maintenance
+- **ComfyUI updated to v0.34.0**: the bundled ComfyUI pin moves from v0.31.0 to v0.34.0, so fresh installs and the in-app Update ComfyUI action both target the current release. This also picks up ComfyUI's native support for Anima tunes with extra blocks, which means community checkpoints like Anima 2.9B load without any extra custom node. ([#638](https://github.com/Mooshieblob1/MooshieUI/pull/638))
+- **Fixed the weekly ComfyUI compatibility check**: the check required the Anima TeaCache node but never deployed it into its test ComfyUI, so it had been failing since mid-August and holding the ComfyUI pin back. The app itself always installed the node correctly, so nothing was broken for users. ([#638](https://github.com/Mooshieblob1/MooshieUI/pull/638))
+
+---
+
 ## What's New in v2.2.0
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
### Fixes and maintenance
- **ComfyUI updated to v0.34.0**: the bundled ComfyUI pin moves from v0.31.0 to v0.34.0, so fresh installs and the in-app Update ComfyUI action both target the current release. This also picks up ComfyUI's native support for Anima tunes with extra blocks, which means community checkpoints like Anima 2.9B load without any extra custom node. (#638)
- **Fixed the weekly ComfyUI compatibility check**: the check required the Anima TeaCache node but never deployed it into its test ComfyUI, so it had been failing since mid-August and holding the ComfyUI pin back. The app itself always installed the node correctly, so nothing was broken for users. (#638)

Version bumped in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` and `Cargo.lock`. The `comfyui-compat` smoke test passed against v0.34.0 on run 33002552047.