### PR TITLE
v2.2.4: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## What's New in v2.2.4
+
+### Fixes and maintenance
+- **NovelAI Enhance shows its result**: after pressing Enhance in NAI mode the preview kept showing the original image. The preview's mode tracking re-ran whenever any result landed and snapped back to the last text-to-image output; it now only follows a real mode change, so the enhanced image appears as soon as it arrives.
+- **Enhance remembers resolution and magnitude**: the Enhance modal now opens on the scale (1x, 1.5x, Max) and magnitude the last enhance was sent with, persisted across launches. Cancelling, upscaling or making variations does not overwrite them.
+- **NAI quality tags and UC preset stay put**: quality tags default on and the undesired content preset defaults to Heavy, and whatever you set is kept. In browser and LAN mode a change made in the last couple of seconds before closing the tab could be lost to the debounced preference sync and overwritten by the older server snapshot on the next launch; pending preference pushes are now flushed when the page is hidden or closed.
+- **Escape closes the right thing**: with the Enhance or Director Tools modal open on top of the lightbox, Escape closed the lightbox underneath instead of the modal.
+- **Director Tools results follow into the lightbox**: a Director Tools run started from the lightbox now opens its result there, the same as Enhance.
+- **Clearer remote prompt assistant errors**: a remote chat completion that fails now reports the underlying cause (TLS, DNS, timeout) instead of reqwest's generic wording, and vision requests get a 300s budget instead of 120s since hosted models routinely take longer on image turns.
+
+---
+
 ## What's New in v2.2.3
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+## What's New in v2.2.4
+
+### Fixes and maintenance
+- **NovelAI Enhance shows its result**: after pressing Enhance in NAI mode the preview kept showing the original image. The preview's mode tracking re-ran whenever any result landed and snapped back to the last text-to-image output; it now only follows a real mode change, so the enhanced image appears as soon as it arrives.
+- **Enhance remembers resolution and magnitude**: the Enhance modal now opens on the scale (1x, 1.5x, Max) and magnitude the last enhance was sent with, persisted across launches. Cancelling, upscaling or making variations does not overwrite them.
+- **NAI quality tags and UC preset stay put**: quality tags default on and the undesired content preset defaults to Heavy, and whatever you set is kept. In browser and LAN mode a change made in the last couple of seconds before closing the tab could be lost to the debounced preference sync and overwritten by the older server snapshot on the next launch; pending preference pushes are now flushed when the page is hidden or closed.
+- **Escape closes the right thing**: with the Enhance or Director Tools modal open on top of the lightbox, Escape closed the lightbox underneath instead of the modal.
+- **Director Tools results follow into the lightbox**: a Director Tools run started from the lightbox now opens its result there, the same as Enhance.
+- **Clearer remote prompt assistant errors**: a remote chat completion that fails now reports the underlying cause (TLS, DNS, timeout) instead of reqwest's generic wording, and vision requests get a 300s budget instead of 120s since hosted models routinely take longer on image turns.
+
+---
+
 ## What's New in v2.2.3
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/prompt_assistant/server.rs
+++ b/src-tauri/src/prompt_assistant/server.rs
@@ -420,22 +420,69 @@ fn external_models_urls(base_url: &str) -> Vec<String> {
     versioned_candidates(base, "models")
 }
 
