### PR TITLE
v2.2.6: Quick release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## What's New in v2.2.6
+
+### Fixes and maintenance
+- **NovelAI `Text:` lettering no longer picks up a stray comma**: a prompt laid out as `Text:` on its own line followed by the words to render used to reach NovelAI as `Text:, Mumei`, so the comma was drawn into the image. NovelAI prompts now keep their line breaks on the way out (blank lines still separate one rendered string from the next); ComfyUI prompts are folded into commas as before.
+- **Quality tags and the undesired content preset stop resetting themselves**: importing any NovelAI image (including the app's own gallery output) forced Quality tags off and the preset back to Heavy, and the import dialog defaults to importing settings, so the panel kept losing what you had set. The import now restores the Quality tags and preset the image was actually generated with, a clean import strips NovelAI's baked-in quality tags from the prompt, and an un-clean import turns the toggles off so the tags are not sent twice.
+- **NovelAI img2img controls sit under the image**: Strength, Noise and the inpainting "Keep the area outside the mask" switch moved out of the NovelAI panel to directly under the image upload, in the slot the Denoise slider occupies for local models.
+
+---
+
 ## What's New in v2.2.5
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## What's New in v2.2.6
+
+### Fixes and maintenance
+- **NovelAI `Text:` lettering no longer picks up a stray comma**: a prompt laid out as `Text:` on its own line followed by the words to render used to reach NovelAI as `Text:, Mumei`, so the comma was drawn into the image. NovelAI prompts now keep their line breaks on the way out (blank lines still separate one rendered string from the next); ComfyUI prompts are folded into commas as before.
+- **Quality tags and the undesired content preset stop resetting themselves**: importing any NovelAI image (including the app's own gallery output) forced Quality tags off and the preset back to Heavy, and the import dialog defaults to importing settings, so the panel kept losing what you had set. The import now restores the Quality tags and preset the image was actually generated with, a clean import strips NovelAI's baked-in quality tags from the prompt, and an un-clean import turns the toggles off so the tags are not sent twice.
+- **NovelAI img2img controls sit under the image**: Strength, Noise and the inpainting "Keep the area outside the mask" switch moved out of the NovelAI panel to directly under the image upload, in the slot the Denoise slider occupies for local models.
+
+---
+
 ## What's New in v2.2.5
 
 ### New features

--- a/docs/NOVELAI.md
+++ b/docs/NOVELAI.md
@@ -201,8 +201,9 @@ resizable panel and a warning when two circles sit closer than NovelAI's own
 space, so saved positions load unchanged), Precise Reference, Vibe
 Transfer, the NovelAI-only sampling options (quality tags, undesired-content
 preset, Variety+, dynamic thresholding, guidance rescale, undesired-content
-strength), the img2img/inpainting strength and noise, and the local
-post-process toggle.
+strength) and the local post-process toggle. The img2img/inpainting strength
+and noise sit under the image upload instead, in the slot the ComfyUI denoise
+slider uses, so they stay next to the image they act on.
 
 Sampler, steps and guidance are deliberately **not** in it. Those are top-level
 generation params shared with ComfyUI, so they stay in the Sampler panel and do
@@ -2519,9 +2520,10 @@ Two things worth stating plainly, because neither matches the literal ask:
 Restored settings land in the right halves of the panel: NovelAI's sampler and
 noise schedule go into `novelaiSettings`, not the top-level `samplerName` and
 `scheduler`, which stay ComfyUI values for the local post-process pass. The
-quality toggle and UC preset are forced off on import, because the captured
+quality toggle and UC preset were forced off on import, because the captured
 prompt already has their text folded into it and re-enabling them would append
-a second copy.
+a second copy. (Superseded on 2026-09-06: the import now restores the toggles
+the image recorded, see that entry.)
 
 **Testing required: yes.** Steps 3 and 6 are the ones that cannot be inferred
 from the code.
@@ -2806,3 +2808,49 @@ from re-billing.
 **Do not skip:** 1, 7, 11, 17. Those cover the section wiring, the exclusivity
 rule, the cost estimate and the free local pass.
 **Low-risk, skip if short on time:** 6, 18, 19.
