### PR TITLE
restore wildcard rolls for inline @preset tokens

### DIFF
--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -82,7 +82,7 @@ const de: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— fügen Sie dies an beliebiger Stelle im Prompt ein, um den Inhalt genau dort einzusetzen. Die ältere Form @preset:name funktioniert weiterhin.",
+  "generation.presets.inline_token_help": "— fügen Sie dies an beliebiger Stelle im Prompt ein. Einzeiliger Inhalt wird genau dort eingesetzt; bei mehrzeiligem Inhalt wird pro Generierung eine Zeile zufällig gewählt, wie bei einer Wildcard. Die ältere Form @preset:name funktioniert weiterhin.",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -593,7 +593,7 @@ const en: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— drop this anywhere in your prompt to splice the content in at that exact spot. The older @preset:name form still works.",
+  "generation.presets.inline_token_help": "— drop this anywhere in your prompt. A single-line chunk is inserted at that exact spot; a multi-line chunk picks one line at random per generation, like a wildcard. The older @preset:name form still works.",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -538,7 +538,7 @@ const es: Record<string, string> = {
   "generation.presets.name_placeholder": "p. ej. colores de pelo bonitos",
   "generation.presets.inline_token": "Token en línea:",
   "generation.presets.copy_inline_token": "Haz clic para copiar",
-  "generation.presets.inline_token_help": "— colócalo en cualquier lugar de tu prompt para insertar el contenido exactamente ahí. La forma antigua @preset:nombre sigue funcionando.",
+  "generation.presets.inline_token_help": "— colócalo en cualquier lugar de tu prompt. El contenido de una sola línea se inserta exactamente ahí; con varias líneas se elige una al azar por generación, como un comodín. La forma antigua @preset:nombre sigue funcionando.",
   "generation.presets.content_label": "Contenido",
   "generation.presets.wildcard_option": "{count} opción wildcard",
   "generation.presets.wildcard_options": "{count} opciones wildcard",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -82,7 +82,7 @@ const fr: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— placez ceci n'importe où dans votre prompt pour y insérer le contenu à cet endroit précis. L'ancienne forme @preset:nom fonctionne toujours.",
+  "generation.presets.inline_token_help": "— placez ceci n'importe où dans votre prompt. Un contenu d'une seule ligne est inséré à cet endroit précis ; avec plusieurs lignes, une ligne est tirée au hasard à chaque génération, comme un wildcard. L'ancienne forme @preset:nom fonctionne toujours.",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -84,7 +84,7 @@ const it: Record<string, string> = {
     "generation.presets.name_placeholder": "e.g. Cool hair colors",
     "generation.presets.inline_token": "Inline token:",
     "generation.presets.copy_inline_token": "Click to copy",
-    "generation.presets.inline_token_help": "— inseriscilo in qualsiasi punto del prompt per innestare il contenuto esattamente lì. La vecchia forma @preset:nome funziona ancora.",
+    "generation.presets.inline_token_help": "— inseriscilo in qualsiasi punto del prompt. Un contenuto su una sola riga viene innestato esattamente lì; con più righe ne viene scelta una a caso per ogni generazione, come una wildcard. La vecchia forma @preset:nome funziona ancora.",
     "generation.presets.content_label": "Content",
     "generation.presets.wildcard_option": "{count} wildcard option",
     "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -84,7 +84,7 @@ const ja: Record<string, string> = {
     "generation.presets.name_placeholder": "e.g. Cool hair colors",
     "generation.presets.inline_token": "Inline token:",
     "generation.presets.copy_inline_token": "Click to copy",
-    "generation.presets.inline_token_help": "— プロンプトの任意の位置に置くと、その場所に内容が差し込まれます。従来の @preset:名前 形式も引き続き使えます。",
+    "generation.presets.inline_token_help": "— プロンプトの任意の位置に置けます。1行の内容はその場所に差し込まれ、複数行の内容はワイルドカードとして生成ごとに1行がランダムに選ばれます。従来の @preset:名前 形式も引き続き使えます。",
     "generation.presets.content_label": "Content",
     "generation.presets.wildcard_option": "{count} wildcard option",
     "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -84,7 +84,7 @@ const ko: Record<string, string> = {
     "generation.presets.name_placeholder": "e.g. Cool hair colors",
     "generation.presets.inline_token": "Inline token:",
     "generation.presets.copy_inline_token": "Click to copy",
-    "generation.presets.inline_token_help": "— 프롬프트의 원하는 위치에 넣으면 그 자리에 내용이 삽입됩니다. 기존 @preset:이름 형식도 계속 사용할 수 있습니다.",
+    "generation.presets.inline_token_help": "— 프롬프트의 원하는 위치에 넣을 수 있습니다. 한 줄짜리 내용은 그 자리에 삽입되고, 여러 줄인 경우 와일드카드처럼 생성할 때마다 한 줄이 무작위로 선택됩니다. 기존 @preset:이름 형식도 계속 사용할 수 있습니다.",
     "generation.presets.content_label": "Content",
     "generation.presets.wildcard_option": "{count} wildcard option",
     "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -575,7 +575,7 @@ const pl: Record<string, string> = {
   "generation.presets.name_placeholder": "np. Fajne kolory włosów",
   "generation.presets.inline_token": "Token inline:",
   "generation.presets.copy_inline_token": "Kliknij, aby skopiować",
-  "generation.presets.inline_token_help": "— upuść to w dowolnym miejscu promptu, aby wstawić treść w tym konkretnym miejscu. Starsza forma @preset:nazwa nadal działa.",
+  "generation.presets.inline_token_help": "— upuść to w dowolnym miejscu promptu. Treść jednoliniowa jest wstawiana dokładnie w tym miejscu; przy wielu liniach jedna z nich jest losowana przy każdej generacji, jak wildcard. Starsza forma @preset:nazwa nadal działa.",
   "generation.presets.content_label": "Treść",
   "generation.presets.wildcard_option": "{count} opcja wildcard",
   "generation.presets.wildcard_options": "{count} opcji wildcard",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -84,7 +84,7 @@ const pt: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— coloque isto em qualquer ponto do prompt para inserir o conteúdo exatamente ali. A forma antiga @preset:nome continua funcionando.",
+  "generation.presets.inline_token_help": "— coloque isto em qualquer ponto do prompt. Conteúdo de uma única linha é inserido exatamente ali; com várias linhas, uma é escolhida ao acaso a cada geração, como um curinga. A forma antiga @preset:nome continua funcionando.",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -84,7 +84,7 @@ const ru: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— вставьте это в любое место промпта, чтобы содержимое подставилось именно там. Прежняя форма @preset:имя по-прежнему работает.",
+  "generation.presets.inline_token_help": "— вставьте это в любое место промпта. Однострочное содержимое подставляется именно там; из многострочного при каждой генерации случайно выбирается одна строка, как в вайлдкарде. Прежняя форма @preset:имя по-прежнему работает.",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -84,7 +84,7 @@ const zhTw: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— 放在提示詞的任意位置，內容就會在該處展開。舊的 @preset:名稱 形式仍然可用。",
+  "generation.presets.inline_token_help": "— 放在提示詞的任意位置。單行內容會在該處直接展開；多行內容則像萬用字元一樣，每次生成隨機選取一行。舊的 @preset:名稱 形式仍然可用。",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -84,7 +84,7 @@ const zh: Record<string, string> = {
   "generation.presets.name_placeholder": "e.g. Cool hair colors",
   "generation.presets.inline_token": "Inline token:",
   "generation.presets.copy_inline_token": "Click to copy",
-  "generation.presets.inline_token_help": "— 放在提示词的任意位置，内容就会在该处展开。旧的 @preset:名称 形式仍然可用。",
+  "generation.presets.inline_token_help": "— 放在提示词的任意位置。单行内容会在该处直接展开；多行内容则像通配符一样，每次生成随机选取一行。旧的 @preset:名称 形式仍然可用。",
   "generation.presets.content_label": "Content",
   "generation.presets.wildcard_option": "{count} wildcard option",
   "generation.presets.wildcard_options": "{count} wildcard options",

--- a/src/lib/stores/promptPresets.svelte.ts
+++ b/src/lib/stores/promptPresets.svelte.ts
@@ -400,8 +400,8 @@ class PromptPresetsStore {
    * Resolve inline chunk directives within a prompt string, in either
    * spelling: `@preset:<slug>` and `@[Chunk Name]`.
    * - Single-line preset content is inserted verbatim (trimmed).
-   * - Multi-line preset content is spliced in whole, lines joined with
-   *   ", ", matching what click-activating the chunk inserts.
+   * - Multi-line preset content acts as an inline wildcard: one line is
+   *   picked at random per generation (a `fixedChoices` entry pins it).
    * - Empty presets resolve to an empty string; adjacent commas/whitespace
    *   are tidied so the prompt doesn't end up with `, ,` artefacts.
    * - Unknown names are left untouched (so typos are debuggable).
@@ -416,12 +416,12 @@ class PromptPresetsStore {
       if (fixedChoice) return fixedChoice;
       const choices = splitWildcardChoices(preset.content);
       if (choices.length === 0) return preset.content.trim();
-      // Splice the whole chunk in, lines joined with commas so per-line
-      // trailing commas from the editor do not double up. Typing a token
-      // means "insert this chunk here", the same as clicking it, which is
-      // what the inline help text promises. Random rolls stay an activation
-      // feature (the wildcard modes).
-      return choices.join(", ");
+      if (choices.length === 1) return choices[0];
+      // A multi-line chunk is an inline wildcard: exactly one line rolls in
+      // per generation, at this spot in the prompt. Users build prompts on
+      // this to control where a wildcard lands (activation-mode wildcards
+      // can only append) — joining every line instead breaks them (#642).
+      return choices[Math.floor(Math.random() * choices.length)];
     });
     // Tidy up commas/whitespace left behind when a preset resolved to "".
     resolved = resolved


### PR DESCRIPTION
Fixes #642.

Since 2.2.0, inline @preset:name and @[name] tokens spliced every line of a multi-line chunk into the prompt instead of rolling one line at random per generation (a deliberate change in #618 that broke prompts built on the old behavior).

- resolveInline now picks one random line for multi-line chunks, restoring the 2.1.5 behavior; single-line chunks still insert verbatim at that spot
- fixedChoices pinning, the @[name] spelling, and loose slug matching are unchanged
- inline token help text updated in all 12 locales to describe the wildcard behavior accurately (the old text promised a splice even back when the code rolled)

 src/lib/locales/de.ts                  |  2 +-
 src/lib/locales/en.ts                  |  2 +-
 src/lib/locales/es.ts                  |  2 +-
 src/lib/locales/fr.ts                  |  2 +-
 src/lib/locales/it.ts                  |  2 +-
 src/lib/locales/ja.ts                  |  2 +-
 src/lib/locales/ko.ts                  |  2 +-
 src/lib/locales/pl.ts                  |  2 +-
 src/lib/locales/pt.ts                  |  2 +-
 src/lib/locales/ru.ts                  |  2 +-
 src/lib/locales/zh-tw.ts               |  2 +-
 src/lib/locales/zh.ts                  |  2 +-
 src/lib/stores/promptPresets.svelte.ts | 16 ++++++++--------
 13 files changed, 20 insertions(+), 20 deletions(-)