### PR TITLE
v2.3.0: Style Creator, full-size style thumbnails, NovelAI artist: prefix stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## What's New in v2.3.0
+
+### New features
+- **Style Creator**: a new tab in the bottom panel that helps you find artist tag combinations you like. It draws random combinations from the Artists index, generates two of them on the same seed, and shows the pair in a full-app lightbox so you can compare them properly. Pick the one you prefer, Pick and edit to adjust the weights or add known artists before saving, Save both if you like them both, or Skip to draw again. Whatever you save becomes an Artist Style with that image as its thumbnail. Every combination you accept or reject is remembered, so the same set never comes back, including the same artists in a different order. Anchor artists pins one or more tags (typed, loaded from a saved style, or none at all) and varies only the extras around them; Artists per combination, Extra artists, Favourites only and Vary weights control the draw. Works in both ComfyUI and NovelAI modes, where the `@` artist sigil is omitted and a per round Anlas estimate is shown next to Start.
+- **Artist Style thumbnails open full size**: clicking a thumbnail in Artist Styles opens the image in a lightbox that covers the whole app instead of being trapped inside the bottom panel. The saved gallery image is loaded at its full resolution rather than upscaling the small tile, and it falls back to the tile when the gallery entry is gone.
+- **Generate a thumbnail for a style that does not have one**: styles with no thumbnail now show a Generate thumbnail button in Artist Styles, and a Generate button in the style editor. It renders one image using whatever prompt you currently have typed, with that style's artist tags applied on top, and saves the result as the thumbnail. Disabled while a generation is already running or when the style has no artists.
+
+### Fixes and maintenance
+- **NovelAI no longer rate limits the Style Creator**: NovelAI rejects two generations started at once with a 429, so the pair is now staggered, the second image starting after the first finishes. The panel says so in NovelAI mode rather than leaving you to guess why one side is waiting.
+- **Start reopens a stopped round**: after stopping a round and closing the lightbox, pressing Start again did nothing. It now starts a fresh round.
+- **The `artist:` prefix is dropped from outgoing NovelAI prompts**: Danbooru tags its posts with the bare artist name, so `artist:` is a search box filter the model was never trained on and it only spends tokens. It is now stripped from the base prompt, the negative prompt and every character prompt and undesired content field on the way to NovelAI. It is removed only at a tag boundary, so `artist name`, `artist_name` and `subartist:` survive, and `Text:` lettering is left alone. Your prompt box and the saved image metadata keep exactly what you typed.
+- **Enhance for V5 stops leaving an unused character box behind**: asking for a one character scene with two boxes open rewrote box one and left box two standing, so the extra character still went into the image and looked like a duplicate. A box the rewrite drops is now shown in the review as a ticked row reading `before -> (empty)` with a removed chip, which you can untick to keep the box. The model is also told that returning fewer blocks is how a character is removed, rather than padding the count, and a returned `(empty)` placeholder is read as the blank it means instead of becoming a character box that renders the word.
+
+---
+
 ## What's New in v2.2.8
 
 ### Fixes and maintenance

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## What's New in v2.3.0
+
+### New features
+- **Style Creator**: a new tab in the bottom panel that helps you find artist tag combinations you like. It draws random combinations from the Artists index, generates two of them on the same seed, and shows the pair in a full-app lightbox so you can compare them properly. Pick the one you prefer, Pick and edit to adjust the weights or add known artists before saving, Save both if you like them both, or Skip to draw again. Whatever you save becomes an Artist Style with that image as its thumbnail. Every combination you accept or reject is remembered, so the same set never comes back, including the same artists in a different order. Anchor artists pins one or more tags (typed, loaded from a saved style, or none at all) and varies only the extras around them; Artists per combination, Extra artists, Favourites only and Vary weights control the draw. Works in both ComfyUI and NovelAI modes, where the `@` artist sigil is omitted and a per round Anlas estimate is shown next to Start.
+- **Artist Style thumbnails open full size**: clicking a thumbnail in Artist Styles opens the image in a lightbox that covers the whole app instead of being trapped inside the bottom panel. The saved gallery image is loaded at its full resolution rather than upscaling the small tile, and it falls back to the tile when the gallery entry is gone.
+- **Generate a thumbnail for a style that does not have one**: styles with no thumbnail now show a Generate thumbnail button in Artist Styles, and a Generate button in the style editor. It renders one image using whatever prompt you currently have typed, with that style's artist tags applied on top, and saves the result as the thumbnail. Disabled while a generation is already running or when the style has no artists.
+
+### Fixes and maintenance
+- **NovelAI no longer rate limits the Style Creator**: NovelAI rejects two generations started at once with a 429, so the pair is now staggered, the second image starting after the first finishes. The panel says so in NovelAI mode rather than leaving you to guess why one side is waiting.
+- **Start reopens a stopped round**: after stopping a round and closing the lightbox, pressing Start again did nothing. It now starts a fresh round.
+- **The `artist:` prefix is dropped from outgoing NovelAI prompts**: Danbooru tags its posts with the bare artist name, so `artist:` is a search box filter the model was never trained on and it only spends tokens. It is now stripped from the base prompt, the negative prompt and every character prompt and undesired content field on the way to NovelAI. It is removed only at a tag boundary, so `artist name`, `artist_name` and `subartist:` survive, and `Text:` lettering is left alone. Your prompt box and the saved image metadata keep exactly what you typed.
+- **Enhance for V5 stops leaving an unused character box behind**: asking for a one character scene with two boxes open rewrote box one and left box two standing, so the extra character still went into the image and looked like a duplicate. A box the rewrite drops is now shown in the review as a ticked row reading `before -> (empty)` with a removed chip, which you can untick to keep the box. The model is also told that returning fewer blocks is how a character is removed, rather than padding the count, and a returned `(empty)` placeholder is read as the blank it means instead of becoming a character box that renders the word.
+
+---
+
 ## What's New in v2.2.8
 
 ### Fixes and maintenance

