### PR TITLE
v2.3.1: generation pause/resume and personal NovelAI keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## What's New in v2.3.1
+
+### New features
+- **Pause and continue image generation**: choose **Pause at step** in Text to Image, inspect the preview, then continue with a different prompt, CFG, sampler or LoRAs. A final continuation can change the step count and scheduler. **Paint a correction** opens the paused preview in the inpaint canvas so masked edits can be blended into the remaining generation. Keep the pause to try another ending, or discard it to start fresh. ComfyUI only; upscaling and detail passes wait until sampling finishes. ([#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+- **Personal NovelAI keys for hosted accounts**: regular users and moderators can save and manage their own encrypted NovelAI API key. These accounts use their own credentials and never fall back to the host's key. The desktop owner's shared configuration remains separate, and moderators cannot read or replace that owner key through configuration updates. ([#691](https://github.com/Mooshieblob1/MooshieUI/pull/691))
+- **NovelAI Face Detailer**: faces are detected locally and repainted with NovelAI or a local checkpoint. Choose a face prompt and crop-cost policy; each NovelAI crop streams its preview and progress. Face steps follow the main Steps setting until overridden, and notices explain skipped, partial or failed passes. New settings start at Confidence 0.4 and Strength 0.5. ([#688](https://github.com/Mooshieblob1/MooshieUI/pull/688), [#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+
+### Fixes and maintenance
+- **NovelAI character references** are fitted to an accepted canvas with letterboxing, avoiding rejected reference requests. ([#687](https://github.com/Mooshieblob1/MooshieUI/pull/687))
+- **NovelAI PNG metadata survives clipboard copying and face detailing**, retaining the original text chunks alongside post-processing information. Importing V5 images ignores the placeholder zero for undesired content strength while preserving meaningful values from older models. ([#689](https://github.com/Mooshieblob1/MooshieUI/pull/689), [#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+- **Reliable continuations** keep queued runs' pause histories separate, retain the original seed, apply the correct latent noise scaling for flow models, and preserve DPM2/UniPC noise boundaries. Switching to NovelAI does not carry ComfyUI pause state into a request. ([#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+
+### Experimental macOS builds
+- **Native Apple Silicon candidates** use an ARM64 app and managed Python/PyTorch runtime for macOS 14 or later, with Metal checks, conservative unified-memory handling, and guards against unsupported CUDA attention and FP8 settings. Builds use free ad-hoc signing and are not notarized by Apple. ([#690](https://github.com/Mooshieblob1/MooshieUI/pull/690))
+- **Mac installers remain experimental** while physical-Mac installation, real model generation and application-update qualification are pending. Candidate DMGs and checksums are available from the [macOS Native Validation workflow](https://github.com/Mooshieblob1/MooshieUI/actions/workflows/macos-native.yml); stable macOS downloads and automatic updates remain gated. See the [Mac installation and qualification guide](https://github.com/Mooshieblob1/MooshieUI/blob/v2.3.1/docs/MACOS.md).
+
+---
+
 ## What's New in v2.3.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+## What's New in v2.3.1
+
+### New features
+- **Pause and continue image generation**: choose **Pause at step** in Text to Image, inspect the preview, then continue with a different prompt, CFG, sampler or LoRAs. A final continuation can change the step count and scheduler. **Paint a correction** opens the paused preview in the inpaint canvas so masked edits can be blended into the remaining generation. Keep the pause to try another ending, or discard it to start fresh. ComfyUI only; upscaling and detail passes wait until sampling finishes. ([#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+- **Personal NovelAI keys for hosted accounts**: regular users and moderators can save and manage their own encrypted NovelAI API key. These accounts use their own credentials and never fall back to the host's key. The desktop owner's shared configuration remains separate, and moderators cannot read or replace that owner key through configuration updates. ([#691](https://github.com/Mooshieblob1/MooshieUI/pull/691))
+- **NovelAI Face Detailer**: faces are detected locally and repainted with NovelAI or a local checkpoint. Choose a face prompt and crop-cost policy; each NovelAI crop streams its preview and progress. Face steps follow the main Steps setting until overridden, and notices explain skipped, partial or failed passes. New settings start at Confidence 0.4 and Strength 0.5. ([#688](https://github.com/Mooshieblob1/MooshieUI/pull/688), [#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+
+### Fixes and maintenance
+- **NovelAI character references** are fitted to an accepted canvas with letterboxing, avoiding rejected reference requests. ([#687](https://github.com/Mooshieblob1/MooshieUI/pull/687))
+- **NovelAI PNG metadata survives clipboard copying and face detailing**, retaining the original text chunks alongside post-processing information. Importing V5 images ignores the placeholder zero for undesired content strength while preserving meaningful values from older models. ([#689](https://github.com/Mooshieblob1/MooshieUI/pull/689), [#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+- **Reliable continuations** keep queued runs' pause histories separate, retain the original seed, apply the correct latent noise scaling for flow models, and preserve DPM2/UniPC noise boundaries. Switching to NovelAI does not carry ComfyUI pause state into a request. ([#692](https://github.com/Mooshieblob1/MooshieUI/pull/692))
+
+### Experimental macOS builds
+- **Native Apple Silicon candidates** use an ARM64 app and managed Python/PyTorch runtime for macOS 14 or later, with Metal checks, conservative unified-memory handling, and guards against unsupported CUDA attention and FP8 settings. Builds use free ad-hoc signing and are not notarized by Apple. ([#690](https://github.com/Mooshieblob1/MooshieUI/pull/690))
+- **Mac installers remain experimental** while physical-Mac installation, real model generation and application-update qualification are pending. Candidate DMGs and checksums are available from the [macOS Native Validation workflow](https://github.com/Mooshieblob1/MooshieUI/actions/workflows/macos-native.yml); stable macOS downloads and automatic updates remain gated. See the [Mac installation and qualification guide](https://github.com/Mooshieblob1/MooshieUI/blob/v2.3.1/docs/MACOS.md).
+
+---
+
 ## What's New in v2.3.0
 
 ### New features

--- a/docs/MACOS_RELEASE_PLAN.md
+++ b/docs/MACOS_RELEASE_PLAN.md
@@ -4,8 +4,8 @@ Status: implementation complete; physical-Mac qualification pending, 2026-09-10.
 Native CI, managed runtime pins,
 MPS setup verification, packaging, updater collection and publication gating are
 implemented. Local and native Mac build gates pass. See [MACOS.md](MACOS.md) for the
-current candidate and release procedure. Versions remain 2.3.0 until the normal
-2.3.1 release process.
+current candidate and release procedure. Release metadata now targets 2.3.1. Stable Mac publication remains gated until
+physical-Mac acceptance is complete; other platforms can release independently.
 
 ## Automated candidate evidence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-desktop",
-  "version": "2.2.4",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-desktop",
-      "version": "2.2.4",
+      "version": "2.3.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@jsquash/avif": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-desktop",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "comfyui-desktop"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "argon2",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comfyui-desktop"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 default-run = "comfyui-desktop"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicerlab/files/main/tauri/tauri.conf.json.schema",
   "productName": "MooshieUI",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "identifier": "com.mooshieui.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release v2.3.1 with generation pause/continue, masked painted corrections, personal NovelAI keys for regular users and moderators, and the NovelAI face detailer improvements merged since v2.3.0. Also includes the character-reference canvas and clipboard/PNG metadata fixes.

This PR synchronizes package, Tauri and Cargo versions plus their root lockfile entries, prepends release notes and changelog, and updates the Mac release-status document. It does not change generation code or dependency versions.

macOS remains experimental: automated ARM64/MPS validation has passed, but physical-Mac installation, real model generation and application-update qualification are still pending. MACOS_RELEASE_ENABLED remains unset. The normal release publishes Windows and Linux assets; the macOS validation workflow supplies an experimental 2.3.1 candidate.

Validation: desktop and server cargo check, 557 Rust tests passed (one existing ignored), cargo fmt, production frontend build, translation parity and five release-artifact tests passed. All package/Tauri/Cargo versions match v2.3.1.

Release triage:
- No conflicting release branch or existing v2.3.1 tag/release.
- PRs #687-#692 have no outstanding review findings.
- The ten dependency PRs #667-#676 are green and remain outside the agreed scope. Their missing-label notices are deferred as repository housekeeping, with no runtime impact.
- Existing feature/integration branch references are retained. Wiki coverage is current; a clipboard-metadata note is prepared for NovelAI Backend.