+/// Per-request ceiling for a remote chat completion.
+///
+/// A vision turn ships up to four ~1 MP JPEGs and asks for a long answer, and
+/// hosted models routinely take well over two minutes on that; a text-only
+/// turn that has not answered in two minutes is not going to.
+fn chat_timeout(has_images: bool) -> Duration {
+    if has_images {
+        Duration::from_secs(300)
+    } else {
+        Duration::from_secs(120)
+    }
+}
+
+/// The whole cause chain of an error, outermost first.
+///
+/// reqwest's `Display` prints only its own kind and the URL ("error sending
+/// request for url (...)"), hiding the TLS, DNS or timeout detail underneath
+/// that is the only part worth reading in a log.
+fn error_chain(err: &dyn std::error::Error) -> String {
+    let mut out = err.to_string();
+    let mut cur = err.source();
+    while let Some(src) = cur {
+        let text = src.to_string();
+        if !out.contains(&text) {
+            out.push_str(": ");
+            out.push_str(&text);
+        }
+        cur = src.source();
+    }
+    out
+}
+
+/// Human-readable reason a request never produced a response.
+///
+/// A timeout is named as such (with the budget it blew) instead of being
+/// buried under reqwest's generic "error sending request" wording.
+fn describe_request_error(err: &reqwest::Error, timeout: Duration) -> String {
+    if err.is_timeout() {
+        return format!(
+            "timed out after {}s waiting for the model to answer",
+            timeout.as_secs()
+        );
+    }
+    error_chain(err)
+}
+
 async fn send_external_chat(
     client: &reqwest::Client,
     url: &str,
     api_key: &str,
     body: &serde_json::Value,
+    timeout: Duration,
 ) -> Result<reqwest::Response, AppError> {
-    let mut req = client
-        .post(url)
-        .json(body)
-        .timeout(Duration::from_secs(120));
+    let mut req = client.post(url).json(body).timeout(timeout);
     if !api_key.is_empty() {
         req = req.bearer_auth(api_key);
     }
-    req.send()
-        .await
-        .map_err(|e| AppError::LlmError(format!("External LLM request failed: {e}")))
+    req.send().await.map_err(|e| {
+        AppError::LlmError(format!(
+            "External LLM request failed: {}",
+            describe_request_error(&e, timeout)
+        ))
+    })
 }
 
 /// Send a chat completion to an external OpenAI-compatible endpoint (LM Studio,
@@ -492,14 +539,15 @@ pub async fn chat_external(
         "stream": false
     });
     let urls = external_chat_urls(base_url);
-    let mut resp = send_external_chat(client, &urls[0], api_key, &body).await?;
+    let timeout = chat_timeout(!images.is_empty());
+    let mut resp = send_external_chat(client, &urls[0], api_key, &body, timeout).await?;
     if resp.status().as_u16() == 404 && urls.len() > 1 {
         log::info!(
             "[prompt-assistant] {} returned 404, retrying at {}",
             urls[0],
             urls[1]
         );
-        resp = send_external_chat(client, &urls[1], api_key, &body).await?;
+        resp = send_external_chat(client, &urls[1], api_key, &body, timeout).await?;
     }
     if !resp.status().is_success() {
         let status = resp.status();
@@ -641,15 +689,21 @@ pub async fn chat_anthropic(
         "temperature": 0.7,
         "messages": [ { "role": "user", "content": user_content } ]
     });
+    let timeout = chat_timeout(!images.is_empty());
     let resp = client
         .post(anthropic_url(base_url, "messages"))
         .header("x-api-key", api_key)
         .header("anthropic-version", ANTHROPIC_VERSION)
         .json(&body)
-        .timeout(Duration::from_secs(120))
+        .timeout(timeout)
         .send()
         .await
-        .map_err(|e| AppError::LlmError(format!("Anthropic request failed: {e}")))?;
+        .map_err(|e| {
+            AppError::LlmError(format!(
+                "Anthropic request failed: {}",
+                describe_request_error(&e, timeout)
+            ))
+        })?;
     if !resp.status().is_success() {
         let status = resp.status();
         let detail = error_detail(resp).await;
@@ -750,13 +804,19 @@ pub async fn list_models(
         }
         req.send()
     };