+
+### 2026-09-06 - Text: lettering, import toggles, img2img controls under the upload
+
+Three fixes from one bug report.
+
+- **A `Text:` block reached NovelAI as `Text:, Mumei`.** `toParams` ran every
+  backend's prompt through `sanitizePromptForSend`, which folds newlines into
+  `, `. NovelAI reads the prompt line by line: the `Text:` line opens the
+  lettering block and a blank line separates one rendered string from the next,
+  so the fold produced `..., Text:, Mumei` and NovelAI rendered the comma. The
+  sanitizer now takes `keepNewlines`, set on the NovelAI path only: `BREAK`
+  stripping and comma-run cleanup still run per line, but the line structure
+  survives and runs of blank lines collapse to one.
+- **Quality tags kept switching off and the UC preset kept landing on Heavy.**
+  Both NovelAI PNG readers (`novelaiPngMetadata.ts` and `novelai/metadata.rs`)
+  stamped `mooshie_novelai_quality_toggle=false` and `mooshie_novelai_uc_preset=0`
+  on every NovelAI image, and `0` is Heavy, not None. The import dialog opens for
+  any NovelAI PNG dropped or pasted, including the app's own gallery output
+  (saved byte-for-byte with its chunks), with Settings ticked by default, so each
+  import wrote those two values over the panel and persisted them. The readers
+  now report the `qualityToggle` and `ucPreset` the image actually ran with, and
+  leave both unset when the Comment lacks them. Clean imports strip NovelAI's
+  quality filler from the prompt; an un-clean prompt import is the only case
+  that still turns the quality toggle off (and an un-clean UC import sets the
+  preset to None), because that is the case where the folded-in stack would be
+  sent twice.
+- **Strength and noise moved out of the NovelAI panel.** They render in
+  `NovelAiImageSettings.svelte` directly under the image upload, in the slot the
+  ComfyUI denoise slider uses, along with the inpainting paste-back switch.
+
+**Testing required: yes.** Steps 1 and 3 are the ones that cannot be inferred
+from the code.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | In NovelAI mode, end the prompt with `Text:` on its own line and `Mumei` on the next, generate | The lettering reads `Mumei` with no leading comma |
+| 2 | Put two strings in the Text: block separated by a blank line | Both render as separate strings |
+| 3 | Tick Quality tags, set UC preset to Light, then paste one of your own NovelAI gallery PNGs and import with Settings ticked | Quality tags stays ticked and the preset stays Light (the image recorded them that way) |
+| 4 | Import a NovelAI PNG made with the preset on None | The preset lands on None, not Heavy |
+| 5 | Import with Clean off and Prompt ticked | Quality tags switches off; the prompt keeps its full quality stack |
+| 6 | Switch to img2img in NovelAI mode | Strength and Noise sit under the image upload; the NovelAI panel no longer shows them |
+| 7 | Switch to inpainting in NovelAI mode | "Keep the area outside the mask" appears under the upload too |
+| 8 | Switch to a local model in img2img | The denoise slider is back in the same slot |
+
+**Do not skip:** 1, 3.
+**Low-risk, skip if short on time:** 2, 7, 8.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.5"
+version = "2.2.6"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/novelai/metadata.rs
+++ b/src-tauri/src/novelai/metadata.rs
@@ -153,12 +153,18 @@ pub fn parse_chunks(chunks: &HashMap<String, String>) -> Option<HashMap<String, 
         if let Some(characters) = parse_characters(comment) {
             params.insert("mooshie_novelai_characters".into(), characters);
         }
-    }
 
