### PR TITLE
show Style Creator rounds in a lightbox

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -59,6 +59,7 @@
   import NaiEnhanceModal from "./lib/components/generation/NaiEnhanceModal.svelte";
   import DirectorToolsModal from "./lib/components/generation/DirectorToolsModal.svelte";
   import NaiImageEnhanceModal from "./lib/components/generation/NaiImageEnhanceModal.svelte";
+  import StyleCreatorLightbox from "./lib/components/generation/StyleCreatorLightbox.svelte";
   import NovelAiPositionModal from "./lib/components/generation/NovelAiPositionModal.svelte";
   import StyleEditor from "./lib/components/generation/StyleEditor.svelte";
   import PresetEditor from "./lib/components/generation/PresetEditor.svelte";
@@ -369,12 +370,14 @@
   // The enhance and Director Tools modals stack on the lightbox the same way
   // and own Escape while open; this document handler would otherwise run first
   // (document before window) and close the lightbox underneath the modal.
+  // The Style Creator lightbox is a full-screen overlay of the same kind.
   $effect(() => {
     if (
       !gallery.lightboxOpen ||
       gallery.compareOpen ||
       naiImageEnhance.isOpen ||
-      directorTools.isOpen
+      directorTools.isOpen ||
+      styleCreator.viewerOpen
     )
       return;
     const handler = (e: KeyboardEvent) => {
@@ -4568,6 +4571,10 @@
 <!-- NovelAI image Enhance. Root-mounted for the same reason Director Tools is:
      it acts on whatever image is open, not on the generation panel. -->
 <NaiImageEnhanceModal />
+
+<!-- Style Creator round. Root-mounted so the pair covers the whole window
+     instead of the bottom panel that starts the round. -->
+<StyleCreatorLightbox />
 
 <!-- NovelAI character placement. Root-mounted because the prompt panel that
      opens it is a scroll container, which would bound the fixed overlay. -->

--- a/src/lib/components/generation/StyleCreatorLightbox.svelte
+++ b/src/lib/components/generation/StyleCreatorLightbox.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  /**
+   * Full-screen view of the round in flight. The pair is compared one card at
+   * a time on the whole frame instead of side by side in the bottom panel, and
+   * the controls stay out of the way until the pointer enters the frame.
+   */
+  import { styleCreator } from "../../stores/styleCreator.svelte.js";
+  import { generation } from "../../stores/generation.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+  import { stripArtistSigil } from "../../utils/artistTag.js";
+  import type { StyleArtist } from "../../stores/styles.svelte.js";
+
+  const cards = $derived(styleCreator.round?.cards ?? []);
+  // The round can shrink between renders (a second card that could not be
+  // drawn), so the stored index is clamped rather than trusted.
+  const index = $derived(Math.min(styleCreator.viewerIndex, Math.max(cards.length - 1, 0)));
+  const card = $derived(cards[index] ?? null);
+  const choosing = $derived(styleCreator.phase === "choosing");
+  const open = $derived(styleCreator.viewerOpen && cards.length > 0);
+
+  function chipLabel(artist: StyleArtist): string {
+    const tag = generation.isNovelAi ? stripArtistSigil(artist.tag) : artist.tag;
+    return artist.weight === 1 ? tag : `${tag}:${artist.weight}`;
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (!open) return;
+    // The name field owns its own keys: typing a left arrow in it must move
+    // the caret, not the card.
+    const target = e.target as HTMLElement | null;
+    if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      styleCreator.closeViewer();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      styleCreator.switchCard();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if open}
+  <div class="fixed inset-0 z-[60] flex flex-col bg-black/95">
+    <button
+      type="button"
+      class="absolute right-3 top-3 z-10 rounded border border-neutral-700 bg-neutral-900/80 px-2 py-1 text-xs text-neutral-300 hover:border-indigo-500 hover:text-indigo-200"
+      aria-label={locale.t("common.close")}
+      title={locale.t("common.close")}
+      onclick={() => styleCreator.closeViewer()}>x</button
+    >
+
+    <div class="group relative min-h-0 flex-1">
+      {#if card?.image}
+        <img src={card.image.url} alt="" class="h-full w-full object-contain" />
+      {:else}
+        <div class="absolute inset-0 flex flex-col items-center justify-center gap-3">
+          <div class="h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"></div>
+          {#if styleCreator.staggering}
+            <p class="max-w-md px-6 text-center text-[11px] text-neutral-400">
+              {locale.t("style_creator.nai_stagger")}
+            </p>
+          {/if}
+        </div>
+      {/if}
+
+      <!-- Controls: hidden until the pointer is over the frame, so the image
+           is judged on its own. focus-within keeps them up for keyboard use. -->
+      <div
+        class="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-4 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100"
+      >
+        <div
+          class="pointer-events-auto flex max-w-full flex-col items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-950/90 p-3 shadow-xl"
+        >
+          {#if card}
+            <div class="flex flex-wrap justify-center gap-1">
+              {#each card.artists as artist, j (artist.tag + j)}
+                <span class="rounded bg-neutral-800 px-1.5 py-0.5 text-[11px] text-neutral-200">
+                  {chipLabel(artist)}
+                </span>
+              {/each}
+            </div>
+          {/if}
+
+          {#if styleCreator.error}
+            <p class="text-[11px] text-red-400">{styleCreator.error}</p>
+          {/if}
+          {#if styleCreator.note}
+            <p class="text-[11px] text-amber-400">{styleCreator.note}</p>
+          {/if}
+
+          <div class="flex flex-wrap items-center justify-center gap-2">
+            {#if cards.length > 1}
+              <button
+                type="button"
+                class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+                onclick={() => styleCreator.switchCard()}
+              >
+                {locale.t("style_creator.switch_card")}
+                <span class="ml-1 text-neutral-500">{index + 1}/{cards.length}</span>
+              </button>
+            {/if}
+
+            {#if card?.saveable}
+              <input
+                type="text"
+                value={card.name}
+                placeholder={locale.t("style_creator.name")}
+                oninput={(e) =>
+                  styleCreator.setCardName(index, (e.currentTarget as HTMLInputElement).value)}
+                class="w-48 rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+              />
+              <button
+                type="button"
+                class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+                disabled={!choosing}
+                onclick={() => void styleCreator.pick(index)}>{locale.t("style_creator.pick")}</button
+              >
+              <button
+                type="button"
+                class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-[11px] text-neutral-300 hover:text-indigo-200 disabled:opacity-50"
+                disabled={!choosing}
+                onclick={() => void styleCreator.pick(index, true)}
+                >{locale.t("style_creator.pick_edit")}</button
+              >
+            {:else if card}
+              <span class="text-[11px] text-neutral-500">{locale.t("style_creator.anchor_alone")}</span>
+              <button
+                type="button"
+                class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+                disabled={!choosing}
+                onclick={() => void styleCreator.pick(index)}>{locale.t("style_creator.pick")}</button
+              >
+            {/if}
+
+            <button
+              type="button"
+              class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-50"
+              disabled={!choosing}
+              onclick={() => styleCreator.skip()}>{locale.t("style_creator.skip")}</button
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/generation/StyleCreatorPanel.svelte
+++ b/src/lib/components/generation/StyleCreatorPanel.svelte
@@ -22,7 +22,6 @@
   // NovelAI generates server-side, so a round is impossible without a key.
   const naiKeyMissing = $derived(generation.isNovelAi && !novelai.apiKeyConfigured);
   const canStart = $derived(indexReady && !naiKeyMissing);
-  const choosing = $derived(styleCreator.phase === "choosing");
 
   /**
    * Per-round Anlas: the single-image estimate times the number of cards. A
@@ -229,65 +228,15 @@
 
   <!-- Round -->
   {#if styleCreator.round}
-    <div class="flex gap-3">
-      {#each styleCreator.round.cards as card, i (i)}
-        <div class="flex min-w-0 flex-1 flex-col gap-2 rounded-lg border border-neutral-800 bg-neutral-950/50 p-2">
-          <div class="flex flex-wrap gap-1">
-            {#each card.artists as artist, j (artist.tag + j)}
-              <span class="rounded bg-neutral-800 px-1.5 py-0.5 text-[11px] text-neutral-200">
-                {chipLabel(artist)}
-              </span>
-            {/each}
-          </div>
-          <div class="relative aspect-square w-full overflow-hidden rounded border border-neutral-800 bg-neutral-900">
-            {#if card.image}
-              <img src={card.image.url} alt="" class="h-full w-full object-contain" />
-            {:else}
-              <div class="absolute inset-0 flex items-center justify-center">
-                <div class="w-5 h-5 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin"></div>
-              </div>
-            {/if}
-          </div>
-          {#if card.saveable}
-            <input
-              type="text"
-              value={card.name}
-              placeholder={locale.t("style_creator.name")}
-              oninput={(e) => styleCreator.setCardName(i, (e.currentTarget as HTMLInputElement).value)}
-              class="w-full rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
-            />
-            <div class="flex gap-2">
-              <button
-                type="button"
-                class="flex-1 rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
-                disabled={!choosing}
-                onclick={() => void styleCreator.pick(i)}>{locale.t("style_creator.pick")}</button
-              >
-              <button
-                type="button"
-                class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-[11px] text-neutral-300 hover:text-indigo-200 disabled:opacity-50"
-                disabled={!choosing}
-                onclick={() => void styleCreator.pick(i, true)}>{locale.t("style_creator.pick_edit")}</button
-              >
-            </div>
-          {:else}
-            <p class="text-center text-[11px] text-neutral-500">{locale.t("style_creator.anchor_alone")}</p>
-            <button
-              type="button"
-              class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-50"
-              disabled={!choosing}
-              onclick={() => void styleCreator.pick(i)}>{locale.t("style_creator.pick")}</button
-            >
-          {/if}
-        </div>
-      {/each}
-    </div>
-    <button
-      type="button"
-      class="self-start rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500 disabled:opacity-50"
-      disabled={!choosing}
-      onclick={() => styleCreator.skip()}>{locale.t("style_creator.skip")}</button
-    >
+    <!-- The pair lives in its own lightbox so each image gets the full frame;
+         this only puts it back on screen after Escape closed it. -->
+    {#if !styleCreator.viewerOpen}
+      <button
+        type="button"
+        class="self-start rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+        onclick={() => styleCreator.openViewer()}>{locale.t("style_creator.show_round")}</button
+      >
+    {/if}
   {:else if noManifest}
     <div class="rounded border border-dashed border-neutral-800 bg-neutral-950/50 p-4 text-center text-[11px] text-neutral-500">
       {locale.t("style_creator.no_manifest_url")}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1853,6 +1853,8 @@ const de: Record<string, string> = {
   "style_creator.no_manifest_url": "Für die Künstler-Galerie ist keine Manifest-URL konfiguriert, daher kann der Künstlerindex nicht geladen werden",
   "style_creator.novelai_key_required": "Fügen Sie unter Einstellungen > NovelAI einen NovelAI-API-Schlüssel hinzu, um den Style Creator zu nutzen",
   "style_creator.nai_stagger": "NovelAI drosselt zwei gleichzeitige Generierungen, daher startet das zweite Bild erst, wenn das erste fertig ist.",
+  "style_creator.switch_card": "Wechseln",
+  "style_creator.show_round": "Runde anzeigen",
   "style_creator.pool_short": "Nur {count} Künstler verfügbar, es wird aus allen gezogen",
   "style_creator.pool_empty": "Keine Künstler zum Ziehen verfügbar",
   "style_creator.exhausted": "Alle Kombinationen wurden ausprobiert. Leere den Verlauf oder ändere die Einstellungen.",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1585,6 +1585,8 @@ const en: Record<string, string> = {
   "style_creator.no_manifest_url": "No Artist Gallery manifest URL is configured, so the Artists index cannot load",
   "style_creator.novelai_key_required": "Add a NovelAI API key in Settings > NovelAI to use Style Creator",
   "style_creator.nai_stagger": "NovelAI rate limits two generations at once, so the second image starts after the first finishes.",
+  "style_creator.switch_card": "Switch",
+  "style_creator.show_round": "Show round",
   "style_creator.pool_short": "Only {count} artists available, drawing from all of them",
   "style_creator.pool_empty": "No artists available to draw from",
   "style_creator.exhausted": "Every combination has been tried. Clear the history or change the settings.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1895,6 +1895,8 @@ const es: Record<string, string> = {
   "style_creator.no_manifest_url": "No hay ninguna URL de manifiesto de la Galería de artistas configurada, así que el índice de artistas no puede cargarse",
   "style_creator.novelai_key_required": "Añade una clave de API de NovelAI en Ajustes > NovelAI para usar el Creador de estilos",
   "style_creator.nai_stagger": "NovelAI limita dos generaciones a la vez, así que la segunda imagen empieza cuando termina la primera.",
+  "style_creator.switch_card": "Cambiar",
+  "style_creator.show_round": "Mostrar ronda",
   "style_creator.pool_short": "Solo hay {count} artistas disponibles, se usan todos",
   "style_creator.pool_empty": "No hay artistas disponibles para el sorteo",
   "style_creator.exhausted": "Se han probado todas las combinaciones. Borra el historial o cambia los ajustes.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1857,6 +1857,8 @@ const fr: Record<string, string> = {
   "style_creator.no_manifest_url": "Aucune URL de manifeste pour la Galerie d'artistes n'est configurée, l'index des artistes ne peut donc pas se charger",
   "style_creator.novelai_key_required": "Ajoutez une clé API NovelAI dans Paramètres > NovelAI pour utiliser le Créateur de styles",
   "style_creator.nai_stagger": "NovelAI limite deux générations simultanées, la seconde image démarre donc une fois la première terminée.",
+  "style_creator.switch_card": "Changer",
+  "style_creator.show_round": "Afficher la manche",
   "style_creator.pool_short": "Seulement {count} artistes disponibles, tirage sur l'ensemble",
   "style_creator.pool_empty": "Aucun artiste disponible pour le tirage",
   "style_creator.exhausted": "Toutes les combinaisons ont été essayées. Effacez l'historique ou changez les réglages.",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1832,6 +1832,8 @@ const it: Record<string, string> = {
   "style_creator.no_manifest_url": "Nessun URL manifest della Galleria artisti è configurato, quindi l'indice degli artisti non può caricarsi",
   "style_creator.novelai_key_required": "Aggiungi una chiave API NovelAI in Impostazioni > NovelAI per usare il Creatore di stili",
   "style_creator.nai_stagger": "NovelAI limita due generazioni contemporanee, quindi la seconda immagine parte quando la prima è finita.",
+  "style_creator.switch_card": "Cambia",
+  "style_creator.show_round": "Mostra round",
   "style_creator.pool_short": "Solo {count} artisti disponibili, si pesca da tutti",
   "style_creator.pool_empty": "Nessun artista disponibile da pescare",
   "style_creator.exhausted": "Tutte le combinazioni sono state provate. Cancella la cronologia o cambia le impostazioni.",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1857,6 +1857,8 @@ const ja: Record<string, string> = {
   "style_creator.no_manifest_url": "アーティストギャラリーのマニフェストURLが設定されていないため、アーティストインデックスを読み込めません",
   "style_creator.novelai_key_required": "スタイルクリエーターを使うには、設定 > NovelAI で NovelAI の API キーを追加してください",
   "style_creator.nai_stagger": "NovelAI は同時に 2 件の生成を制限するため、2 枚目は 1 枚目の完了後に開始します。",
+  "style_creator.switch_card": "切り替え",
+  "style_creator.show_round": "ラウンドを表示",
   "style_creator.pool_short": "利用できるアーティストは {count} 名のみです。すべてから抽選します",
   "style_creator.pool_empty": "抽選できるアーティストがいません",
   "style_creator.exhausted": "すべての組み合わせを試しました。履歴をクリアするか設定を変更してください。",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1832,6 +1832,8 @@ const ko: Record<string, string> = {
   "style_creator.no_manifest_url": "아티스트 갤러리 매니페스트 URL이 설정되어 있지 않아 아티스트 색인을 불러올 수 없습니다",
   "style_creator.novelai_key_required": "스타일 크리에이터를 사용하려면 설정 > NovelAI에서 NovelAI API 키를 추가하세요",
   "style_creator.nai_stagger": "NovelAI는 동시 생성 2건을 제한하므로 두 번째 이미지는 첫 번째가 끝난 뒤에 시작합니다.",
+  "style_creator.switch_card": "전환",
+  "style_creator.show_round": "라운드 보기",
   "style_creator.pool_short": "아티스트가 {count}명뿐이라 전부에서 뽑습니다",
   "style_creator.pool_empty": "뽑을 아티스트가 없습니다",
   "style_creator.exhausted": "모든 조합을 시도했습니다. 기록을 지우거나 설정을 바꾸세요.",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1539,6 +1539,8 @@ const pl: Record<string, string> = {
   "style_creator.no_manifest_url": "Nie skonfigurowano adresu URL manifestu Galerii artystów, więc indeks artystów nie może się wczytać",
   "style_creator.novelai_key_required": "Dodaj klucz API NovelAI w Ustawienia > NovelAI, aby korzystać z Kreatora stylów",
   "style_creator.nai_stagger": "NovelAI ogranicza dwa jednoczesne generowania, więc drugi obraz startuje po zakończeniu pierwszego.",
+  "style_creator.switch_card": "Przełącz",
+  "style_creator.show_round": "Pokaż rundę",
   "style_creator.pool_short": "Dostępnych jest tylko {count} artystów, losowanie ze wszystkich",
   "style_creator.pool_empty": "Brak artystów do losowania",
   "style_creator.exhausted": "Wypróbowano już wszystkie kombinacje. Wyczyść historię lub zmień ustawienia.",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1832,6 +1832,8 @@ const pt: Record<string, string> = {
   "style_creator.no_manifest_url": "Nenhum URL de manifesto da Galeria de artistas está configurado, então o índice de artistas não pode carregar",
   "style_creator.novelai_key_required": "Adicione uma chave de API do NovelAI em Configurações > NovelAI para usar o Criador de estilos",
   "style_creator.nai_stagger": "O NovelAI limita duas gerações ao mesmo tempo, então a segunda imagem começa depois que a primeira termina.",
+  "style_creator.switch_card": "Alternar",
+  "style_creator.show_round": "Mostrar rodada",
   "style_creator.pool_short": "Apenas {count} artistas disponíveis, sorteando entre todos",
   "style_creator.pool_empty": "Nenhum artista disponível para sortear",
   "style_creator.exhausted": "Todas as combinações já foram testadas. Limpe o histórico ou mude as configurações.",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1832,6 +1832,8 @@ const ru: Record<string, string> = {
   "style_creator.no_manifest_url": "URL манифеста Галереи художников не настроен, поэтому индекс художников не может загрузиться",
   "style_creator.novelai_key_required": "Добавьте ключ API NovelAI в разделе Настройки > NovelAI, чтобы использовать Создатель стилей",
   "style_creator.nai_stagger": "NovelAI ограничивает две генерации одновременно, поэтому второе изображение начнётся после завершения первого.",
+  "style_creator.switch_card": "Переключить",
+  "style_creator.show_round": "Показать раунд",
   "style_creator.pool_short": "Доступно только {count} художников, выбор из всех",
   "style_creator.pool_empty": "Нет художников для выбора",
   "style_creator.exhausted": "Все сочетания уже опробованы. Очистите историю или измените настройки.",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1832,6 +1832,8 @@ const zhTw: Record<string, string> = {
   "style_creator.no_manifest_url": "未設定繪師圖庫的 manifest URL，因此無法載入畫師索引",
   "style_creator.novelai_key_required": "請在 設定 > NovelAI 中新增 NovelAI API 金鑰以使用風格產生器",
   "style_creator.nai_stagger": "NovelAI 會限制同時進行兩次生成，因此第二張圖會在第一張完成後才開始。",
+  "style_creator.switch_card": "切換",
+  "style_creator.show_round": "顯示本輪",
   "style_creator.pool_short": "只有 {count} 位畫師可用，將從全部中抽取",
   "style_creator.pool_empty": "沒有可抽取的畫師",
   "style_creator.exhausted": "所有組合都試過了。請清除紀錄或更改設定。",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1873,6 +1873,8 @@ const zh: Record<string, string> = {
   "style_creator.no_manifest_url": "未配置画师图库的 manifest URL，因此无法加载画师索引",
   "style_creator.novelai_key_required": "请在 设置 > NovelAI 中添加 NovelAI API 密钥以使用风格生成器",
   "style_creator.nai_stagger": "NovelAI 会限制同时进行两次生成，因此第二张图会在第一张完成后才开始。",
+  "style_creator.switch_card": "切换",
+  "style_creator.show_round": "显示本轮",
   "style_creator.pool_short": "只有 {count} 位画师可用，将从全部中抽取",
   "style_creator.pool_empty": "没有可抽取的画师",
   "style_creator.exhausted": "所有组合都已尝试过。请清除记录或更改设置。",

--- a/src/lib/stores/styleCreator.svelte.ts
+++ b/src/lib/stores/styleCreator.svelte.ts
@@ -165,6 +165,15 @@ class StyleCreatorStore {
    * the cards go out one at a time and the panel says why.
    */
   staggering = $state(false);
+  /**
+   * Whether the round is on screen in its own lightbox. The two cards are
+   * compared full size there rather than side by side in the bottom panel,
+   * and closing the lightbox does not judge the round, so the panel can
+   * reopen it.
+   */
+  viewerOpen = $state(false);
+  /** Which card the lightbox is showing. */
+  viewerIndex = $state(0);
 
   /** promptId -> card index for the round in flight. */
   private pending = new Map<string, number>();
@@ -357,6 +366,8 @@ class StyleCreatorStore {
     this.pending.clear();
     this.round = round;
     this.phase = "generating";
+    this.viewerIndex = 0;
+    this.viewerOpen = true;
     void this.submitRound(round, serial);
   }
 
@@ -481,6 +492,7 @@ class StyleCreatorStore {
     this.pending.clear();
     this.pendingAnchorSignature = null;
     this.round = null;
+    this.viewerOpen = false;
     this.phase = "idle";
     this.running = false;
     this.error = asNote ? null : message;
@@ -512,6 +524,7 @@ class StyleCreatorStore {
     this.pending.clear();
     this.pendingAnchorSignature = null;
     this.round = null;
+    this.viewerOpen = false;
     this.phase = "idle";
     // When the loop is not continuing, a stale "only N artists available"
     // note (set by nextRound for the round just judged) would otherwise sit
@@ -589,8 +602,29 @@ class StyleCreatorStore {
       this.pending.clear();
       this.pendingAnchorSignature = null;
       this.round = null;
+      this.viewerOpen = false;
       this.phase = "idle";
     }
+  }
+
+  /** Reopen the round's lightbox after it was closed with Escape. */
+  openViewer(): void {
+    if (!this.round) return;
+    this.viewerOpen = true;
+  }
+
+  closeViewer(): void {
+    this.viewerOpen = false;
+  }
+
+  /**
+   * Move to the next card, wrapping. One button switches between the pair
+   * rather than showing both at once, so each card gets the full frame.
+   */
+  switchCard(): void {
+    const round = this.round;
+    if (!round || round.cards.length < 2) return;
+    this.viewerIndex = (this.viewerIndex + 1) % round.cards.length;
   }
 
   /**


### PR DESCRIPTION
The Style Creator round now opens in its own full screen lightbox instead of sitting as two small cards in the bottom panel.

- One card fills the frame at a time. A Switch button (with an n/total counter) flips between the pair, and the left/right arrow keys do the same.
- The controls sit in a bar at the bottom that stays invisible until the pointer is over the image, so each candidate is judged on its own. It holds the artist chips, the name field, Pick, Pick and edit, and Skip.
- The lightbox opens as soon as a round starts, so cards that have not landed yet show the spinner there. In NovelAI mode the stagger explanation shows next to the spinner too.
- Escape closes the lightbox without judging the round. The bottom panel gets a Show round button to put it back on screen.
- The bottom panel keeps the anchor, the draw settings, Start/Stop and the history controls, and loses the side by side image cards.

New locale keys style_creator.switch_card and style_creator.show_round added to all 12 locale files.