-    let mut resp = send(urls[0].clone())
-        .await
-        .map_err(|e| AppError::LlmError(format!("Model list request failed: {e}")))?;
+    let mut resp = send(urls[0].clone()).await.map_err(|e| {
+        AppError::LlmError(format!(
+            "Model list request failed: {}",
+            describe_request_error(&e, Duration::from_secs(30))
+        ))
+    })?;
     if resp.status().as_u16() == 404 && urls.len() > 1 {
-        resp = send(urls[1].clone())
-            .await
-            .map_err(|e| AppError::LlmError(format!("Model list request failed: {e}")))?;
+        resp = send(urls[1].clone()).await.map_err(|e| {
+            AppError::LlmError(format!(
+                "Model list request failed: {}",
+                describe_request_error(&e, Duration::from_secs(30))
+            ))
+        })?;
     }
     if !resp.status().is_success() {
         let status = resp.status();
@@ -964,8 +1024,48 @@ fn extract_all_into(archive_path: &Path, dir: &Path) -> Result<(), AppError> {
 
 #[cfg(test)]
 mod tests {
-    use super::completion_content;
+    use super::{chat_timeout, completion_content, error_chain};
     use serde_json::json;
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct Outer(std::io::Error);
+
+    impl std::fmt::Display for Outer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "error sending request for url (https://api.x.ai/v1)")
+        }
+    }
+
+    impl std::error::Error for Outer {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[test]
+    fn error_chain_appends_the_hidden_cause() {
+        let e = Outer(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset by peer",
+        ));
+        assert_eq!(
+            error_chain(&e),
+            "error sending request for url (https://api.x.ai/v1): connection reset by peer"
+        );
+    }
+
+    #[test]
+    fn error_chain_without_a_source_is_just_the_message() {
+        let e = std::io::Error::other("plain");
+        assert_eq!(error_chain(&e), "plain");
+    }
+
+    #[test]
+    fn vision_requests_get_a_longer_budget() {
+        assert!(chat_timeout(true) > chat_timeout(false));
+        assert_eq!(chat_timeout(false), Duration::from_secs(120));
+    }
 
     #[test]
     fn returns_the_message_content() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -355,8 +355,17 @@
   // Document-level keyboard handler for lightbox (fallback for browser focus issues).
   // The compare viewer sits on top of the lightbox and owns Escape/arrows while
   // it is open, so stand down rather than closing the lightbox underneath it.
