### PR TITLE
v2.2.8: NovelAI Text: comma fix at the merge step, Enhance for V5 rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ add-locale-stubs.ps1
 new_keys.txt
 .github/check_env_token.ps1
 .github/poll_pr169.ps1
+
+# Local LLM-agent NovelAI V5 prompting spec (not shipped)
+docs/NAI_V5_PROMPTING_AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## What's New in v2.2.8
+
+### Fixes and maintenance
+- **The comma before NovelAI `Text:` lettering is actually gone this time**: v2.2.6 fixed the sanitizer, but the step after it flattened the prompt again. Whenever a style preset, an Artist Style or a Prompt Chunk was active, the merge that adds their tags split the whole prompt on commas and rejoined it with ", ", so `1girl, rain,` followed by `Text:` on the next line still reached NovelAI as `1girl, rain, Text:, Mumei`. That is why it looked random: it followed the active style, not the prompt. NovelAI prompts now keep their layout through the merge, new tags are spliced in ahead of the `Text:` block (on a new line when the last line is a sentence), and the Rust side moves a `Text:` label that still arrives after a comma onto its own line as a last stop. ComfyUI prompts are merged flat as before.
+- **Transparent BG no longer writes its tag into the lettering**: with a `Text:` block in the prompt, the `2.1::transparent background::` tag was appended after it and rendered as text. It now goes in front of the block.
+- **Toggling an artist tag off keeps your prompt layout**: removing or replacing an artist from the artist gallery rebuilt the whole prompt as one comma list. Only the line holding that tag is rewritten now; every other line, `Text:` blocks and blank lines included, is left as written.
+- **Enhance for V5 follows the V5 Full and V5 Curated prompting rules**: the rewrite no longer pads a quota of emphasised tags or a long undesired content list. BASE is a tag line plus a few natural language sentences with `high complexity` by default, emphasis is reserved for locking or killing a motif, UC is custom motif only and may be empty when the preset is on, and quality filler (`masterpiece`, `best quality`, `very aesthetic`) is dropped from every field. The normalizer now reorders digit-suffix artist names to the front of `n::...::` spans, turns em and en dashes in prompt fields into commas, rewrites a character box starting with `1girl` or `Character 1` instead of failing the review, and strips preset UC junk like `worst quality` and `lowres`. `Text:` lettering is left alone. Cached self-authored notes are refreshed once on the first enhance after updating.
+
+---
+
 ## What's New in v2.2.7
 
 ### Fixes and maintenance

--- a/IDEA.md
+++ b/IDEA.md
@@ -1,0 +1,1 @@
+MooshieUI, a frontend UI for ComfyUI

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+## What's New in v2.2.8
+
+### Fixes and maintenance
+- **The comma before NovelAI `Text:` lettering is actually gone this time**: v2.2.6 fixed the sanitizer, but the step after it flattened the prompt again. Whenever a style preset, an Artist Style or a Prompt Chunk was active, the merge that adds their tags split the whole prompt on commas and rejoined it with ", ", so `1girl, rain,` followed by `Text:` on the next line still reached NovelAI as `1girl, rain, Text:, Mumei`. That is why it looked random: it followed the active style, not the prompt. NovelAI prompts now keep their layout through the merge, new tags are spliced in ahead of the `Text:` block (on a new line when the last line is a sentence), and the Rust side moves a `Text:` label that still arrives after a comma onto its own line as a last stop. ComfyUI prompts are merged flat as before.
+- **Transparent BG no longer writes its tag into the lettering**: with a `Text:` block in the prompt, the `2.1::transparent background::` tag was appended after it and rendered as text. It now goes in front of the block.
+- **Toggling an artist tag off keeps your prompt layout**: removing or replacing an artist from the artist gallery rebuilt the whole prompt as one comma list. Only the line holding that tag is rewritten now; every other line, `Text:` blocks and blank lines included, is left as written.
+- **Enhance for V5 follows the V5 Full and V5 Curated prompting rules**: the rewrite no longer pads a quota of emphasised tags or a long undesired content list. BASE is a tag line plus a few natural language sentences with `high complexity` by default, emphasis is reserved for locking or killing a motif, UC is custom motif only and may be empty when the preset is on, and quality filler (`masterpiece`, `best quality`, `very aesthetic`) is dropped from every field. The normalizer now reorders digit-suffix artist names to the front of `n::...::` spans, turns em and en dashes in prompt fields into commas, rewrites a character box starting with `1girl` or `Character 1` instead of failing the review, and strips preset UC junk like `worst quality` and `lowres`. `Text:` lettering is left alone. Cached self-authored notes are refreshed once on the first enhance after updating.
+
+---
+
 ## What's New in v2.2.7
 
 ### Fixes and maintenance

--- a/docs/NOVELAI.md
+++ b/docs/NOVELAI.md
@@ -1508,14 +1508,18 @@ modal, with the named rule in the amber problem list after the single retry
 fails to clear it.
 
 5. Empty `BASE:`. Problem names the empty base field.
-6. An em dash or en dash anywhere in any field. Problem names the dash.
+6. An em dash or an en dash in BASE or UC (not inside a `Text:` block). The
+   normalizer rewrites it to a comma; no problem line. A dash that survives
+   into a field (for example inside `Text:`) still names the dash.
 7. A markdown fence around the answer. The fence is stripped by the parser; if
    one survives into a field, the problem names it.
-8. `CHAR 1:` starting with `1girl`. Problem says counts belong in BASE only.
-9. `CHAR 1:` starting with `Character 1`. Problem says start the box with girl,
-   boy or other.
-10. Quality filler (`masterpiece`, `best quality`) in BASE with the quality
-    toggle on. Problem names the filler found.
+8. `CHAR 1:` starting with `1girl`. The normalizer rewrites it to `girl`; no
+   problem line. A count tag still sitting later in the box is reported.
+9. `CHAR 1:` starting with `Character 1`. The normalizer strips the numbered
+   label; no problem line if the rest already starts with girl, boy or other.
+10. Quality filler (`masterpiece`, `best quality`, `very aesthetic`) in BASE.
+    The normalizer drops those tags; no problem line. Filler that cannot be
+    pulled out as a comma/span item is still reported.
 11. Content after the `Text:` block in BASE. Problem says the Text block must be
     last.
 12. Unbalanced `{` or `[` in BASE. Problem names the brackets.
@@ -1525,6 +1529,10 @@ fails to clear it.
 14. A chatty preamble before the first label ("Sure, here you go"). Dropped by
     the parser, no problem line.
 15. No labels at all, just a bare prompt. Treated as BASE, no problem line.
+16. `1.2::rain, as109::` in BASE. The normalizer reorders to
+    `1.2::as109, rain::`. No problem line.
+17. Preset UC junk (`worst quality`, `lowres`) in UC. The normalizer drops
+    those tags; custom motif UC is kept. No problem line.
 
 **Digit suffix artist names.** Prompt:
 
@@ -2820,7 +2828,9 @@ Three fixes from one bug report.
   so the fold produced `..., Text:, Mumei` and NovelAI rendered the comma. The
   sanitizer now takes `keepNewlines`, set on the NovelAI path only: `BREAK`
   stripping and comma-run cleanup still run per line, but the line structure
-  survives and runs of blank lines collapse to one.
+  survives and runs of blank lines collapse to one. (Incomplete: the merge
+  step after the sanitizer flattened the prompt again whenever a style or
+  chunk was active. See 2026-09-07, "The comma before Text: was still there".)
 - **Quality tags kept switching off and the UC preset kept landing on Heavy.**
   Both NovelAI PNG readers (`novelaiPngMetadata.ts` and `novelai/metadata.rs`)
   stamped `mooshie_novelai_quality_toggle=false` and `mooshie_novelai_uc_preset=0`
