### PR TITLE
Bump ComfyUI pin to v0.35.0 and unlink the audio VAE from native ref2va

### DIFF
--- a/docs/MACOS_RELEASE_PLAN.md
+++ b/docs/MACOS_RELEASE_PLAN.md
@@ -69,9 +69,9 @@ qualification is tracked separately below.
 | Optional native tools | [interrogator.rs](../src-tauri/src/interrogator.rs) selects macOS ARM ONNX Runtime; [prompt_assistant/server.rs](../src-tauri/src/prompt_assistant/server.rs) selects macOS ARM llama.cpp and Metal. | Test actual downloads, executable modes, dynamic library loading, tagging, prompt assistance, and video codecs in the installed app. |
 | ComfyUI compatibility | [comfyui-compat.yml](../.github/workflows/comfyui-compat.yml) tests node registration on Linux CPU with Python 3.12. Setup normally installs Python 3.11. | Add macOS ARM installation/import coverage using the production runtime versions. Extend compatibility validation to preserve the Mac support claim when ComfyUI is updated. |
 
-The current ComfyUI pin is `v0.34.0` in
+The current ComfyUI pin is `v0.35.0` in
 [comfyui_version.rs](../src-tauri/src/comfyui_version.rs). Its
-[device management](https://github.com/Comfy-Org/ComfyUI/blob/v0.34.0/comfy/model_management.py)
+[device management](https://github.com/Comfy-Org/ComfyUI/blob/v0.35.0/comfy/model_management.py)
 already selects `torch.device("mps")` and shared-memory handling when available.
 MooshieUI should use this existing backend and validate the resulting behavior.
 

--- a/src-tauri/src/comfyui_version.rs
+++ b/src-tauri/src/comfyui_version.rs
@@ -30,7 +30,7 @@ pub fn update_is_incomplete(comfyui_dir: &Path) -> bool {
 /// whatever `master` happened to be at install time. The scheduled
 /// `comfyui-compat` workflow opens a bot PR bumping this constant once the
 /// custom-node smoke test passes against a newer ComfyUI release.
-pub const COMFYUI_REF: &str = "v0.34.0";
+pub const COMFYUI_REF: &str = "v0.35.0";
 
 /// Read the installed ComfyUI version from its `comfyui_version.py` file
 /// (`__version__ = "0.26.0"`). Returns `None` if the file is missing or

--- a/src-tauri/src/templates/video.rs
+++ b/src-tauri/src/templates/video.rs
@@ -389,7 +389,11 @@ pub fn build(params: &GenerationParams, seed: i64, include_metadata: bool) -> Va
         let mut inputs = serde_json::Map::new();
         inputs.insert("clip".to_string(), json!([clip_id.as_str(), 0]));
         inputs.insert("vae".to_string(), json!([vae_id.as_str(), 0]));
-        inputs.insert("audio_vae".to_string(), json!([audio_vae_id.as_str(), 0]));
+        // `audio_vae` is optional on the node since ComfyUI v0.35.0 and only
+        // encodes reference audio. This path never wires `ref_audios` or
+        // `ref_videos`, so the socket stays unconnected; the audio VAE loader
+        // still feeds `VAEDecodeAudio` below. (The Director path keeps it: its
+        // timeline can carry audio cues.)
         inputs.insert("prompt".to_string(), json!(params.positive_prompt));
         inputs.insert("width".to_string(), json!(width));
         inputs.insert("height".to_string(), json!(height));
@@ -890,7 +894,10 @@ mod tests {
         let workflow = build(&params, 1, false);
         assert!(nodes_of_class(&workflow, "MiniMaxH3ImageToVideo").is_empty());
         let h3 = nodes_of_class(&workflow, "MiniMaxH3ReferenceToVideo")[0];
-        assert!(h3["inputs"]["audio_vae"].is_array());
+        assert!(h3["inputs"]["vae"].is_array());
+        // No reference audio can reach this node, so the optional audio VAE
+        // socket is left unconnected; the decode chain still owns the loader.
+        assert!(h3["inputs"].get("audio_vae").is_none());
         assert_eq!(h3["inputs"]["ref_image_size"], json!("match"));
         assert!(h3["inputs"]["ref_images.ref_image_0"].is_array());
         assert!(h3["inputs"]["ref_images.ref_image_1"].is_array());


### PR DESCRIPTION
## Summary

Moves `COMFYUI_REF` from v0.34.0 to v0.35.0. The release makes both VAE inputs on `MiniMaxH3ReferenceToVideo` optional, respects the container cgroup memory limit instead of host RAM, and fixes alpha-channel handling across the core image nodes. Fresh installs and the in-app "Update ComfyUI" action now target the new tag.

The plain ref2va graph never wires reference audio or reference videos, so its `audio_vae` socket is now left unconnected. The audio VAE loader still feeds `VAEDecodeAudio`, and the Director path keeps its link because a timeline can carry audio cues. The template test asserts the socket is absent.

Also updates the pin reference in `docs/MACOS_RELEASE_PLAN.md`.

Validation:
- `scripts/comfyui-compat/smoke_test.py` passes against v0.35.0 in CPU mode (15 required node classes registered, 2 core node signatures intact).
- `cargo test` green under both feature sets (desktop and server).
- `cargo check` for desktop and server, `cargo fmt --check`, and `cargo clippy` clean for the touched files.

## Linked issue

None.

## How this fits the project scope

Keeps the orchestrated ComfyUI on a tested release and tidies the H3 video graph. No new feature surface.

## Guideline checklist

- [x] i18n: no new user-facing strings.
- [x] a11y: no UI changes.
- [ ] I ran `npm run check` locally and addressed issues in the files I changed. (No frontend files changed; only Rust and docs.)
- [x] This change is within the scope described in `SCOPE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VhBb3CT6xKNHgMwefE3UM3)_