### PR TITLE
open artist style thumbnails in a full-app lightbox

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -62,6 +62,7 @@
   import StyleCreatorLightbox from "./lib/components/generation/StyleCreatorLightbox.svelte";
   import NovelAiPositionModal from "./lib/components/generation/NovelAiPositionModal.svelte";
   import StyleEditor from "./lib/components/generation/StyleEditor.svelte";
+  import StyleThumbnailLightbox from "./lib/components/generation/StyleThumbnailLightbox.svelte";
   import PresetEditor from "./lib/components/generation/PresetEditor.svelte";
   import { styleEditors } from "./lib/stores/styleEditors.svelte.js";
   import ReportErrorModal from "./lib/components/errors/ReportErrorModal.svelte";
@@ -4711,3 +4712,6 @@
 {#if styleEditors.presetId}
   <PresetEditor presetId={styleEditors.presetId} onclose={() => styleEditors.closePreset()} />
 {/if}
+
+<!-- Same reason: the style list that opens this lives in the bottom panel. -->
+<StyleThumbnailLightbox />

--- a/src/lib/components/generation/StyleManager.svelte
+++ b/src/lib/components/generation/StyleManager.svelte
@@ -261,7 +261,17 @@
             <li class="flex items-center gap-3 rounded-lg border {active ? 'border-indigo-500/60 bg-indigo-500/5' : 'border-neutral-800 bg-neutral-950/60'} p-2">
               <div class="h-14 w-14 shrink-0 overflow-hidden rounded border border-neutral-800 bg-neutral-900">
                 {#if style.thumbnail}
-                  <img src={style.thumbnail} alt="" class="h-full w-full object-cover" />
+                  <!-- The full-size view is a lightbox mounted at the app root,
+                       so it covers the window rather than this panel. -->
+                  <button
+                    type="button"
+                    class="h-full w-full cursor-zoom-in"
+                    title={locale.t("styles.manager.view_thumb")}
+                    aria-label={locale.t("styles.manager.view_thumb")}
+                    onclick={() => styleEditors.openThumbnail(style.id)}
+                  >
+                    <img src={style.thumbnail} alt="" class="h-full w-full object-cover" />
+                  </button>
                 {:else}
                   <div class="flex h-full w-full items-center justify-center text-[9px] text-neutral-600">{locale.t("styles.manager.no_thumb")}</div>
                 {/if}

--- a/src/lib/components/generation/StyleThumbnailLightbox.svelte
+++ b/src/lib/components/generation/StyleThumbnailLightbox.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  /**
+   * Full-size view of a style's thumbnail. Mounted at the app root rather than
+   * in the Styles tab so the overlay covers the whole window, not just the
+   * bottom panel the list lives in.
+   */
+  import { styles } from "../../stores/styles.svelte.js";
+  import { styleEditors } from "../../stores/styleEditors.svelte.js";
+  import { locale } from "../../stores/locale.svelte.js";
+
+  const style = $derived(
+    styleEditors.thumbnailStyleId
+      ? (styles.styles.find((s) => s.id === styleEditors.thumbnailStyleId) ?? null)
+      : null,
+  );
+  // A style can lose its thumbnail while the lightbox is up (cleared from the
+  // editor), which leaves nothing to show.
+  const open = $derived(style !== null && !!style.thumbnail);
+
+  function onKeydown(e: KeyboardEvent) {
+    if (!open) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      styleEditors.closeThumbnail();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if open && style}
+  <div class="fixed inset-0 z-[70] flex flex-col bg-black/95">
+    <div class="flex shrink-0 items-center justify-between gap-3 px-4 py-3">
+      <p class="truncate text-sm text-neutral-100">{style.name}</p>
+      <button
+        type="button"
+        class="shrink-0 rounded border border-neutral-700 bg-neutral-900/80 px-2 py-1 text-xs text-neutral-300 hover:border-indigo-500 hover:text-indigo-200"
+        aria-label={locale.t("common.close")}
+        title={locale.t("common.close")}
+        onclick={() => styleEditors.closeThumbnail()}>x</button
+      >
+    </div>
+    <div class="min-h-0 flex-1 p-4">
+      <img
+        src={style.thumbnail}
+        alt={locale.t("styles.editor.thumbnail_alt")}
+        class="h-full w-full object-contain"
+      />
+    </div>
+  </div>
+{/if}

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -2473,6 +2473,7 @@ const de: Record<string, string> = {
   "styles.manager.empty_styles": "Noch keine Stile erstellt.",
   "styles.manager.empty_presets": "Noch keine Bausteine. Erstellen Sie einen für ein wiederverwendbares Prompt-Fragment oder eine Wildcard-Liste.",
   "styles.manager.no_thumb": "kein Vorschaubild",
+  "styles.manager.view_thumb": "Vollbild anzeigen",
   "styles.manager.active": "aktiv",
   "styles.manager.artists_count": "{count} Künstler",
   "styles.manager.artists_count_plural": "{count} Künstler",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -2726,6 +2726,7 @@ const en: Record<string, string> = {
   "styles.manager.empty_styles": "You haven't created any styles yet.",
   "styles.manager.empty_presets": "No chunks yet. Create one to store a reusable prompt fragment or a wildcard list.",
   "styles.manager.no_thumb": "no thumb",
+  "styles.manager.view_thumb": "View full image",
   "styles.manager.active": "active",
   "styles.manager.artists_count": "{count} artist",
   "styles.manager.artists_count_plural": "{count} artists",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -2515,6 +2515,7 @@ const es: Record<string, string> = {
   "styles.manager.empty_styles": "Aún no has creado ningún estilo.",
   "styles.manager.empty_presets": "No hay bloques. Crea uno para guardar un fragmento de prompt reutilizable o una lista de comodines.",
   "styles.manager.no_thumb": "sin miniatura",
+  "styles.manager.view_thumb": "Ver imagen completa",
   "styles.manager.active": "activo",
   "styles.manager.artists_count": "{count} artista",
   "styles.manager.artists_count_plural": "{count} artistas",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -2477,6 +2477,7 @@ const fr: Record<string, string> = {
   "styles.manager.empty_styles": "Vous n'avez pas encore créé de styles.",
   "styles.manager.empty_presets": "Aucun bloc. Créez-en un pour stocker un fragment de prompt réutilisable ou une liste de jokers.",
   "styles.manager.no_thumb": "pas de vignette",
+  "styles.manager.view_thumb": "Afficher en grand",
   "styles.manager.active": "actif",
   "styles.manager.artists_count": "{count} artiste",
   "styles.manager.artists_count_plural": "{count} artistes",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -2451,6 +2451,7 @@ const it: Record<string, string> = {
   "styles.manager.empty_styles": "Non hai ancora creato alcuno stile.",
   "styles.manager.empty_presets": "Nessun blocco. Creane uno per memorizzare un frammento di prompt riutilizzabile o un elenco wildcard.",
   "styles.manager.no_thumb": "nessuna anteprima",
+  "styles.manager.view_thumb": "Visualizza immagine intera",
   "styles.manager.active": "attivo",
   "styles.manager.artists_count": "{count} artista",
   "styles.manager.artists_count_plural": "{count} artisti",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -2476,6 +2476,7 @@ const ja: Record<string, string> = {
   "styles.manager.empty_styles": "まだスタイルを作成していません。",
   "styles.manager.empty_presets": "チャンクがありません。再利用可能なプロンプト断片やワイルドカードリストを保存するには作成してください。",
   "styles.manager.no_thumb": "サムネなし",
+  "styles.manager.view_thumb": "画像を拡大表示",
   "styles.manager.active": "有効",
   "styles.manager.artists_count": "アーティスト {count} 件",
   "styles.manager.artists_count_plural": "アーティスト {count} 件",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -2451,6 +2451,7 @@ const ko: Record<string, string> = {
   "styles.manager.empty_styles": "아직 만든 스타일이 없습니다.",
   "styles.manager.empty_presets": "청크가 없습니다. 재사용 가능한 프롬프트 조각이나 와일드카드 목록을 저장하려면 하나를 만드세요.",
   "styles.manager.no_thumb": "썸네일 없음",
+  "styles.manager.view_thumb": "전체 이미지 보기",
   "styles.manager.active": "활성",
   "styles.manager.artists_count": "아티스트 {count}명",
   "styles.manager.artists_count_plural": "아티스트 {count}명",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -2674,6 +2674,7 @@ const pl: Record<string, string> = {
   "styles.manager.empty_styles": "Nie utworzono jeszcze żadnych stylów.",
   "styles.manager.empty_presets": "Brak bloków. Utwórz jeden, aby przechować wielokrotnie używany fragment Promptu lub listę wildcardów.",
   "styles.manager.no_thumb": "brak miniatury",
+  "styles.manager.view_thumb": "Zobacz pełny obraz",
   "styles.manager.active": "aktywny",
   "styles.manager.artists_count": "{count} artysta",
   "styles.manager.artists_count_plural": "{count} artystów",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -2452,6 +2452,7 @@ const pt: Record<string, string> = {
   "styles.manager.empty_styles": "Você ainda não criou nenhum estilo.",
   "styles.manager.empty_presets": "Nenhum bloco. Crie um para armazenar um fragmento de prompt reutilizável ou uma lista de curingas.",
   "styles.manager.no_thumb": "sem miniatura",
+  "styles.manager.view_thumb": "Ver imagem completa",
   "styles.manager.active": "ativo",
   "styles.manager.artists_count": "{count} artista",
   "styles.manager.artists_count_plural": "{count} artistas",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -2451,6 +2451,7 @@ const ru: Record<string, string> = {
   "styles.manager.empty_styles": "Вы ещё не создали ни одного стиля.",
   "styles.manager.empty_presets": "Блоков пока нет. Создайте один для хранения фрагмента промпта или списка wildcard.",
   "styles.manager.no_thumb": "нет миниатюры",
+  "styles.manager.view_thumb": "Открыть изображение целиком",
   "styles.manager.active": "активен",
   "styles.manager.artists_count": "{count} художник",
   "styles.manager.artists_count_plural": "{count} художников",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -2451,6 +2451,7 @@ const zhTw: Record<string, string> = {
   "styles.manager.empty_styles": "您尚未建立任何風格。",
   "styles.manager.empty_presets": "尚無片段。建立一個以儲存可重複使用的提示詞片段或萬用字元清單。",
   "styles.manager.no_thumb": "無縮圖",
+  "styles.manager.view_thumb": "檢視完整圖片",
   "styles.manager.active": "已啟用",
   "styles.manager.artists_count": "{count} 位藝術家",
   "styles.manager.artists_count_plural": "{count} 位藝術家",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -2492,6 +2492,7 @@ const zh: Record<string, string> = {
   "styles.manager.empty_styles": "您尚未创建任何风格。",
   "styles.manager.empty_presets": "暂无片段。创建一个以存储可复用的提示词片段或通配符列表。",
   "styles.manager.no_thumb": "无缩略图",
+  "styles.manager.view_thumb": "查看完整图片",
   "styles.manager.active": "已激活",
   "styles.manager.artists_count": "{count} 位艺术家",
   "styles.manager.artists_count_plural": "{count} 位艺术家",

--- a/src/lib/stores/styleEditors.svelte.ts
+++ b/src/lib/stores/styleEditors.svelte.ts
@@ -13,6 +13,12 @@ class StyleEditorsStore {
   styleId = $state<string | null>(null);
   /** Prompt chunk being edited, or null when the chunk editor is closed. */
   presetId = $state<string | null>(null);
+  /**
+   * Artist style whose thumbnail is being viewed full size, or null when that
+   * lightbox is closed. Same reason as the editors: the list it opens from
+   * lives in the bottom panel, but the overlay has to cover the whole app.
+   */
+  thumbnailStyleId = $state<string | null>(null);
 
   openStyle(id: string): void {
     this.styleId = id;
@@ -28,6 +34,14 @@ class StyleEditorsStore {
 
   closePreset(): void {
     this.presetId = null;
+  }
+
+  openThumbnail(id: string): void {
+    this.thumbnailStyleId = id;
+  }
+
+  closeThumbnail(): void {
+    this.thumbnailStyleId = null;
   }
 }
 


### PR DESCRIPTION
Clicking a style thumbnail in the Artist Styles list now opens the image at full size.

The overlay is mounted at the app root through the styleEditors store, the same pattern the style and chunk editors use, so it covers the whole window instead of being trapped inside the bottom panel's transformed wrapper.

- New `StyleThumbnailLightbox.svelte`: full-frame view with the style name, a close button, and Escape to close.
- `styleEditors` gains `thumbnailStyleId` plus open/close methods.
- Thumbnails without an image stay non-interactive.
- New key `styles.manager.view_thumb` added to all 12 locales.