--- a/docs/NOVELAI.md
+++ b/docs/NOVELAI.md
@@ -491,6 +491,18 @@ artist tag looks like any other danbooru tag, the artist index is what tells
 them apart. Saved styles keep a narrower rule (`animaArtistTagPrefix`), because
 only Anima-family checkpoints were trained on `@artist`.
 
+The `artist:` prefix is dropped on the way out. Danbooru tags its posts with the
+bare artist name; `artist:` is the search-box category filter, and NovelAI's
+tag suggestion box uses the same word to filter suggestions to artists, which is
+how it ends up in prompts. The model never saw it, so it only spends tokens.
+`payload::strip_artist_prefixes` removes it (any case, plus spaces after the
+colon) at tag boundaries in the base prompt, the negative prompt and every
+character prompt and UC. It has to follow a comma, newline, `::`, `{`, `[`, `(`
+or the start of the prompt, so `artist name`, `artist_name` and `subartist:`
+survive. The `Text:` block is lettering and is left alone. The prompt box and
+the saved metadata keep what the user typed; the NovelAI token bar counts the
+typed text, so it reads a few tokens high when prefixes are present.
+
 On V5, quoted prompt text is auto-formatted into a `Text:` block, mirroring
 what NovelAI's own frontend does for V5's text rendering.
 `payload::with_text_blocks` collects everything inside `"..."`, `“...”` or
@@ -609,6 +621,29 @@ and the direction of `percent`, the streaming protocol, and that
 Nothing in this backend is covered by an automated test that touches NovelAI's
 servers, so every phase that ships is followed by a hand-test pass recorded
 here, newest first. Each entry says plainly whether testing is needed at all.
+
+### 2026-09-07 - The artist: prefix is stripped from outgoing NovelAI prompts
+
+**Requested by:** the user, after asking whether `artist:jtveemo` does anything
+`jtveemo` does not: "for token saving sakes let's make MooshieUI omit artist:
+in actual tag submission and only submit the raw artist tag".
+
+**What changed.** `payload::strip_artist_prefixes` runs on the base prompt (via
+`without_artist_prefixes`, which skips the `Text:` block), the negative prompt
+and each character prompt and UC. It is case-insensitive, eats spaces after the
+colon, and fires only at a tag boundary. Nothing in the frontend changed: the
+textarea, styles, artist index and metadata all keep the typed text. Four unit
+tests cover boundaries, lookalikes, the `Text:` block and the full payload.
+
+**Testing needed:** yes, one request, to confirm the strip is visible in the
+request and nowhere else.
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | NovelAI mode, prompt `artist:jtveemo, 1girl, artist name`, generate | Rust log shows the payload prompt as `jtveemo, 1girl, artist name`; the image is in jtveemo's style |
+| 2 | Same prompt, add a character with prompt `1girl, artist:as109` and UC `artist:wlop` | Payload character prompt is `1girl, as109`, its UC is `wlop` |
+| 3 | Prompt `artist:foo, 1girl` then a `Text:` line reading `artist:foo` | Payload is `foo, 1girl` with the `Text:` line still reading `artist:foo` |
+| 4 | Open the generated image's metadata in the lightbox | The prompt shows `artist:jtveemo` as typed; the textarea is unchanged |
 
 ### 2026-09-05 - NovelAI img2img and inpainting returned a 500, and imports never change the resolution
 
@@ -3081,3 +3116,67 @@ only be seen end to end.
 
 **Do not skip:** 1, 6, 8, 9, 14, 15.
 **Low-risk, skip if short on time:** 3, 10, 16.