@@ -2906,3 +2916,107 @@ and 8 of the second.
 | 6 | NAI mode, inpainting. Load an image | Width and height equal the image's exact size, as before |
 | 7 | ComfyUI backend, 1024x1024. Load a 1216x832 image | Reads 3 : 2, resolution recomputed to 3:2 at side 1024 on the 8 grid |
 | 8 | ComfyUI backend at 21:9, switch to a NovelAI model | Ratio still reads 21 : 9, dimensions only snap to the 64 grid |
+
+### 2026-09-07 - Enhance for V5 follows V5 Full / Curated prompting
+
+**Requested by:** the user: make the existing Enhance for V5 path work like
+the V5 Full and V5 Curated prompting specs (hybrid tags + NL, custom UC only,
+no quality stacks, digit-suffix artist spans).
+
+**What was wrong.** The rewrite asked for a quota of emphasised tags and a
+ten-to-thirty-item UC list, so the model padded both. Quality filler was a
+short list checked only in BASE, digit-suffix artist spans were described in
+the spec but never reordered, and a leading `1girl` in a character box cost a
+retry instead of being repaired. The result did not look like a paste-ready
+V5 pack.
+
+**What changed.**
+
+- The system prompt is hybrid: tags lock identity, natural language owns
+  camera, layout and mood. Default complexity is `high complexity`. Emphasis
+  is for locking or killing a motif, not a quota. UC is custom motif only
+  and may be empty when the preset is on. Quality / aesthetic filler is
+  forbidden in every field. Explicit ideas keep real Danbooru tags; the
+  rewrite does not sanitize them and does not invent them.
+- The normalizer now does the work the spec already promised: digit-suffix
+  names go first inside `n::...::` spans (trailing comma when every token
+  still ends in a digit), quality filler and preset quality-UC junk are
+  stripped, em/en dashes in prompt fields become commas, and a box that
+  starts `1girl` / `Character 1` is rewritten to `girl` / stripped. `Text:`
+  lettering is left alone.
+- Cached self-authored notes are invalidated (`SKILL_VERSION` 5) because
+  the job they were written for changed.
+
+**Where nothing changed.** The modal, the review gate, reference images, and
+the language select are untouched. Settings (steps, guidance, sampler) stay
+on the panel; the rewrite still returns labelled fields only.
+
+**Testing required: yes.** The LLM half cannot be asserted automatically.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | V5 Curated, Enhance for V5, `a girl standing in the rain at night, neon signs` | Review BASE is a tag line plus 1-3 NL sentences, includes `high complexity`, no `masterpiece` / `best quality` / `very aesthetic`. UC is short or empty, no `lowres` / `worst quality` |
+| 2 | Same idea on V5 Full | Review subtitle says V5 Full. NL body may be longer. Still no quality stack |
+| 3 | Instruction that is explicit | Real Danbooru tags in BASE/CHAR, not euphemisms |
+| 4 | `1.2::rain, as109::` in a rewrite that keeps that artist span | Applied BASE has `1.2::as109, rain::` |
+| 5 | First enhance after this change, same backend as before | Skill authoring runs once (notes cache miss), then later rewrites skip it |
+
+### 2026-09-07 - The comma before Text: was still there
+
+**Requested by:** the user: the 2026-09-06 fix did not take, the lettering
+still rendered with a leading comma.
+
+**What was wrong.** The 2026-09-06 change fixed `sanitizePromptForSend`, and
+that step does keep the newlines now. The flattening happened one step later.
+`toParams` merges system fragments into the prompt with `mergeTagPrompts`:
+the style preset's positive and negative tags, the active Artist Styles
+fragment, and a Prompt Chunk's prepend and append. That helper splits the
+whole prompt on commas, dedupes, and rejoins with ", ". A NovelAI prompt laid
+out the normal way, one tag line ending in a comma and then `Text:` on the
+next line, came out as `1girl, rain, Text:, Mumei`. It ran whenever any of
+those fragments was non-empty, even when the dedupe added nothing, which is
+why the bug looked intermittent: it followed the Artist Style or chunk, not
+the prompt. The gallery PNGs confirmed it: the sent prompt had every
+comma-terminated line joined with ", " and the `Text:` label mid-line, while
+the character captions, which never pass through the merge, kept their
+newlines.
+
+Two smaller flatteners sat next to it. Toggling an artist tag off from the
+artist gallery (or replacing one) rebuilt the prompt box with `join(", ")`,
+and the Transparent BG toggle appended its tag after a user-written `Text:`
+block, so the tag became lettering.
+
+**What changed.**
+
+- `mergeNovelAiTags` in `promptSanitize.ts` merges a fragment without
+  re-tokenizing the prompt: it splits off the `Text:` block, dedupes the new
+  tags against the head (case-insensitive, split on commas and newlines),
+  splices them in before or after the head, and reattaches the block with
+  its original newline. It returns the prompt untouched when nothing new is
+  left. Tags appended after a prose line that ends in a period start a new
+  line instead of joining the sentence.
+- `generation.svelte.ts` routes all five merge sites through
+  `mergeIntoPrompt`, which picks `mergeNovelAiTags` in NovelAI mode and the
+  old `mergeTagPrompts` elsewhere. ComfyUI prompts are unchanged.
+- `artistInsert.remove` and `apply("replace")` use `filterPromptTags`, which
+  rewrites only the lines that hold the dropped tag and leaves every other
+  line, blank lines included, byte for byte.
+- `payload.rs` gained a last-stop normaliser, `text_block_on_own_line`: a
+  `Text:` label that arrives after a comma on the same line is moved onto its
+  own line, and `with_transparency` now inserts its tag in front of a
+  user-written `Text:` block instead of after it. Both have `#[test]`s.
+
+**Testing required: yes.** The Rust tests cover the payload; the store-level
+merge can only be seen end to end.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | NovelAI V5, activate an Artist Style (or a Prompt Chunk with an append). Prompt: `1girl, rain,` newline `Text:` newline `Mumei`. Generate | Lettering reads `Mumei`, no comma. The PNG Comment `prompt` has `rain, <style tags>` then a newline before `Text:` |
+| 2 | Same prompt, no style or chunk active | Same result (the 2026-09-06 path) |
+| 3 | Prose line ending in a period before the `Text:` block, style active | Style tags land on their own line after the sentence, `Text:` still last |
+| 4 | Transparent BG on, prompt ends with a `Text:` block | Image is transparent, lettering has no `2.1::transparent background::` in it |
+| 5 | Prompt with an artist tag on line 1 and a `Text:` block below, toggle that artist off in the artist gallery | Line 1 loses the tag, every other line (and the blank line in the block) is unchanged |
+| 6 | Local model (ComfyUI), style active, multi-line prompt | Sent prompt is the flat comma list it always was |
+
+**Do not skip:** 1, 4.
+**Low-risk, skip if short on time:** 3, 6.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.2.7"
+version = "2.2.8"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.7"
+version = "2.2.8"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/novelai/payload.rs
+++ b/src-tauri/src/novelai/payload.rs
@@ -35,9 +35,11 @@ pub fn build(
     model: &NovelAiModel,
 ) -> Result<Value, String> {
     let action = normalise_action(&nai.action, input);
-    // Transparency first, text second, so the `Text:` block ends up last: the
-    // API wants it at the very end of the prompt, after every tag.
-    let positive_prompt = with_transparency(&input.positive_prompt, nai, model);
+    // Own-line first, transparency second, text third, so the `Text:` block
+    // ends up last and on its own line: the API wants it at the very end of
+    // the prompt, after every tag, and reads `, Text:` as a comma to render.
+    let positive_prompt = text_block_on_own_line(&input.positive_prompt);
+    let positive_prompt = with_transparency(&positive_prompt, nai, model);
     let positive_prompt = with_text_blocks(&positive_prompt, model);
     let mut parameters = Map::new();
 
@@ -183,11 +185,70 @@ fn with_transparency(prompt: &str, nai: &NovelAiParams, model: &NovelAiModel) ->
     if prompt.to_lowercase().contains("transparent background") {
         return prompt.to_string();
     }
-    let trimmed = prompt.trim_end().trim_end_matches(',').trim_end();
-    if trimmed.is_empty() {
-        return TRANSPARENCY_TAG.to_string();
+    // The tag joins the tag list, never the lettering: a user-written `Text:`
+    // block must stay the last thing in the prompt, so the tag goes in front
+    // of it.
+    let (head, text) = split_text_block(prompt);
+    let trimmed = head.trim_end().trim_end_matches(',').trim_end();
+    let tags = if trimmed.is_empty() {
+        TRANSPARENCY_TAG.to_string()
+    } else {
+        format!("{trimmed}, {TRANSPARENCY_TAG}")
+    };
+    if text.is_empty() {
+        tags
+    } else {
+        format!("{tags}\n{text}")
     }
-    format!("{trimmed}, {TRANSPARENCY_TAG}")
+}
+
+/// Split a prompt at the first `Text:` label that starts a line. The tail
+/// begins at the label itself (leading blank lines are dropped); it is empty
+/// when the prompt has no lettering block.
+fn split_text_block(prompt: &str) -> (&str, &str) {
+    let mut offset = 0;
+    for line in prompt.split_inclusive('\n') {
+        if line.trim_start().starts_with("Text:") {
+            let head = &prompt[..offset];
+            let tail = prompt[offset..].trim_start();
+            return (head, tail);
+        }
+        offset += line.len();
+    }
+    (prompt, "")
+}
+
+/// Move a `Text:` label that arrived comma-joined onto its own line.
+///
+/// NovelAI reads the prompt line by line and everything after `Text:` is
+/// lettering, so `1girl, rain, Text: Mumei` renders a stray comma while
+/// `1girl, rain\nText: Mumei` renders `Mumei`. Every frontend path is meant to
+/// keep the newline, but this is the last stop before the payload, so the
+/// label is put back on its own line here whenever it follows a comma on the
+/// same line. A `Text:` that already starts a line, or that is glued to a
+/// word (`SubText:`), is left alone.
+fn text_block_on_own_line(prompt: &str) -> String {
+    for (idx, _) in prompt.match_indices("Text:") {
+        let head = &prompt[..idx];
+        let boundary = head
+            .chars()
+            .next_back()
+            .is_none_or(|c| c.is_whitespace() || c == ',');
+        if !boundary {
+            continue;
+        }
+        let stripped = head.trim_end();
+        // Already at the start of the prompt or of a line: nothing to fix.
+        if stripped.is_empty() || head[stripped.len()..].contains('\n') {
+            return prompt.to_string();
+        }
+        if !stripped.ends_with(',') {
+            return prompt.to_string();
+        }
+        let body = stripped.trim_end_matches(|c: char| c == ',' || c.is_whitespace());
+        return format!("{body}\n{}", &prompt[idx..]);
+    }
+    prompt.to_string()
 }
 
 /// Quote pairs that mark text to be rendered in the image. NovelAI's V5
@@ -932,5 +993,61 @@ mod tests {
         let body = build(&input(), &n, v5()).unwrap();
         let caps = &body["parameters"]["v4_prompt"]["caption"]["char_captions"];
         assert_eq!(caps.as_array().unwrap().len(), 8);
+    }
+
+    #[test]
+    fn a_comma_joined_text_label_is_moved_onto_its_own_line() {
+        assert_eq!(
+            text_block_on_own_line("1girl, rain, Text: Mumei"),
+            "1girl, rain\nText: Mumei"
+        );
+        // Trailing whitespace and repeated commas before the label go too.
+        assert_eq!(
+            text_block_on_own_line("1girl, rain,, Text:\nMumei\n\nHello"),
+            "1girl, rain\nText:\nMumei\n\nHello"
+        );
+    }
+
+    #[test]
+    fn a_text_label_already_on_its_own_line_is_untouched() {
+        for prompt in [
+            "1girl, rain\nText: Mumei",
+            "1girl, rain,\nText: Mumei",
+            "1girl, rain,\n\nText:\nMumei",
+            "Text: Mumei",
+            // Glued to a word it is not a label, and without a comma it is left
+            // to the user (a sentence can legitimately end in "Text:").
+            "1girl, SubText: foo",
+            "1girl rain Text: foo",
+            "1girl, rain",
+        ] {
+            assert_eq!(text_block_on_own_line(prompt), prompt, "{prompt:?}");
+        }
+    }
+
+    #[test]
+    fn build_puts_a_comma_joined_text_label_on_its_own_line() {
+        let mut i = input();
+        i.positive_prompt = "1girl, rain, Text: Mumei".into();
+        let body = build(&i, &nai(), v5()).unwrap();
+        let expected = "1girl, rain\nText: Mumei";
+        assert_eq!(body["input"], expected);
+        assert_eq!(
+            body["parameters"]["v4_prompt"]["caption"]["base_caption"],
+            expected
+        );
+    }
+
+    #[test]
+    fn transparency_goes_in_front_of_a_manual_text_block() {
+        let mut n = nai();
+        n.transparent_background = true;
+        let mut i = input();
+        i.positive_prompt = "1girl, rain,\nText:\nMumei\n\nHello".into();
+        let body = build(&i, &n, v5()).unwrap();
+        assert_eq!(
+            body["input"],
+            "1girl, rain, 2.1::transparent background::\nText:\nMumei\n\nHello"
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/stores/artistInsert.svelte.ts
+++ b/src/lib/stores/artistInsert.svelte.ts
@@ -15,6 +15,7 @@ import { generation } from "./generation.svelte.js";
 import { gallery } from "./gallery.svelte.js";
 import {
   artistTagBodiesMatch,
+  filterPromptTags,
   isArtistTagToken,
   splitPromptTags,
 } from "../utils/artistTag.js";
@@ -75,8 +76,9 @@ class ArtistInsertStore {
   remove(tag: string): void {
     const existing = generation.positivePrompt.trim();
     if (!existing) return;
-    const filtered = splitPromptTags(existing).filter((t) => !artistTagBodiesMatch(t, tag));
-    generation.positivePrompt = filtered.join(", ");
+    // Layout-preserving: only the lines holding the tag are rewritten, so a
+    // NovelAI `Text:` block or prose line survives the toggle untouched.
+    generation.positivePrompt = filterPromptTags(existing, (t) => artistTagBodiesMatch(t, tag));
     generation.saveSettings();
     this.pending = null;
   }
@@ -89,9 +91,7 @@ class ArtistInsertStore {
     let newPrompt: string;
     if (mode === "replace") {
       const drop = new Set(this.existingArtistTags());
-      const stripped = splitPromptTags(existing)
-        .filter((s) => !drop.has(s))
-        .join(", ");
+      const stripped = filterPromptTags(existing, (s) => drop.has(s));
       newPrompt = stripped ? `${cleaned}, ${stripped}` : cleaned;
     } else {
       newPrompt = existing ? `${cleaned}, ${existing}` : cleaned;

--- a/src/lib/stores/generation.svelte.ts
+++ b/src/lib/stores/generation.svelte.ts
@@ -8,7 +8,11 @@ import {
   parseScheduledPrompt,
 } from "../utils/promptSchedule.js";
 import { parseSegmentDetailPrompt } from "../utils/promptSegmentDetail.js";
-import { joinPromptBoxes, sanitizePromptForSend } from "../utils/promptSanitize.js";
+import {
+  joinPromptBoxes,
+  mergeNovelAiTags,
+  sanitizePromptForSend,
+} from "../utils/promptSanitize.js";
 import { expandRandomPrompt, hasRandomSyntax } from "../utils/randomPrompt.js";
 import { extractScaleFromModel } from "../utils/upscalers.js";
 import {
@@ -1695,6 +1699,21 @@ class GenerationStore {
     return merged.join(", ");
   }
 
+  /**
+   * Merge a system tag fragment (style preset, Artist Style, Prompt Chunk)
+   * into a prompt. ComfyUI prompts are flat tag lists, so `mergeTagPrompts`
+   * may re-tokenize them freely. NovelAI prompts carry layout that matters
+   * (a `Text:` block on its own line, blank lines between rendered strings,
+   * prose lines), so they go through `mergeNovelAiTags`, which splices the
+   * new tags in ahead of the `Text:` block and leaves the rest untouched.
+   */
+  private mergeIntoPrompt(prompt: string, tags: string, where: "before" | "after"): string {
+    if (this.isNovelAi) return mergeNovelAiTags(prompt, tags, where);
+    return where === "before"
+      ? this.mergeTagPrompts(tags, prompt)
+      : this.mergeTagPrompts(prompt, tags);
+  }
+
   private loadPromptHistory() {
     try {
       const raw = localStorage.getItem(PROMPT_HISTORY_KEY);
@@ -3219,8 +3238,15 @@ class GenerationStore {
     // tags) are merged in — a trailing-form segment must not swallow them.
     const parsedSegmentDetails = parseSegmentDetailPrompt(inlinePositive);
 
-    let positivePrompt = this.mergeTagPrompts(parsedSegmentDetails.baseText, style.positive);
-    let negativePrompt = this.mergeTagPrompts(inlineNegative, style.negative);
+    // Every merge below goes through mergeIntoPrompt: in NovelAI mode the
+    // comma re-tokenizer would fold `1girl, rain,\nText:\nMumei` into
+    // `1girl, rain, Text:, Mumei` the moment any style or chunk is active.
+    let positivePrompt = this.mergeIntoPrompt(
+      parsedSegmentDetails.baseText,
+      style.positive,
+      "after",
+    );
+    let negativePrompt = this.mergeIntoPrompt(inlineNegative, style.negative, "after");
 
     // Inject tags contributed by any currently-active Artist Styles. These are
     // not visible in the prompt textbox — they flow straight into the payload
@@ -3230,7 +3256,7 @@ class GenerationStore {
     // the prompt-chunk sigil on NovelAI, not an artist marker.
     const styleFragment = styles.buildPromptFragment(this.isNovelAi);
     if (styleFragment) {
-      positivePrompt = this.mergeTagPrompts(positivePrompt, styleFragment);
+      positivePrompt = this.mergeIntoPrompt(positivePrompt, styleFragment, "after");
     }
 
     // Inject active Prompt Presets (prepend / append / wildcard). Wildcards
@@ -3242,10 +3268,10 @@ class GenerationStore {
       advanceFixedOrdered: false,
     });
     if (preset.prepend) {
-      positivePrompt = this.mergeTagPrompts(preset.prepend, positivePrompt);
+      positivePrompt = this.mergeIntoPrompt(positivePrompt, preset.prepend, "before");
     }
     if (preset.append) {
-      positivePrompt = this.mergeTagPrompts(positivePrompt, preset.append);
+      positivePrompt = this.mergeIntoPrompt(positivePrompt, preset.append, "after");
     }
 
     // Auto-apply quality tags for supported model families.

--- a/src/lib/utils/artistTag.ts
+++ b/src/lib/utils/artistTag.ts
@@ -104,3 +104,25 @@ export function isArtistTagToken(
   if (!index || index.size === 0) return false;
   return index.has(artistIndexKey(token));
 }
+
+/**
+ * Drop the tags `shouldDrop` flags from a prompt while keeping its layout.
+ *
+ * Lines that hold no dropped tag come back byte for byte, so a NovelAI `Text:`
+ * block, blank lines between rendered strings, and prose lines all survive an
+ * artist tag toggle. A line that loses tags is rejoined with ", " and keeps a
+ * trailing comma if it had one; a line left with nothing is removed.
+ */
+export function filterPromptTags(prompt: string, shouldDrop: (tag: string) => boolean): string {
+  return prompt
+    .split("\n")
+    .map((line) => {
+      const parts = line.split(",");
+      if (!parts.some((part) => part.trim() && shouldDrop(part.trim()))) return line;
+      const kept = parts.map((part) => part.trim()).filter((part) => part && !shouldDrop(part));
+      if (kept.length === 0) return null;
+      return kept.join(", ") + (/,\s*$/.test(line) ? "," : "");
+    })
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}

--- a/src/lib/utils/naiParse.ts
+++ b/src/lib/utils/naiParse.ts
@@ -11,7 +11,7 @@
  * Leaf util. It must not import any store.
  */
 
-import { NAI_QUALITY_FILLER } from "./naiPrompt.js";
+import { NAI_PRESET_UC_JUNK, NAI_QUALITY_FILLER } from "./naiPrompt.js";
 
 /** What one full rewrite turn (attempt plus optional retry) produced. */
 export interface NaiRewriteResult {
@@ -171,12 +171,176 @@ export function normalizeWeightSpans(text: string): string {
   return count % 2 === 0 ? trimmed : `${trimmed}::`;
 }
 
+/** True when a span token would make novelai.net treat `::` as part of the name. */
+function endsInDigit(token: string): boolean {
+  return /\d$/.test(token.trim());
+}
+
+/**
+ * Put digit-suffix names first inside numeric weight spans.
+ *
+ * NovelAI's website parser reads trailing digits on the last token of a
+ * `n::...::` span as the start of an unclosed weight, so `1.2::rain, as109::`
+ * breaks when pasted into novelai.net. Generation through the API is fine;
+ * users still copy prompts out. If every token ends in a digit, a trailing
+ * comma is the remaining fix: `1.2::as109, pigeon666,::`.
+ */
+export function normalizeNumericSpans(text: string): string {
+  if (!text) return text;
+  return text.replace(/(-?\d+(?:\.\d+)?)::((?:(?!::)[\s\S])*?)::/g, (_m, weight: string, inner: string) => {
+    const tokens = inner
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t !== "");
+    // An empty span is not this function's problem; leave it as the model wrote it.
+    if (tokens.length === 0) return _m;
+    const head = tokens.filter(endsInDigit);
+    const rest = tokens.filter((t) => !endsInDigit(t));
+    const ordered = [...head, ...rest];
+    let body = ordered.join(", ");
+    if (ordered.length > 0 && endsInDigit(ordered[ordered.length - 1])) body += ",";
+    return `${weight}::${body}::`;
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Split a field at its Text: block. The newline(s) that precede the label stay
+ * with the tail, so a caller can trim the head and concatenate the two without
+ * gluing the last prompt line onto `Text:`.
+ */
+function splitTextBlock(text: string): { head: string; tail: string } {
+  const match = text.match(/(^|\n)(\s*Text\s*:)/i);
+  if (!match || match.index === undefined) return { head: text, tail: "" };
+  return { head: text.slice(0, match.index), tail: text.slice(match.index) };
+}
+
+/**
+ * Comma- or span-bounded tag match. The `m` flag lets `^`/`$` stand in for a
+ * newline, so the pattern never has to write one into a string constructor.
+ */
+function listedTagPattern(tag: string, flags: string): RegExp {
+  return new RegExp("(^|,|::)\\s*" + escapeRegExp(tag) + "\\s*(?=,|$|::)", flags);
+}
+
+/**
+ * Strip listed tags from one line. Returns the line untouched when nothing
+ * matched, `null` when the strip emptied it, and otherwise the line with only
+ * the delimiters the removal orphaned repaired. Anything the model wrote
+ * correctly, including a deliberate trailing comma, is left alone.
+ */
+function stripTagsFromLine(line: string, tags: readonly string[]): string | null {
+  let out = line;
+  for (const tag of tags) {
+    const re = listedTagPattern(tag, "gi");
+    let prev = "";
+    while (prev !== out) {
+      prev = out;
+      out = out.replace(re, "$1");
+    }
+  }
+  if (out === line) return line;
+  const hadTrailingComma = /,\s*$/.test(line);
+  out = out
+    // The removed item was first inside a span: `1.2::, rain::`.
+    .replace(/(-?\d+(?:\.\d+)?)::\s*,\s*/g, "$1::")
+    // The removed item was last inside a span: `1.2::rain,::`.
+    .replace(/,\s*::/g, "::")
+    // The span held nothing but filler.
+    .replace(/-?\d+(?:\.\d+)?::::/g, "")
+    // The removed item sat between two others.
+    .replace(/,(?:\s*,)+/g, ",")
+    // The removed item was first on the line.
+    .replace(/^\s*,\s*/, "")
+    .trim();
+  if (!hadTrailingComma) out = out.replace(/,\s*$/, "");
+  return out === "" ? null : out;
+}
+
+/**
+ * Drop listed tags as comma (or span) delimited items, leaving the Text: block
+ * untouched. Used for quality filler and preset UC junk the model still emits.
+ *
+ * Works line by line so that a line the strip never touched comes back
+ * byte-for-byte, and a line it emptied disappears along with its newline.
+ */
+export function stripListedTags(text: string, tags: readonly string[]): string {
+  if (!text || tags.length === 0) return text;
+  const { head, tail } = splitTextBlock(text);
+  const lines = head
+    .split("\n")
+    .map((line) => stripTagsFromLine(line, tags))
+    .filter((line): line is string => line !== null);
+  const out = lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return out === "" ? tail.trimStart() : `${out}${tail}`;
+}
+
+function fieldContainsListedTag(text: string, tags: readonly string[]): string[] {
+  const { head } = splitTextBlock(text);
+  return tags.filter((tag) => listedTagPattern(tag, "im").test(head));
+}
+
+/** Em dash and en dash break NovelAI gens. A comma is the prescribed substitute. */
+export function replaceLongDashes(text: string): string {
+  if (!text) return text;
+  const { head, tail } = splitTextBlock(text);
+  const cleaned = head
+    .replace(/[ \t]*[–—][ \t]*/g, ", ")
+    .replace(/,(?:[ \t]*,)+/g, ",")
+    .replace(/[ \t]+$/gm, "")
+    .trim();
+  return `${cleaned}${tail}`;
+}
+
+/**
+ * Salvage the two ways a model numbers a character box.
+ *
+ * Counts belong in BASE; a leading `1girl` or `Character 1:` is a formatting
+ * miss, not a different character, and is cheaper to repair than to retry.
+ */
+export function normalizeCharIdentity(box: string): string {
+  let text = (box ?? "").trim();
+  if (!text) return "";
+  text = text.replace(/^(?:character|char)\s*\d+\s*[:,.\-–—]?\s*/i, "");
+  text = text.replace(
+    /^(\d+)\s*(girls?|boys?|others?)\b/i,
+    (_m, _n: string, noun: string) => {
+      const lower = noun.toLowerCase();
+      if (lower.startsWith("girl")) return "girl";
+      if (lower.startsWith("boy")) return "boy";
+      return "other";
+    },
+  );
+  return text.trim();
+}
+
+/**
+ * One field through every repair, in dependency order: dashes become commas,
+ * a hanging span is closed, filler comes out, and only then are digit-suffix
+ * names reordered, so the trailing comma that step may add is never mistaken
+ * for a strip artefact and removed again.
+ */
+function normalizeField(text: string, extraTags: readonly string[] = []): string {
+  return normalizeNumericSpans(
+    stripListedTags(normalizeWeightSpans(replaceLongDashes(text)), [
+      ...NAI_QUALITY_FILLER,
+      ...extraTags,
+    ]),
+  );
+}
+
 /** Run the normalizer over every field of a parsed response. */
 export function normalizeNaiResponse(parsed: NaiParsedResponse): NaiParsedResponse {
   return {
-    base: normalizeWeightSpans(parsed.base),
-    uc: normalizeWeightSpans(parsed.uc),
-    characters: parsed.characters.map(normalizeWeightSpans),
+    base: normalizeField(parsed.base),
+    uc: normalizeField(parsed.uc, NAI_PRESET_UC_JUNK),
+    characters: parsed.characters.map((box) => normalizeField(normalizeCharIdentity(box))),
     note: parsed.note.trim(),
   };
 }
@@ -225,12 +389,26 @@ export function validateNaiResponse(parsed: NaiParsedResponse): string[] {
 
   // Unconditional: the model is never the one who writes the quality stack.
   // With NovelAI's toggle on this would double it, and with the toggle off the
-  // user has asked for no stack at all.
-  const lowerBase = parsed.base.toLowerCase();
-  const filler = NAI_QUALITY_FILLER.filter((q) => lowerBase.includes(q));
-  if (filler.length > 0) {
+  // user has asked for no stack at all. Checked on every field because models
+  // also dump filler into UC and character boxes.
+  const fillerFields: Array<[string, string]> = [
+    ["BASE", parsed.base],
+    ["UC", parsed.uc],
+    ...parsed.characters.map((box, i): [string, string] => [`CHAR ${i + 1}`, box]),
+  ];
+  for (const [label, text] of fillerFields) {
+    const filler = fieldContainsListedTag(text, NAI_QUALITY_FILLER);
+    if (filler.length > 0) {
+      problems.push(
+        `${label} contained quality filler (${filler.join(", ")}). NovelAI's quality toggle owns that stack, so remove it.`,
+      );
+    }
+  }
+
+  const ucJunk = fieldContainsListedTag(parsed.uc, NAI_PRESET_UC_JUNK);
+  if (ucJunk.length > 0) {
     problems.push(
-      `BASE contained quality filler (${filler.join(", ")}). NovelAI's quality toggle owns that stack, so remove it.`,
+      `UC restated the preset (${ucJunk.join(", ")}). Keep custom motif undesirables only.`,
     );
   }
 

--- a/src/lib/utils/naiPrompt.ts
+++ b/src/lib/utils/naiPrompt.ts
@@ -1,19 +1,21 @@
 /**
  * The NovelAI Diffusion V5 prompt specification, assembled per request.
  *
- * V5 does not want what the danbooru enhance produces. It wants a natural
- * language scene body, structured character boxes, its own emphasis syntax and a
- * short list of formatting rules that break generations when violated. Feeding
- * it tag soup produces worse images than the raw prompt the user typed, which is
- * why this path exists beside the existing enhance rather than inside it.
+ * V5 does not want what the danbooru enhance produces. It wants a hybrid of
+ * identity tags plus a natural language scene body, structured character boxes,
+ * its own emphasis syntax and a short list of formatting rules that break
+ * generations when violated. Feeding it tag soup produces worse images than the
+ * raw prompt the user typed, which is why this path exists beside the existing
+ * enhance rather than inside it.
  *
  * Curated and Full are mutually exclusive. Exactly one variant block is built
  * per request, and when Full is selected the model never sees a word of Curated
  * guidance. V4.5 and V4 are out of scope entirely and keep the existing
  * danbooru-tag enhance unchanged.
  *
- * Leaf util. It must not import any store, or the generation store that needs it
- * would form a cycle.
+ * The rules here track NovelAI Diffusion V5 prompting (hybrid tags + NL, custom
+ * UC only, no quality stacks). Leaf util: it must not import any store, or the
+ * generation store that needs it would form a cycle.
  */
 
 import { naiLanguageDirective } from "./naiLanguage.js";
@@ -97,17 +99,57 @@ export const NAI_VARIANT_BUDGET: Record<NaiVariant, number> = {
  */
 export const NAI_MAX_TOKENS = 2400;
 
-/** The quality stack NovelAI prepends itself, named so the model can avoid it. */
+/**
+ * The quality stack NovelAI prepends itself, named so the model can avoid it.
+ *
+ * Matches the V5 quality-toggle vocabulary plus the usual aesthetic filler
+ * models still emit. Never paste any of these: the toggle owns them.
+ */
 export const NAI_QUALITY_FILLER = [
   "masterpiece",
   "best quality",
-  "very aesthetic",
-  "absurdres",
   "amazing quality",
+  "great quality",
+  "very aesthetic",
+  "aesthetic",
+  "absurdres",
   "high quality",
+  "beautiful detailed eyes",
+] as const;
+
+/**
+ * Generic UC the Heavy / Light / Human Focus presets already cover.
+ *
+ * Custom motif UC is the rewrite's job. Restating this list wastes tokens and
+ * double-stacks the preset.
+ */
+export const NAI_PRESET_UC_JUNK = [
+  "lowres",
+  "worst quality",
+  "bad quality",
+  "jpeg artifacts",
+  "too many watermarks",
+  "scan artifacts",
+  "film grain",
 ] as const;
 
 const SHARED_RULES = `You are rewriting a user's idea into a NovelAI Diffusion V5 prompt.
+
+V5 is hybrid. Danbooru-style tags lock identity. Natural language owns camera, layout, relations, lighting and mood. Tag soup with no prose is a failed rewrite. An essay with no tags is also a failed rewrite.
+
+HYBRID FORMAT
+- Tags lock counts, series, character, hair, eyes, body, outfit, pose, artists, framing and location.
+- Natural language owns who stands where, what they are doing, the camera, panel structure, lighting and mood.
+- Separate tags with a comma and a space.
+- Important first in the base tag line: counts, then series and character ids, then complexity, then shot and framing, then location.
+
+BASE ORDER
+{count}, {series/character ids}, {complexity}, {shot/framing}, {location/time}, {artists and medium}, {misc tags}
+
+{natural language: camera + spatial layout + action + mood + lighting}
+
+Text: ...
+The Text: sub-block is only for in-image lettering and is always last in BASE.
 
 EMPHASIS SYNTAX
 - {tag} multiplies that tag's weight by 1.05. Nesting stacks, so {{tag}} is 1.05 squared.
@@ -115,9 +157,9 @@ EMPHASIS SYNTAX
 - 1.5::rain, night:: applies an explicit weight of 1.5 to everything inside the span.
 - 0.5::coat:: weakens it. -1::hat:: suppresses it.
 - :: closes a span. Every span you open must be closed, or the weight swallows the rest of the prompt.
-- Group artist names by the weight you want them at rather than weighting each one separately.
-- Actually use this syntax. Every rewrite should weight two to five load bearing elements, the ones the image fails without, and leave the rest at their natural weight. A prompt with no emphasis anywhere is an unfinished prompt.
-- Inside a numeric span, put any artist name ending in a digit first: write 1.2::as109, rain:: and not 1.2::rain, as109::.
+- Use emphasis to lock a load-bearing motif or to kill a ghost with -1::trait::. Do not sprinkle weights as decoration and do not force a quota of emphasised tags. An unweighted prompt is fine when nothing needs locking.
+- Group artist names of the same weight in one span: 0.6::name a, name b:: rather than one span per name.
+- Never end a numeric span with a name that ends in digits. as109, pigeon666 and k7 go first inside the span, or stay unweighted. Write 0.6::as109, tianliang duohe fangdongye:: and not 0.6::tianliang duohe fangdongye, as109::.
 - The same markers work inside undesired content, where the sense inverts: {tag} avoids it harder and [tag] avoids it less.
 
 STRUCTURE
@@ -125,8 +167,7 @@ STRUCTURE
 - Character boxes start with girl, boy or other, and are never numbered. Write "girl, silver hair, red coat". Do not write "1girl" and do not write "Character 1".
 - A Text: block, when present, goes last in the base prompt. Anything written after it is swallowed.
 - Omit by default: something the user never mentioned belongs nowhere, not in undesired content.
-- Negate deliberately when a detail is likely to arrive uninvited. A named character's default outfit when the user dressed them otherwise, a lookalike character, garbled lettering when the image has words: those have to be named in undesired content or the model supplies them anyway.
-- When the user tells you to leave something out, that is an instruction to you and not text for the prompt. Never write "no inset" or "without speech bubbles" into the base or a box, because naming a thing tokenises it and invites it in. Drop it silently, and reach for undesired content only when it would ghost in regardless.
+- When the user tells you to leave something out, that is an instruction to you and not text for the prompt. Never write "no inset" or "without speech bubbles" into the base or a box, because naming a thing tokenises it and invites it in. Drop it silently, and reach for undesired content or -1::trait:: only when it would ghost in regardless.
 
 NAMED SUBJECTS
 - A character the user names by name is the single most load bearing thing in the prompt. Never generalize one away. If the user writes Anis, the prompt says Anis; it does not say a young woman, a girl or the subject.
@@ -136,11 +177,18 @@ NAMED SUBJECTS
 - When the user puts character A in character B's outfit, the person is A and only the clothing comes from B. A keeps their own hair, eyes and face, and B's own hair, eyes and face go into undesired content.
 - If you do not know a name the user used, keep the name tag anyway, build the box from whatever the user described, and say which name you did not recognise in a NOTE: line at the very end. Never quietly substitute a character you do know, and never fall back to a generic person.
 
+VOCABULARY
+- Write real Danbooru tags for what the user asked. Euphemisms are untrained noise.
+- If the idea is explicit, name it the way Danbooru does: nude, topless, bottomless, nipples, areolae, pussy, sex, cowgirl position, doggystyle, paizuri, oral, fellatio, cum, creampie, and the rest. Exposure-state tags are ordinary: clothes lift, clothes pulled aside, shirt up, no bra, no panties. Add rating:explicit when the scene is explicit.
+- Do not sanitize, soften, lecture or refuse. Do not add explicit tags the user did not ask for, and do not strip the ones they did.
+
 FORBIDDEN CHARACTERS
-- Never use an em dash or an en dash anywhere in any field. Use a comma or a period instead.
+- Never use an em dash or an en dash anywhere in any field. Use a comma, a period, a colon or an ASCII hyphen.
 
 V5 CUSTOM TAGS
 These are trained V5 tokens and are available to you: depthness, attractive male, low complexity, medium complexity, high complexity, ultra complexity, transparent background, has alpha, alpha transparency, meta:novel era, meta:golden era, visual novel art, bg, cg, chibi, sprite.
+- Default complexity is high complexity. That is the pretty default, not a quality stack.
+- Add depthness when the scene needs volume or deeper shading.
 - Strengthen a weak alpha with 2.1::transparent background:: rather than repeating the tag.
 
 DATASET PREFIXES
@@ -159,26 +207,27 @@ TEXT AND COMIC TAGS
 - Sound effects are ordinary tags or prose. They do not go in the Text: block unless you want them rendered as lettering.
 - If short lettering is the whole point of the image, the quality stack's own no text fights it. Say so in a NOTE: line and suggest turning the quality toggle off for that generation.
 
+ARTISTS
+- If the user named artists, put them in the base tag line, grouped by weight as above.
+- Do not invent an artist stack the user did not ask for.
+
 V5 TAG NAMES
 - V5 renamed several danbooru staples. Write peace sign rather than v, double peace for both hands, bar eyes, neutral face, and character image rather than tachi-e.`;
 
 const TECHNIQUE = `CAST HANDLING
 - One or two characters is comfortable. Three is the usual party size. V5 has been driven to twenty or more in testing, so a large cast is possible rather than forbidden, but every box costs budget and raises the risk of attributes bleeding between them.
+- A single subject needs at most one CHAR box. Do not invent extra boxes. Identity can live in BASE alone when there is nothing to separate.
 - Past four, keep every box thin and make the silhouettes unmistakable: one distinctive hair colour each, one dominant garment colour each, no shared descriptors you can avoid.
-- When you are over budget, compress in this order: per character emphasis first, then the base natural language body, then quality tag extras, then drop a character.
+- When you are over budget, compress in this order: per character emphasis first, then the base natural language body, then drop a character.
 - Prevent bleed by giving each character a distinct hair colour, a distinct dominant colour and a distinct silhouette.
 - Snipe strays with per character undesired content, or with -1::trait:: in the box itself.
-- Order character boxes left to right as they appear in the scene.`;
+- Order character boxes left to right as they appear in the scene.
 
-/**
- * What the model is allowed to draw on, which depends on what it was given.
- *
- * Blind is the default and the stricter of the two: with no prompt in front of
- * it, anything that reads like a half-remembered earlier draft is a hallucination
- * and has to be named as one. Once the user hands their prompt over, the same
- * instinct becomes the job, and the rule that matters instead is that a revision
- * must return the parts it was not asked to touch unchanged.
- */
+ITERATION
+- When revising an existing prompt, change only what the instruction names. Keep every prior lock unless it was revised.
+- Never redesign wholesale for a one line fix.
+- When a motif is retired, strip it from BASE and the character box, and add it to UC so it does not ghost back in.`;
+
 /**
  * What to do with the attached images.
  *
@@ -241,7 +290,7 @@ const VARIANT_BLOCKS: Record<NaiVariant, string> = {
   full: `VARIANT: V5 FULL
 - Prompt budget: about 1471 tokens for the whole prompt, base and character boxes together. That figure is also NovelAI's hard ceiling, so treat it as a wall rather than a target.
 - Rendered lettering has its own budget of about 750 characters, counted separately from the prompt.
-- The natural language body can be rich and run to several paragraphs. Full rewards detail.
+- The natural language body can be rich and run to several paragraphs. Full rewards detail: layout, interactions, panel structure and distinct silhouettes, not repeated aesthetics.
 - Use high complexity for detailed work, and ultra complexity for ornate illustration and comics.
 - For comics, write full pages: name the speaker in each panel, and include sound effects.
 - If the idea does not fit the budget, compress it in place. Do not suggest another model.`,
@@ -256,7 +305,7 @@ const VARIANT_BLOCKS: Record<NaiVariant, string> = {
  * theirs to say and not the rewrite's to overrule.
  */
 const QUALITY_TAGS = `QUALITY TAGS
-Never write quality filler. Never include masterpiece, best quality, very aesthetic, absurdres, amazing quality or high quality anywhere in your answer. That stack belongs to NovelAI's own quality toggle, which the user controls: writing it yourself doubles it when the toggle is on, and overrules them when it is off.`;
+Never write quality or aesthetic filler. Never include masterpiece, best quality, amazing quality, great quality, very aesthetic, aesthetic, absurdres, high quality or beautiful detailed eyes anywhere in your answer. That stack belongs to NovelAI's own quality toggle, which the user controls: writing it yourself doubles it when the toggle is on, and overrules them when it is off. high complexity and depthness are V5 utility tags, not quality filler, and you should use them.`;
 
 function ucPresetName(ucPreset: number): string {
   switch (ucPreset) {
@@ -276,27 +325,30 @@ function ucPresetName(ucPreset: number): string {
 function ucPresetDirective(ucPreset: number): string {
   if (ucPreset === 3) {
     return `UNDESIRED CONTENT
-The user has the undesired content preset set to None, so nothing is applied for them. Write a short undesired content list covering the obvious anatomy and artefact failures for this scene, plus any motif the user wants excluded.`;
+The user has the undesired content preset set to None, so nothing is applied for them. Write a short undesired content list covering the obvious anatomy and artefact failures for this scene, plus any motif the user wants excluded. Still skip quality-stack negatives such as worst quality, lowres and jpeg artifacts.`;
   }
   return `UNDESIRED CONTENT
-The user is on the ${ucPresetName(ucPreset)} undesired content preset, so the generic quality, anatomy and artefact negatives are already applied server side. Do not repeat them: no bad hands, no worst quality, no jpeg artifacts, no lowres.
+The user is on the ${ucPresetName(ucPreset)} undesired content preset, so the generic quality, anatomy and artefact negatives are already applied server side. Write custom motif UC only. Empty UC is correct when there is nothing motif-specific to exclude.
 
-Write the motif specific half instead, the part no preset can know. Work through these and include every one that applies:
+Never repeat preset junk: lowres, worst quality, bad quality, jpeg artifacts, too many watermarks, logo, watermark, signature, username, blurry, scan artifacts, film grain, or greyscale/monochrome boilerplate.
+
+Include a tag only when it applies:
 - The canonical appearance you displaced. When a character wears someone else's outfit, negate that someone else by name along with their hair colour, eye colour and signature features. When a character is out of their usual clothes, negate those clothes by name.
 - Lookalike characters the description could collapse into.
 - Setting elements one word away from the one asked for, such as train platform when the scene is a bus stop.
 - Framing you do not want, when the composition matters.
-- Text failures, whenever the image contains written words: garbled text, misspelled text, watermark, signature.
+- Text failures, whenever the image contains written words: garbled text, misspelled text.
+- Bleed kills on a multi-character scene: extra arms, the wrong bust size, the wrong eye colour.
 
-This list is usually ten to thirty comma separated tags, and it is rarely empty. Leave UC blank only when the idea has no displaced canon, no lookalikes, no lettering and no framing risk.`;
+Do not pad. A tight list of five real risks beats a dump of thirty generic ones. Leave UC blank when the idea has no displaced canon, no lookalikes, no lettering and no framing risk.`;
 }
 
 const OUTPUT_CONTRACT = `OUTPUT FORMAT
-Answer with labelled fields and nothing else. No preamble, no closing remark, no markdown fences, no explanation.
+Answer with labelled fields and nothing else. No preamble, no closing remark, no markdown fences, no explanation, no settings table.
 
 BASE is built in three parts, in this order, separated by blank lines.
 
-First a tag line: the count, then series and character tags, then the V5 complexity tokens you are using, then framing and composition, then the setting. Comma separated, no sentences. If the image contains written words, end this line with text and the language tags for it, such as english text or japanese text.
+First a tag line: the count, then series and character tags, then the V5 complexity tokens you are using, then framing and composition, then the setting, then artists if the user named any. Comma separated, no sentences. If the image contains written words, end this line with text and the language tags for it, such as english text or japanese text.
 
 Then the natural language body, describing the scene as prose: who the focus is, what they are doing, the light, the surfaces, the depth. This is the part V5 was trained for, so write it properly rather than reciting the tag line back.
 
@@ -305,7 +357,7 @@ Then, only if the image contains written words, a Text: sub-block: the literal w
 Each CHAR block is comma separated tags grouped into sections, one section per line, in this order: identity, then body, then face and expression, then outfit head to toe, then pose and placement in frame. Identity starts with girl, boy or other, then the danbooru character tag if the user named one, then hair, eyes and distinguishing features spelled out. A section with nothing to say is simply left out.
 
 BASE:
-1girl, solo, <series>, <character>, high complexity, depthness, <framing>, <setting tags>
+1girl, solo, <series>, <character>, high complexity, <framing>, <setting tags>
 
 <the natural language body>
 
@@ -313,7 +365,7 @@ Text:
 <the lettering, a blank line between separate strings, and nothing after it>
 
 UC:
-<motif specific undesired content, as instructed above>
+<custom motif undesired content only, or leave this field empty>
 
 CHAR 1:
 girl, <name>, <hair>, <eyes>, <features>,
@@ -325,7 +377,7 @@ girl, <name>, <hair>, <eyes>, <features>,
 CHAR 2:
 boy, <the same five sections>
 
-Write one CHAR block per character that needs its own box, numbered in order. Write no CHAR blocks at all if the image has no distinct characters to separate. BASE is required. Everything else is optional.`;
+Write one CHAR block per distinct character that needs its own box, numbered in order. Write no CHAR blocks at all if the image has no distinct characters to separate. BASE is required. Everything else is optional.`;
 
 /** The system turn for one rewrite. */
 export function naiRewriteSystemPrompt(ctx: NaiPromptContext): string {
@@ -386,6 +438,10 @@ function instruction(prompt: string, references: string[]): string {
   return references.length > 0 ? IMPLIED_INSTRUCTION : text;
 }
 
+function variantLabel(variant: NaiVariant): string {
+  return variant === "full" ? "Full" : "Curated";
+}
+
 /** The user turn: the raw prompt plus what the model needs to know about the scene. */
 export function naiUserPrompt(prompt: string, ctx: NaiPromptContext): string {
   if (ctx.existing) return naiEditUserPrompt(prompt, ctx.existing, ctx.references);
@@ -400,7 +456,7 @@ export function naiUserPrompt(prompt: string, ctx: NaiPromptContext): string {
   const inputs = ctx.references.length
     ? "This text and the attached images are your only input, so build the whole prompt from them and invent nothing beyond them"
     : "This text is your only input, so build the whole prompt from it and invent nothing beyond it";
-  return `Rewrite this into a V5 prompt. ${inputs}:
+  return `Rewrite this into a V5 ${variantLabel(ctx.variant)} prompt. Hybrid tags plus natural language. Custom undesired content only. No quality or aesthetic filler. ${inputs}:
 
 ${instruction(prompt, ctx.references)}${refs}${boxes}`;
 }
@@ -432,7 +488,7 @@ ${mark(existing.base)}
 UC:
 ${mark(existing.uc)}${boxes ? `\n\n${boxes}` : ""}
 
-Apply this instruction to it, and return the whole prompt again in the output format with every field present, changed or not:
+Apply this instruction to it, and return the whole prompt again in the output format with every field present, changed or not. Hybrid tags plus natural language. Custom undesired content only. No quality or aesthetic filler.
 
 ${instruction(prompt, references)}${referenceManifest(references)}`;
 }

--- a/src/lib/utils/naiSkill.ts
+++ b/src/lib/utils/naiSkill.ts
@@ -23,7 +23,7 @@ import type { NaiPromptContext } from "./naiPrompt.js";
  * Bump to invalidate every cached skill at once, after changing the authoring
  * prompt or the V5 specification it is written against.
  */
-const SKILL_VERSION = 4;
+const SKILL_VERSION = 5;
 
 const CACHE_PREFIX = "mooshieui.naiskill.";
 
@@ -109,9 +109,9 @@ export function naiSkillAuthoringUser(ctx: NaiPromptContext): string {
     curated ? "Curated" : "Full"
   } prompt.
 
-The output is ${shape}, returned as labelled fields: a base prompt holding the subject counts and a natural language scene description, an optional undesired content list, and one optional box per character. It uses NovelAI's own emphasis syntax, where markers must be opened and closed in pairs. Prose commentary, markdown and explanation are all failures.
+The output is ${shape}, returned as labelled fields: a base prompt that is hybrid (Danbooru tags plus a natural language scene body), an optional custom-motif undesired content list, and one optional box per distinct character. Quality stacks and preset UC junk are forbidden. It uses NovelAI's own emphasis syntax, where markers must be opened and closed in pairs. Prose commentary, markdown, settings tables and explanation are all failures.
 
-The input is either an idea to build a prompt from, or the user's existing prompt together with an instruction for revising it. There is no conversation history and no image behind either one. In the second case every field has to come back in full, including the ones the instruction never mentions.
+The input is either an idea to build a prompt from, or the user's existing prompt together with an instruction for revising it. Reference images are sometimes attached as wording aids. There is no conversation history. In the revision case every field has to come back in full, including the ones the instruction never mentions.
 
 Write your notes now.`;
 }

--- a/src/lib/utils/promptSanitize.ts
+++ b/src/lib/utils/promptSanitize.ts
@@ -75,3 +75,84 @@ export function sanitizePromptForSend(prompt: string, options: SanitizeOptions =
       .trim()
   );
 }
+
+// ---------------------------------------------------------------------------
+// NovelAI tag merging
+//
+// `toParams` merges system fragments (style presets, active Artist Styles,
+// Prompt Chunk prepend/append) into the user's prompt. The ComfyUI merge
+// re-tokenizes the whole prompt on commas and rejoins with ", ", which is fine
+// for a flat tag list but destroys a NovelAI prompt: every line that ends in a
+// comma (the normal tag-line layout) loses its newline, so a prompt laid out as
+//
+//   1girl, rain,
+//   Text:
+//   Mumei
+//
+// leaves as `1girl, rain, Text:, Mumei`. The helpers below never re-tokenize
+// the prompt. They only look at it to dedupe the incoming tags, splice those
+// tags in before the `Text:` block, and hand the rest back byte for byte.
+// ---------------------------------------------------------------------------
+
+/** The first `Text:` label that starts a line, with any blank lines before it. */
+const NAI_TEXT_BLOCK_RE = /(^|\n)(\s*Text\s*:)/i;
+
+/**
+ * Split a NovelAI prompt into the tag/prose head and the `Text:` lettering
+ * block. The tail keeps the newline (and any blank lines) that preceded the
+ * label so it can be reattached unchanged. `text` is "" when there is no block.
+ */
+export function splitNovelAiTextBlock(prompt: string): { head: string; text: string } {
+  const match = NAI_TEXT_BLOCK_RE.exec(prompt);
+  if (!match || match.index === undefined) return { head: prompt, text: "" };
+  return { head: prompt.slice(0, match.index), text: prompt.slice(match.index) };
+}
+
+/** Tags split on commas or newlines, trimmed, empties dropped. */
+function splitLooseTags(text: string): string[] {
+  return text
+    .split(/[\n,]/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * Merge a comma-separated tag fragment into a NovelAI prompt without touching
+ * the prompt's layout.
+ *
+ * - Tags already present anywhere in the head (case-insensitive) are dropped;
+ *   the prompt is returned untouched when nothing new is left.
+ * - `"before"` puts the new tags in front of the head, `"after"` puts them at
+ *   the end of the head, on the same line unless that line is prose ending in
+ *   sentence punctuation, where they start a new line instead.
+ * - The `Text:` block always stays last, on its own line, exactly as written.
+ */
+export function mergeNovelAiTags(prompt: string, tags: string, where: "before" | "after"): string {
+  if (!tags) return prompt;
+  const { head, text } = splitNovelAiTextBlock(prompt);
+  const seen = new Set(splitLooseTags(head).map((tag) => tag.toLowerCase()));
+  const fresh: string[] = [];
+  for (const tag of splitLooseTags(tags)) {
+    const key = tag.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    fresh.push(tag);
+  }
+  if (fresh.length === 0) return prompt;
+
+  const joined = fresh.join(", ");
+  const trimmedHead = head.trim();
+  let merged: string;
+  if (!trimmedHead) {
+    merged = joined;
+  } else if (where === "before") {
+    merged = `${joined}, ${trimmedHead}`;
+  } else {
+    const body = trimmedHead.replace(/[,\s]+$/, "");
+    merged = /[.!?]$/.test(body) ? `${body}\n${joined}` : `${body}, ${joined}`;
+  }
+  if (!text) return merged;
+  // The tail carries its own leading newline unless the prompt began with the
+  // label itself, in which case the block needs one to stay on its own line.
+  return text.startsWith("\n") ? `${merged}${text}` : `${merged}\n${text}`;
+}


### PR DESCRIPTION
## What's New in v2.2.8

### Fixes and maintenance
- The comma before NovelAI `Text:` lettering is actually gone this time. v2.2.6 fixed the sanitizer, but the merge step after it (style preset, Artist Style, Prompt Chunk prepend/append) split the prompt on commas and rejoined with ", ", so `Text:` still arrived mid-line. NovelAI prompts now keep their layout through the merge (new `mergeNovelAiTags`, routed via `mergeIntoPrompt` at all five call sites), and `payload.rs` moves a comma-joined `Text:` label onto its own line as a last stop. ComfyUI merging is unchanged.
- Transparent BG inserts its tag in front of a user `Text:` block instead of after it.
- Toggling or replacing an artist tag from the artist gallery rewrites only the line holding that tag (`filterPromptTags`), so `Text:` blocks and blank lines survive.
- Enhance for V5 follows the V5 Full / V5 Curated prompting rules: hybrid tags + natural language, no quality stacks, custom UC only, digit-suffix artist names reordered inside `n::...::` spans, em/en dashes in prompt fields become commas, `1girl` / `Character 1` character-box starts are repaired instead of retried. `SKILL_VERSION` bumped to 5 to refresh cached notes.

### Validation
- `npm run build`, `cargo check` (desktop and server), `cargo test` (456 passed), `cargo fmt --check` and clippy all green.
- 4 new Rust tests in `novelai::payload`.

### Bot triage
- No open PRs targeting main. No bot comments on #663 or #664 since the v2.2.7 tag.