-    // The captured prompt and UC already have the quality tags and the preset
-    // text folded in, so re-enabling either toggle would append a second copy.
-    params.insert("mooshie_novelai_quality_toggle".into(), "false".into());
-    params.insert("mooshie_novelai_uc_preset".into(), "0".into());
+        // NovelAI records both toggles as it ran them. The quality tags and
+        // the preset text are folded into the captured prompt and UC as well;
+        // the frontend import deals with that on the prompt side rather than
+        // by forcing the panel's toggles off.
+        if let Some(quality) = comment.get("qualityToggle").and_then(string_of) {
+            params.insert("mooshie_novelai_quality_toggle".into(), quality);
+        }
+        if let Some(preset) = comment.get("ucPreset").and_then(string_of) {
+            params.insert("mooshie_novelai_uc_preset".into(), preset);
+        }
+    }
 
     if let Some(source) = chunks.get("Source") {
         params.insert("mooshie_novelai_source".into(), source.clone());
@@ -310,6 +316,8 @@ mod tests {
             "sampler": "k_euler_ancestral",
             "noise_schedule": "karras",
             "dynamic_thresholding": false,
+            "qualityToggle": true,
+            "ucPreset": 1,
             "skip_cfg_above_sigma": serde_json::Value::Null,
             "uc": "lowres, {bad anatomy}",
             "v4_prompt": {
@@ -383,14 +391,23 @@ mod tests {
     }
 
     #[test]
-    fn the_baked_in_quality_tags_are_not_re_enabled() {
+    fn the_recorded_toggles_are_read_back_as_the_image_ran_them() {
         let map = chunks(&[("Software", "NovelAI"), ("Comment", &v4_comment())]);
         let params = parse_chunks(&map).expect("novelai chunks");
         assert_eq!(
             params.get("mooshie_novelai_quality_toggle").unwrap(),
-            "false"
+            "true"
         );
-        assert_eq!(params.get("mooshie_novelai_uc_preset").unwrap(), "0");
+        assert_eq!(params.get("mooshie_novelai_uc_preset").unwrap(), "1");
+    }
+
+    #[test]
+    fn missing_toggles_leave_the_panel_alone() {
+        let comment = serde_json::json!({ "prompt": "1girl" }).to_string();
+        let map = chunks(&[("Software", "NovelAI"), ("Comment", &comment)]);
+        let params = parse_chunks(&map).expect("novelai chunks");
+        assert!(!params.contains_key("mooshie_novelai_quality_toggle"));
+        assert!(!params.contains_key("mooshie_novelai_uc_preset"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/GenerationPage.svelte
+++ b/src/lib/components/generation/GenerationPage.svelte
@@ -13,6 +13,7 @@
   import UpscaleSettings from "./UpscaleSettings.svelte";
   import FaceFixSettings from "./FaceFixSettings.svelte";
   import NovelAiSettings from "./NovelAiSettings.svelte";
+  import NovelAiImageSettings from "./NovelAiImageSettings.svelte";
   import ControlNetSettings from "./ControlNetSettings.svelte";
   import StyleTransferSettings from "./StyleTransferSettings.svelte";
   import StyleReferenceSection from "./StyleReferenceSection.svelte";
@@ -1701,8 +1702,10 @@
             {/if}
           </div>
 
-          <!-- NovelAI has its own strength and noise controls in the NovelAI panel. -->
-          {#if !generation.isNovelAi}
+          <!-- NovelAI drives img2img with strength and noise instead of denoise. -->
+          {#if generation.isNovelAi}
+          <NovelAiImageSettings />
+          {:else}
           <div use:scrollCapture>
             <label class="flex items-center justify-between text-xs text-neutral-400 mb-1">
               <span>{locale.t('generation.image.denoise')}<InfoTip text={locale.t('generation.image.denoise_tip')} /></span>

--- a/src/lib/components/generation/NovelAiImageSettings.svelte
+++ b/src/lib/components/generation/NovelAiImageSettings.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  /**
+   * NovelAI's img2img controls: strength and noise, plus the inpainting
+   * paste-back switch. Rendered directly under the image upload, in the slot
+   * the local denoise slider occupies for ComfyUI, so the controls live next
+   * to the image they act on rather than in the NovelAI panel.
+   */
+  import { generation } from "../../stores/generation.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import InfoTip from "../ui/InfoTip.svelte";
+
+  const nai = $derived(generation.novelaiSettings);
+</script>
+
+<div class="space-y-2">
+  <span class="text-xs text-neutral-400">{locale.t("generation.novelai.image.title")}</span>
+
+  <label class="block text-[11px] text-neutral-500">
+    {locale.t("generation.novelai.image.strength")}
+    {nai.strength.toFixed(2)}
+    <input
+      type="range"
+      min="0.01"
+      max="0.99"
+      step="0.01"
+      class="w-full accent-indigo-500"
+      value={nai.strength}
+      oninput={(e) => generation.updateNovelAiSettings({ strength: Number(e.currentTarget.value) })}
+    />
+  </label>
+
+  <label class="block text-[11px] text-neutral-500">
+    {locale.t("generation.novelai.image.noise")}
+    {nai.noise.toFixed(2)}
+    <input
+      type="range"
+      min="0"
+      max="1"
+      step="0.01"
+      class="w-full accent-indigo-500"
+      value={nai.noise}
+      oninput={(e) => generation.updateNovelAiSettings({ noise: Number(e.currentTarget.value) })}
+    />
+  </label>
+
+  {#if generation.mode === "inpainting"}
+    <label class="flex items-center gap-2 text-xs text-neutral-300">
+      <input
+        type="checkbox"
+        class="accent-indigo-500"
+        checked={nai.add_original_image}
+        onchange={(e) =>
+          generation.updateNovelAiSettings({ add_original_image: e.currentTarget.checked })}
+      />
+      {locale.t("generation.novelai.image.add_original")}
+      <InfoTip text={locale.t("generation.novelai.image.add_original_desc")} />
+    </label>
+  {/if}
+</div>

--- a/src/lib/components/generation/NovelAiSettings.svelte
+++ b/src/lib/components/generation/NovelAiSettings.svelte
@@ -16,7 +16,6 @@
   const UC_PRESETS = [0, 1, 2, 3];
 
   const nai = $derived(generation.novelaiSettings);
-  const isImageMode = $derived(generation.mode === "img2img" || generation.mode === "inpainting");
   const postProcessArmed = $derived(generation.upscaleEnabled || generation.facefixEnabled);
 
   /**
@@ -172,55 +171,6 @@
       </p>
     {/if}
   </div>
-
-  {#if isImageMode}
-    <div class="border-t border-neutral-800 pt-3 space-y-2">
-      <span class="text-xs text-neutral-400">{locale.t("generation.novelai.image.title")}</span>
-
-      <label class="block text-[11px] text-neutral-500">
-        {locale.t("generation.novelai.image.strength")}
-        {nai.strength.toFixed(2)}
-        <input
-          type="range"
-          min="0.01"
-          max="0.99"
-          step="0.01"
-          class="w-full accent-indigo-500"
-          value={nai.strength}
-          oninput={(e) =>
-            generation.updateNovelAiSettings({ strength: Number(e.currentTarget.value) })}
-        />
-      </label>
-
-      <label class="block text-[11px] text-neutral-500">
-        {locale.t("generation.novelai.image.noise")}
-        {nai.noise.toFixed(2)}
-        <input
-          type="range"
-          min="0"
-          max="1"
-          step="0.01"
-          class="w-full accent-indigo-500"
-          value={nai.noise}
-          oninput={(e) => generation.updateNovelAiSettings({ noise: Number(e.currentTarget.value) })}
-        />
-      </label>
-
-      {#if generation.mode === "inpainting"}
-        <label class="flex items-center gap-2 text-xs text-neutral-300">
-          <input
-            type="checkbox"
-            class="accent-indigo-500"
-            checked={nai.add_original_image}
-            onchange={(e) =>
-              generation.updateNovelAiSettings({ add_original_image: e.currentTarget.checked })}
-          />
-          {locale.t("generation.novelai.image.add_original")}
-          <InfoTip text={locale.t("generation.novelai.image.add_original_desc")} />
-        </label>
-      {/if}
-    </div>
-  {/if}
 
   <div class="border-t border-neutral-800 pt-3 space-y-2">
     <label class="flex items-center gap-2 text-xs text-neutral-300">

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -3165,11 +3165,16 @@ class GenerationStore {
     // like chained ComfyUI string-concatenate nodes), then strip BREAK/<break>
     // and layout newlines. This runs before inline preset resolution so that
     // `@preset:` tokens inside extra boxes still flow through the pipeline.
+    // NovelAI reads the prompt line by line (a `Text:` line opens the lettering
+    // block), so its layout is preserved instead of folded into commas.
+    const sanitizeOptions = { keepNewlines: this.isNovelAi };
     const effectivePositive = sanitizePromptForSend(
-      joinPromptBoxes([this.positivePrompt, ...this.extraPositiveBoxes.map((b) => b.content)])
+      joinPromptBoxes([this.positivePrompt, ...this.extraPositiveBoxes.map((b) => b.content)]),
+      sanitizeOptions
     );
     const effectiveNegative = sanitizePromptForSend(
-      joinPromptBoxes([this.negativePrompt, ...this.extraNegativeBoxes.map((b) => b.content)])
+      joinPromptBoxes([this.negativePrompt, ...this.extraNegativeBoxes.map((b) => b.content)]),
+      sanitizeOptions
     );
 
     // Expand inline `@preset:<slug>` directives in the user-typed prompts

--- a/src/lib/utils/metadataImport.ts
+++ b/src/lib/utils/metadataImport.ts
@@ -9,6 +9,7 @@ import { parseSegmentDetailPrompt } from "./promptSegmentDetail.js";
 import type { NovelAiCharacter } from "../types/index.js";
 import { novelAiMaxCharacters, isNovelAiModel } from "./novelaiModels.js";
 import { novelaiImport } from "../stores/novelaiImport.svelte.js";
+import { NAI_QUALITY_FILLER } from "./naiPrompt.js";
 import type {
   NovelAiImportSelection,
   NovelAiImportSource,
@@ -112,8 +113,9 @@ function splitQualityTagCandidates(prompt: string): string[] {
 }
 
 /** Remove auto-applied quality tags and SwarmUI syntax from a prompt string. */
-function stripQualityTags(prompt: string): string {
+function stripQualityTags(prompt: string, extraTags: readonly string[] = []): string {
   const autoTags = buildAutoQualityTagSet();
+  for (const tag of extraTags) autoTags.add(tag.toLowerCase());
   const cleaned = stripSwarmUITags(prompt);
   const tags = splitQualityTagCandidates(cleaned);
   const filtered = tags.filter((t) => !autoTags.has(t.toLowerCase()));
@@ -129,13 +131,20 @@ function stripQualityTags(prompt: string): string {
  * here understands. Turning it off imports the prompt exactly as the image
  * carries it.
  */
-function promptForImport(text: string, clean: boolean): string {
-  return clean ? stripQualityTags(text) : text.trim();
+function promptForImport(
+  text: string,
+  clean: boolean,
+  extraTags: readonly string[] = [],
+): string {
+  return clean ? stripQualityTags(text, extraTags) : text.trim();
 }
 
 function applyPositivePrompt(meta: Record<string, string>, clean = true): boolean {
   if (meta.positive_prompt === undefined) return false;
-  generation.positivePrompt = promptForImport(meta.positive_prompt, clean);
+  // A NovelAI image carries its quality stack folded into the prompt; the
+  // panel's quality toggle puts it back at send time, so it comes out here.
+  const extraTags = isNovelAiMeta(meta) ? NAI_QUALITY_FILLER : [];
+  generation.positivePrompt = promptForImport(meta.positive_prompt, clean, extraTags);
   generation.extraPositiveBoxes = [];
   return true;
 }
@@ -490,6 +499,15 @@ export function applyNovelAiSelection(
   if (selection.prompt && applyPositivePrompt(meta, selection.clean)) applied.push("prompt");
   if (selection.undesired && applyNegativePrompt(meta, selection.clean)) {
     applied.push("undesired");
+  }
+  // An un-clean import keeps NovelAI's quality stack and preset text exactly
+  // as the image carries them, so the toggles that would append a second copy
+  // go off for it. Every other combination leaves the panel's own choice alone.
+  if (!selection.clean) {
+    const patch: Partial<NovelAiSettings> = {};
+    if (selection.prompt && meta.positive_prompt !== undefined) patch.quality_toggle = false;
+    if (selection.undesired && meta.negative_prompt !== undefined) patch.uc_preset = 3;
+    if (Object.keys(patch).length > 0) generation.updateNovelAiSettings(patch);
   }
   if (selection.seed && applySeed(meta)) applied.push("seed");
 

--- a/src/lib/utils/novelaiPngMetadata.ts
+++ b/src/lib/utils/novelaiPngMetadata.ts
@@ -147,6 +147,12 @@ export function parseNovelAiChunks(chunks: Record<string, string>): Record<strin
       ["cfg_rescale", "mooshie_novelai_cfg_rescale"],
       ["uncond_scale", "mooshie_novelai_uncond_scale"],
       ["dynamic_thresholding", "mooshie_novelai_dynamic_thresholding"],
+      // NovelAI records both toggles as it ran them. The quality tags and the
+      // preset text are folded into the captured prompt and UC as well; the
+      // import handles that on the prompt side (see `applyNovelAiSelection`)
+      // rather than by forcing the panel's toggles off.
+      ["qualityToggle", "mooshie_novelai_quality_toggle"],
+      ["ucPreset", "mooshie_novelai_uc_preset"],
       // Which endpoint made the image. An `Img2ImgRequest` was seeded by a
       // source image nothing in the metadata carries, so the settings here
       // cannot reproduce it and the import dialog says so.
@@ -174,11 +180,6 @@ export function parseNovelAiChunks(chunks: Record<string, string>): Record<strin
     const characters = parseCharacters(comment);
     if (characters !== undefined) params.mooshie_novelai_characters = characters;
   }
-
-  // The captured prompt and UC already have the quality tags and the preset
-  // text folded in, so re-enabling either toggle would append a second copy.
-  params.mooshie_novelai_quality_toggle = "false";
-  params.mooshie_novelai_uc_preset = "0";
 
   if (chunks.Source) {
     params.mooshie_novelai_source = chunks.Source;

--- a/src/lib/utils/promptSanitize.ts
+++ b/src/lib/utils/promptSanitize.ts
@@ -28,19 +28,43 @@ export function joinPromptBoxes(contents: string[]): string {
   return contents.map(trimFragment).filter((frag) => frag.length > 0).join(", ");
 }
 
+export interface SanitizeOptions {
+  /**
+   * Keep line breaks instead of folding them into ", ". NovelAI reads the
+   * prompt line by line: a `Text:` line opens the lettering block, and a blank
+   * line inside it separates one rendered string from the next. Folding that
+   * layout into commas turns `Text:\nMumei` into `Text:, Mumei`, and NovelAI
+   * then renders the comma into the image.
+   */
+  keepNewlines?: boolean;
+}
+
 /**
  * Remove BREAK / <break> tokens and normalize newlines to ", " so the outgoing
  * prompt is a single clean comma-separated string regardless of how the user
  * laid it out in the textarea.
+ *
+ * With `keepNewlines` every line is cleaned on its own and the line structure
+ * survives, with runs of blank lines collapsed to a single blank line.
  */
-export function sanitizePromptForSend(prompt: string): string {
+export function sanitizePromptForSend(prompt: string, options: SanitizeOptions = {}): string {
   if (!prompt) return "";
+  const stripped = prompt
+    // A1111 chunk keyword — case-sensitive whole word so "BREAKFAST" survives.
+    .replace(/\bBREAK\b/g, " ")
+    // Angle-bracket form some tools emit; case-insensitive.
+    .replace(/<break>/gi, " ");
+  if (options.keepNewlines) {
+    return stripped
+      .replace(/\r\n?/g, "\n")
+      .split("\n")
+      .map((line) => trimFragment(line).replace(/,\s*(?:,\s*)+/g, ", "))
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
   return (
-    prompt
-      // A1111 chunk keyword — case-sensitive whole word so "BREAKFAST" survives.
-      .replace(/\bBREAK\b/g, " ")
-      // Angle-bracket form some tools emit; case-insensitive.
-      .replace(/<break>/gi, " ")
+    stripped
       // Newlines used for visual layout become tag separators.
       .split("\n")
       .map(trimFragment)


### PR DESCRIPTION
Quick release v2.2.6.

- NovelAI `Text:` lettering no longer picks up a stray comma: NovelAI prompts keep their line breaks on the way out instead of being folded into `, `, so `Text:` followed by a line of words is sent as NovelAI expects. ComfyUI prompts are folded as before.
- Quality tags and the undesired content preset stop resetting themselves: both NovelAI PNG readers used to stamp Quality tags off and the preset to Heavy on every imported NovelAI image (including the app's own gallery output). The import now restores the `qualityToggle` and `ucPreset` the image recorded, a clean import strips NovelAI's baked-in quality tags from the prompt, and an un-clean import turns the toggles off so the tags are not sent twice.
- NovelAI img2img controls (Strength, Noise, and the inpainting "Keep the area outside the mask" switch) moved from the NovelAI panel to directly under the image upload, where the Denoise slider sits for local models.
- docs/NOVELAI.md updated with the new layout and a manual test table.

Validated before the release: npm run build, cargo check (desktop and server), cargo test (452 passed), cargo fmt.