+### 2026-09-07 - Enhance left the old character box behind
+
+**Reported by:** the user, in one line: enhance "sometimes duplicates
+characters if I prompt 2 characters but then use enhance to make a new image
+to only prompt 1 instead of deleting the old unused character slot".
+
+**What was wrong.** Three things, one on top of the other.
+
+- `apply()` in `naiEnhance.svelte.ts` only wrote the rows it was given, and
+  the modal built one row per returned `CHAR` block. With two boxes open and
+  one block back, box two had no row at all: it was not in the diff, it was
+  never cleared, and it went into the payload next to a base prompt written
+  for a single character. That is the extra character the user saw.
+- `naiPrompt.ts` told the model "The user has N character boxes open. Return
+  at least that many CHAR blocks." Asked for a one character scene with two
+  boxes open, the model padded, and padding usually came back as a near copy
+  of the character it had just written. That is why the extra one looked like
+  a duplicate rather than a leftover. The edit path had no wording at all for
+  taking a character out.
+- `naiParse.ts` dropped empty `CHAR` blocks with a plain `!== ""` filter,
+  which closes the gap and shifts every later block onto the wrong box, since
+  `targetIndex` is just the array position.
+
+**What changed.**
+
+- `NaiEnhanceCharacterRow` gained `targetIndex` (which box the row writes to,
+  null for a character the rewrite invented) and `removes` (the box the
+  rewrite dropped). The modal now emits a removal row for every filled box
+  past the end of the returned cast: `before -> (empty)`, labelled removed,
+  ticked by default. Unticking it keeps the box.
+- `apply()` collects deletions into a set and filters after the writes, so
+  every `targetIndex` still points at the box it was built against while the
+  writes run. `undo()` needed no change: it restores the whole snapshotted
+  `characters` array, deletions included.
+- The prompt rules now say the count follows the scene. The no-existing path
+  asks for one block per character the idea calls for and forbids padding;
+  the edit path says a character the instruction takes out is removed by
+  leaving its block out, renumbered from `CHAR 1`, never blanked and never
+  replaced by a repeat of another character.
+- `naiParse.ts` treats `(empty)`, `none`, `n/a`, `blank`, `removed` and
+  `deleted` as blanks as well as the empty string, since a model told to
+  return every field will echo the `(empty)` marker the edit turn wrote.
+  `unchanged` is deliberately not on that list: a model writing it is asking
+  to keep the box, and reading it as a blank would delete what it meant to
+  protect.
+
+**Testing required: yes.** The bug is entirely in TypeScript and Svelte and
+this repo has no frontend test framework, so it is hand-tested. `npm run
+build`, `npm run check:i18n` and `npm run check` are clean (`check` still
+reports its four pre-existing errors, none in these files).
+
+| # | Step | Expected |
+|---|------|----------|
+| 1 | V5 checkpoint, fill two character boxes, Enhance for V5, ask for a scene with one character | The review lists CHAR 1 as a normal diff and CHAR 2 as a ticked row reading `before -> (empty)` with a removed chip |
+| 2 | Press Apply | One character box is left, holding the rewritten text. The base prompt describes one character |
+| 3 | Press Undo inside the 10s window | Both boxes come back with their original text |
+| 4 | Same as 1, but untick the CHAR 2 removal row before Apply | Box two survives untouched |
+| 5 | Two boxes, ask for a two character scene | No removal rows. Both boxes are written in place, box two still means the same character |
+| 6 | Two boxes, the second one empty, ask for one character | No removal row for the blank box. It is left alone |
+| 7 | One box, ask for a three character scene | Box one is written, two rows are labelled new, Apply appends two boxes (capped at the checkpoint's limit) |
+| 8 | Enhance with an instruction that removes a character ("drop the second girl") | Same as 1: a removal row, not a blanked box and not a repeat of character one |
+
+**Do not skip:** 1, 2, 3, 4.
+**Low-risk, skip if short on time:** 6, 7.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.2.8",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.2.8"
+version = "2.3.0"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.2.8"
+version = "2.3.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/src/novelai/payload.rs
+++ b/src-tauri/src/novelai/payload.rs
@@ -7,7 +7,7 @@
 use serde_json::{json, Map, Value};
 
 use super::models::{self, NovelAiModel};
-use super::params::NovelAiParams;
+use super::params::{NovelAiCharacter, NovelAiParams};
 
 /// The generic half of a generation, extracted from `GenerationParams`.
 #[derive(Debug, Clone, Default)]
@@ -39,8 +39,10 @@ pub fn build(
     // ends up last and on its own line: the API wants it at the very end of
     // the prompt, after every tag, and reads `, Text:` as a comma to render.
     let positive_prompt = text_block_on_own_line(&input.positive_prompt);
+    let positive_prompt = without_artist_prefixes(&positive_prompt);
     let positive_prompt = with_transparency(&positive_prompt, nai, model);
     let positive_prompt = with_text_blocks(&positive_prompt, model);
+    let negative_prompt = strip_artist_prefixes(&input.negative_prompt);
     let mut parameters = Map::new();
 
     parameters.insert("params_version".into(), json!(model.params_version));
@@ -65,7 +67,7 @@ pub fn build(
     parameters.insert("legacy_v3_extend".into(), json!(false));
     parameters.insert("prefer_brownian".into(), json!(true));
     parameters.insert("deliberate_euler_ancestral_bug".into(), json!(false));
-    parameters.insert("negative_prompt".into(), json!(input.negative_prompt));
+    parameters.insert("negative_prompt".into(), json!(negative_prompt));
 
     // "Variety+" disables CFG for the earliest, highest-noise steps. NovelAI
     // derives the cutoff from the pixel count rather than exposing a slider.
@@ -82,6 +84,14 @@ pub fn build(
     // past the cap is untested, and a 400 there costs the user a paid request.
     let mut characters = nai.active_characters();
     characters.truncate(model.max_characters);
+    let characters: Vec<NovelAiCharacter> = characters
+        .into_iter()
+        .map(|c| NovelAiCharacter {
+            prompt: strip_artist_prefixes(&c.prompt),
+            negative_prompt: strip_artist_prefixes(&c.negative_prompt),
+            ..c.clone()
+        })
+        .collect();
     parameters.insert("use_coords".into(), json!(nai.use_coords));
 
     if model.v4_prompt {
@@ -110,7 +120,7 @@ pub fn build(
             "v4_negative_prompt".into(),
             json!({
                 "caption": {
-                    "base_caption": input.negative_prompt,
+                    "base_caption": negative_prompt,
                     "char_captions": characters
                         .iter()
                         .map(|c| json!({
@@ -249,6 +259,49 @@ fn text_block_on_own_line(prompt: &str) -> String {
         return format!("{body}\n{}", &prompt[idx..]);
     }
     prompt.to_string()
+}
+
+/// Drop the `artist:` prefix people carry over from Danbooru's search box and
+/// NovelAI's tag suggestion filter. Danbooru posts are tagged with the bare
+/// name, so that is what the model was trained on; the prefix is dead weight
+/// in the token budget and, inside a weight span, a little dilution. The
+/// prefix is removed only at a tag boundary (start, after a comma, newline,
+/// `::`, `{`, `[` or `(`), together with any spaces after the colon, so
+/// `artist name`, `artist_name` and `subartist:` are untouched. The prompt box
+/// keeps what the user typed; this runs on the outgoing payload only.
+fn strip_artist_prefixes(prompt: &str) -> String {
+    const PREFIX: &str = "artist:";
+    let mut out = String::with_capacity(prompt.len());
+    let mut rest = prompt;
+    let mut prev: Option<char> = None;
+    while let Some(c) = rest.chars().next() {
+        let at_boundary =
+            prev.is_none_or(|p| p.is_whitespace() || matches!(p, ',' | ':' | '{' | '[' | '('));
+        if at_boundary
+            && rest.len() >= PREFIX.len()
+            && rest.is_char_boundary(PREFIX.len())
+            && rest[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        {
+            rest = rest[PREFIX.len()..].trim_start_matches([' ', '\t']);
+            continue;
+        }
+        out.push(c);
+        prev = Some(c);
+        rest = &rest[c.len_utf8()..];
+    }
+    out
+}
+
+/// [`strip_artist_prefixes`] for the positive prompt: the `Text:` block is
+/// lettering and is handed back byte for byte.
+fn without_artist_prefixes(prompt: &str) -> String {
+    let (head, text) = split_text_block(prompt);
+    let head = strip_artist_prefixes(head);
+    if text.is_empty() {
+        head
+    } else {
+        format!("{head}{text}")
+    }
 }
 
 /// Quote pairs that mark text to be rendered in the image. NovelAI's V5
@@ -466,9 +519,7 @@ pub(super) fn strip_data_url(s: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::novelai::params::{
-        NovelAiCharacter, NovelAiCoord, NovelAiDirectorReference, NovelAiVibe,
-    };
+    use crate::novelai::params::{NovelAiCoord, NovelAiDirectorReference, NovelAiVibe};
 
     fn input() -> PayloadInput {
         PayloadInput {
@@ -1036,6 +1087,76 @@ mod tests {
             body["parameters"]["v4_prompt"]["caption"]["base_caption"],
             expected
         );
+    }
+
+    #[test]
+    fn artist_prefixes_are_stripped_at_tag_boundaries() {
+        for (prompt, want) in [
+            ("artist:jtveemo, 1girl", "jtveemo, 1girl"),
+            ("1girl, artist:jtveemo", "1girl, jtveemo"),
+            ("1girl,\nArtist: k7", "1girl,\nk7"),
+            ("1.2::artist:as109, artist:wlop::", "1.2::as109, wlop::"),
+            (
+                "{artist:foo}, [artist:bar], (artist:baz:1.1)",
+                "{foo}, [bar], (baz:1.1)",
+            ),
+            ("artist:  spaced", "spaced"),
+            ("ARTIST:caps", "caps"),
+        ] {
+            assert_eq!(strip_artist_prefixes(prompt), want, "{prompt:?}");
+        }
+    }
+
+    #[test]
+    fn artist_lookalikes_are_untouched() {
+        for prompt in [
+            "artist name, artist_name, artist self-insert",
+            "subartist:foo, myartist:bar",
+            "1girl, solo",
+            "",
+        ] {
+            assert_eq!(strip_artist_prefixes(prompt), prompt, "{prompt:?}");
+        }
+    }
+
+    #[test]
+    fn artist_prefix_inside_the_text_block_is_lettering() {
+        assert_eq!(
+            without_artist_prefixes("artist:foo, 1girl,\n\nText:\nartist:foo\n\nHello"),
+            "foo, 1girl,\n\nText:\nartist:foo\n\nHello"
+        );
+    }
+
+    #[test]
+    fn build_strips_artist_prefixes_from_every_prompt_field() {
+        let mut n = nai();
+        n.characters = vec![NovelAiCharacter {
+            prompt: "1girl, artist:as109".into(),
+            negative_prompt: "artist:wlop".into(),
+            enabled: true,
+            ..Default::default()
+        }];
+        let mut i = input();
+        i.positive_prompt = "artist:jtveemo, 1girl, rain, Text: Mumei".into();
+        i.negative_prompt = "artist:k7, lowres".into();
+        let body = build(&i, &n, v5()).unwrap();
+        let p = &body["parameters"];
+        assert_eq!(body["input"], "jtveemo, 1girl, rain\nText: Mumei");
+        assert_eq!(
+            p["v4_prompt"]["caption"]["base_caption"],
+            "jtveemo, 1girl, rain\nText: Mumei"
+        );
+        assert_eq!(p["negative_prompt"], "k7, lowres");
+        assert_eq!(
+            p["v4_negative_prompt"]["caption"]["base_caption"],
+            "k7, lowres"
+        );
+        let ch = &p["v4_prompt"]["caption"]["char_captions"][0];
+        assert_eq!(ch["char_caption"], "1girl, as109");
+        let uc = &p["v4_negative_prompt"]["caption"]["char_captions"][0];
+        assert_eq!(uc["char_caption"], "wlop");
+        assert_eq!(p["characterPrompts"][0]["prompt"], "1girl, as109");
+        assert_eq!(p["characterPrompts"][0]["uc"], "wlop");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.2.8",
+  "version": "2.3.0",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/lib/components/generation/NaiEnhanceModal.svelte
+++ b/src/lib/components/generation/NaiEnhanceModal.svelte
@@ -176,12 +176,32 @@
         // character boxes no longer match.
         base: { before: generation.positivePrompt, after: result.parsed.base, selected: true },
         uc: { before: generation.negativePrompt, after: result.parsed.uc, selected: true },
-        characters: result.parsed.characters.map((after, i) => ({
-          before: boxes[i]?.prompt ?? "",
-          after,
-          selected: true,
-          targetIndex: i < boxes.length ? i : null,
-        })),
+        characters: [
+          ...result.parsed.characters.map((after, i) => ({
+            before: boxes[i]?.prompt ?? "",
+            after,
+            selected: true,
+            targetIndex: i < boxes.length ? i : null,
+            removes: false,
+          })),
+          // Boxes the rewrite came back short of. The base prompt it wrote
+          // describes the cast it returned, so a box left standing puts a
+          // character in the image that nothing asked for -- the duplicate the
+          // user sees after asking for a smaller cast. Offered as a ticked
+          // removal row rather than cleared behind their back, and only for
+          // boxes with something in them: an already blank slot sends nothing.
+          ...boxes
+            .map((box, i) => ({ box, i }))
+            .slice(result.parsed.characters.length)
+            .filter(({ box }) => (box.prompt ?? "").trim() !== "")
+            .map(({ box, i }) => ({
+              before: box.prompt ?? "",
+              after: "",
+              selected: true,
+              targetIndex: i,
+              removes: true,
+            })),
+        ],
       });
     } catch (e) {
       console.error("NovelAI V5 prompt rewrite failed:", e);
@@ -567,13 +587,21 @@
           )}
           {#each pending.characters as char, i (i)}
             {@render row(
-              locale.t("prompt_assistant.nai_field_character", { index: String(i + 1) }),
+              locale.t("prompt_assistant.nai_field_character", {
+                // A removal row is named after the box it deletes, not its place
+                // in this list, so the number matches the panel underneath.
+                index: String((char.targetIndex ?? i) + 1),
+              }),
               char.before,
               char.after,
               char.selected,
               pending.budget,
               () => naiEnhance.toggleCharacter(i),
-              char.targetIndex === null ? locale.t("prompt_assistant.nai_new_character") : "",
+              char.removes
+                ? locale.t("prompt_assistant.nai_removed_character")
+                : char.targetIndex === null
+                  ? locale.t("prompt_assistant.nai_new_character")
+                  : "",
             )}
           {/each}
         </div>

--- a/src/lib/locales/de.ts
+++ b/src/lib/locales/de.ts
@@ -2924,6 +2924,7 @@ const de: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Unerwünschter Inhalt",
   "prompt_assistant.nai_field_character": "Charakter {index}",
   "prompt_assistant.nai_new_character": "neu",
+  "prompt_assistant.nai_removed_character": "entfernt",
   "prompt_assistant.nai_before": "Jetzt",
   "prompt_assistant.nai_after": "Vorschlag",
   "prompt_assistant.nai_empty": "leer",

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -3029,6 +3029,7 @@ const en: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Undesired content",
   "prompt_assistant.nai_field_character": "Character {index}",
   "prompt_assistant.nai_new_character": "new",
+  "prompt_assistant.nai_removed_character": "removed",
   "prompt_assistant.nai_before": "Now",
   "prompt_assistant.nai_after": "Proposed",
   "prompt_assistant.nai_empty": "empty",

--- a/src/lib/locales/es.ts
+++ b/src/lib/locales/es.ts
@@ -2950,6 +2950,7 @@ const es: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Contenido no deseado",
   "prompt_assistant.nai_field_character": "Personaje {index}",
   "prompt_assistant.nai_new_character": "nuevo",
+  "prompt_assistant.nai_removed_character": "eliminado",
   "prompt_assistant.nai_before": "Ahora",
   "prompt_assistant.nai_after": "Propuesto",
   "prompt_assistant.nai_empty": "vacío",

--- a/src/lib/locales/fr.ts
+++ b/src/lib/locales/fr.ts
@@ -2947,6 +2947,7 @@ const fr: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Contenu indésirable",
   "prompt_assistant.nai_field_character": "Personnage {index}",
   "prompt_assistant.nai_new_character": "nouveau",
+  "prompt_assistant.nai_removed_character": "supprimé",
   "prompt_assistant.nai_before": "Actuel",
   "prompt_assistant.nai_after": "Proposé",
   "prompt_assistant.nai_empty": "vide",

--- a/src/lib/locales/it.ts
+++ b/src/lib/locales/it.ts
@@ -2921,6 +2921,7 @@ const it: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Contenuto indesiderato",
   "prompt_assistant.nai_field_character": "Personaggio {index}",
   "prompt_assistant.nai_new_character": "nuovo",
+  "prompt_assistant.nai_removed_character": "rimosso",
   "prompt_assistant.nai_before": "Ora",
   "prompt_assistant.nai_after": "Proposto",
   "prompt_assistant.nai_empty": "vuoto",

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -2946,6 +2946,7 @@ const ja: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "不要な要素",
   "prompt_assistant.nai_field_character": "キャラクター {index}",
   "prompt_assistant.nai_new_character": "新規",
+  "prompt_assistant.nai_removed_character": "削除",
   "prompt_assistant.nai_before": "現在",
   "prompt_assistant.nai_after": "提案",
   "prompt_assistant.nai_empty": "空",

--- a/src/lib/locales/ko.ts
+++ b/src/lib/locales/ko.ts
@@ -2921,6 +2921,7 @@ const ko: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "제외할 내용",
   "prompt_assistant.nai_field_character": "캐릭터 {index}",
   "prompt_assistant.nai_new_character": "신규",
+  "prompt_assistant.nai_removed_character": "삭제",
   "prompt_assistant.nai_before": "현재",
   "prompt_assistant.nai_after": "제안",
   "prompt_assistant.nai_empty": "비어 있음",

--- a/src/lib/locales/pl.ts
+++ b/src/lib/locales/pl.ts
@@ -2970,6 +2970,7 @@ const pl: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Niepożądana treść",
   "prompt_assistant.nai_field_character": "Postać {index}",
   "prompt_assistant.nai_new_character": "nowa",
+  "prompt_assistant.nai_removed_character": "usunięta",
   "prompt_assistant.nai_before": "Teraz",
   "prompt_assistant.nai_after": "Propozycja",
   "prompt_assistant.nai_empty": "puste",

--- a/src/lib/locales/pt.ts
+++ b/src/lib/locales/pt.ts
@@ -2922,6 +2922,7 @@ const pt: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Conteúdo indesejado",
   "prompt_assistant.nai_field_character": "Personagem {index}",
   "prompt_assistant.nai_new_character": "novo",
+  "prompt_assistant.nai_removed_character": "removido",
   "prompt_assistant.nai_before": "Agora",
   "prompt_assistant.nai_after": "Proposto",
   "prompt_assistant.nai_empty": "vazio",

--- a/src/lib/locales/ru.ts
+++ b/src/lib/locales/ru.ts
@@ -2921,6 +2921,7 @@ const ru: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "Нежелательное содержимое",
   "prompt_assistant.nai_field_character": "Персонаж {index}",
   "prompt_assistant.nai_new_character": "новый",
+  "prompt_assistant.nai_removed_character": "удалён",
   "prompt_assistant.nai_before": "Сейчас",
   "prompt_assistant.nai_after": "Предложено",
   "prompt_assistant.nai_empty": "пусто",

--- a/src/lib/locales/zh-tw.ts
+++ b/src/lib/locales/zh-tw.ts
@@ -2921,6 +2921,7 @@ const zhTw: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "負面內容",
   "prompt_assistant.nai_field_character": "角色 {index}",
   "prompt_assistant.nai_new_character": "新增",
+  "prompt_assistant.nai_removed_character": "移除",
   "prompt_assistant.nai_before": "目前",
   "prompt_assistant.nai_after": "建議",
   "prompt_assistant.nai_empty": "空",

--- a/src/lib/locales/zh.ts
+++ b/src/lib/locales/zh.ts
@@ -2922,6 +2922,7 @@ const zh: Record<string, string> = {
   "prompt_assistant.nai_field_uc": "负面内容",
   "prompt_assistant.nai_field_character": "角色 {index}",
   "prompt_assistant.nai_new_character": "新增",
+  "prompt_assistant.nai_removed_character": "移除",
   "prompt_assistant.nai_before": "当前",
   "prompt_assistant.nai_after": "建议",
   "prompt_assistant.nai_empty": "空",

--- a/src/lib/stores/naiEnhance.svelte.ts
+++ b/src/lib/stores/naiEnhance.svelte.ts
@@ -44,6 +44,17 @@ export interface NaiEnhanceCharacterRow extends NaiEnhanceRow {
    * a character the user does not have a slot for yet.
    */
   targetIndex: number | null;
+  /**
+   * True for a box the rewrite dropped, where `after` is empty and applying the
+   * row deletes the slot outright.
+   *
+   * A rewrite that comes back with fewer characters than the user has boxes
+   * open has written a base prompt for the smaller cast, so a box left behind
+   * puts a character in the image that nothing in the prompt asked for. It is
+   * offered as a ticked row rather than cleared silently, because the box may
+   * hold work the user tuned by hand.
+   */
+  removes: boolean;
 }
 
 export interface NaiEnhancePending {
@@ -283,15 +294,24 @@ class NaiEnhanceStore {
     if (p.uc.selected) generation.negativePrompt = p.uc.after;
 
     const chars = generation.novelaiSettings.characters.map((c) => ({ ...c }));
+    // Deletions are collected and applied after the writes rather than spliced
+    // as they are met, so that every `targetIndex` keeps pointing at the box it
+    // was built against. Appended slots land past the end and are never in the
+    // set, so the filter cannot catch one.
+    const dropped = new Set<number>();
     for (const row of p.characters) {
       if (!row.selected) continue;
-      if (row.targetIndex !== null && row.targetIndex < chars.length) {
+      if (row.removes) {
+        if (row.targetIndex !== null) dropped.add(row.targetIndex);
+      } else if (row.targetIndex !== null && row.targetIndex < chars.length) {
         chars[row.targetIndex] = { ...chars[row.targetIndex], prompt: row.after };
       } else if (chars.length < novelAiMaxCharacters(generation.checkpoint)) {
         chars.push({ ...createNovelAiCharacter(), prompt: row.after });
       }
     }
-    generation.updateNovelAiSettings({ characters: chars });
+    generation.updateNovelAiSettings({
+      characters: chars.filter((_, i) => !dropped.has(i)),
+    });
     generation.saveSettings();
 
     this.stage = null;

--- a/src/lib/utils/naiParse.ts
+++ b/src/lib/utils/naiParse.ts
@@ -131,9 +131,29 @@ export function parseNaiResponse(raw: string): NaiParsedResponse {
     // it wrote the scene body first and started labelling at CHAR 1.
     base: joinedBase || (sawBaseLabel ? "" : joinField(stripLeadIn(preamble))),
     uc: joinField(uc),
-    characters: chars.map((c) => joinField(c)).filter((c) => c !== ""),
+    characters: chars.map((c) => joinField(c)).filter((c) => !isBlankBox(c)),
     note: joinField(note),
   };
+}
+
+/**
+ * Placeholders a model returns instead of leaving a character box out.
+ *
+ * The edit turn writes `(empty)` under a box that has no text, and a model
+ * asked to return every field will sometimes echo that marker back rather than
+ * omit the block. Taken literally it becomes a character box whose prompt is
+ * the word "(empty)", which NovelAI would dutifully render. Treated as the
+ * blank it means, the block drops out and the box is offered for removal
+ * instead, which is what a shorter cast is supposed to do.
+ *
+ * Deliberately not on this list: "unchanged". A model writing that is asking to
+ * keep the box, and reading it as a blank would delete the very thing it meant
+ * to protect.
+ */
+const BLANK_BOX = /^[\s.\-*_]*(?:\(?\s*(?:empty|none|n\/a|blank|removed|deleted)\s*\)?)?[\s.\-*_]*$/i;
+
+function isBlankBox(box: string): boolean {
+  return BLANK_BOX.test(box);
 }
 
 /**

--- a/src/lib/utils/naiPrompt.ts
+++ b/src/lib/utils/naiPrompt.ts
@@ -259,7 +259,8 @@ function sourceFidelity(
 - The user's current prompt is given to you below, and their message is an instruction for changing it. This is a revision, not a fresh start.
 - Return every field in full, including the ones you did not change. Your answer replaces their prompt outright, so anything you leave out is deleted.
 - Carry the untouched parts over word for word wherever the wording still works. The user tuned those parts on purpose, and quietly rewording them is the failure this mode exists to avoid.
-- Return one CHAR block per box they already have, in the same order, so that box three still means the same character afterwards. Add a box only if the instruction calls for a new character.
+- Return one CHAR block per character that survives the instruction, in their existing order, so that box three still means the same character afterwards. Add a box only if the instruction calls for a new character.
+- When the instruction cuts the cast down, return only the characters that remain, renumbered from CHAR 1. Their boxes are resized to match, so returning fewer blocks is how a character is removed. Never keep a dropped character alive by repeating another one to fill the slot, and never return an empty CHAR block as a placeholder.
 - Apply the instruction completely, and nothing beyond it. Do not take the chance to add a location, a time of day, weather, a wardrobe, a mood or a camera angle they did not ask for.
 - If the current prompt is not in V5 shape, put it in V5 shape as you go. That is repair, and it is expected of you; it is not licence to invent.
 - A named character keeps their name, their tags and their canon through the revision. Never generalize one away while editing.`;
@@ -450,7 +451,7 @@ export function naiUserPrompt(prompt: string, ctx: NaiPromptContext): string {
     ctx.characterCount > 0
       ? `\n\nThe user has ${ctx.characterCount} character box${
           ctx.characterCount === 1 ? "" : "es"
-        } open, whose contents you have not been given. Return at least that many CHAR blocks, written from the idea above alone. Add more only if the scene needs them.`
+        } open, whose contents you have not been given, and their boxes will be resized to match your answer. Write one CHAR block per character the idea above actually calls for, and no more. Returning fewer blocks than they have boxes is correct whenever the idea is smaller than what they had; never pad the count with a character the idea does not name.`
       : "";
   const refs = referenceManifest(ctx.references);
   const inputs = ctx.references.length
@@ -488,7 +489,7 @@ ${mark(existing.base)}
 UC:
 ${mark(existing.uc)}${boxes ? `\n\n${boxes}` : ""}
 
-Apply this instruction to it, and return the whole prompt again in the output format with every field present, changed or not. Hybrid tags plus natural language. Custom undesired content only. No quality or aesthetic filler.
+Apply this instruction to it, and return the whole prompt again in the output format: BASE and UC always, changed or not, then one CHAR block for each character still in the scene. A character the instruction takes out is removed by leaving its block out, not by blanking it. Hybrid tags plus natural language. Custom undesired content only. No quality or aesthetic filler.
 
 ${instruction(prompt, references)}${referenceManifest(references)}`;
 }


### PR DESCRIPTION
Release v2.3.0.

## New features
- **Style Creator** (new bottom panel tab, both ComfyUI and NovelAI modes): draws random artist combinations from the Artists index, generates two on the same seed, shows the pair in a full-app lightbox. Pick / Pick and edit / Save both / Skip, Stop, side by side or one at a time. Accepted and rejected combinations are remembered, including reorderings. Anchor artists (typed, loaded from a saved style, or none), Artists per combination, Extra artists, Favourites only, Vary weights. NovelAI mode omits the `@` sigil and shows a per round Anlas estimate.
- **Artist Style thumbnails open full size** in an overlay that covers the whole app, loading the saved gallery image at full resolution with a fallback to the tile.
- **Generate thumbnail** for styles that do not have one, from Artist Styles or the style editor, using the currently typed prompt plus that style's artist tags.

## Fixes and maintenance
- NovelAI 429 on the Style Creator pair: the two generations are now staggered, with a note in the panel explaining why.
- Start reopens a stopped round instead of doing nothing (#682).
- The `artist:` prefix is stripped from every outgoing NovelAI prompt field (base, negative, per character prompt and undesired content). Tag-boundary only, so `artist name` and `subartist:` survive; `Text:` lettering is untouched. Prompt box and saved metadata keep what the user typed. Four new unit tests.
- Enhance for V5 no longer leaves a stale character box behind. Dropped boxes appear in the review as ticked `before -> (empty)` rows with a removed chip that can be unticked, the model is told to return fewer blocks rather than pad, and an `(empty)` placeholder is read as a blank instead of becoming a character.

## Validation
- `cargo check` (desktop + server): pass
- `cargo test`: 460 passed, 0 failed
- `npm run build`: pass
- `npm run check:i18n`: parity OK

## Bot triage
No bot comments or reviews on any PR merged since v2.2.8 (#677 through #684). Nothing to Fix, Skip, or Defer.
