### PR TITLE
stagger Style Creator generations on NovelAI

### DIFF
--- a/src/lib/components/generation/StyleCreatorPanel.svelte
+++ b/src/lib/components/generation/StyleCreatorPanel.svelte
@@ -223,6 +223,9 @@
   {#if styleCreator.note}
     <p class="text-[11px] text-amber-400">{styleCreator.note}</p>
   {/if}
+  {#if styleCreator.staggering}
+    <p class="text-[11px] text-neutral-400">{locale.t("style_creator.nai_stagger")}</p>
+  {/if}
 
   <!-- Round -->
   {#if styleCreator.round}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1852,6 +1852,7 @@ const de: Record<string, string> = {
   "style_creator.index_loading": "Der Künstlerindex wird noch geladen",
   "style_creator.no_manifest_url": "Für die Künstler-Galerie ist keine Manifest-URL konfiguriert, daher kann der Künstlerindex nicht geladen werden",
   "style_creator.novelai_key_required": "Fügen Sie unter Einstellungen > NovelAI einen NovelAI-API-Schlüssel hinzu, um den Style Creator zu nutzen",
+  "style_creator.nai_stagger": "NovelAI drosselt zwei gleichzeitige Generierungen, daher startet das zweite Bild erst, wenn das erste fertig ist.",
   "style_creator.pool_short": "Nur {count} Künstler verfügbar, es wird aus allen gezogen",
   "style_creator.pool_empty": "Keine Künstler zum Ziehen verfügbar",
   "style_creator.exhausted": "Alle Kombinationen wurden ausprobiert. Leere den Verlauf oder ändere die Einstellungen.",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1584,6 +1584,7 @@ const en: Record<string, string> = {
   "style_creator.index_loading": "The Artists index is still loading",
   "style_creator.no_manifest_url": "No Artist Gallery manifest URL is configured, so the Artists index cannot load",
   "style_creator.novelai_key_required": "Add a NovelAI API key in Settings > NovelAI to use Style Creator",
+  "style_creator.nai_stagger": "NovelAI rate limits two generations at once, so the second image starts after the first finishes.",
   "style_creator.pool_short": "Only {count} artists available, drawing from all of them",
   "style_creator.pool_empty": "No artists available to draw from",
   "style_creator.exhausted": "Every combination has been tried. Clear the history or change the settings.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1894,6 +1894,7 @@ const es: Record<string, string> = {
   "style_creator.index_loading": "El índice de artistas todavía se está cargando",
   "style_creator.no_manifest_url": "No hay ninguna URL de manifiesto de la Galería de artistas configurada, así que el índice de artistas no puede cargarse",
   "style_creator.novelai_key_required": "Añade una clave de API de NovelAI en Ajustes > NovelAI para usar el Creador de estilos",
+  "style_creator.nai_stagger": "NovelAI limita dos generaciones a la vez, así que la segunda imagen empieza cuando termina la primera.",
   "style_creator.pool_short": "Solo hay {count} artistas disponibles, se usan todos",
   "style_creator.pool_empty": "No hay artistas disponibles para el sorteo",
   "style_creator.exhausted": "Se han probado todas las combinaciones. Borra el historial o cambia los ajustes.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1856,6 +1856,7 @@ const fr: Record<string, string> = {
   "style_creator.index_loading": "L'index des artistes est encore en cours de chargement",
   "style_creator.no_manifest_url": "Aucune URL de manifeste pour la Galerie d'artistes n'est configurée, l'index des artistes ne peut donc pas se charger",
   "style_creator.novelai_key_required": "Ajoutez une clé API NovelAI dans Paramètres > NovelAI pour utiliser le Créateur de styles",
+  "style_creator.nai_stagger": "NovelAI limite deux générations simultanées, la seconde image démarre donc une fois la première terminée.",
   "style_creator.pool_short": "Seulement {count} artistes disponibles, tirage sur l'ensemble",
   "style_creator.pool_empty": "Aucun artiste disponible pour le tirage",
   "style_creator.exhausted": "Toutes les combinaisons ont été essayées. Effacez l'historique ou changez les réglages.",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1831,6 +1831,7 @@ const it: Record<string, string> = {
   "style_creator.index_loading": "L'indice degli artisti si sta ancora caricando",
   "style_creator.no_manifest_url": "Nessun URL manifest della Galleria artisti è configurato, quindi l'indice degli artisti non può caricarsi",
   "style_creator.novelai_key_required": "Aggiungi una chiave API NovelAI in Impostazioni > NovelAI per usare il Creatore di stili",
+  "style_creator.nai_stagger": "NovelAI limita due generazioni contemporanee, quindi la seconda immagine parte quando la prima è finita.",
   "style_creator.pool_short": "Solo {count} artisti disponibili, si pesca da tutti",
   "style_creator.pool_empty": "Nessun artista disponibile da pescare",
   "style_creator.exhausted": "Tutte le combinazioni sono state provate. Cancella la cronologia o cambia le impostazioni.",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1856,6 +1856,7 @@ const ja: Record<string, string> = {
   "style_creator.index_loading": "アーティストインデックスを読み込み中です",
   "style_creator.no_manifest_url": "アーティストギャラリーのマニフェストURLが設定されていないため、アーティストインデックスを読み込めません",
   "style_creator.novelai_key_required": "スタイルクリエーターを使うには、設定 > NovelAI で NovelAI の API キーを追加してください",
+  "style_creator.nai_stagger": "NovelAI は同時に 2 件の生成を制限するため、2 枚目は 1 枚目の完了後に開始します。",
   "style_creator.pool_short": "利用できるアーティストは {count} 名のみです。すべてから抽選します",
   "style_creator.pool_empty": "抽選できるアーティストがいません",
   "style_creator.exhausted": "すべての組み合わせを試しました。履歴をクリアするか設定を変更してください。",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1831,6 +1831,7 @@ const ko: Record<string, string> = {
   "style_creator.index_loading": "아티스트 색인을 아직 불러오는 중입니다",
   "style_creator.no_manifest_url": "아티스트 갤러리 매니페스트 URL이 설정되어 있지 않아 아티스트 색인을 불러올 수 없습니다",
   "style_creator.novelai_key_required": "스타일 크리에이터를 사용하려면 설정 > NovelAI에서 NovelAI API 키를 추가하세요",
+  "style_creator.nai_stagger": "NovelAI는 동시 생성 2건을 제한하므로 두 번째 이미지는 첫 번째가 끝난 뒤에 시작합니다.",
   "style_creator.pool_short": "아티스트가 {count}명뿐이라 전부에서 뽑습니다",
   "style_creator.pool_empty": "뽑을 아티스트가 없습니다",
   "style_creator.exhausted": "모든 조합을 시도했습니다. 기록을 지우거나 설정을 바꾸세요.",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1538,6 +1538,7 @@ const pl: Record<string, string> = {
   "style_creator.index_loading": "Indeks artystów wciąż się wczytuje",
   "style_creator.no_manifest_url": "Nie skonfigurowano adresu URL manifestu Galerii artystów, więc indeks artystów nie może się wczytać",
   "style_creator.novelai_key_required": "Dodaj klucz API NovelAI w Ustawienia > NovelAI, aby korzystać z Kreatora stylów",
+  "style_creator.nai_stagger": "NovelAI ogranicza dwa jednoczesne generowania, więc drugi obraz startuje po zakończeniu pierwszego.",
   "style_creator.pool_short": "Dostępnych jest tylko {count} artystów, losowanie ze wszystkich",
   "style_creator.pool_empty": "Brak artystów do losowania",
   "style_creator.exhausted": "Wypróbowano już wszystkie kombinacje. Wyczyść historię lub zmień ustawienia.",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1831,6 +1831,7 @@ const pt: Record<string, string> = {
   "style_creator.index_loading": "O índice de artistas ainda está carregando",
   "style_creator.no_manifest_url": "Nenhum URL de manifesto da Galeria de artistas está configurado, então o índice de artistas não pode carregar",
   "style_creator.novelai_key_required": "Adicione uma chave de API do NovelAI em Configurações > NovelAI para usar o Criador de estilos",
+  "style_creator.nai_stagger": "O NovelAI limita duas gerações ao mesmo tempo, então a segunda imagem começa depois que a primeira termina.",
   "style_creator.pool_short": "Apenas {count} artistas disponíveis, sorteando entre todos",
   "style_creator.pool_empty": "Nenhum artista disponível para sortear",
   "style_creator.exhausted": "Todas as combinações já foram testadas. Limpe o histórico ou mude as configurações.",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1831,6 +1831,7 @@ const ru: Record<string, string> = {
   "style_creator.index_loading": "Индекс художников ещё загружается",
   "style_creator.no_manifest_url": "URL манифеста Галереи художников не настроен, поэтому индекс художников не может загрузиться",
   "style_creator.novelai_key_required": "Добавьте ключ API NovelAI в разделе Настройки > NovelAI, чтобы использовать Создатель стилей",
+  "style_creator.nai_stagger": "NovelAI ограничивает две генерации одновременно, поэтому второе изображение начнётся после завершения первого.",
   "style_creator.pool_short": "Доступно только {count} художников, выбор из всех",
   "style_creator.pool_empty": "Нет художников для выбора",
   "style_creator.exhausted": "Все сочетания уже опробованы. Очистите историю или измените настройки.",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1831,6 +1831,7 @@ const zhTw: Record<string, string> = {
   "style_creator.index_loading": "畫師索引仍在載入中",
   "style_creator.no_manifest_url": "未設定繪師圖庫的 manifest URL，因此無法載入畫師索引",
   "style_creator.novelai_key_required": "請在 設定 > NovelAI 中新增 NovelAI API 金鑰以使用風格產生器",
+  "style_creator.nai_stagger": "NovelAI 會限制同時進行兩次生成，因此第二張圖會在第一張完成後才開始。",
   "style_creator.pool_short": "只有 {count} 位畫師可用，將從全部中抽取",
   "style_creator.pool_empty": "沒有可抽取的畫師",
   "style_creator.exhausted": "所有組合都試過了。請清除紀錄或更改設定。",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1872,6 +1872,7 @@ const zh: Record<string, string> = {
   "style_creator.index_loading": "画师索引仍在加载中",
   "style_creator.no_manifest_url": "未配置画师图库的 manifest URL，因此无法加载画师索引",
   "style_creator.novelai_key_required": "请在 设置 > NovelAI 中添加 NovelAI API 密钥以使用风格生成器",
+  "style_creator.nai_stagger": "NovelAI 会限制同时进行两次生成，因此第二张图会在第一张完成后才开始。",
   "style_creator.pool_short": "只有 {count} 位画师可用，将从全部中抽取",
   "style_creator.pool_empty": "没有可抽取的画师",
   "style_creator.exhausted": "所有组合都已尝试过。请清除记录或更改设置。",

--- a/src/lib/stores/styleCreator.svelte.ts
+++ b/src/lib/stores/styleCreator.svelte.ts
@@ -159,6 +159,12 @@ class StyleCreatorStore {
   round = $state<StyleCreatorRound | null>(null);
   error = $state<string | null>(null);
   note = $state<string | null>(null);
+  /**
+   * True while a NovelAI round holds back its next card. NovelAI rate limits
+   * an account that runs two generations at once (429), so on that backend
+   * the cards go out one at a time and the panel says why.
+   */
+  staggering = $state(false);
 
   /** promptId -> card index for the round in flight. */
   private pending = new Map<string, number>();
@@ -169,6 +175,8 @@ class StyleCreatorStore {
   private lastAnchorSignature: string | null = null;
   private lastAnchorImage: OutputImage | null = null;
   private pendingAnchorSignature: string | null = null;
+  /** Resolves the NovelAI stagger wait once the card in flight settles. */
+  private staggerRelease: (() => void) | null = null;
 
   constructor() {
     this.load();
@@ -352,8 +360,15 @@ class StyleCreatorStore {
     void this.submitRound(round, serial);
   }
 
-  /** Submit each card left to right on the round's seed. */
+  /**
+   * Submit each card left to right on the round's seed.
+   *
+   * NovelAI rejects a second concurrent generation on the same account with
+   * a 429, so on that backend a card is not submitted until the previous one
+   * has landed. Every other backend queues fine and submits back to back.
+   */
   private async submitRound(round: StyleCreatorRound, serial: number): Promise<void> {
+    const stagger = generation.isNovelAi;
     for (let i = 0; i < round.cards.length; i++) {
       if (!this.running || this.roundSerial !== serial) return;
       const card = round.cards[i];
@@ -382,11 +397,34 @@ class StyleCreatorStore {
         const promptId = await submitGeneration(params);
         if (!this.running || this.roundSerial !== serial) return;
         this.pending.set(promptId, i);
+        if (stagger && i < round.cards.length - 1) {
+          this.staggering = true;
+          await this.waitForCard();
+          if (!this.running || this.roundSerial !== serial) return;
+        }
       } catch (err) {
         this.submitFailed(err, serial);
         return;
       }
     }
+  }
+
+  /**
+   * Block until the card in flight settles: `resolve()` consumes its prompt
+   * id when the image lands, and every teardown path (failure, stop, round
+   * finished) releases the wait so the loop can never hang on a dead round.
+   */
+  private waitForCard(): Promise<void> {
+    return new Promise((release) => {
+      this.staggerRelease = release;
+    });
+  }
+
+  private releaseStagger(): void {
+    const release = this.staggerRelease;
+    this.staggerRelease = null;
+    this.staggering = false;
+    release?.();
   }
 
   private submitFailed(err: unknown, serial: number): void {
@@ -410,6 +448,7 @@ class StyleCreatorStore {
     const index = this.pending.get(promptId);
     if (index === undefined) return null;
     this.pending.delete(promptId);
+    this.releaseStagger();
     return index;
   }
 
@@ -438,6 +477,7 @@ class StyleCreatorStore {
    * channel.
    */
   private endRound(message: string | null, asNote = false): void {
+    this.releaseStagger();
     this.pending.clear();
     this.pendingAnchorSignature = null;
     this.round = null;
@@ -468,6 +508,7 @@ class StyleCreatorStore {
       const keys = round.cards.map((c) => c.key).filter((k) => k.length > 0);
       if (keys.length > 0) this.history = capHistory(new Set([...this.history, ...keys]));
     }
+    this.releaseStagger();
     this.pending.clear();
     this.pendingAnchorSignature = null;
     this.round = null;
@@ -543,6 +584,7 @@ class StyleCreatorStore {
     this.running = false;
     this.error = null;
     this.note = null;
+    this.releaseStagger();
     if (this.phase === "generating") {
       this.pending.clear();
       this.pendingAnchorSignature = null;


### PR DESCRIPTION
NovelAI rate limits an account that runs two generations at once, so a Style Creator round with two cards returned `API error (429): NovelAI is rate limiting this account. Try again shortly.` and the round was torn down.

On NovelAI only, a round now submits one card at a time: the next card goes out after the previous one has landed. Every other backend queues fine and keeps submitting back to back, so its behaviour is unchanged.

While a NovelAI round is holding a card back, the panel explains why:

"NovelAI rate limits two generations at once, so the second image starts after the first finishes."

The wait is released by every teardown path (image landed, generation failed, Stop, round finished), so a dead round can never leave the submit loop hanging.

New key `style_creator.nai_stagger` added to all 12 locale files.