+  // The enhance and Director Tools modals stack on the lightbox the same way
+  // and own Escape while open; this document handler would otherwise run first
+  // (document before window) and close the lightbox underneath the modal.
   $effect(() => {
-    if (!gallery.lightboxOpen || gallery.compareOpen) return;
+    if (
+      !gallery.lightboxOpen ||
+      gallery.compareOpen ||
+      naiImageEnhance.isOpen ||
+      directorTools.isOpen
+    )
+      return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") gallery.closeLightbox();
       if (e.key === "ArrowLeft") navigateLightbox("prev");
@@ -2143,8 +2152,13 @@
     // is showing: the source is what was being looked at, and the result is the
     // point of the click.  Placed here rather than further down because the
     // artist-preview and style-thumbnail blocks below return early.
-    if (gallery.takeLightboxFollow(promptId) && gallery.lightboxOpen && newImages[0]) {
-      void gallery.openLightbox(newImages[0]);
+    if (gallery.takeLightboxFollow(promptId)) {
+      if (gallery.lightboxOpen && newImages[0]) {
+        console.log("[lightbox] follow", promptId, "->", newImages[0].filename);
+        void gallery.openLightbox(newImages[0]);
+      } else {
+        console.log("[lightbox] follow skipped, lightbox closed before", promptId, "landed");
+      }
     }
 
     // Route a finished artist-preview generation back to its placeholder card.

--- a/src/lib/components/generation/DirectorToolsModal.svelte
+++ b/src/lib/components/generation/DirectorToolsModal.svelte
@@ -54,6 +54,11 @@
       // "image_edit" and not "img2img": the result is a pass over an existing
       // image, and tagging it img2img would overwrite that tab's last output.
       progress.enqueue(result.prompt_id, false, "image_edit", null);
+      // Started from the lightbox, the result belongs there: what is on screen
+      // is the source, and the point of the click is to see what replaced it.
+      // Only when it is already open, so a card's DT button does not force a
+      // lightbox the user did not ask for.
+      if (gallery.lightboxOpen) gallery.markLightboxFollow(result.prompt_id);
       directorTools.dismiss();
       gallery.showToast(locale.t("novelai.director.started"), "success");
     } catch (e) {

--- a/src/lib/components/generation/NaiImageEnhanceModal.svelte
+++ b/src/lib/components/generation/NaiImageEnhanceModal.svelte
@@ -326,6 +326,13 @@
       // what replaced it.  Only when it is already open, so an enhance started
       // from a gallery card does not force a lightbox the user did not ask for.
       if (gallery.lightboxOpen) gallery.markLightboxFollow(result.prompt_id);
+      // Only a sent enhance is worth remembering: a dismissed modal is a
+      // change of mind, and upscale/variations have no scale or magnitude.
+      if (current === "enhance")
+        generation.rememberNaiEnhance(
+          naiImageEnhance.scaleChoice,
+          naiImageEnhance.magnitude,
+        );
       naiImageEnhance.dismiss();
       gallery.showToast(
         locale.t(

--- a/src/lib/components/progress/PreviewImage.svelte
+++ b/src/lib/components/progress/PreviewImage.svelte
@@ -18,6 +18,7 @@
   import ContextMenu, { type ContextMenuItem } from "../ui/ContextMenu.svelte";
   import VideoPlayer from "../video/VideoPlayer.svelte";
   import type { GenerationParams } from "../../types/index.js";
+  import { untrack } from "svelte";
 
   let currentTipIndex = $state(0);
   let progressPercent = $state(0);
@@ -273,8 +274,13 @@
     }
   }
 
+  // Only the mode is a dependency here. `setActiveMode` reads
+  // `progress.modeLastOutput`, and tracking that too made this re-run every
+  // time any mode's result landed -- an NAI Enhance arrives as `image_edit`,
+  // so the re-run snapped the preview straight back to the txt2img image.
   $effect(() => {
-    progress.setActiveMode(generation.mode);
+    const mode = generation.mode;
+    untrack(() => progress.setActiveMode(mode));
   });
 
   /** What the Refine button does here: NovelAI's Enhance, or the local upscale

--- a/src/lib/stores/gallery.svelte.ts
+++ b/src/lib/stores/gallery.svelte.ts
@@ -509,6 +509,7 @@ class GalleryStore {
   /** Ask for `promptId`'s result to take over the lightbox when it lands. */
   markLightboxFollow(promptId: string) {
     if (!promptId || this.lightboxFollowIds.includes(promptId)) return;
+    console.log("[lightbox] follow marked for", promptId);
     this.lightboxFollowIds = [...this.lightboxFollowIds, promptId].slice(
       -VARIATION_BATCH_MEMORY,
     );

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -43,6 +43,12 @@ import {
   computeH3FrameLength,
 } from "../utils/videoParams.js";
 import type { NaiLanguageChoice } from "../utils/naiLanguage.js";
+import {
+  clampMagnitude,
+  isEnhanceScaleChoice,
+  MAGNITUDE_DEFAULT,
+  type EnhanceScaleChoice,
+} from "../utils/novelaiEnhance.js";
 import type { ModelFamily, TurboModelVariant } from "../utils/modelFamily.js";
 import type {
   ExtraPromptBox,
@@ -613,6 +619,14 @@ class GenerationStore {
    * because someone iterating on one image wants it for the whole session.
    */
   naiEnhanceIncludeExisting = $state(false);
+  /**
+   * What the last NovelAI image Enhance was run with. The Enhance modal opens
+   * on these, so someone who always enhances at 1.5x / magnitude 4 is not
+   * reset to the defaults every launch. Written only when an enhance is
+   * actually sent, not while the modal is being fiddled with.
+   */
+  naiEnhanceScaleChoice = $state<EnhanceScaleChoice>("1x");
+  naiEnhanceMagnitude = $state(MAGNITUDE_DEFAULT);
   vae = $state("");
   loras = $state<LoraEntry[]>([]);
   samplerName = $state("euler_cfg_pp");
@@ -2536,6 +2550,10 @@ class GenerationStore {
           this.naiEnhanceLanguage = saved.naiEnhanceLanguage;
         if (saved.naiEnhanceIncludeExisting !== undefined)
           this.naiEnhanceIncludeExisting = saved.naiEnhanceIncludeExisting;
+        if (isEnhanceScaleChoice(saved.naiEnhanceScaleChoice))
+          this.naiEnhanceScaleChoice = saved.naiEnhanceScaleChoice;
+        if (typeof saved.naiEnhanceMagnitude === "number")
+          this.naiEnhanceMagnitude = clampMagnitude(saved.naiEnhanceMagnitude);
         if (saved.styleTransferLowScaleEnd !== undefined) this.styleTransferLowScaleEnd = saved.styleTransferLowScaleEnd;
         if (saved.styleTransferHighScaleStart !== undefined) this.styleTransferHighScaleStart = saved.styleTransferHighScaleStart;
         if (saved.styleTransferBeta !== undefined) this.styleTransferBeta = saved.styleTransferBeta;
@@ -2774,6 +2792,8 @@ class GenerationStore {
         showNovelaiUsage: this.showNovelaiUsage,
         naiEnhanceLanguage: this.naiEnhanceLanguage,
         naiEnhanceIncludeExisting: this.naiEnhanceIncludeExisting,
+        naiEnhanceScaleChoice: this.naiEnhanceScaleChoice,
+        naiEnhanceMagnitude: this.naiEnhanceMagnitude,
       });
       triggerSync();
     } catch (e) {
@@ -2917,7 +2937,16 @@ class GenerationStore {
       showNovelaiUsage: this.showNovelaiUsage,
       naiEnhanceLanguage: this.naiEnhanceLanguage,
       naiEnhanceIncludeExisting: this.naiEnhanceIncludeExisting,
+      naiEnhanceScaleChoice: this.naiEnhanceScaleChoice,
+      naiEnhanceMagnitude: this.naiEnhanceMagnitude,
     };
+  }
+
+  /** Record what an Enhance was just sent with, so the next one opens on it. */
+  rememberNaiEnhance(scale: EnhanceScaleChoice, magnitude: number): void {
+    this.naiEnhanceScaleChoice = scale;
+    this.naiEnhanceMagnitude = clampMagnitude(magnitude);
+    this.saveSettings();
   }
 
   /** Collect prompt history for server-side sync. */

--- a/src/lib/stores/naiImageEnhance.svelte.ts
+++ b/src/lib/stores/naiImageEnhance.svelte.ts
@@ -14,6 +14,7 @@ import {
   VARIATION_COUNT_DEFAULT,
   VARIETY_DEFAULT,
   type EnhanceDenoise,
+  type EnhanceScaleChoice,
 } from "../utils/novelaiEnhance.js";
 import type { OutputImage } from "../types/index.js";
 
@@ -35,8 +36,9 @@ import type { OutputImage } from "../types/index.js";
  * image arrives in the session grid and the gallery on its own.
  */
 
-/** Which of the upscale buttons is selected. */
-export type EnhanceScaleChoice = "1x" | "1.5x" | "max";
+/** Which of the upscale buttons is selected. Defined in the utils module so
+ *  the hub `generation` store can persist it without importing this store. */
+export type { EnhanceScaleChoice } from "../utils/novelaiEnhance.js";
 
 /**
  * Which of the three things this modal can do to the image is showing.
@@ -222,9 +224,10 @@ class NaiImageEnhanceStore {
   /**
    * Open on an image.
    *
-   * Every field resets rather than carrying over: the last image's magnitude is
-   * rarely the right one for this image, and a stale setting quietly spending
-   * Anlas on the wrong result is worse than re-picking it.
+   * The scale and magnitude open on what the last enhance was run with, read
+   * from the persisted generation settings so they survive a relaunch; the
+   * modal shows both before anything is spent. Everything else resets: the
+   * variation and advanced controls describe one image rather than a habit.
    */
   open(
     image: OutputImage,
@@ -238,12 +241,12 @@ class NaiImageEnhanceStore {
     this.sourceHeight = 0;
     this.imageBase64 = null;
     this.loadingSource = false;
-    this.scaleChoice = "1x";
-    this.magnitude = MAGNITUDE_DEFAULT;
+    this.scaleChoice = generation.naiEnhanceScaleChoice;
+    this.magnitude = clampMagnitude(generation.naiEnhanceMagnitude);
     this.variationCount = VARIATION_COUNT_DEFAULT;
     this.variety = VARIETY_DEFAULT;
     this.showAdvanced = false;
-    const denoise = magnitudeToDenoise(MAGNITUDE_DEFAULT);
+    const denoise = magnitudeToDenoise(this.magnitude);
     this.strength = denoise.strength;
     this.noise = denoise.noise;
     this.busy = false;

--- a/src/lib/stores/prefsSync.svelte.ts
+++ b/src/lib/stores/prefsSync.svelte.ts
@@ -36,6 +36,18 @@ class PrefsSyncStore {
 
   constructor() {
     registerSyncHandler(() => this.scheduleSync());
+    // A change made in the last two seconds before the tab closes would
+    // otherwise sit in the debounce timer and never reach the server, and the
+    // next launch's `loadAndApply` would then overwrite it with the stale
+    // snapshot. `pagehide` is the last reliable event on both desktop and
+    // mobile browsers; hidden tabs count too, because a backgrounded tab may
+    // be discarded without ever firing `pagehide`.
+    if (typeof window !== "undefined") {
+      window.addEventListener("pagehide", () => this.flush());
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") this.flush();
+      });
+    }
   }
 
   /** Gather the current state of all participating stores. */
@@ -123,7 +135,18 @@ class PrefsSyncStore {
     }, 2000);
   }
 
-  private async _doSync(): Promise<void> {
+  /**
+   * Push now if a debounced push is waiting. A no-op when nothing has changed
+   * since the last push, so it is safe to call on every hide.
+   */
+  flush(): void {
+    if (this._syncTimer === null) return;
+    clearTimeout(this._syncTimer);
+    this._syncTimer = null;
+    this._doSync({ keepalive: true }).catch(() => {});
+  }
+
+  private async _doSync(options: { keepalive?: boolean } = {}): Promise<void> {
     // If a push is already in flight, mark that another is needed rather than
     // dropping it — changes made mid-flight would otherwise never reach the
     // server until the next unrelated save.
@@ -133,7 +156,7 @@ class PrefsSyncStore {
     }
     this._syncing = true;
     try {
-      await pushServerPrefs(this.collectAll());
+      await pushServerPrefs(this.collectAll(), options);
     } finally {
       this._syncing = false;
     }

--- a/src/lib/utils/novelaiEnhance.ts
+++ b/src/lib/utils/novelaiEnhance.ts
@@ -118,6 +118,16 @@ export const MAGNITUDE_MAX = 5;
 /** The middle of the range, and what NovelAI's own panel opens on. */
 export const MAGNITUDE_DEFAULT = 3;
 
+/** Which of the Enhance modal's upscale buttons is selected. */
+export type EnhanceScaleChoice = "1x" | "1.5x" | "max";
+
+const ENHANCE_SCALE_CHOICES: readonly EnhanceScaleChoice[] = ["1x", "1.5x", "max"];
+
+/** Type guard for a persisted scale choice, which may come from an older blob. */
+export function isEnhanceScaleChoice(value: unknown): value is EnhanceScaleChoice {
+  return (ENHANCE_SCALE_CHOICES as readonly unknown[]).includes(value);
+}
+
 export interface EnhanceDenoise {
   /** img2img strength. Higher redraws more of the image. */
   strength: number;

--- a/src/lib/utils/serverPrefs.ts
+++ b/src/lib/utils/serverPrefs.ts
@@ -58,7 +58,10 @@ export async function fetchServerPrefs(): Promise<UserPrefsData | null> {
  * Push the current user's preferences to the server.
  * Fire-and-forget — never throws; failures are logged but do not block the UI.
  */
-export async function pushServerPrefs(prefs: UserPrefsData): Promise<void> {
+export async function pushServerPrefs(
+  prefs: UserPrefsData,
+  options: { keepalive?: boolean } = {},
+): Promise<void> {
   if (!isBrowserMode) return;
   const token = getAuthToken();
   if (!token) return;
@@ -70,6 +73,10 @@ export async function pushServerPrefs(prefs: UserPrefsData): Promise<void> {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(prefs),
+      // Lets a push started from `pagehide` outlive the page. Browsers cap
+      // keepalive bodies (64 KB), so it is opt-in for that one case rather
+      // than the default.
+      keepalive: options.keepalive === true,
     });
   } catch (e) {
     console.warn("[prefsSync] server push failed:", e);


### PR DESCRIPTION
- NovelAI Enhance now shows its result in the preview instead of the original image (mode tracking effect no longer re-runs on every landed result).
- Enhance modal remembers the last-used scale and magnitude across launches.
- NAI quality tags (on) and UC preset (Heavy) defaults confirmed; pending preference pushes are flushed on page hide in browser/LAN mode so a last-second change is not overwritten by the stale server snapshot.
- Escape closes the Enhance or Director Tools modal instead of the lightbox underneath.
- Director Tools results started from the lightbox open there.
- Remote prompt assistant errors report the underlying cause; vision requests get a 300s timeout.