### PR TITLE
add stop and side by side view to the style creator lightbox

### DIFF
--- a/src/lib/components/generation/StyleCreatorLightbox.svelte
+++ b/src/lib/components/generation/StyleCreatorLightbox.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   /**
-   * Full-screen view of the round in flight. The pair is compared one card at
-   * a time on the whole frame instead of side by side in the bottom panel, and
-   * the controls stay out of the way until the pointer enters the frame.
+   * Full-screen view of the round in flight. The pair is compared on the whole
+   * frame instead of side by side in the bottom panel, either one card at a
+   * time or both at once, and the controls stay out of the way until the
+   * pointer enters the frame.
    */
-  import { styleCreator } from "../../stores/styleCreator.svelte.js";
+  import { styleCreator, type RoundCard } from "../../stores/styleCreator.svelte.js";
   import { generation } from "../../stores/generation.svelte.js";
   import { locale } from "../../stores/locale.svelte.js";
   import { stripArtistSigil } from "../../utils/artistTag.js";
@@ -17,6 +18,9 @@
   const card = $derived(cards[index] ?? null);
   const choosing = $derived(styleCreator.phase === "choosing");
   const open = $derived(styleCreator.viewerOpen && cards.length > 0);
+  // With one card there is nothing to lay out beside it, so the pair controls
+  // collapse to the single-card form regardless of the stored preference.
+  const sideBySide = $derived(styleCreator.viewerSideBySide && cards.length > 1);
 
   function chipLabel(artist: StyleArtist): string {
     const tag = generation.isNovelAi ? stripArtistSigil(artist.tag) : artist.tag;
@@ -32,7 +36,7 @@
     if (e.key === "Escape") {
       e.preventDefault();
       styleCreator.closeViewer();
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+    } else if (!sideBySide && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
       e.preventDefault();
       styleCreator.switchCard();
     }
@@ -40,6 +44,67 @@
 </script>
 
 <svelte:window onkeydown={onKeydown} />
+
+{#snippet frame(c: RoundCard | null)}
+  {#if c?.image}
+    <img src={c.image.url} alt="" class="h-full w-full object-contain" />
+  {:else}
+    <div class="absolute inset-0 flex flex-col items-center justify-center gap-3">
+      <div
+        class="h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"
+      ></div>
+      {#if styleCreator.staggering}
+        <p class="max-w-md px-6 text-center text-[11px] text-neutral-400">
+          {locale.t("style_creator.nai_stagger")}
+        </p>
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet cardControls(c: RoundCard, i: number)}
+  <div class="flex min-w-0 flex-col items-center gap-2">
+    <div class="flex flex-wrap justify-center gap-1">
+      {#each c.artists as artist, j (artist.tag + j)}
+        <span class="rounded bg-neutral-800 px-1.5 py-0.5 text-[11px] text-neutral-200">
+          {chipLabel(artist)}
+        </span>
+      {/each}
+    </div>
+    <div class="flex flex-wrap items-center justify-center gap-2">
+      {#if c.saveable}
+        <input
+          type="text"
+          value={c.name}
+          placeholder={locale.t("style_creator.name")}
+          oninput={(e) => styleCreator.setCardName(i, (e.currentTarget as HTMLInputElement).value)}
+          class="w-48 rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
+        />
+        <button
+          type="button"
+          class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          disabled={!choosing}
+          onclick={() => void styleCreator.pick(i)}>{locale.t("style_creator.pick")}</button
+        >
+        <button
+          type="button"
+          class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-[11px] text-neutral-300 hover:text-indigo-200 disabled:opacity-50"
+          disabled={!choosing}
+          onclick={() => void styleCreator.pick(i, true)}
+          >{locale.t("style_creator.pick_edit")}</button
+        >
+      {:else}
+        <span class="text-[11px] text-neutral-500">{locale.t("style_creator.anchor_alone")}</span>
+        <button
+          type="button"
+          class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          disabled={!choosing}
+          onclick={() => void styleCreator.pick(i)}>{locale.t("style_creator.pick")}</button
+        >
+      {/if}
+    </div>
+  </div>
+{/snippet}
 
 {#if open}
   <div class="fixed inset-0 z-[60] flex flex-col bg-black/95">
@@ -52,17 +117,14 @@
     >
 
     <div class="group relative min-h-0 flex-1">
-      {#if card?.image}
-        <img src={card.image.url} alt="" class="h-full w-full object-contain" />
-      {:else}
-        <div class="absolute inset-0 flex flex-col items-center justify-center gap-3">
-          <div class="h-8 w-8 animate-spin rounded-full border-2 border-indigo-500 border-t-transparent"></div>
-          {#if styleCreator.staggering}
-            <p class="max-w-md px-6 text-center text-[11px] text-neutral-400">
-              {locale.t("style_creator.nai_stagger")}
-            </p>
-          {/if}
+      {#if sideBySide}
+        <div class="flex h-full w-full gap-1">
+          {#each cards as c, i (i)}
+            <div class="relative min-w-0 flex-1">{@render frame(c)}</div>
+          {/each}
         </div>
+      {:else}
+        {@render frame(card)}
       {/if}
 
       <!-- Controls: hidden until the pointer is over the frame, so the image
@@ -73,14 +135,14 @@
         <div
           class="pointer-events-auto flex max-w-full flex-col items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-950/90 p-3 shadow-xl"
         >
-          {#if card}
-            <div class="flex flex-wrap justify-center gap-1">
-              {#each card.artists as artist, j (artist.tag + j)}
-                <span class="rounded bg-neutral-800 px-1.5 py-0.5 text-[11px] text-neutral-200">
-                  {chipLabel(artist)}
-                </span>
+          {#if sideBySide}
+            <div class="flex flex-wrap items-start justify-center gap-6">
+              {#each cards as c, i (i)}
+                {@render cardControls(c, i)}
               {/each}
             </div>
+          {:else if card}
+            {@render cardControls(card, index)}
           {/if}
 
           {#if styleCreator.error}
@@ -92,45 +154,23 @@
 
           <div class="flex flex-wrap items-center justify-center gap-2">
             {#if cards.length > 1}
+              {#if !sideBySide}
+                <button
+                  type="button"
+                  class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
+                  onclick={() => styleCreator.switchCard()}
+                >
+                  {locale.t("style_creator.switch_card")}
+                  <span class="ml-1 text-neutral-500">{index + 1}/{cards.length}</span>
+                </button>
+              {/if}
               <button
                 type="button"
-                class="rounded border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-xs text-neutral-200 hover:border-indigo-500"
-                onclick={() => styleCreator.switchCard()}
-              >
-                {locale.t("style_creator.switch_card")}
-                <span class="ml-1 text-neutral-500">{index + 1}/{cards.length}</span>
-              </button>
-            {/if}
-
-            {#if card?.saveable}
-              <input
-                type="text"
-                value={card.name}
-                placeholder={locale.t("style_creator.name")}
-                oninput={(e) =>
-                  styleCreator.setCardName(index, (e.currentTarget as HTMLInputElement).value)}
-                class="w-48 rounded border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-100 placeholder-neutral-500 focus:border-indigo-500 focus:outline-none"
-              />
-              <button
-                type="button"
-                class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
-                disabled={!choosing}
-                onclick={() => void styleCreator.pick(index)}>{locale.t("style_creator.pick")}</button
-              >
-              <button
-                type="button"
-                class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-[11px] text-neutral-300 hover:text-indigo-200 disabled:opacity-50"
-                disabled={!choosing}
-                onclick={() => void styleCreator.pick(index, true)}
-                >{locale.t("style_creator.pick_edit")}</button
-              >
-            {:else if card}
-              <span class="text-[11px] text-neutral-500">{locale.t("style_creator.anchor_alone")}</span>
-              <button
-                type="button"
-                class="rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
-                disabled={!choosing}
-                onclick={() => void styleCreator.pick(index)}>{locale.t("style_creator.pick")}</button
+                class="rounded border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-[11px] text-neutral-300 hover:text-indigo-200"
+                onclick={() => styleCreator.setViewerSideBySide(!sideBySide)}
+                >{sideBySide
+                  ? locale.t("style_creator.view_single")
+                  : locale.t("style_creator.view_side_by_side")}</button
               >
             {/if}
 
@@ -140,6 +180,15 @@
               disabled={!choosing}
               onclick={() => styleCreator.skip()}>{locale.t("style_creator.skip")}</button
             >
+            <!-- Rounds keep drawing until they are stopped, so the stop has to
+                 be reachable without leaving the lightbox. -->
+            {#if styleCreator.running}
+              <button
+                type="button"
+                class="rounded bg-neutral-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-neutral-600"
+                onclick={() => styleCreator.stop()}>{locale.t("style_creator.stop")}</button
+              >
+            {/if}
           </div>
         </div>
       </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -1855,6 +1855,8 @@ const de: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI drosselt zwei gleichzeitige Generierungen, daher startet das zweite Bild erst, wenn das erste fertig ist.",
   "style_creator.switch_card": "Wechseln",
   "style_creator.show_round": "Runde anzeigen",
+  "style_creator.view_side_by_side": "Nebeneinander",
+  "style_creator.view_single": "Einzeln",
   "style_creator.pool_short": "Nur {count} Künstler verfügbar, es wird aus allen gezogen",
   "style_creator.pool_empty": "Keine Künstler zum Ziehen verfügbar",
   "style_creator.exhausted": "Alle Kombinationen wurden ausprobiert. Leere den Verlauf oder ändere die Einstellungen.",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1587,6 +1587,8 @@ const en: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI rate limits two generations at once, so the second image starts after the first finishes.",
   "style_creator.switch_card": "Switch",
   "style_creator.show_round": "Show round",
+  "style_creator.view_side_by_side": "Side by side",
+  "style_creator.view_single": "One at a time",
   "style_creator.pool_short": "Only {count} artists available, drawing from all of them",
   "style_creator.pool_empty": "No artists available to draw from",
   "style_creator.exhausted": "Every combination has been tried. Clear the history or change the settings.",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -1897,6 +1897,8 @@ const es: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI limita dos generaciones a la vez, así que la segunda imagen empieza cuando termina la primera.",
   "style_creator.switch_card": "Cambiar",
   "style_creator.show_round": "Mostrar ronda",
+  "style_creator.view_side_by_side": "Lado a lado",
+  "style_creator.view_single": "Uno a uno",
   "style_creator.pool_short": "Solo hay {count} artistas disponibles, se usan todos",
   "style_creator.pool_empty": "No hay artistas disponibles para el sorteo",
   "style_creator.exhausted": "Se han probado todas las combinaciones. Borra el historial o cambia los ajustes.",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -1859,6 +1859,8 @@ const fr: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI limite deux générations simultanées, la seconde image démarre donc une fois la première terminée.",
   "style_creator.switch_card": "Changer",
   "style_creator.show_round": "Afficher la manche",
+  "style_creator.view_side_by_side": "Côte à côte",
+  "style_creator.view_single": "Un par un",
   "style_creator.pool_short": "Seulement {count} artistes disponibles, tirage sur l'ensemble",
   "style_creator.pool_empty": "Aucun artiste disponible pour le tirage",
   "style_creator.exhausted": "Toutes les combinaisons ont été essayées. Effacez l'historique ou changez les réglages.",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -1834,6 +1834,8 @@ const it: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI limita due generazioni contemporanee, quindi la seconda immagine parte quando la prima è finita.",
   "style_creator.switch_card": "Cambia",
   "style_creator.show_round": "Mostra round",
+  "style_creator.view_side_by_side": "Affiancate",
+  "style_creator.view_single": "Una alla volta",
   "style_creator.pool_short": "Solo {count} artisti disponibili, si pesca da tutti",
   "style_creator.pool_empty": "Nessun artista disponibile da pescare",
   "style_creator.exhausted": "Tutte le combinazioni sono state provate. Cancella la cronologia o cambia le impostazioni.",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1859,6 +1859,8 @@ const ja: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI は同時に 2 件の生成を制限するため、2 枚目は 1 枚目の完了後に開始します。",
   "style_creator.switch_card": "切り替え",
   "style_creator.show_round": "ラウンドを表示",
+  "style_creator.view_side_by_side": "並べて表示",
+  "style_creator.view_single": "1枚ずつ",
   "style_creator.pool_short": "利用できるアーティストは {count} 名のみです。すべてから抽選します",
   "style_creator.pool_empty": "抽選できるアーティストがいません",
   "style_creator.exhausted": "すべての組み合わせを試しました。履歴をクリアするか設定を変更してください。",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -1834,6 +1834,8 @@ const ko: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI는 동시 생성 2건을 제한하므로 두 번째 이미지는 첫 번째가 끝난 뒤에 시작합니다.",
   "style_creator.switch_card": "전환",
   "style_creator.show_round": "라운드 보기",
+  "style_creator.view_side_by_side": "나란히 보기",
+  "style_creator.view_single": "한 장씩",
   "style_creator.pool_short": "아티스트가 {count}명뿐이라 전부에서 뽑습니다",
   "style_creator.pool_empty": "뽑을 아티스트가 없습니다",
   "style_creator.exhausted": "모든 조합을 시도했습니다. 기록을 지우거나 설정을 바꾸세요.",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -1541,6 +1541,8 @@ const pl: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI ogranicza dwa jednoczesne generowania, więc drugi obraz startuje po zakończeniu pierwszego.",
   "style_creator.switch_card": "Przełącz",
   "style_creator.show_round": "Pokaż rundę",
+  "style_creator.view_side_by_side": "Obok siebie",
+  "style_creator.view_single": "Pojedynczo",
   "style_creator.pool_short": "Dostępnych jest tylko {count} artystów, losowanie ze wszystkich",
   "style_creator.pool_empty": "Brak artystów do losowania",
   "style_creator.exhausted": "Wypróbowano już wszystkie kombinacje. Wyczyść historię lub zmień ustawienia.",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -1834,6 +1834,8 @@ const pt: Record<string, string> = {
   "style_creator.nai_stagger": "O NovelAI limita duas gerações ao mesmo tempo, então a segunda imagem começa depois que a primeira termina.",
   "style_creator.switch_card": "Alternar",
   "style_creator.show_round": "Mostrar rodada",
+  "style_creator.view_side_by_side": "Lado a lado",
+  "style_creator.view_single": "Uma de cada vez",
   "style_creator.pool_short": "Apenas {count} artistas disponíveis, sorteando entre todos",
   "style_creator.pool_empty": "Nenhum artista disponível para sortear",
   "style_creator.exhausted": "Todas as combinações já foram testadas. Limpe o histórico ou mude as configurações.",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -1834,6 +1834,8 @@ const ru: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI ограничивает две генерации одновременно, поэтому второе изображение начнётся после завершения первого.",
   "style_creator.switch_card": "Переключить",
   "style_creator.show_round": "Показать раунд",
+  "style_creator.view_side_by_side": "Рядом",
+  "style_creator.view_single": "По одной",
   "style_creator.pool_short": "Доступно только {count} художников, выбор из всех",
   "style_creator.pool_empty": "Нет художников для выбора",
   "style_creator.exhausted": "Все сочетания уже опробованы. Очистите историю или измените настройки.",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -1834,6 +1834,8 @@ const zhTw: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI 會限制同時進行兩次生成，因此第二張圖會在第一張完成後才開始。",
   "style_creator.switch_card": "切換",
   "style_creator.show_round": "顯示本輪",
+  "style_creator.view_side_by_side": "並排顯示",
+  "style_creator.view_single": "逐張顯示",
   "style_creator.pool_short": "只有 {count} 位畫師可用，將從全部中抽取",
   "style_creator.pool_empty": "沒有可抽取的畫師",
   "style_creator.exhausted": "所有組合都試過了。請清除紀錄或更改設定。",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -1875,6 +1875,8 @@ const zh: Record<string, string> = {
   "style_creator.nai_stagger": "NovelAI 会限制同时进行两次生成，因此第二张图会在第一张完成后才开始。",
   "style_creator.switch_card": "切换",
   "style_creator.show_round": "显示本轮",
+  "style_creator.view_side_by_side": "并排显示",
+  "style_creator.view_single": "逐张显示",
   "style_creator.pool_short": "只有 {count} 位画师可用，将从全部中抽取",
   "style_creator.pool_empty": "没有可抽取的画师",
   "style_creator.exhausted": "所有组合都已尝试过。请清除记录或更改设置。",

--- a/src/lib/stores/styleCreator.svelte.ts
+++ b/src/lib/stores/styleCreator.svelte.ts
@@ -149,6 +149,12 @@ class StyleCreatorStore {
   favouritesOnly = $state(false);
   varyWeights = $state(false);
   pairInNai = $state(true);
+  /**
+   * Show both cards at once in the lightbox instead of one at a time with
+   * the Switch button. Persisted: it is a viewing preference, not part of
+   * the round.
+   */
+  viewerSideBySide = $state(false);
   anchor = $state<StyleArtist[]>([]);
   anchorStyleId = $state<string | null>(null);
   history = $state<Set<string>>(new Set());
@@ -217,6 +223,14 @@ class StyleCreatorStore {
 
   setPairInNai(v: boolean): void {
     this.pairInNai = v;
+    this.saveSettings();
+  }
+
+  setViewerSideBySide(v: boolean): void {
+    this.viewerSideBySide = v;
+    // Nothing is hidden in side by side, so the single-card index would be
+    // stale on the way back. Start from the first card again.
+    if (v) this.viewerIndex = 0;
     this.saveSettings();
   }
 
@@ -685,6 +699,7 @@ class StyleCreatorStore {
       if (data.favouritesOnly !== undefined) this.favouritesOnly = !!data.favouritesOnly;
       if (data.varyWeights !== undefined) this.varyWeights = !!data.varyWeights;
       if (data.pairInNai !== undefined) this.pairInNai = !!data.pairInNai;
+      if (data.viewerSideBySide !== undefined) this.viewerSideBySide = !!data.viewerSideBySide;
       if (data.anchor?.artists !== undefined && Array.isArray(data.anchor.artists)) {
         this.anchor = data.anchor.artists
           .filter((a: any) => a && typeof a.tag === "string" && a.tag.trim())
@@ -714,6 +729,7 @@ class StyleCreatorStore {
           favouritesOnly: this.favouritesOnly,
           varyWeights: this.varyWeights,
           pairInNai: this.pairInNai,
+          viewerSideBySide: this.viewerSideBySide,
           anchor: {
             artists: this.anchor.map((a) => ({ tag: a.tag, slug: a.slug, weight: a.weight })),
             styleId: this.anchorStyleId,


### PR DESCRIPTION
Rounds keep drawing until they are stopped, and Stop only lived in the Style Creator tab, so ending the loop meant leaving the lightbox first. Stop now sits on the lightbox control bar while a run is going.

Also adds a side by side mode. Both cards can share the frame instead of taking turns, so the Switch button and the arrow keys collapse away while it is on. The toggle reads "Side by side" or "One at a time" depending on where you are, and the choice persists like the other Style Creator settings.

A single card round (NovelAI with "Two per round" off) falls back to the one at a time layout regardless of the setting, since there is nothing to put beside it.
