### PR TITLE
v2.2.3: sampler guidance, DMD2 preset, Anima ReStyler, GMFSS and SeedVR2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## What's New in v2.2.3
+
+### New features
+- **Sampler guidance controls**: three new guidance options in Sampler settings. RescaleCFG rescales the guidance vector each step so v-prediction checkpoints stop blowing out contrast and saturation at normal CFG. NAG (Normalized Attention Guidance) applies the negative prompt inside attention, so it keeps working at low CFG and low step counts where ordinary CFG stops doing anything. APG (Adaptive Projected Guidance) splits the guidance update into direction and magnitude with eta, norm threshold and momentum controls, so a high CFG improves prompt adherence without oversaturating colors. APG is flagged as inert at CFG 1 or below rather than silently doing nothing.
+- **DMD2 4-step preset for SDXL**: a single toggle that downloads the DMD2 distillation LoRA and switches the sampler to 4 steps, CFG 1, LCM and SGM uniform. Turning it back off removes the LoRA and leaves the sampler settings alone so you can restore your own. Pairs with NAG, which is the one guidance method that still applies a negative prompt at CFG 1.
+- **Anima ReStyler image editing**: a new edit family that redraws the character from a reference image in the Anima style, at the reference image's own size. A Reference strength slider controls how closely the output follows the source, and a Drastic restyle option runs the original split-screen recipe (reference and blank canvas generated side by side, new half cropped as the output) for much stronger style changes at roughly twice the generation time. The Anima Edit LoRA downloads from within the app.
+- **GMFSS frame interpolation**: GMFSS Fortuna is selectable alongside RIFE for both inline and post-hoc video interpolation. It is slower than RIFE but built for anime, with cleaner line art and flat shading and less warping. It comes from the same custom node pack as RIFE, so no extra install is needed, though it does fetch its own checkpoints on first use.
+- **SeedVR2 upscaling**: SeedVR2 is available as an upscale method. It is a one-step diffusion restoration model that rebuilds real detail while upscaling rather than just resizing, with no denoise or step count to tune. Its model and VAE download from within the app.
+
+### Fixes and maintenance
+- **Running out of system RAM now reports itself properly**: when the machine had no free RAM left to pin (or the page file drive was full), generation failed with a raw `hostbuf_file_reader_read failed` in a generic error toast. That failure now has its own error with actionable advice, and it no longer gets mistaken for a VRAM problem, so the dialog stops telling you to lower your resolution when the fix is freeing system RAM or disk space. ([#641](https://github.com/Mooshieblob1/MooshieUI/pull/641), fixes [#619](https://github.com/Mooshieblob1/MooshieUI/issues/619))
+- **Inline `@preset` tokens roll a random line again**: since v2.2.0 an inline `@preset:name` or `@[name]` token spliced every line of a multi-line preset into the prompt instead of picking one at random per generation, which broke prompts built on the older behavior. Multi-line presets roll one line again; single-line presets still insert verbatim, and pinning is unchanged. ([#643](https://github.com/Mooshieblob1/MooshieUI/pull/643), fixes [#642](https://github.com/Mooshieblob1/MooshieUI/issues/642))
+- **Dependency updates**: konva 10.3.1, marked 18.0.10, dompurify 3.4.14, svelte 5.56.10, serde_json 1.0.151, uuid 1.25.0, open 5.4.1, and the docker/setup-buildx-action and swatinem/rust-cache CI actions. ([#623](https://github.com/Mooshieblob1/MooshieUI/pull/623)-[#631](https://github.com/Mooshieblob1/MooshieUI/pull/631))
+
+---
+
 ## What's New in v2.2.2
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+## What's New in v2.2.3
+
+### New features
+- **Sampler guidance controls**: three new guidance options in Sampler settings. RescaleCFG rescales the guidance vector each step so v-prediction checkpoints stop blowing out contrast and saturation at normal CFG. NAG (Normalized Attention Guidance) applies the negative prompt inside attention, so it keeps working at low CFG and low step counts where ordinary CFG stops doing anything. APG (Adaptive Projected Guidance) splits the guidance update into direction and magnitude with eta, norm threshold and momentum controls, so a high CFG improves prompt adherence without oversaturating colors. APG is flagged as inert at CFG 1 or below rather than silently doing nothing.
+- **DMD2 4-step preset for SDXL**: a single toggle that downloads the DMD2 distillation LoRA and switches the sampler to 4 steps, CFG 1, LCM and SGM uniform. Turning it back off removes the LoRA and leaves the sampler settings alone so you can restore your own. Pairs with NAG, which is the one guidance method that still applies a negative prompt at CFG 1.
+- **Anima ReStyler image editing**: a new edit family that redraws the character from a reference image in the Anima style, at the reference image's own size. A Reference strength slider controls how closely the output follows the source, and a Drastic restyle option runs the original split-screen recipe (reference and blank canvas generated side by side, new half cropped as the output) for much stronger style changes at roughly twice the generation time. The Anima Edit LoRA downloads from within the app.
+- **GMFSS frame interpolation**: GMFSS Fortuna is selectable alongside RIFE for both inline and post-hoc video interpolation. It is slower than RIFE but built for anime, with cleaner line art and flat shading and less warping. It comes from the same custom node pack as RIFE, so no extra install is needed, though it does fetch its own checkpoints on first use.
+- **SeedVR2 upscaling**: SeedVR2 is available as an upscale method. It is a one-step diffusion restoration model that rebuilds real detail while upscaling rather than just resizing, with no denoise or step count to tune. Its model and VAE download from within the app.
+
+### Fixes and maintenance
+- **Running out of system RAM now reports itself properly**: when the machine had no free RAM left to pin (or the page file drive was full), generation failed with a raw `hostbuf_file_reader_read failed` in a generic error toast. That failure now has its own error with actionable advice, and it no longer gets mistaken for a VRAM problem, so the dialog stops telling you to lower your resolution when the fix is freeing system RAM or disk space. ([#641](https://github.com/Mooshieblob1/MooshieUI/pull/641), fixes [#619](https://github.com/Mooshieblob1/MooshieUI/issues/619))
+- **Inline `@preset` tokens roll a random line again**: since v2.2.0 an inline `@preset:name` or `@[name]` token spliced every line of a multi-line preset into the prompt instead of picking one at random per generation, which broke prompts built on the older behavior. Multi-line presets roll one line again; single-line presets still insert verbatim, and pinning is unchanged. ([#643](https://github.com/Mooshieblob1/MooshieUI/pull/643), fixes [#642](https://github.com/Mooshieblob1/MooshieUI/issues/642))
+- **Dependency updates**: konva 10.3.1, marked 18.0.10, dompurify 3.4.14, svelte 5.56.10, serde_json 1.0.151, uuid 1.25.0, open 5.4.1, and the docker/setup-buildx-action and swatinem/rust-cache CI actions. ([#623](https://github.com/Mooshieblob1/MooshieUI/pull/623)-[#631](https://github.com/Mooshieblob1/MooshieUI/pull/631))
+
+---
+
 ## What's New in v2.2.2
 
 ### Fixes and maintenance

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release cut for v2.2.3.

## Version bump
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock` all at 2.2.3.

## Changelog
- v2.2.3 block prepended to both `RELEASE_NOTES.md` and `CHANGELOG.md`.

## What ships
New features (all landed in #644):
- Sampler guidance controls: RescaleCFG, NAG, APG.
- DMD2 4-step preset for SDXL.
- Anima ReStyler image editing with Reference strength and Drastic restyle.
- GMFSS Fortuna frame interpolation alongside RIFE.
- SeedVR2 upscale method.

Fixes and maintenance:
- Host buffer / system RAM exhaustion now reports its own error instead of a raw `hostbuf_file_reader_read failed` (#641, fixes #619).
- Inline `@preset` tokens roll a random line again (#643, fixes #642).
- Dependency updates (#623-#631).

## Validation
- `npm run build` pass
- `npm run check:i18n` pass
- `cargo check` (desktop) pass
- `cargo check --no-default-features --features server` pass
- `cargo test` 412 passed, 0 failed
- `cargo fmt --check` clean

## Bot triage
No bot comments were posted on #641, #643 or #644, so nothing to triage from those merges.
