### PR TITLE
make Start reopen a stopped round instead of doing nothing

### DIFF
--- a/src/lib/stores/styleCreator.svelte.ts
+++ b/src/lib/stores/styleCreator.svelte.ts
@@ -631,8 +631,10 @@ class StyleCreatorStore {
     this.error = null;
     this.running = true;
     // A round left in "choosing" keeps its cards: Start resumes the loop only
-    // after that round is judged.
+    // after that round is judged. Closing the lightbox on such a round hides
+    // it, so put it back on screen rather than letting Start look dead.
     if (this.phase === "idle") this.nextRound();
+    else if (this.round) this.viewerOpen = true;
   }
 
   /**


### PR DESCRIPTION
Stopping the Style Creator while a pair is waiting to be judged keeps that pair on purpose, so the phase stays "choosing". Closing the lightbox then hid it, and pressing Start after that set the run going but skipped nextRound(), because nextRound only fires from the idle phase. Nothing appeared to happen.

Start now puts the pending round back on screen when there is one, so the user can judge it and the loop carries on from there. A round that was already judged or abandoned still starts a fresh draw as before.
